### PR TITLE
Create AllowAbsolutePathForPartWrite- PH62271

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.servlet-servletSpi1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.servlet-servletSpi1.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.servlet-servletSpi1.0
 WLP-DisableAllFeatures-OnConflict: false
 visibility=private
 -jars=com.ibm.websphere.appserver.spi.servlet; location:=dev/spi/ibm/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.servlet_2.14-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.servlet_2.15-javadoc.zip
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.servlet-servletSpi2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.servlet-servletSpi2.0.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.servlet-servletSpi2.0
 visibility=private
 -jars=io.openliberty.servlet.spi; location:=dev/spi/ibm/
--files=dev/spi/ibm/javadoc/io.openliberty.servlet.spi_2.14-javadoc.zip
+-files=dev/spi/ibm/javadoc/io.openliberty.servlet.spi_2.15-javadoc.zip
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.spi.servlet/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.servlet/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
 
 -sub: *.bnd
 
-bVersion: 2.14
+bVersion: 2.15
 
 Import-Package: com.ibm.wsspi.webcontainer.extension,com.ibm.wsspi.webcontainer.webapp,com.ibm.wsspi.webcontainer.filter,com.ibm.wsspi.webcontainer.collaborator,com.ibm.wsspi.webcontainer.osgi.extension,com.ibm.wsspi.webcontainer.servlet,com.ibm.ws.webcontainer.extension,com.ibm.websphere.servlet.filter,com.ibm.wsspi.webcontainer,com.ibm.wsspi.webcontainer.metadata,com.ibm.websphere.servlet.response,com.ibm.ws.webcontainer.spiadapter.collaborator
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/.classpath
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/.classpath
@@ -27,6 +27,7 @@
 	<classpathentry kind="src" path="test-applications/CDI12TestV2Upgrade.war/src"/>
 	<classpathentry kind="src" path="test-applications/CDI12TestV2Dynamic.war/src"/>
 	<classpathentry kind="src" path="test-applications/CDI12TestV2Listeners.war/src"/>
+	<classpathentry kind="src" path="test-applications/PH62271.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/bnd.bnd
@@ -37,7 +37,8 @@ src:\
     test-applications/TestServlet31AltVHost1.war/src,\
     test-applications/TestServlet31AltVHost2.war/src,\
     test-applications/TestServletMapping.war/src,\
-    test-applications/TestServletMappingAnno.war/src
+    test-applications/TestServletMappingAnno.war/src,\
+    test-applications/PH62271.war/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
@@ -31,6 +31,7 @@ import com.ibm.ws.webcontainer.servlet31.fat.tests.CDIUpgradeHandlerTest;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.DecodeUrlPlusSignTests;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.HttpSessionAttListenerHttpUnit;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.JSPServerHttpUnit;
+import com.ibm.ws.webcontainer.servlet31.fat.tests.PH62271Test;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.PrivateHeaderTest;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.ServletMappingTests;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.VHServerHttpUnit;
@@ -65,7 +66,8 @@ import componenttest.topology.impl.LibertyServer;
                 WCServletContextUnsupportedOperationExceptionTest.class,
                 PrivateHeaderTest.class,
                 DecodeUrlPlusSignTests.class,
-                ServletMappingTests.class
+                ServletMappingTests.class,
+                PH62271Test.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/PH62271Test.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/PH62271Test.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.servlet31.fat.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.logging.Logger;
+import java.io.InputStream;
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.webcontainer.servlet31.fat.FATSuite;
+import com.meterware.httpunit.PostMethodWebRequest;
+import com.meterware.httpunit.UploadFileSpec;
+import com.meterware.httpunit.WebConversation;
+import com.meterware.httpunit.WebForm;
+import com.meterware.httpunit.WebRequest;
+import com.meterware.httpunit.WebResponse;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEEAction;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Test that the allowAbsoluteFileNameForPartWrite works as intended.
+ * When true the filename in part.write method should be treated as an absolute location.
+ * When false the filename will be handled as a relative path.
+ * The default in servlet-6.0 and earlier is false. The default in servlet-6.1 and later is true.
+ * @author Thomas Smith
+ */
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class PH62271Test {
+
+    private static final Logger LOG = Logger.getLogger(PH62271Test.class.getName());
+
+    private static final String PH62271_APP_NAME = "PH62271";
+
+    protected static final Class<?> c = PH62271Test.class;
+
+    @Server("servlet31_PH62271")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Build the war app and add the dependencies
+        WebArchive PH62271App = ShrinkHelper.buildDefaultApp(PH62271_APP_NAME + ".war", "com.ibm.ws.webcontainer.servlet_31_fat.PH62271");
+
+        // Export the application.
+        ShrinkHelper.exportDropinAppToServer(server, PH62271App);
+
+        server.startServer(c.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /*
+     * Mainly copied over from JSPServerHttpUnit#testFileUpload_test_getSubmittedFileName
+     * Tests that the allowAbsoluteFileNameForPartWrite in the server.xml works correctly
+     */ 
+    @Test
+    public void testPH62271 () throws Exception {
+
+        if (JakartaEEAction.isEE11OrLaterActive()){
+            ServerConfiguration config = server.getServerConfiguration();
+            // Set to null for servlet 6.1 and higher to test default behavior
+            config.getWebContainer().setAllowAbsoluteFileNameForPartWrite(null);
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(null);
+        }
+
+        LOG.info("\n /******************************************************************************/");
+        LOG.info("\n [WebContainer | Part#write]: Testing Part.write");
+        LOG.info("\n /******************************************************************************/");
+        WebConversation wc = new WebConversation();
+        String contextRoot = "/PH62271";
+        wc.setExceptionsThrownOnErrorStatus(false);
+        WebRequest request = new PostMethodWebRequest("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + contextRoot + "/index.jsp");
+
+        WebResponse response = wc.getResponse(request);
+        LOG.info(response.getText());
+
+        WebForm loginForm = response.getForms()[0];
+        request = loginForm.getRequest();
+
+        String fileName = "myTempFile.txt";
+
+        // Get test file
+        InputStream in = this.getClass().getResourceAsStream("/com/ibm/ws/fat/resources/" + fileName);
+        LOG.info(in == null ? "/com/ibm/ws/fat/resources/" + fileName + " in is null" : "/com/ibm/ws/fat/resources/" + fileName + " in is not null");
+
+        String uploadFileName = "myFileUploadFile.txt";
+        UploadFileSpec file = new UploadFileSpec(uploadFileName, in, "ISO-8859-1");
+        request.setParameter("files", new UploadFileSpec[] { file });
+        request.setParameter("location", server.getServerRoot());
+
+        response = wc.getResponse(request);
+        int code = response.getResponseCode();
+
+        LOG.info("/*************************************************/");
+        LOG.info("[WebContainer | Part#write]: Return Code is: " + code);
+        LOG.info("[WebContainer | Part#write]: Response is: ");
+        LOG.info(response.getText());
+        LOG.info("/*************************************************/");
+
+        assertTrue("Did not get 200 response code, got " + code + " response code instead.", code==200);
+
+        File uploadedFile = new File(server.getServerRoot() + "/uploads/" + uploadFileName);
+        assertTrue("Did not find the uploaded file at its absolute path location. The absolute path is: " + server.getServerRoot() + "/uploads/" + uploadFileName, uploadedFile.exists());
+    }
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_PH62271/.gitignore
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_PH62271/.gitignore
@@ -1,0 +1,1 @@
+/dropins

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_PH62271/bootstrap.properties
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_PH62271/bootstrap.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2014 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+# Copied from servlet31_jspServer
+bootstrap.include=../testports.properties
+osgi.console=7777
+# com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_PH62271/server.xml
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_PH62271/server.xml
@@ -1,0 +1,22 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+
+ -->
+<server description="Server for testing PH62271">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>jsp-2.3</feature>
+    </featureManager>
+
+    <webContainer allowAbsoluteFileNameForPartWrite="true" />
+    
+</server>

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/PH62271.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/PH62271.war/resources/WEB-INF/web.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<web-app
+    version="3.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+  <display-name>PH62271 Test</display-name>
+    
+</web-app>

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/PH62271.war/resources/index.jsp
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/PH62271.war/resources/index.jsp
@@ -1,0 +1,29 @@
+<%@ page language="java" session="true" contentType="text/html;charset=UTF-8" %>
+    <!--
+    Copyright (c) 2013 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+    <html>
+    <head>
+        <title></title>
+    </head>
+    <body>
+        <h2>Testing Part#write Servlet 3.0</h2>
+        Using multipart/form-data annotation in the servlet to make sure getPart() works
+        <p>File size need to be less than maxfilesize=50000<p>
+        <form action="/PH62271/PH62271Servlet" enctype="multipart/form-data" method="POST">
+            <P>UploadFile Name<p>
+            <input TYPE="file" size="55" NAME="files"><BR></P>
+            <input TYPE="text" NAME="location" value=''>
+            <input TYPE="SUBMIT" name="SubmitButton" value="Submit">
+        </form>
+    </body>
+    </html>

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/PH62271.war/src/com/ibm/ws/webcontainer/servlet_31_fat/PH62271/PH62271Servlet.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/PH62271.war/src/com/ibm/ws/webcontainer/servlet_31_fat/PH62271/PH62271Servlet.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.servlet_31_fat.PH62271;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.File;
+import java.util.Collection;
+import java.util.Iterator;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.annotation.MultipartConfig;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+
+/**
+ * This servlet tests whether the absolute or relative path is used
+ * within the server to save the file uploaded depending on the
+ * allowAbsolutePathForPartWriting parameter.
+ */
+@WebServlet("/PH62271Servlet")
+@MultipartConfig(fileSizeThreshold = 50, location = "", maxFileSize = 5000, maxRequestSize = 1000)
+public class PH62271Servlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public PH62271Servlet() {
+        super();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        try {
+            ServletOutputStream outputStream = response.getOutputStream();
+            Part part = request.getPart("files");
+
+            String ss;
+            ss = "--------  Using getPart(\"files\") --------";
+            outputStream.println(ss);
+            outputStream.println(" ");
+
+            if (part != null){
+                String path = request.getParameterMap().get("location")[0];
+                outputStream.println("Server Path: " + path);
+                String final_path = path + "/uploads/" + part.getSubmittedFileName();
+                final_path = final_path.replace('/', File.separator.charAt(0)).replace('\\', File.separator.charAt(0));
+                outputStream.println("Final Write Path: " + final_path);
+
+                part.write(final_path); // KEY PART OF TEST -- writes to absolute location based on allowAbsoluteFileNameForPartWrite
+            } else {
+                outputStream.println("Part was null");
+            }
+        } catch (Exception e) {
+            ServletOutputStream outputStream = response.getOutputStream();
+            String ss = "--------  Exception Output --------";
+            outputStream.println(ss);
+            outputStream.println(e.getMessage());
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2023 IBM Corporation and others.
+# Copyright (c) 2011, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -197,3 +197,6 @@ donotCloseOutputOnForwardForServletError.desc=When this property is set to true,
 
 set400SCOnTooManyParentDirs.name=Set 400 for invalid path traversal request
 set400SCOnTooManyParentDirs.desc=When this property is set to true, a request with an invalid path traversal is returned with a 400 status code instead of 500. The default is false. You can use this property with servlet-5.0 and earlier. For servlet-6.0 and later, the 400 response code is returned by default and this property has no effect.
+
+allowAbsoluteFileNameForPartWrite.name=Write part files to absolute file locations
+allowAbsoluteFileNameForPartWrite.desc=When this property is set to true, the runtime treats the filename argument on the part.write method call as an absolute location, rather than saving the filename arguement under the temporary location. In servlet-6.0 and earlier, the default value is false. In servlet-6.1 and later, the default value is true.

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2023 IBM Corporation and others.
+    Copyright (c) 2011, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -366,6 +366,12 @@
             name="%donotCloseOutputOnForwardForServletError.name"
             description="%donotCloseOutputOnForwardForServletError.desc"
             required="false" type="Boolean" />
+        
+            <!-- Default not specified since it changes for servlet-6.1 -->
+        <AD id="allowAbsoluteFileNameForPartWrite"
+            name="%allowAbsoluteFileNameForPartWrite.name"
+            description="%allowAbsoluteFileNameForPartWrite.desc"
+            required="false" type="Boolean" /> 
 
         <AD name="internal" description="internal use only"
             id="extensionFactory" required="true" type="String" cardinality="100"
@@ -389,4 +395,3 @@
     </Designate>
     
 </metatype:MetaData>
-

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/package-info.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/package-info.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright (c) 2010, 2023 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 /**
- * @version 1.14.0
+ * @version 1.15.0
  */
-@org.osgi.annotation.versioning.Version("1.14.0")
+@org.osgi.annotation.versioning.Version("1.15.0")
 package com.ibm.wsspi.webcontainer;

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/WebContainerElement.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/WebContainerElement.java
@@ -105,6 +105,7 @@ public class WebContainerElement extends ConfigElement {
     private Boolean deferServletRequestListenerDestroyOnError; //PI26908
     private Boolean allowExpressionFactoryPerApp; // PI31922
     private Boolean useMaxRequestsizeforMultipart; //PI75528
+    private Boolean allowAbsoluteFileNameForPartWrite; //PH62271
 
     /**
      * @return the listeners
@@ -635,6 +636,13 @@ public class WebContainerElement extends ConfigElement {
         return useMaxRequestsizeforMultipart;
     }
 
+    /*
+     * @return the allowAbsoluteFileNameForPartWrite
+     */
+    public Boolean getAllowAbsoluteFileNameForPartWrite(){
+        return allowAbsoluteFileNameForPartWrite;
+    }
+
     @XmlAttribute(name = "listeners")
     public void setListeners(String s) {
         this.listeners = s;
@@ -1102,6 +1110,14 @@ public class WebContainerElement extends ConfigElement {
         this.useMaxRequestsizeforMultipart = useMaxRequestsizeforMultipart;
     }//PI75528
 
+    /**
+     * @param allowAbsoluteFileNameForPartWrite the allowAbsoluteFileNameForPartWrite to set
+     */
+    @XmlAttribute(name = "com.ibm.ws.webcontainer.allowAbsoluteFileNameForPartWrite")
+    public void setAllowAbsoluteFileNameForPartWrite(Boolean allowAbsoluteFileNameForPartWrite) {
+        this.allowAbsoluteFileNameForPartWrite = allowAbsoluteFileNameForPartWrite;
+    }
+
     /*
      * listeners
      * decodeurlasutf8
@@ -1332,6 +1348,10 @@ public class WebContainerElement extends ConfigElement {
         //PI75528
         if (useMaxRequestsizeforMultipart != null)
             buf.append("useMaxRequestsizeforMultipart=\"" + useMaxRequestsizeforMultipart + "\" ");
+
+        //PH62271
+        if (allowAbsoluteFileNameForPartWrite != null)
+            buf.append("allowAbsoluteFileNameForPartWrite=\"" + allowAbsoluteFileNameForPartWrite + "\" ");
 
         buf.append("}");
         return buf.toString();

--- a/dev/wlp-jakartaee-transform/rules/jakarta-versions-ee10.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-versions-ee10.properties
@@ -27,7 +27,7 @@ com.ibm.wsspi.security.jaspi=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.wim.model=[10.0,11);Export-Package=10.0
-com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.4
+com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.5
 com.ibm.wsspi.webcontainer.collaborator=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.filter=[10.0,11);Export-Package=10.0

--- a/dev/wlp-jakartaee-transform/rules/jakarta-versions-ee10plus.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-versions-ee10plus.properties
@@ -27,7 +27,7 @@ com.ibm.wsspi.security.jaspi=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.wim.model=[10.0,11);Export-Package=10.0
-com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.4
+com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.5
 com.ibm.wsspi.webcontainer.collaborator=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.filter=[10.0,11);Export-Package=10.0

--- a/dev/wlp-jakartaee-transform/rules/jakarta-versions-ee11.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-versions-ee11.properties
@@ -27,7 +27,7 @@ com.ibm.wsspi.security.jaspi=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.wim.model=[10.0,11);Export-Package=10.0
-com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.4
+com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.5
 com.ibm.wsspi.webcontainer.collaborator=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.filter=[10.0,11);Export-Package=10.0

--- a/dev/wlp-jakartaee-transform/rules/jakarta-versions-ee9.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-versions-ee9.properties
@@ -27,7 +27,7 @@ com.ibm.wsspi.security.jaspi=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.wim.model=[10.0,11);Export-Package=10.0
-com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.4
+com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.5
 com.ibm.wsspi.webcontainer.collaborator=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.filter=[10.0,11);Export-Package=10.0

--- a/dev/wlp-jakartaee-transform/rules/jakarta-versions-ee9and10.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-versions-ee9and10.properties
@@ -27,7 +27,7 @@ com.ibm.wsspi.security.jaspi=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.wim.model=[10.0,11);Export-Package=10.0
-com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.4
+com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.5
 com.ibm.wsspi.webcontainer.collaborator=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.filter=[10.0,11);Export-Package=10.0

--- a/dev/wlp-jakartaee-transform/rules/jakarta-versions.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-versions.properties
@@ -27,7 +27,7 @@ com.ibm.wsspi.security.jaspi=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.tai.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.security.wim.model=[10.0,11);Export-Package=10.0
-com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.4
+com.ibm.wsspi.webcontainer=[10.0,11);Export-Package=10.5
 com.ibm.wsspi.webcontainer.collaborator=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.extension=[10.0,11);Export-Package=10.0
 com.ibm.wsspi.webcontainer.filter=[10.0,11);Export-Package=10.0


### PR DESCRIPTION
fixes #29055

fixes #PH62271

The fix for this relies on a new property: **allowabsolutefilenameforpartwrite**. If an absolute path is needed, please add the following server.xml config:

`<webContainer allowAbsoluteFileNameForPartWrite="true" />`


This change is guarded by a property to avoid regressions for any apps that may depend on this current behavior. It will  be fixed by default for servlet-6.1 as it's not yet released.  

______
- [x] Considered risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes)
- [x] Resolved Issues: Fixes #FILLMEIN... (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions)
- [x] Resolved external Known Issues (including APARS): Fixes #FILLMEIN...
