### PR TITLE
print versionless messages after resolution

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -978,8 +978,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
 
         if(isBeta && result != null){
             if(!result.getResolvedPlatforms().isEmpty()){
-                System.out.println("CWWKF0053I: Feature resolution selected the " + result.getResolvedPlatforms() + " platforms.");
-                //Tr.info(tc, "RESOLVED_PLATFORM", result.getResolvedPlatforms());
+                Tr.info(tc, "RESOLVED_PLATFORM", result.getResolvedPlatforms());
             }
 
             List<String> resolvedVersionless = new ArrayList<>();
@@ -2005,6 +2004,41 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
 
         if(isBeta){
 
+            if(!result.getDuplicatePlatforms().isEmpty()){
+                for(Map.Entry<String, Set<String>> duplicatePlatforms : result.getDuplicatePlatforms().entrySet()){
+                    Tr.error(tc, "DUPLICATE_PLATFORMS", duplicatePlatforms.getValue());
+                }
+            }
+
+            if(!result.getMissingPlatforms().isEmpty()){
+                reportedErrors = true;
+                Set<String> remainingMissingPlatforms = new HashSet<String>();
+                if(platformEnvironmentVariable != null){
+                    for(String plat : result.getMissingPlatforms()){
+                        if(platformEnvironmentVariable.contains(plat)){
+                            Tr.error(tc, "UNKNOWN_PLATFORM_VALUE_ENV_VAR", plat);
+                        }
+                        else{
+                            remainingMissingPlatforms.add(plat);
+                        }
+                    }
+                }
+                else{
+                    remainingMissingPlatforms.addAll(result.getMissingPlatforms());
+                }
+                if(!remainingMissingPlatforms.isEmpty()){
+                    for(String missingPlat : remainingMissingPlatforms){
+                        Tr.error(tc, "UNKNOWN_PLATFORM_ELEMENT", missingPlat);
+                    }
+                }
+            }
+
+            if(!result.getNoPlatformVersionless().isEmpty()){
+                for (Map.Entry<String, Set<String>> noPlatformVersionless : result.getNoPlatformVersionless().entrySet()) {
+                    Tr.error(tc, "NO_RESOLVED_PLATFORM", noPlatformVersionless.getValue());
+                }
+            }
+
             List<String> unresolvedVersionless = new ArrayList<>();
             for (Map.Entry<String, String> versionlessResolved : result.getVersionlessFeatures().entrySet()) {
                 if(versionlessResolved.getValue() == null){
@@ -2016,8 +2050,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
                             if(resolvedPlat.toLowerCase().startsWith(platformBaseName.toLowerCase()) && 
                                 featureRepository.getVersionlessFeatureVersionForPlatform(versionlessResolved.getKey(), resolvedPlat) == null){
 
-                                System.out.println("CWWKF0054E: The " + versionlessResolved.getKey() + " versionless feature does not have a version belonging to the " + resolvedPlat + " platform.");
-                                //Tr.error(tc, "INCOMPATIBLE_VERSIONLESS_FEATURE_WITH_PLATFORM", versionlessResolved.getKey(), resolvedPlat);
+                                Tr.error(tc, "INCOMPATIBLE_VERSIONLESS_FEATURE_WITH_PLATFORM", getFeatureName(versionlessResolved.getKey()), resolvedPlat);
                                 compatibleWithPlatform = false;
                                 break;
                             }
@@ -2025,50 +2058,13 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
                     }
 
                     if(compatibleWithPlatform){
-                        unresolvedVersionless.add(versionlessResolved.getKey());
+                        unresolvedVersionless.add(getFeatureName(versionlessResolved.getKey()));
                     }
                 }
             }
             if(!unresolvedVersionless.isEmpty()){
                 reportedErrors = true;
                 Tr.error(tc, "UNRESOLVED_VERSIONLESS_FEATURE", unresolvedVersionless);
-            }
-
-            if(!result.getDuplicatePlatforms().isEmpty()){
-                for(Map.Entry<String, Set<String>> duplicatePlatforms : result.getDuplicatePlatforms().entrySet()){
-                    System.out.println("CWWKF0049E: The following configured platform versions are in conflict: " + duplicatePlatforms.getValue());
-                    //Tr.error(tc, "DUPLICATE_PLATFORMS", duplicatePlatforms.getValue());
-                }
-            }
-
-            if(!result.getMissingPlatforms().isEmpty()){
-                reportedErrors = true;
-                Set<String> remainingMissingPlatforms = new HashSet<String>();
-                if(platformEnvironmentVariable != null){
-                    for(String plat : result.getMissingPlatforms()){
-                        if(platformEnvironmentVariable.contains(plat)){
-                            System.out.println("CWWKF0048E: The " + plat + " value of the PREFERRED_PLATFORM_VERSIONS platform environment variable does not contain a valid version.");
-                            //Tr.error(tc, "UNKNOWN_PLATFORM_ELEMENT", plat);
-                        }
-                        else{
-                            remainingMissingPlatforms.add(plat);
-                        }
-                    }
-                }
-                else{
-                    remainingMissingPlatforms.addAll(result.getMissingPlatforms());
-                }
-                if(!remainingMissingPlatforms.isEmpty()){
-                    System.out.println("CWWKF0052E: The " + remainingMissingPlatforms + " platforms are not valid");
-                    //Tr.error(tc, "UNKNOWN_PLATFORM_ELEMENT", remainingMissingPlatforms);
-                }
-            }
-
-            if(!result.getNoPlatformVersionless().isEmpty()){
-                for (Map.Entry<String, Set<String>> noPlatformVersionless : result.getNoPlatformVersionless().entrySet()) {
-                    System.out.println("CWWKF0055E: The " + noPlatformVersionless.getValue() + " versionless features do not have a configured platform.");
-                    //Tr.error(tc, "NO_RESOLVED_PLATFORM", noPlatformVersionless.getValue());
-                }
             }
 
         }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -748,6 +748,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
 
         HashSet<String> preInstalledAutoFeatures = new HashSet<String>();
         HashSet<String> preInstalledPublicAutoFeatures = new HashSet<String>();
+        Result result = null;
 
         try {
             switch (featureChange.provisioningMode) {
@@ -813,8 +814,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
                 featureChange.features = getPublicFeatures(preInstalledFeatures, false).toArray(new String[] {});
             }
 
-            updateFeatures(locationService, provisioner, preInstalledFeatures, featureChange, featureUpdateNumber.incrementAndGet());
-
+            result = updateFeatures(locationService, provisioner, preInstalledFeatures, featureChange, featureUpdateNumber.incrementAndGet());
             // All done with the updates we could find...
             switch (featureChange.provisioningMode) {
                 case CONTENT_REQUEST:
@@ -861,7 +861,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             // Update/progress messages -- AFTER we've written cache files
 
             fixLock.set(false);
-            writeUpdateMessages(featureChange.provisioningMode, preInstalledFeatures, deletedAutoFeatures, deletedPublicAutoFeatures);
+            writeUpdateMessages(featureChange.provisioningMode, preInstalledFeatures, deletedAutoFeatures, deletedPublicAutoFeatures, result);
         }
     }
 
@@ -968,7 +968,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
      *                                      auto features have been deleted.
      */
     private void writeUpdateMessages(ProvisioningMode provisioningMode, Set<String> preInstalledFeatures, Set<String> deletedAutoFeatures,
-                                     Set<String> deletedPublicAutoFeatures) {
+                                     Set<String> deletedPublicAutoFeatures, Result result) {
         writeServiceMessages();
 
         Set<String> postInstalledFeatures = new HashSet<>(featureRepository.getResolvedFeatures());
@@ -976,29 +976,29 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             Tr.debug(tc, "all installed features " + postInstalledFeatures);
         }
 
-        if(isBeta){
-            for(String feature : postInstalledFeatures){
-                if(feature.indexOf("internal.versionless") == -1){
+        if(isBeta && result != null){
+            if(!result.getResolvedPlatforms().isEmpty()){
+                System.out.println("CWWKF0053I: Feature resolution selected the " + result.getResolvedPlatforms() + " platforms.");
+                //Tr.info(tc, "RESOLVED_PLATFORM", result.getResolvedPlatforms());
+            }
+
+            List<String> resolvedVersionless = new ArrayList<>();
+            List<String> resolvedVersioned = new ArrayList<>();
+            for (Map.Entry<String, String> versionlessResolved : result.getVersionlessFeatures().entrySet()) {
+                if(versionlessResolved.getValue() == null){
                     continue;
                 }
-                String featureName = feature.substring(36);
-                String alternateName = featureRepository.matchesAlternate(featureName);
-                if(postInstalledFeatures.contains(featureName)){
-                    if(postInstalledFeatures.contains(featureName.split("-")[0])){
-                        Tr.info(tc, "VERSIONLESS_FEATURE_RESOLVED_TO_FEATURE", featureName.split("-")[0], featureName);
-                    }
-                    else if(alternateName != null && postInstalledFeatures.contains(alternateName.split("-")[0])){
-                        Tr.info(tc, "VERSIONLESS_FEATURE_RESOLVED_TO_FEATURE", alternateName.split("-")[0], featureName);
-                    }
+                ProvisioningFeatureDefinition versionless = featureRepository.getFeature(versionlessResolved.getKey());
+                ProvisioningFeatureDefinition versioned = featureRepository.getFeature(versionlessResolved.getValue());
+                if((postInstalledFeatures.contains(versionless.getFeatureName()) || postInstalledFeatures.contains(versionless.getSymbolicName()))
+                    && (postInstalledFeatures.contains(versioned.getFeatureName()) || postInstalledFeatures.contains(versioned.getSymbolicName()))){
+                    
+                    resolvedVersionless.add(versionless.getFeatureName());
+                    resolvedVersioned.add(versioned.getFeatureName());
                 }
-                else if(alternateName != null && postInstalledFeatures.contains(alternateName)){
-                    if(postInstalledFeatures.contains(featureName.split("-")[0])){
-                        Tr.info(tc, "VERSIONLESS_FEATURE_RESOLVED_TO_FEATURE", featureName.split("-")[0], alternateName);
-                    }
-                    else if(postInstalledFeatures.contains(alternateName.split("-")[0])){
-                        Tr.info(tc, "VERSIONLESS_FEATURE_RESOLVED_TO_FEATURE", alternateName.split("-")[0], alternateName);
-                    }
-                }
+            }
+            if(!resolvedVersionless.isEmpty()){
+                Tr.info(tc, "VERSIONLESS_FEATURE_RESOLVED_TO_FEATURE", resolvedVersionless, resolvedVersioned);
             }
         }
 
@@ -1500,6 +1500,15 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
                 return Collections.emptySet();
             }
 
+            @Override
+            public Map<String, Set<String>> getDuplicatePlatforms(){
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public Map<String, Set<String>> getNoPlatformVersionless(){
+                return Collections.emptyMap();
+            }
         };
     }
 
@@ -1513,7 +1522,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
      * @return true if no errors occurred during the update, false otherwise
      */
     @FFDCIgnore(Throwable.class)
-    protected boolean updateFeatures(WsLocationAdmin locService,
+    protected Result updateFeatures(WsLocationAdmin locService,
                                      Provisioner provisioner,
                                      Set<String> preInstalledFeatures,
                                      FeatureChange featureChange,
@@ -1521,6 +1530,8 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
         // NOTE RE: FFDCIgnore above-- The catch block for Throwable below, stores
         // the exception in an InstallStatus object and calls FFDC at a more appropriate time.
         BundleList newBundleList = null;
+
+        Result result = null;
 
         // In 850 we were not case sensitive so we need to stay that way.
         // Use a set to eliminate duplicates.
@@ -1555,7 +1566,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
                 // This will be populated by resolveFeatures if there are any restricted access attempts during resolution
                 Collection<String> restrictedAccessAttempts = new ArrayList<String>();
 
-                Result result = resolveFeatures(newConfiguredFeatures, restrictedAccessAttempts, featureChange.provisioningMode, newConfiguredPlatforms);
+                result = resolveFeatures(newConfiguredFeatures, restrictedAccessAttempts, featureChange.provisioningMode, newConfiguredPlatforms);
                 boolean reportedConfigurationErrors = reportErrors(result, restrictedAccessAttempts, newConfiguredFeatures, installStatus);
                 goodFeatures = result.getResolvedFeatures();
 
@@ -1700,7 +1711,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             eventAdminService.postEvent(e);
         }
 
-        return status;
+        return result;
     }
 
     /**
@@ -1993,12 +2004,73 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
         }
 
         if(isBeta){
+
+            List<String> unresolvedVersionless = new ArrayList<>();
             for (Map.Entry<String, String> versionlessResolved : result.getVersionlessFeatures().entrySet()) {
                 if(versionlessResolved.getValue() == null){
-                    reportedErrors = true;
-                    Tr.error(tc, "UNRESOLVED_VERSIONLESS_FEATURE", versionlessResolved.getKey());
+                    String platformBaseName = featureRepository.getPlatformForVersionlessFeature(versionlessResolved.getKey());
+
+                    boolean compatibleWithPlatform = true;
+                    if(platformBaseName != null && !result.getResolvedPlatforms().isEmpty()){
+                        for(String resolvedPlat : result.getResolvedPlatforms()){
+                            if(resolvedPlat.toLowerCase().startsWith(platformBaseName.toLowerCase()) && 
+                                featureRepository.getVersionlessFeatureVersionForPlatform(versionlessResolved.getKey(), resolvedPlat) == null){
+
+                                System.out.println("CWWKF0054E: The " + versionlessResolved.getKey() + " versionless feature does not have a version belonging to the " + resolvedPlat + " platform.");
+                                //Tr.error(tc, "INCOMPATIBLE_VERSIONLESS_FEATURE_WITH_PLATFORM", versionlessResolved.getKey(), resolvedPlat);
+                                compatibleWithPlatform = false;
+                                break;
+                            }
+                        }
+                    }
+
+                    if(compatibleWithPlatform){
+                        unresolvedVersionless.add(versionlessResolved.getKey());
+                    }
                 }
             }
+            if(!unresolvedVersionless.isEmpty()){
+                reportedErrors = true;
+                Tr.error(tc, "UNRESOLVED_VERSIONLESS_FEATURE", unresolvedVersionless);
+            }
+
+            if(!result.getDuplicatePlatforms().isEmpty()){
+                for(Map.Entry<String, Set<String>> duplicatePlatforms : result.getDuplicatePlatforms().entrySet()){
+                    System.out.println("CWWKF0049E: The following configured platform versions are in conflict: " + duplicatePlatforms.getValue());
+                    //Tr.error(tc, "DUPLICATE_PLATFORMS", duplicatePlatforms.getValue());
+                }
+            }
+
+            if(!result.getMissingPlatforms().isEmpty()){
+                reportedErrors = true;
+                Set<String> remainingMissingPlatforms = new HashSet<String>();
+                if(platformEnvironmentVariable != null){
+                    for(String plat : result.getMissingPlatforms()){
+                        if(platformEnvironmentVariable.contains(plat)){
+                            System.out.println("CWWKF0048E: The " + plat + " value of the PREFERRED_PLATFORM_VERSIONS platform environment variable does not contain a valid version.");
+                            //Tr.error(tc, "UNKNOWN_PLATFORM_ELEMENT", plat);
+                        }
+                        else{
+                            remainingMissingPlatforms.add(plat);
+                        }
+                    }
+                }
+                else{
+                    remainingMissingPlatforms.addAll(result.getMissingPlatforms());
+                }
+                if(!remainingMissingPlatforms.isEmpty()){
+                    System.out.println("CWWKF0052E: The " + remainingMissingPlatforms + " platforms are not valid");
+                    //Tr.error(tc, "UNKNOWN_PLATFORM_ELEMENT", remainingMissingPlatforms);
+                }
+            }
+
+            if(!result.getNoPlatformVersionless().isEmpty()){
+                for (Map.Entry<String, Set<String>> noPlatformVersionless : result.getNoPlatformVersionless().entrySet()) {
+                    System.out.println("CWWKF0055E: The " + noPlatformVersionless.getValue() + " versionless features do not have a configured platform.");
+                    //Tr.error(tc, "NO_RESOLVED_PLATFORM", noPlatformVersionless.getValue());
+                }
+            }
+
         }
 
         List<Entry<String, Collection<Chain>>> sortedConflicts = new ArrayList<Entry<String, Collection<Chain>>>(result.getConflicts().entrySet());

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -776,8 +776,8 @@ public class FeatureResolverImpl implements FeatureResolver {
                     for(String platform : versionedFeature.getPlatformNames()){
                         if(rootPlatforms.contains(allCompatibilityFeatures.get(platform.toLowerCase()).getSymbolicName())){
                             addFeature = true;
-                            filteredVersionless.add(rootFeatureDef.getSymbolicName());
-                            filteredVersionless.add(linkingDef.getSymbolicName());
+                            filteredVersionless.add(rootFeatureDef.getFeatureName());
+                            filteredVersionless.add(linkingDef.getFeatureName());
                             addedRootFeatures.add(versionedFeature.getSymbolicName());
                             break;
                         }
@@ -787,19 +787,19 @@ public class FeatureResolverImpl implements FeatureResolver {
             if(!addFeature){
                 if(!usedPlatforms.contains(platformBase)){
                     if(noPlatformFeatures.containsKey(platformBase)){
-                        noPlatformFeatures.get(platformBase).add(feature);
+                        noPlatformFeatures.get(platformBase).add(rootFeatureDef.getFeatureName());
                     }
                     else{
                         Set<String> featureWithoutPlatform = new HashSet<>();
-                        featureWithoutPlatform.add(feature);
+                        featureWithoutPlatform.add(rootFeatureDef.getFeatureName());
                         noPlatformFeatures.put(platformBase, featureWithoutPlatform);
                     }
                 }
-                filteredVersionless.add(rootFeatureDef.getSymbolicName());
-                selectionContext.getResult().addVersionlessFeature(rootFeatureDef.getSymbolicName(), null);
+                filteredVersionless.add(rootFeatureDef.getFeatureName());
+                selectionContext.getResult().addVersionlessFeature(rootFeatureDef.getFeatureName(), null);
             }
             if(!hasMultiplePlatforms){
-                removedVersionlessFeatures.add(feature);
+                removedVersionlessFeatures.add(rootFeatureDef.getSymbolicName());
             }
             else{
                 linkingFeatureBaseNameToPlatform.put(linkingFeatureBase, platformBase);
@@ -937,7 +937,7 @@ public class FeatureResolverImpl implements FeatureResolver {
                     if (versionedFeatureDef.getVisibility() != Visibility.PUBLIC) {
                         continue;
                     }
-                    selectionContext.getResult().addVersionlessFeature(versionless, versionedFeatureDef.getSymbolicName());
+                    selectionContext.getResult().addVersionlessFeature(versionless, versionedFeatureDef.getFeatureName());
                     added = true;
                 }
             }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -259,21 +259,42 @@ public class FeatureResolverImpl implements FeatureResolver {
             return null;
         }
         List<String> compatibilityFeatures = new ArrayList<String>();
+        Map<String, Set<String>> duplicates = new HashMap<>();
 
         for (String plat : rootPlatforms) {
             //needs check for duplicate platforms with different versions, ex. can't have javaee7.0 and javaee8.0
             plat = plat.trim();
 
-            ProvisioningFeatureDefinition platformFeature = allCompatibilityFeatures.get(plat);
+            ProvisioningFeatureDefinition platformFeature = allCompatibilityFeatures.get(plat.toLowerCase());
 
             if(platformFeature == null){
                 selectionContext.getResult().addMissingPlatform(plat);
                 continue;
             }
-            if(featureListContainsFeatureBaseName(compatibilityFeatures, parseName(platformFeature.getSymbolicName()))){
-                //duplicate platform error
+            if(duplicates.containsKey(parseName(platformFeature.getSymbolicName()))){
+                duplicates.get(parseName(platformFeature.getSymbolicName())).add(plat);
             }
-            compatibilityFeatures.add(platformFeature.getSymbolicName());
+            else if(featureListContainsFeatureBaseName(compatibilityFeatures, parseName(platformFeature.getSymbolicName()))){
+                Set<String> dupes = new HashSet<String>();
+                dupes.add(plat);
+                String removeDuplicate = "";
+                for(String compatibility : compatibilityFeatures){
+                    if(compatibility.startsWith(parseName(platformFeature.getSymbolicName()))){
+                        removeDuplicate = compatibility;
+                        break;
+                    }
+                }
+                compatibilityFeatures.remove(removeDuplicate);
+                dupes.add(repo.getFeature(removeDuplicate).getPlatformName());
+                duplicates.put(parseName(platformFeature.getSymbolicName()), dupes);
+            }
+            else{
+                compatibilityFeatures.add(platformFeature.getSymbolicName());
+            }
+        }
+
+        for(Map.Entry<String, Set<String>> entry : duplicates.entrySet()){
+            selectionContext.getResult().addDuplicatePlatforms(entry.getKey(), entry.getValue());
         }
 
         return compatibilityFeatures;
@@ -310,9 +331,9 @@ public class FeatureResolverImpl implements FeatureResolver {
         List<String> compatibilityFeatures = new ArrayList<String>();
 
         for (String plat : preferredPlatforms) {
-            plat = plat.trim().toLowerCase();
+            plat = plat.trim();
 
-            ProvisioningFeatureDefinition platformFeature = allCompatibilityFeatures.get(plat);
+            ProvisioningFeatureDefinition platformFeature = allCompatibilityFeatures.get(plat.toLowerCase());
             if (platformFeature != null) {
                 String baseName = parseName(platformFeature.getSymbolicName());
 
@@ -686,10 +707,11 @@ public class FeatureResolverImpl implements FeatureResolver {
         Set<String> addedRootFeatures = new HashSet<>();
         Set<String> removedVersionlessFeatures = new HashSet<>();
         Set<String> multiplePlatforms = new HashSet<>();
+        Map<String, Set<String>> noPlatformFeatures = new HashMap<>();
 
         //Check if there is multiple rootPlatforms configured from the environment variable
         //if there are, we can't preresolve but instead we setup the compatibility feature to be postponed
-        List<String> usedPlatforms = new ArrayList<>();
+        Set<String> usedPlatforms = new HashSet<>();
         for(String rootPlatform : rootPlatforms){
             String baseCompatibilityName = parseName(rootPlatform);
             if(usedPlatforms.contains(baseCompatibilityName)){
@@ -762,16 +784,30 @@ public class FeatureResolverImpl implements FeatureResolver {
                     }
                 }
             }
-            if(!addFeature && !hasMultiplePlatforms){
-                //if we didn't add a versioned feature, its an error, no compatible platform for feature.
+            if(!addFeature){
+                if(!usedPlatforms.contains(platformBase)){
+                    if(noPlatformFeatures.containsKey(platformBase)){
+                        noPlatformFeatures.get(platformBase).add(feature);
+                    }
+                    else{
+                        Set<String> featureWithoutPlatform = new HashSet<>();
+                        featureWithoutPlatform.add(feature);
+                        noPlatformFeatures.put(platformBase, featureWithoutPlatform);
+                    }
+                }
+                filteredVersionless.add(rootFeatureDef.getSymbolicName());
+                selectionContext.getResult().addVersionlessFeature(rootFeatureDef.getSymbolicName(), null);
             }
             if(!hasMultiplePlatforms){
                 removedVersionlessFeatures.add(feature);
             }
             else{
                 linkingFeatureBaseNameToPlatform.put(linkingFeatureBase, platformBase);
-                selectionContext.getResult().addVersionlessFeature(rootFeatureDef.getSymbolicName(), null);
             }
+        }
+
+        for(Map.Entry<String, Set<String>> featuresWithoutPlatform : noPlatformFeatures.entrySet()){
+            selectionContext.getResult().addNoPlatformVersionless(featuresWithoutPlatform.getKey(), featuresWithoutPlatform.getValue());
         }
 
         rootFeatures.addAll(addedRootFeatures);
@@ -867,7 +903,22 @@ public class FeatureResolverImpl implements FeatureResolver {
     private void finalizeVersionlessResults(SelectionContext selectionContext, List<String> filteredVersionless){
         selectionContext.getResult()._resolved.addAll(filteredVersionless);
 
+        //If platform environment variable was used, getResolvedPlatforms() may have multiple platforms
+        //Remove every platform except for the one that was used
+        Set<String> existingPlatforms = new HashSet<String>();
+        existingPlatforms.addAll(selectionContext.getResult().getResolvedPlatforms());
+        selectionContext.getResult().emptyResolvedPlatforms();
+        for(String feature : selectionContext.getResult().getResolvedFeatures()){
+            ProvisioningFeatureDefinition featureDef = selectionContext.getRepository().getFeature(feature);
+            if(featureDef.isCompatibility()){
+                if(existingPlatforms.contains(featureDef.getPlatformName())){
+                    selectionContext.getResult().addResolvedPlatform(featureDef.getPlatformName());
+                }
+            }
+        }
+
         for(String versionless : filteredVersionless){
+            boolean added = false;
             ProvisioningFeatureDefinition versionlessFD = selectionContext.getRepository().getFeature(versionless);
             if(!versionlessFD.isVersionless()){
                 continue;
@@ -887,14 +938,21 @@ public class FeatureResolverImpl implements FeatureResolver {
                         continue;
                     }
                     selectionContext.getResult().addVersionlessFeature(versionless, versionedFeatureDef.getSymbolicName());
+                    added = true;
                 }
+            }
+            if(!added){
+                selectionContext.getResult().addVersionlessFeature(versionless, null);
             }
         }
         //if versionless features didn't resolve, make sure their result feature is null
         List<String> unresolvedVersionless = new ArrayList<String>();
         for(Map.Entry<String, String> entry : selectionContext.getResult().getVersionlessFeatures().entrySet()){
             //check symbolic name
-            if (!selectionContext.getResult()._resolved.contains(entry.getValue())
+            if(entry.getValue() == null){
+                unresolvedVersionless.add(entry.getKey());
+            }
+            else if (!selectionContext.getResult()._resolved.contains(entry.getValue())
                 && !selectionContext.getResult()._resolved.contains(selectionContext.getRepository().getFeature(entry.getValue()).getFeatureName())){
                 
                 unresolvedVersionless.add(entry.getKey());

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverResultImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverResultImpl.java
@@ -45,6 +45,9 @@ public class FeatureResolverResultImpl implements Result {
         this._conflicts = new HashMap<>(0);
 
         this._missingPlatforms = new HashSet<String>(0);
+        this._duplicatePlatforms = new HashMap<>(0);
+
+        this._noPlatformVersionless = new HashMap<>(0);
 
         this._versionlessFeatures = new HashMap<>(0);
 
@@ -62,7 +65,8 @@ public class FeatureResolverResultImpl implements Result {
                  _wrongProcessTypes.isEmpty() &&
                  _conflicts.isEmpty() && 
                  !_versionlessFeatures.values().contains(null) &&
-                 _missingPlatforms.isEmpty());
+                 _missingPlatforms.isEmpty() &&
+                 _duplicatePlatforms.isEmpty());
     }
 
     //
@@ -344,6 +348,10 @@ public class FeatureResolverResultImpl implements Result {
         _resolvedPlatforms.add(platform);
     }
 
+    protected void emptyResolvedPlatforms(){
+        _resolvedPlatforms.clear();
+    }
+
     protected final HashSet<String> _missingPlatforms;
 
     @Override
@@ -353,6 +361,28 @@ public class FeatureResolverResultImpl implements Result {
 
     protected void addMissingPlatform(String platform){
         _missingPlatforms.add(platform);
+    }
+
+    protected final Map<String, Set<String>> _duplicatePlatforms;
+
+    @Override
+    public Map<String, Set<String>> getDuplicatePlatforms(){
+        return _duplicatePlatforms;
+    }
+
+    protected void addDuplicatePlatforms(String compatibleFeature, Set<String> platforms){
+        _duplicatePlatforms.put(compatibleFeature, platforms);
+    }
+
+    protected final Map<String, Set<String>> _noPlatformVersionless;
+
+    @Override
+    public Map<String, Set<String>> getNoPlatformVersionless(){
+        return _noPlatformVersionless;
+    }
+
+    protected void addNoPlatformVersionless(String compatibleFeature, Set<String> features){
+        _noPlatformVersionless.put(compatibleFeature, features);
     }
 
     // Remember the resolved in resolution order.

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/resolver/FeatureResolver.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/resolver/FeatureResolver.java
@@ -118,6 +118,10 @@ public interface FeatureResolver {
         Set<String> getResolvedPlatforms();
 
         Set<String> getMissingPlatforms();
+
+        Map<String, Set<String>> getDuplicatePlatforms();
+
+        Map<String, Set<String>> getNoPlatformVersionless();
     }
 
     public static final List<String> EMPTY_STRINGS = Collections.emptyList();


### PR DESCRIPTION
Use messages after feature resolution to display versionless specific information/errors.

- [ ] Considered risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes)
- [ ] Resolved Issues: Fixes #FILLMEIN... (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions)
- [ ] Resolved external Known Issues (including APARS): Fixes #FILLMEIN...
