### PR TITLE
Disable creating a jar flie for the springboot FAT war projects.

### DIFF
--- a/dev/com.ibm.ws.springboot.fat20.war.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.war.app/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -42,7 +42,7 @@ apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 // TODO:
 // Per: https://mvnrepository.com/artifact/javax.servlet/jstl
 // javax.servlet:jstl was moved to:
-// javax.servlet.jsp.jstl » jstl
+// javax.servlet.jsp.jstl ï¿½ jstl
 
 dependencies {
   implementation project(':com.ibm.ws.springboot.fat20.war.app:module')
@@ -51,4 +51,10 @@ dependencies {
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
   providedCompile 'javax.servlet:jstl'
   providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'
+}
+
+// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
+// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
+jar {
+  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat30.war.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.war.app/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -42,7 +42,7 @@ apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 // Per: https://mvnrepository.com/artifact/javax.servlet/jstl
 // javax.servlet:jstl was moved to:
-// javax.servlet.jsp.jstl » jstl
+// javax.servlet.jsp.jstl ï¿½ jstl
 //
 // That seems to be:
 // https://mvnrepository.com/artifact/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api
@@ -54,4 +54,10 @@ dependencies {
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
   providedCompile 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api'
   providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'
+}
+
+// Disable jar because it would need a dependency on ':io.openliberty.springboot.fat30.war.app:module:compileTestJava' and 
+// ':io.openliberty.springboot.fat30.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
+jar {
+  enabled = false
 }


### PR DESCRIPTION
- We only use the war output from the war app projects.  The jar task would need to depend on a few module tasks and there is no reason to do that, so marking the jar task disabled.

- [x] Considered risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes)
- [x] Resolved Issues: Fixes #FILLMEIN... (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions)
- [x] Resolved external Known Issues (including APARS): Fixes #FILLMEIN...
