### PR TITLE
Versionless Repo Resolver additions and Error handling

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -963,9 +963,8 @@ public class InstallKernelMap implements Map {
             if (!isInstallServerFeature) {
                 resolveResult = resolver.resolve((Collection<String>) data.get(InstallConstants.FEATURES_TO_RESOLVE));
             } else {
-                resolveResult = resolver.resolveAsSet((Collection<String>) data.get(InstallConstants.FEATURES_TO_RESOLVE));
-                // TODO - After Resolver changes, also start passing platforms
-                //         (Collection<String>) data.get(InstallConstants.PLATFORMS));
+                resolveResult = resolver.resolveAsSet((Collection<String>) data.get(InstallConstants.FEATURES_TO_RESOLVE),
+                                                      (Collection<String>) data.get(InstallConstants.PLATFORMS));
             }
 
             if (!resolveResult.isEmpty()) {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.osgi.service.resolver.ResolutionException;
 
@@ -40,14 +41,17 @@ public class RepositoryResolutionException extends RepositoryException {
     private final Collection<ProductRequirementInformation> missingProductInformation;
     private final Collection<MissingRequirement> allRequirementsResourcesNotFound;
     private final Map<String, Collection<Chain>> featureConflicts;
+    private Set<String> resolvedPlatforms;
+    private Set<String> missingPlatforms;
+    private boolean hasVersionlessIssue;
 
     /**
      * @param cause
      * @param topLevelFeaturesNotResolved
      * @param allRequirementsNotFound
-     * @param missingProductInformation all the product information requirements that could not be found. Can be empty but must not be <code>null</code>
+     * @param missingProductInformation        all the product information requirements that could not be found. Can be empty but must not be <code>null</code>
      * @param allRequirementsResourcesNotFound The {@link MissingRequirement} objects that were not found. Must not be <code>null</code>.
-     * @param featureConflicts the details of any feature conflicts which occurred during feature resolution, as returned from {@link Result#getConflicts()}
+     * @param featureConflicts                 the details of any feature conflicts which occurred during feature resolution, as returned from {@link Result#getConflicts()}
      */
     public RepositoryResolutionException(ResolutionException cause, Collection<String> topLevelFeaturesNotResolved, Collection<String> allRequirementsNotFound,
                                          Collection<ProductRequirementInformation> missingProductInformation, Collection<MissingRequirement> allRequirementsResourcesNotFound,
@@ -58,6 +62,30 @@ public class RepositoryResolutionException extends RepositoryException {
         this.missingProductInformation = missingProductInformation;
         this.allRequirementsResourcesNotFound = allRequirementsResourcesNotFound;
         this.featureConflicts = featureConflicts;
+    }
+
+    /**
+     * @param object
+     * @param missingTopLevelRequirements
+     * @param missingRequirementNames
+     * @param missingProductInformation2
+     * @param missingRequirements
+     * @param featureConflicts2
+     * @param resolvedPlatforms
+     * @param missingPlatforms
+     */
+    public RepositoryResolutionException(ResolutionException cause, Collection<String> topLevelFeaturesNotResolved, Collection<String> allRequirementsNotFound,
+                                         Collection<ProductRequirementInformation> missingProductInformation, Collection<MissingRequirement> allRequirementsResourcesNotFound,
+                                         Map<String, Collection<Chain>> featureConflicts, Set<String> resolvedPlatforms, Set<String> missingPlatforms) {
+        super(cause);
+        this.topLevelFeaturesNotResolved = topLevelFeaturesNotResolved;
+        this.allRequirementsNotFound = allRequirementsNotFound;
+        this.missingProductInformation = missingProductInformation;
+        this.allRequirementsResourcesNotFound = allRequirementsResourcesNotFound;
+        this.featureConflicts = featureConflicts;
+        this.resolvedPlatforms = resolvedPlatforms;
+        this.missingPlatforms = missingPlatforms;
+        this.hasVersionlessIssue = true;
     }
 
     /**
@@ -106,9 +134,9 @@ public class RepositoryResolutionException extends RepositoryException {
      * on a {@link ProductRequirementInformation} is not in the form digit.digit.digit.digit then it will be ignored.
      *
      * @param productId The product ID to find the minimum missing version for or <code>null</code> to match to all products
-     * @param version The version to find the minimum missing version for by matching the first three parts so if you supply "9.0.0.0" and this item applies to version "8.5.5.3"
-     *            and "9.0.0.1" then "9.0.0.1" will be returned. Supply <code>null</code> to match all versions
-     * @param edition The edition to find the minimum missing version for or <code>null</code> to match to all products
+     * @param version   The version to find the minimum missing version for by matching the first three parts so if you supply "9.0.0.0" and this item applies to version "8.5.5.3"
+     *                      and "9.0.0.1" then "9.0.0.1" will be returned. Supply <code>null</code> to match all versions
+     * @param edition   The edition to find the minimum missing version for or <code>null</code> to match to all products
      * @return The minimum missing version or <code>null</code> if there were no relevant matches
      */
     public String getMinimumVersionForMissingProduct(String productId, String version, String edition) {
@@ -152,7 +180,7 @@ public class RepositoryResolutionException extends RepositoryException {
      * This method will iterate through the missingProductInformation and returned a filtered collection of all the {@link ProductRequirementInformation#versionRange}s.
      *
      * @param productId The product ID to find the version for or <code>null</code> to match to all products
-     * @param edition The edition to find the version for or <code>null</code> to match to all editions
+     * @param edition   The edition to find the version for or <code>null</code> to match to all editions
      *
      * @return the version ranges which apply to the given product ID and edition
      */
@@ -185,9 +213,9 @@ public class RepositoryResolutionException extends RepositoryException {
      * indicate a fairly odd repository setup.</p>
      *
      * @param productId The product ID to find the maximum missing version for or <code>null</code> to match to all products
-     * @param version The version to find the maximum missing version for by matching the first three parts so if you supply "8.5.5.2" and this item applies to version "8.5.5.3"
-     *            and "9.0.0.1" then "8.5.5.3" will be returned. Supply <code>null</code> to match all versions
-     * @param edition The edition to find the maximum missing version for or <code>null</code> to match to all products
+     * @param version   The version to find the maximum missing version for by matching the first three parts so if you supply "8.5.5.2" and this item applies to version "8.5.5.3"
+     *                      and "9.0.0.1" then "8.5.5.3" will be returned. Supply <code>null</code> to match all versions
+     * @param edition   The edition to find the maximum missing version for or <code>null</code> to match to all products
      * @return The maximum missing version or <code>null</code> if there were no relevant matches or the maximum version is unbounded
      */
     public String getMaximumVersionForMissingProduct(String productId, String version, String edition) {
@@ -251,6 +279,18 @@ public class RepositoryResolutionException extends RepositoryException {
     @Override
     public String getMessage() {
         StringBuilder sb = new StringBuilder();
+
+        if (hasVersionlessIssue()) {
+            if (!getMissingPlatforms().isEmpty()) {
+                for (String missing : getMissingPlatforms()) {
+                    sb.append("Platform: ").append(missing).append(" couldn't be found, no versionless features will be resolved").append("\n");
+                }
+            }
+            if (getResolvedPlatforms().isEmpty() && getMissingPlatforms().isEmpty()) {
+                sb.append("Platform couldn't be determined, no versionless features will be resolved").append("\n");
+            }
+        }
+
         for (String missing : getTopLevelFeaturesNotResolved()) {
             sb.append("Top level feature not resolved: resource=").append(missing).append("\n");
         }
@@ -327,6 +367,27 @@ public class RepositoryResolutionException extends RepositoryException {
                     return resource.toString();
             }
         }
+    }
+
+    /**
+     * @return the resolvedPlatforms
+     */
+    public Set<String> getResolvedPlatforms() {
+        return resolvedPlatforms;
+    }
+
+    /**
+     * @return the missingPlatforms
+     */
+    public Set<String> getMissingPlatforms() {
+        return missingPlatforms;
+    }
+
+    /**
+     * @return the hasVersionlessIssue
+     */
+    public boolean hasVersionlessIssue() {
+        return hasVersionlessIssue;
     }
 
 }

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -44,7 +44,6 @@ public class RepositoryResolutionException extends RepositoryException {
     private final Map<String, Collection<Chain>> featureConflicts;
     private Set<String> resolvedPlatforms;
     private Set<String> missingPlatforms;
-    private boolean hasVersionlessIssue;
     private List<String> missingBasePlatforms;
 
     /**
@@ -373,6 +372,7 @@ public class RepositoryResolutionException extends RepositoryException {
     }
 
     /**
+     * This states the target platforms that were used during the resolution
      * @return the resolvedPlatforms
      */
     public Set<String> getResolvedPlatforms() {
@@ -380,6 +380,7 @@ public class RepositoryResolutionException extends RepositoryException {
     }
 
     /**
+     * This describes missspelled or unknown platform names, official names are collected by the feature metadata
      * @return the missingPlatforms
      */
     public Set<String> getMissingPlatforms() {
@@ -387,6 +388,7 @@ public class RepositoryResolutionException extends RepositoryException {
     }
 
     /**
+     * This describes base platforms like "jakartaee" that are not derived, either by passed platform values, or by other included versioned features
      * @return the missingBasePlatforms
      */
     public List<String> getMissingBasePlatforms() {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
@@ -15,6 +15,7 @@ package com.ibm.ws.repository.resolver;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -44,6 +45,7 @@ public class RepositoryResolutionException extends RepositoryException {
     private Set<String> resolvedPlatforms;
     private Set<String> missingPlatforms;
     private boolean hasVersionlessIssue;
+    private List<String> missingBasePlatforms;
 
     /**
      * @param cause
@@ -68,15 +70,17 @@ public class RepositoryResolutionException extends RepositoryException {
      * @param object
      * @param missingTopLevelRequirements
      * @param missingRequirementNames
-     * @param missingProductInformation2
-     * @param missingRequirements
-     * @param featureConflicts2
+     * @param missingProductInformation        all the product information requirements that could not be found. Can be empty but must not be <code>null</code>
+     * @param allRequirementsResourcesNotFound The {@link MissingRequirement} objects that were not found. Must not be <code>null</code>.
+     * @param featureConflicts                 the details of any feature conflicts which occurred during feature resolution, as returned from {@link Result#getConflicts()}
      * @param resolvedPlatforms
-     * @param missingPlatforms
+     * @param missingPlatforms                 Unknown platform names
+     * @param missingBasePlatforms             unresolved versionless features needing platforms defined
      */
     public RepositoryResolutionException(ResolutionException cause, Collection<String> topLevelFeaturesNotResolved, Collection<String> allRequirementsNotFound,
                                          Collection<ProductRequirementInformation> missingProductInformation, Collection<MissingRequirement> allRequirementsResourcesNotFound,
-                                         Map<String, Collection<Chain>> featureConflicts, Set<String> resolvedPlatforms, Set<String> missingPlatforms) {
+                                         Map<String, Collection<Chain>> featureConflicts, Set<String> resolvedPlatforms, Set<String> missingPlatforms,
+                                         List<String> missingBasePlatforms) {
         super(cause);
         this.topLevelFeaturesNotResolved = topLevelFeaturesNotResolved;
         this.allRequirementsNotFound = allRequirementsNotFound;
@@ -85,7 +89,8 @@ public class RepositoryResolutionException extends RepositoryException {
         this.featureConflicts = featureConflicts;
         this.resolvedPlatforms = resolvedPlatforms;
         this.missingPlatforms = missingPlatforms;
-        this.hasVersionlessIssue = true;
+        this.missingBasePlatforms = missingBasePlatforms;
+
     }
 
     /**
@@ -280,15 +285,13 @@ public class RepositoryResolutionException extends RepositoryException {
     public String getMessage() {
         StringBuilder sb = new StringBuilder();
 
-        if (hasVersionlessIssue()) {
-            if (!getMissingPlatforms().isEmpty()) {
-                for (String missing : getMissingPlatforms()) {
-                    sb.append("Platform: ").append(missing).append(" couldn't be found, no versionless features will be resolved").append("\n");
-                }
+        if (!getMissingPlatforms().isEmpty()) {
+            for (String missing : getMissingPlatforms()) {
+                sb.append("Platform: ").append(missing).append(" couldn't be found, no versionless features will be resolved").append("\n");
             }
-            if (getResolvedPlatforms().isEmpty() && getMissingPlatforms().isEmpty()) {
-                sb.append("Platform couldn't be determined, no versionless features will be resolved").append("\n");
-            }
+        }
+        if (getResolvedPlatforms().isEmpty() && getMissingPlatforms().isEmpty()) {
+            sb.append("Platform couldn't be determined, no versionless features will be resolved").append("\n");
         }
 
         for (String missing : getTopLevelFeaturesNotResolved()) {
@@ -384,10 +387,10 @@ public class RepositoryResolutionException extends RepositoryException {
     }
 
     /**
-     * @return the hasVersionlessIssue
+     * @return the missingBasePlatforms
      */
-    public boolean hasVersionlessIssue() {
-        return hasVersionlessIssue;
+    public List<String> getMissingBasePlatforms() {
+        return missingBasePlatforms;
     }
 
 }

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -1012,16 +1012,14 @@ public class RepositoryResolver {
 
         List<String> missingBasePlatforms = new ArrayList<String>();
 
-        // Versionless feature issues
-        if (!missingTopLevelRequirements.isEmpty()) {
-            for (String name : missingTopLevelRequirements) {
-                ProvisioningFeatureDefinition feature = resolverRepository.getFeature(name);
-                if (feature != null && feature.isVersionless()) {
-                    ProvisioningFeatureDefinition firstChild = resolverRepository.findAllPossibleVersions(feature).get(0);
-                    String plat = firstChild.getPlatformName();
-                    if (plat != null && plat.indexOf("-") != -1) {
-                        missingBasePlatforms.add(resolverRepository.getFeatureBaseName(plat));
-                    }
+        // Versionless feature issues will appear in missingTopLevelRequirements, and this will gather the associated platform unable to target.
+        for (String name : missingTopLevelRequirements) {
+            ProvisioningFeatureDefinition feature = resolverRepository.getFeature(name);
+            if (feature != null && feature.isVersionless()) {
+                ProvisioningFeatureDefinition firstChild = resolverRepository.findAllPossibleVersions(feature).get(0);
+                String plat = firstChild.getPlatformName();
+                if (plat != null) {//This will add just the platform name without version
+                    missingBasePlatforms.add(resolverRepository.getFeatureBaseName(plat));
                 }
             }
         }

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -83,6 +83,11 @@ public class RepositoryResolver {
     Set<String> requestedFeatureNames;
 
     /**
+     * The platforms passed to {@link #resolve(Collection)} which will help resolve versionless features
+     */
+    Collection<String> requestedPlatformNames;
+
+    /**
      * The list of samples the user has requested to install
      */
     List<SampleResource> samplesToInstall;
@@ -308,7 +313,7 @@ public class RepositoryResolver {
      * @throws RepositoryResolutionException If the resource cannot be resolved
      */
     public Collection<List<RepositoryResource>> resolve(Collection<String> toResolve) throws RepositoryResolutionException {
-        return resolve(toResolve, ResolutionMode.IGNORE_CONFLICTS);
+        return resolve(toResolve, null, ResolutionMode.IGNORE_CONFLICTS);
     }
 
     /**
@@ -370,14 +375,65 @@ public class RepositoryResolver {
      * @throws RepositoryResolutionException If the resource cannot be resolved
      */
     public Collection<List<RepositoryResource>> resolveAsSet(Collection<String> toResolve) throws RepositoryResolutionException {
-        return resolve(toResolve, ResolutionMode.DETECT_CONFLICTS);
+        return resolve(toResolve, null, ResolutionMode.DETECT_CONFLICTS);
     }
 
-    Collection<List<RepositoryResource>> resolve(Collection<String> toResolve, ResolutionMode resolutionMode) throws RepositoryResolutionException {
+    /**
+     * Takes a list of feature names that the user wants to install and returns a minimal set of the {@link RepositoryResource}s that should be installed to allow those features to
+     * start together in one server.
+     * <p>
+     * This method uses the same resolution logic that is used by the kernel at server startup to decide which features to start. Therefore calling this method with a list of
+     * feature names and installing the resources returned will guarantee that a server which has the same list of feature names in its server.xml will start.
+     * <p>
+     * The caller must provide the full set of features from the server.xml, including those that are already installed, so that tolerated dependencies and auto-features can be
+     * resolved correctly.
+     * <p>
+     * This method will fail if there's no valid set of dependencies for the required features that doesn't include conflicting versions of singleton features.
+     * <p>
+     * For example, {@code resolve(Arrays.asList("javaee-7.0", "javaee-8.0"))} would work but {@code resolveAsSet(Arrays.asList("javaee-7.0", "javaee-8.0"))} would fail because
+     * javaee-7.0 and javaee-8.0 contain features which conflict with each other (and other versions are not tolerated).
+     * <p>
+     * This method guarantees that it will return all the features required to start the requested features but will not ensure that the requested features will work with features
+     * which were already installed but were not requested in the call to this method.
+     * <p>
+     * For example, if {@code ejbLite-3.2} is already installed and {@code resolve(Arrays.asList("cdi-2.0"))} is called, it will not return the autofeature which would be required
+     * for {@code cdi-2.0} and {@code ejbLite-3.2} to work together.
+     *
+     * @param toResolve A collection of the identifiers of the resources to resolve. It should be in the form:</br>
+     *                      <code>{name}/{version}</code></br>
+     *                      <p>Where the <code>{name}</code> can be either the symbolic name, short name or lower case short name of the resource and <code>/{version}</code> is
+     *                      optional. The collection may contain a mixture of symbolic names and short names. Must not be <code>null</code> or empty.</p>
+     * @param platforms A collection of the identifiers of the platforms used for resolving versionless features
+     *
+     * @return <p>A collection of ordered lists of {@link RepositoryResource}s to install. Each list represents a collection of resources that must be installed together or not
+     *         at all. They should be installed in the iteration order of the list(s). Note that if a resource is required by multiple different resources then it will appear in
+     *         multiple lists. For instance if you have requested to install A and B and A requires N which requires M and O whereas B requires Z that requires O then the returned
+     *         collection will be (represented in JSON):</p>
+     *         <code>
+     *         [[M, O, N, A],[O, Z, B]]
+     *         </code>
+     *         <p>This will not return <code>null</code> although it may return an empty collection if there isn't anything to install (i.e. it resolves to resources that are
+     *         already installed)</p>
+     *         <p>Every auto-feature will have it's own list in the collection, this is to stop the failure to install either an auto feature or one of it's dependencies from
+     *         stopping everything from installing. Therefore if you have features A and B that are required to provision auto feature C and you ask to resolve A and B then this
+     *         method will return:</p>
+     *         <code>
+     *         [[A],[B],[A,B,C]]
+     *         </code>
+     *
+     * @throws RepositoryResolutionException If the resource cannot be resolved
+     */
+    public Collection<List<RepositoryResource>> resolveAsSet(Collection<String> toResolve, Collection<String> platforms) throws RepositoryResolutionException {
+        return resolve(toResolve, platforms, ResolutionMode.DETECT_CONFLICTS);
+    }
+
+    Collection<List<RepositoryResource>> resolve(Collection<String> toResolve, Collection<String> platforms, ResolutionMode resolutionMode) throws RepositoryResolutionException {
         initResolve();
         initializeResolverRepository(installDefinition);
 
         processNames(toResolve);
+        //Set platform names passed for kernel resolver resolution
+        requestedPlatformNames = platforms;
 
         if (resolutionMode == ResolutionMode.DETECT_CONFLICTS) {
             // Call the kernel resolver to determine the features needed
@@ -477,7 +533,7 @@ public class RepositoryResolver {
      */
     void resolveFeaturesAsSet() {
         FeatureResolver resolver = new FeatureResolverImpl();
-        Result result = resolver.resolve(resolverRepository, kernelFeatures, featureNamesToResolve, Collections.<String> emptySet(), false, Collections.<String> emptySet());
+        Result result = resolver.resolve(resolverRepository, kernelFeatures, featureNamesToResolve, Collections.<String> emptySet(), false, requestedPlatformNames);
 
         featureConflicts.putAll(result.getConflicts());
 

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
@@ -264,13 +264,12 @@ public class KernelResolverEsa implements ProvisioningFeatureDefinition {
             return false;
         }
 
-        if (getSymbolicName().indexOf(".versionless.") == -1) {
-            return false;
-        } else if (getSymbolicName().indexOf(".internal.versionless.") != -1) {
+        if (getSymbolicName().contains(".versionless.")
+                && !getSymbolicName().contains(".internal.")) {
+            return true;
+        } else {
             return false;
         }
-
-        return true;
     }
 
     @Override

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
@@ -283,7 +283,7 @@ public class KernelResolverEsa implements ProvisioningFeatureDefinition {
      *
      * <ul><li>private</li>
      * <li>do not have a short name</li>
-     * <li>contain ".eeCompatible-" or ".mpCompatible-" in their symbolic name.</li>
+     * <li>has a platform value</li>
      * </ul>
      *
      * @return True or false telling if this is a versionless feature.

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
@@ -227,20 +227,50 @@ public class KernelResolverEsa implements ProvisioningFeatureDefinition {
     }
 
     //
-    
+
     @Override
     public List<String> getPlatformNames() {
-        return null; // TODO
+
+        return esaResource.getPlatforms() == null ? new ArrayList() : new ArrayList(esaResource.getPlatforms());
     }
 
     @Override
     public String getPlatformName() {
-        return null; // TODO
+        return (!getPlatformNames().isEmpty() ? getPlatformNames().get(0) : null);
     }
-    
+
+    /**
+     * Tell if this is a versionless feature.
+     *
+     * Currently these are:
+     *
+     * <ul><li>public</li>
+     * <li>platformless</li>
+     * <li>have a short name that is equal to the feature name</li>
+     * <li>contain ".versionless." in their symbolic name.</li>
+     * <li>does not contain ".internal.versionless." in their symbolic name.</li>
+     * </ul>
+     *
+     * @return True or false telling if this is a versionless feature.
+     */
     @Override
     public boolean isVersionless() {
-        return false; // TODO
+        if (!getVisibility().equals(Visibility.PUBLIC) || (getPlatformName() != null)) {
+            return false;
+        }
+
+        String shortName = getIbmShortName();
+        if ((shortName == null) || !shortName.equals(getFeatureName())) {
+            return false;
+        }
+
+        if (getSymbolicName().indexOf(".versionless.") == -1) {
+            return false;
+        } else if (getSymbolicName().indexOf(".internal.versionless.") != -1) {
+            return false;
+        }
+
+        return true;
     }
 
     @Override
@@ -248,8 +278,23 @@ public class KernelResolverEsa implements ProvisioningFeatureDefinition {
         return false; // TODO
     }
 
+    /**
+     * Tell if this is a compatibility feature.
+     *
+     * <ul><li>private</li>
+     * <li>do not have a short name</li>
+     * <li>contain ".eeCompatible-" or ".mpCompatible-" in their symbolic name.</li>
+     * </ul>
+     *
+     * @return True or false telling if this is a versionless feature.
+     */
     @Override
     public boolean isCompatibility() {
-        return false; // TODO
+        if (!getVisibility().equals(Visibility.PRIVATE)) {
+            return false;
+        } else if (getIbmShortName() != null) {
+            return false;
+        }
+        return (getPlatformName() != null);
     }
 }

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
@@ -258,7 +258,7 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
             publicFeature = getVersionedFeature(dependency.getSymbolicName());
             if (publicFeature != null)
                 result.add(publicFeature);
-            
+
             String baseName = getFeatureBaseName(dependency.getSymbolicName());
             List<String> tolerates = dependency.getTolerates();
             if (tolerates != null) {
@@ -275,13 +275,13 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
 
     /**
      *
-     * Answer the public versioned feature based on the internal versionless linking feature
+     * Answer the public versioned feature based on the internal versionless linking feature, or null if can't be found
      *
      * @param versionlessLinkingFeatureName
      * @return ProvisioningFeatureDefinition
      */
     private ProvisioningFeatureDefinition getVersionedFeature(String versionlessLinkingFeatureName) {
-        ProvisioningFeatureDefinition result = null;
+
         ProvisioningFeatureDefinition feature = getFeature(versionlessLinkingFeatureName);
         if (feature != null) {
             //This is the versionless linking feature pointing to a public versioned feature

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.osgi.framework.Version;
-
 import com.ibm.ws.kernel.feature.Visibility;
 import com.ibm.ws.kernel.feature.provisioning.FeatureResource;
 import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
@@ -37,6 +35,8 @@ import com.ibm.ws.repository.resources.ApplicableToProduct;
 import com.ibm.ws.repository.resources.EsaResource;
 import com.ibm.ws.repository.resources.RepositoryResource;
 import com.ibm.ws.repository.resources.internal.RepositoryResourceImpl;
+
+import junit.runner.Version;
 
 /**
  * Implementation of {@link FeatureResolver.Repository} which is backed by a collection of {@link EsaResource}s.
@@ -283,10 +283,11 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
             for (FeatureResource versionedFeature : feature.getConstituents(SubsystemContentType.FEATURE_TYPE)) {
                 //Find the right public feature (should only be one) - set the result
                 ProvisioningFeatureDefinition versionedFeatureDef = getFeature(versionedFeature.getSymbolicName());
-                if (versionedFeatureDef.getVisibility() != Visibility.PUBLIC) {
-                    continue;
+                if (versionedFeatureDef.getVisibility() == Visibility.PUBLIC) {
+                    return versionedFeatureDef;
                 }
                 result = versionedFeatureDef;
+                break;
             }
         }
         return result;

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepository.java
@@ -24,7 +24,9 @@ import java.util.Map.Entry;
 import org.osgi.framework.Version;
 
 import com.ibm.ws.kernel.feature.Visibility;
+import com.ibm.ws.kernel.feature.provisioning.FeatureResource;
 import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
+import com.ibm.ws.kernel.feature.provisioning.SubsystemContentType;
 import com.ibm.ws.kernel.feature.resolver.FeatureResolver;
 import com.ibm.ws.repository.common.enums.FilterableAttribute;
 import com.ibm.ws.repository.common.enums.ResourceType;
@@ -242,6 +244,71 @@ public class KernelResolverRepository implements FeatureResolver.Repository {
         }
 
         return feature;
+    }
+
+    /**
+     * Answer the list of public versioned features derived from the passed versionless feature or empty List if doesn't exist.
+     *
+     * @return List<ProvisioningFeatureDefinition>
+     */
+    public List<ProvisioningFeatureDefinition> findAllPossibleVersions(ProvisioningFeatureDefinition versionlessFeature) {
+        List<ProvisioningFeatureDefinition> result = new ArrayList<>();
+        for (FeatureResource dependency : versionlessFeature.getConstituents(SubsystemContentType.FEATURE_TYPE)) {
+            result.add(getVersionedFeature(dependency.getSymbolicName()));
+
+            String baseName = getFeatureBaseName(dependency.getSymbolicName());
+            List<String> tolerates = dependency.getTolerates();
+            if (tolerates != null) {
+                for (String toleratedVersion : tolerates) {
+                    String featureName = baseName + toleratedVersion;
+                    result.add(getVersionedFeature(featureName));
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     *
+     * Answer the public versioned feature based on the internal versionless linking feature
+     *
+     * @param versionlessLinkingFeatureName
+     * @return ProvisioningFeatureDefinition
+     */
+    private ProvisioningFeatureDefinition getVersionedFeature(String versionlessLinkingFeatureName) {
+        ProvisioningFeatureDefinition result = null;
+        ProvisioningFeatureDefinition feature = getFeature(versionlessLinkingFeatureName);
+        if (feature != null) {
+            //This is the versionless linking feature pointing to a public versioned feature
+            for (FeatureResource versionedFeature : feature.getConstituents(SubsystemContentType.FEATURE_TYPE)) {
+                //Find the right public feature (should only be one) - set the result
+                ProvisioningFeatureDefinition versionedFeatureDef = getFeature(versionedFeature.getSymbolicName());
+                if (versionedFeatureDef.getVisibility() != Visibility.PUBLIC) {
+                    continue;
+                }
+                result = versionedFeatureDef;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Removes the version from the end of a feature symbolic name
+     * <p>
+     * The version is presumed to start after the last dash character in the name.
+     * <p>
+     * E.g. {@code getFeatureBaseName("com.example.featureA-1.0")} returns {@code "com.example.featureA-"}
+     *
+     * @param nameAndVersion the feature symbolic name
+     * @return the feature symbolic name with any version stripped
+     */
+    public String getFeatureBaseName(String nameAndVersion) {
+        int dashPosition = nameAndVersion.lastIndexOf('-');
+        if (dashPosition != -1) {
+            return nameAndVersion.substring(0, dashPosition + 1);
+        } else {
+            return nameAndVersion;
+        }
     }
 
     /**


### PR DESCRIPTION
This PR uses the resolution Result object to start gathering additional results that could occur in versionless scenarios.
Primarily two main scenarios where messages have been added to the install commands (#29060). Platform can't be found, or platform can't be determined from the set of versionless/versioned features passed.

A few additions to the Repository to handle querying the platform header info now stored in the ESA's.

Started adding install tests, but will be exploring how to test for features not yet part of the public repo.