### PR TITLE
Install errors and messages

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
+++ b/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
@@ -13,12 +13,14 @@
 addRequiredLibraries {
     configurations {
     	usrFeatures
-    	features
+    	features1
+    	features2
     }
     
     dependencies {
       usrFeatures 'test.featureUtility_fat:userFeature:1.0@zip'
-      features 'test.featureUtility_fat:Archive:2.0@zip'
+      features1 'test.featureUtility_fat:Archive:1.0@zip'
+      features2 'test.featureUtility_fat:Archive:2.0@zip'
       requiredLibs project(':com.ibm.ws.org.slf4j.api'),
       	project(':com.ibm.ws.org.slf4j.simple')
     }    
@@ -29,8 +31,13 @@ addRequiredLibraries {
     }
     
     copy {
-        from configurations.features
-        into "publish/repo/archive"
+        from configurations.features1
+        into "publish/repo/archive1"
+    }
+    
+    copy {
+        from configurations.features2
+        into "publish/repo/archive2"
     }
 
     dependsOn copyTestContainers

--- a/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
+++ b/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, 2023 IBM Corporation and others.
+/* Copyright (c) 2021, 2024 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License 2.0
 * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ addRequiredLibraries {
     
     dependencies {
       usrFeatures 'test.featureUtility_fat:userFeature:1.0@zip'
-      features 'test.featureUtility_fat:Archive:1.0@zip'
+      features 'test.featureUtility_fat:Archive:2.0@zip'
       requiredLibs project(':com.ibm.ws.org.slf4j.api'),
       	project(':com.ibm.ws.org.slf4j.simple')
     }    

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FATSuite.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ import componenttest.containers.TestContainerSuite;
 @RunWith(Suite.class)
 @SuiteClasses({
 
-	InstallFeatureTest.class, InstallServerTest.class, HelpActionTest.class
+	InstallFeatureTest.class, InstallServerTest.class, HelpActionTest.class, InstallVersionlessServerTest.class
 
 })
 public class FATSuite extends TestContainerSuite {
@@ -38,8 +38,9 @@ public class FATSuite extends TestContainerSuite {
     @BeforeClass
     public static void beforeSuite() throws Exception {
 	FeatureUtilityToolTest.setupEnv();
-	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo/userFeature/userFeature-1.0.zip"));
-	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo/archive/Archive-2.0.zip"));
+	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo/").toAbsolutePath().toString(),Paths.get("publish/repo/userFeature/userFeature-1.0.zip"));
+	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo/").toAbsolutePath().toString(),Paths.get("publish/repo/archive1/Archive-1.0.zip"));
+	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo2/").toAbsolutePath().toString(),Paths.get("publish/repo/archive2/Archive-2.0.zip")); //New repo has versionless features
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FATSuite.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FATSuite.java
@@ -39,7 +39,7 @@ public class FATSuite extends TestContainerSuite {
     public static void beforeSuite() throws Exception {
 	FeatureUtilityToolTest.setupEnv();
 	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo/userFeature/userFeature-1.0.zip"));
-	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo/archive/Archive-1.0.zip"));
+	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo/archive/Archive-2.0.zip"));
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -372,8 +372,8 @@ public abstract class FeatureUtilityToolTest {
 
     protected ProgramOutput runFeatureUtility(String testcase, String[] params, boolean debug) throws Exception {
         Properties envProps = new Properties();
-	// add beta property here
-	// envProps.put("JVM_ARGS", "-Dbeta.property=true");
+	//add beta property here
+	 envProps.put("JVM_ARGS", "-Dbeta.property=true");
         return runFeatureUtility(testcase, params, envProps);
     }
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -48,7 +48,7 @@ public abstract class FeatureUtilityToolTest {
 
     private static final Class<?> c = FeatureUtilityToolTest.class;
 
-    protected static String libertyVersion = "23.0.0.2";
+    protected static String libertyVersion = "24.0.0.8";
     // ${buildDir}/publish/repo
     protected static String mavenLocalRepo = Paths.get("publish/repo/").toAbsolutePath().toString();
     public static LibertyServer server;

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -48,9 +48,10 @@ public abstract class FeatureUtilityToolTest {
 
     private static final Class<?> c = FeatureUtilityToolTest.class;
 
-    protected static String libertyVersion = "24.0.0.8";
+    protected static String libertyVersion = "23.0.0.2";
     // ${buildDir}/publish/repo
-    protected static String mavenLocalRepo = Paths.get("publish/repo/").toAbsolutePath().toString();
+    protected static String mavenLocalRepo1 = Paths.get("publish/repo/").toAbsolutePath().toString();
+    protected static String mavenLocalRepo2 = Paths.get("publish/repo2/").toAbsolutePath().toString();
     public static LibertyServer server;
     private static String installRoot;
     static String minifiedRoot;
@@ -94,7 +95,8 @@ public abstract class FeatureUtilityToolTest {
         minifiedRoot = exportWlp(installRoot, installRoot + "/../temp/wlp.zip", installRoot + relativeMinifiedRoot);
         Log.info(c, methodName, "minified root: " + minifiedRoot);
 
-	Log.info(c, methodName, "mavenLocalRepo : " + mavenLocalRepo.toString());
+        Log.info(c, methodName, "mavenLocalRepo1 : " + mavenLocalRepo1.toString());
+        Log.info(c, methodName, "mavenLocalRepo2 : " + mavenLocalRepo2.toString());
 
         if(!new File(minifiedRoot).exists()){
             throw new Exception("The minified root does not exist!");
@@ -418,8 +420,10 @@ public abstract class FeatureUtilityToolTest {
     }
     
     protected static boolean deleteRepo(String methodName) throws IOException {
-	boolean repo = TestUtils.deleteFolder(new File(mavenLocalRepo));
-	Log.info(c, methodName, "DELETED REPO : " + mavenLocalRepo + "?" + repo);
+	boolean repo = TestUtils.deleteFolder(new File(mavenLocalRepo1));
+	Log.info(c, methodName, "DELETED REPO : " + mavenLocalRepo1 + "?" + repo);
+	repo  = TestUtils.deleteFolder(new File(mavenLocalRepo2));
+	Log.info(c, methodName, "DELETED REPO : " + mavenLocalRepo2 + "?" + repo);
     	return repo;
     }
 
@@ -507,18 +511,6 @@ public abstract class FeatureUtilityToolTest {
 
     }
 
-    /*
-     * / Copy Maven central features and signatures to local repository
-     */
-    protected static void constructLocalMavenRepo(Path artifactPath) throws Exception {
-	Log.info(c, "constructLocalMavenRepo",
-		"Creating local repository using " + artifactPath.toAbsolutePath().toString());
-
-	ZipFile zipFile = new ZipFile(artifactPath.toFile());
-	TestUtils.unzipFileIntoDirectory(zipFile, Paths.get(mavenLocalRepo).toFile());
-	Log.info(c, "constructLocalMavenRepo", "Unzipped to " + Paths.get(mavenLocalRepo).toAbsolutePath().toString());
-
-    }
 
     /**
      * @param METHOD_NAME
@@ -540,6 +532,19 @@ public abstract class FeatureUtilityToolTest {
 		}
 		String[] param1s = { "installFeature", "jsp-2.2", "jsp-2.3", "--verbose" };
 		runFeatureUtility(METHOD_NAME, param1s);
+	}
+
+	/*
+	 * / Copy Maven central features and signatures to local repository
+	 */
+	protected static void constructLocalMavenRepo(String repoPath,Path artifactPath) throws Exception {
+	Log.info(c, "constructLocalMavenRepo",
+		"Creating local repository using " + artifactPath.toAbsolutePath().toString());
+	
+	ZipFile zipFile = new ZipFile(artifactPath.toFile());
+	TestUtils.unzipFileIntoDirectory(zipFile, Paths.get(repoPath).toFile());
+	Log.info(c, "constructLocalMavenRepo", "Unzipped to " + Paths.get(repoPath).toAbsolutePath().toString());
+	
 	}
 
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -84,7 +84,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	public void beforeSetUp() throws Exception {
 	    copyFileToMinifiedRoot("etc",
 		    "publish/propertyFiles/publishRepoOverrideProps/featureUtility.properties");
-	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "featureLocalRepo", mavenLocalRepo);
+	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "featureLocalRepo", mavenLocalRepo1);
 	}
 
 	@After
@@ -162,7 +162,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    String esaFile = String.format("/io/openliberty/features/json-1.0/%s/json-1.0-%s.esa", libertyVersion,
 		    libertyVersion);
 	    //copy json esa file from local Maven repo to a temporary location (wlp/tmp)
-	    copyFileToMinifiedRoot("tmp", mavenLocalRepo + esaFile);
+	    copyFileToMinifiedRoot("tmp", mavenLocalRepo1 + esaFile);
 	    // Begin Test
 	    String[] param1s = { "installFeature", minifiedRoot + "/tmp/" + String.format("json-1.0-%s.esa", libertyVersion), "--verbose" };
 	    String[] filesList = { "lib/features/com.ibm.websphere.appserver.json-1.0.mf" };
@@ -589,7 +589,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };
 	    
 	    //copy testesa1 esa file from local Maven repo to a temporary location (wlp/tmp)
-	    copyFileToMinifiedRoot("tmp", mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa");
+	    copyFileToMinifiedRoot("tmp", mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa");
 	    
 	    // Begin Test
 	    String[] param1s = { "installFeature", minifiedRoot + "/tmp/testesa1-19.0.0.8.esa", "json-1.0",
@@ -610,7 +610,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    Log.entering(c, METHOD_NAME);
 
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl",
-		    mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
+		    mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "71f8e6239b6834aa");
 
 	    String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };
@@ -632,7 +632,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    final String METHOD_NAME = "testFeatureVerifySKIP";
 	    Log.entering(c, METHOD_NAME);
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl",
-		    mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
+		    mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "71f8e6239b6834aa");
 
 	    String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };
@@ -709,7 +709,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    Log.entering(c, METHOD_NAME);
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "feature.verify", "all");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl",
-		    mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
+		    mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "71f8e6239b6834aa");
 
 	    String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };
@@ -732,7 +732,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    envProps.put("FEATURE_VERIFY", "all");
 
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl",
-		    mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
+		    mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "71f8e6239b6834aa");
 
 	    String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };
@@ -784,15 +784,15 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    envProps.put("FEATURE_VERIFY", "all");
 
 	    // backup the valid user feature signature
-	    Files.move(Paths.get(mavenLocalRepo + userFeatureSigPath),
-		    Paths.get(mavenLocalRepo + userFeatureSigPath + ".bck"));
+	    Files.move(Paths.get(mavenLocalRepo1 + userFeatureSigPath),
+		    Paths.get(mavenLocalRepo1 + userFeatureSigPath + ".bck"));
 	    // overwrite with signature signed by revoked key
-	    Files.copy(Paths.get(mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/revoked/testesa1-19.0.0.8.esa.asc"),
-		    Paths.get(mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa.asc"));
+	    Files.copy(Paths.get(mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/revoked/testesa1-19.0.0.8.esa.asc"),
+		    Paths.get(mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa.asc"));
 
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "feature.verify", "all");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl",
-		    mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/revoked/revokedKey.asc");
+		    mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/revoked/revokedKey.asc");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "2CB7FEADC826EA27");
 
 	    String[] param1s = { "installFeature", "testesa1",
@@ -800,8 +800,8 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 
 	    // Change back to valid signature
-	    Files.move(Paths.get(mavenLocalRepo + userFeatureSigPath + ".bck"),
-		    Paths.get(mavenLocalRepo + userFeatureSigPath),
+	    Files.move(Paths.get(mavenLocalRepo1 + userFeatureSigPath + ".bck"),
+		    Paths.get(mavenLocalRepo1 + userFeatureSigPath),
 		    StandardCopyOption.REPLACE_EXISTING);
 
 	    checkCommandOutput(po, InstallException.SIGNATURE_VERIFICATION_FAILED, "CWWKF1510E", null);
@@ -821,15 +821,15 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    envProps.put("FEATURE_VERIFY", "all");
 
 	    // backup the valid user feature signature
-	    Files.move(Paths.get(mavenLocalRepo + userFeatureSigPath),
-		    Paths.get(mavenLocalRepo + userFeatureSigPath + ".bck"));
+	    Files.move(Paths.get(mavenLocalRepo1 + userFeatureSigPath),
+		    Paths.get(mavenLocalRepo1 + userFeatureSigPath + ".bck"));
 	    // overwrite with signature signed by expired key
-	    Files.copy(Paths.get(mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/expired/testesa1-19.0.0.8.esa.asc"),
-		    Paths.get(mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa.asc"));
+	    Files.copy(Paths.get(mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/expired/testesa1-19.0.0.8.esa.asc"),
+		    Paths.get(mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa.asc"));
 
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "feature.verify", "all");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl",
-		    mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/expired/expiredKey.asc");
+		    mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/expired/expiredKey.asc");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "61B792CE2DAA8C02");
 
 	    String[] param1s = { "installFeature", "testesa1",
@@ -837,8 +837,8 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 
 	    // Change back to valid signature
-	    Files.move(Paths.get(mavenLocalRepo + userFeatureSigPath + ".bck"),
-		    Paths.get(mavenLocalRepo + userFeatureSigPath), StandardCopyOption.REPLACE_EXISTING);
+	    Files.move(Paths.get(mavenLocalRepo1 + userFeatureSigPath + ".bck"),
+		    Paths.get(mavenLocalRepo1 + userFeatureSigPath), StandardCopyOption.REPLACE_EXISTING);
 
 	    checkCommandOutput(po, InstallException.SIGNATURE_VERIFICATION_FAILED, "CWWKF1511E", null);
 	    Log.exiting(c, METHOD_NAME);
@@ -857,7 +857,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "feature.verify", "all");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl",
-		    mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
+		    mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
 
 	    String[] param1s = { "installFeature", "testesa1",
 		    "--featuresBOM=com.ibm.ws.userFeature:features-bom:19.0.0.8", "--verbose" };
@@ -930,25 +930,25 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
 	    envProps.put("FEATURE_VERIFY", "all");
 
 	    // backup the valid user feature signature
-	    Files.move(Paths.get(mavenLocalRepo + userFeatureSigPath),
-		    Paths.get(mavenLocalRepo + userFeatureSigPath + ".bck"));
+	    Files.move(Paths.get(mavenLocalRepo1 + userFeatureSigPath),
+		    Paths.get(mavenLocalRepo1 + userFeatureSigPath + ".bck"));
 	    // overwrtie valid signature to invalid signature
 	    Files.copy(
-		    Paths.get(mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/invalidSig/testesa1-19.0.0.8.esa.asc"),
-		    Paths.get(mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa.asc"));
+		    Paths.get(mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/invalidSig/testesa1-19.0.0.8.esa.asc"),
+		    Paths.get(mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/19.0.0.8/testesa1-19.0.0.8.esa.asc"));
 
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "feature.verify", "all");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "71f8e6239b6834aa");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl",
-		    mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
+		    mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
 
 	    String[] param1s = { "installFeature", "testesa1",
 		    "--featuresBOM=com.ibm.ws.userFeature:features-bom:19.0.0.8", "--verbose" };
 	    ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 
 	    // Change back to valid signature
-	    Files.move(Paths.get(mavenLocalRepo + userFeatureSigPath + ".bck"),
-		    Paths.get(mavenLocalRepo + userFeatureSigPath), StandardCopyOption.REPLACE_EXISTING);
+	    Files.move(Paths.get(mavenLocalRepo1 + userFeatureSigPath + ".bck"),
+		    Paths.get(mavenLocalRepo1 + userFeatureSigPath), StandardCopyOption.REPLACE_EXISTING);
 
 
 	    checkCommandOutput(po, InstallException.SIGNATURE_VERIFICATION_FAILED, "CWWKF1512E", null);

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -44,7 +44,7 @@ public class InstallServerTest extends FeatureUtilityToolTest {
     @Before
     public void beforeSetUp() throws Exception {
 	copyFileToMinifiedRoot("etc", "publish/propertyFiles/publishRepoOverrideProps/featureUtility.properties");
-	writeToProps(minifiedRoot + "/etc/featureUtility.properties", "featureLocalRepo", mavenLocalRepo);
+	writeToProps(minifiedRoot + "/etc/featureUtility.properties", "featureLocalRepo", mavenLocalRepo1);
     }
 
     @After
@@ -157,69 +157,7 @@ public class InstallServerTest extends FeatureUtilityToolTest {
 	Log.exiting(c, METHOD_NAME);
     }
     
-    /**
-     * Test the install of versionless with bogus platform name xxx from maven central. Should throw expected platform name not found
-     *
-     * @throws Exception
-     */
-    
-    @Test
-    public void testVersionlessWithBadPlatformFeatures() throws Exception {
-	final String METHOD_NAME = "testVersionlessWithBadPlatformFeatures";
-	Log.entering(c, METHOD_NAME);
-
-	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessBadPlatform/server.xml");
-	
-	String[] param1s = { "installServerFeatures", "serverX", "--verbose" };
-	
-	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-
-	checkCommandOutput(po, 21, "CWWKF1515E", null); //UnKnown platform error
-	Log.exiting(c, METHOD_NAME);
-    }
-    
-    /**
-     * Test the install of versionless with no platform defined. Should throw expected platform can't be determined error
-     *
-     * @throws Exception
-     */
-    
-    @Test
-    public void testVersionlessWithNoPlatformFeatures() throws Exception {
-	final String METHOD_NAME = "testVersionlessWithNoPlatformFeatures";
-	Log.entering(c, METHOD_NAME);
-
-	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessNoPlatform/server.xml");
-
-	String[] param1s = { "installServerFeatures", "serverX", "--verbose" };
-	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-
-	checkCommandOutput(po, 21, "CWWKF1516E", null); //Platform not determined
-	Log.exiting(c, METHOD_NAME);
-    }
-
-     /**
-     * Test the install of versionless with  platform name. install servlet-6.0 feature
-     *
-     * @throws Exception
-     */
-    
-    @Test
-    public void testVersionlessWithPlatformFeatures() throws Exception {
-	final String METHOD_NAME = "testVersionlessWithPlatformFeatures";
-	Log.entering(c, METHOD_NAME);
-
-	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessWithPlatform/server.xml");
-	
-	String[] param1s = { "installServerFeatures", "serverX", "--verbose" };
-	String[] filesList = { "/lib/features/com.ibm.websphere.appserver.servlet-6.0.mf" };
-	
-	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
-
-	checkCommandOutput(po, 0, null, filesList); //Should have servlet-6.0
-	Log.exiting(c, METHOD_NAME);
-    }
-
+   
     /**
      * Install an user feature with the "--featuresBom" parameters
      */
@@ -334,7 +272,7 @@ public class InstallServerTest extends FeatureUtilityToolTest {
 	    copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/usrFeaturesServerXml/server.xml");
 
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyurl",
-		    mavenLocalRepo + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
+		    mavenLocalRepo1 + "/com/ibm/ws/userFeature/testesa1/valid/validKey.asc");
 	    writeToProps(minifiedRoot + "/etc/featureUtility.properties", "myKey.keyid", "71f8e6239b6834aa");
 
 	    String[] filesList = { "usr/extension/lib/features/testesa1.mf", "usr/extension/bin/testesa1.bat" };

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
@@ -162,7 +162,7 @@ public class InstallServerTest extends FeatureUtilityToolTest {
      *
      * @throws Exception
      */
-    @Ignore
+    
     @Test
     public void testVersionlessWithBadPlatformFeatures() throws Exception {
 	final String METHOD_NAME = "testVersionlessWithBadPlatformFeatures";
@@ -183,7 +183,7 @@ public class InstallServerTest extends FeatureUtilityToolTest {
      *
      * @throws Exception
      */
-    @Ignore
+    
     @Test
     public void testVersionlessWithNoPlatformFeatures() throws Exception {
 	final String METHOD_NAME = "testVersionlessWithNoPlatformFeatures";
@@ -195,6 +195,28 @@ public class InstallServerTest extends FeatureUtilityToolTest {
 	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 
 	checkCommandOutput(po, 21, "CWWKF1516E", null); //Platform not determined
+	Log.exiting(c, METHOD_NAME);
+    }
+
+     /**
+     * Test the install of versionless with  platform name. install servlet-6.0 feature
+     *
+     * @throws Exception
+     */
+    
+    @Test
+    public void testVersionlessWithPlatformFeatures() throws Exception {
+	final String METHOD_NAME = "testVersionlessWithPlatformFeatures";
+	Log.entering(c, METHOD_NAME);
+
+	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessWithPlatform/server.xml");
+	
+	String[] param1s = { "installServerFeatures", "serverX", "--verbose" };
+	String[] filesList = { "/lib/features/com.ibm.websphere.appserver.servlet-6.0.mf" };
+	
+	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+
+	checkCommandOutput(po, 0, null, filesList); //Should have servlet-6.0
 	Log.exiting(c, METHOD_NAME);
     }
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
@@ -158,24 +158,43 @@ public class InstallServerTest extends FeatureUtilityToolTest {
     }
     
     /**
-     * Test the install of versionless servlet from maven central. Multi-version is not
-     * supported with installServerFeature as it cannot be installed to same
-     * resource.
+     * Test the install of versionless with bogus platform name xxx from maven central. Should throw expected platform name not found
      *
      * @throws Exception
      */
     @Ignore
     @Test
-    public void testVersionlessWithPlatformFeatures() throws Exception {
-	final String METHOD_NAME = "testInvalidMultiVersionFeatures";
+    public void testVersionlessWithBadPlatformFeatures() throws Exception {
+	final String METHOD_NAME = "testVersionlessWithBadPlatformFeatures";
 	Log.entering(c, METHOD_NAME);
 
-	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessWPlatform/server.xml");
+	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessBadPlatform/server.xml");
+	
+	String[] param1s = { "installServerFeatures", "serverX", "--verbose" };
+	
+	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+
+	checkCommandOutput(po, 21, "CWWKF1515E", null); //UnKnown platform error
+	Log.exiting(c, METHOD_NAME);
+    }
+    
+    /**
+     * Test the install of versionless with no platform defined. Should throw expected platform can't be determined error
+     *
+     * @throws Exception
+     */
+    @Ignore
+    @Test
+    public void testVersionlessWithNoPlatformFeatures() throws Exception {
+	final String METHOD_NAME = "testVersionlessWithNoPlatformFeatures";
+	Log.entering(c, METHOD_NAME);
+
+	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessNoPlatform/server.xml");
 
 	String[] param1s = { "installServerFeatures", "serverX", "--verbose" };
 	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
 
-	checkCommandOutput(po, 21, "CWWKF1405E", null);
+	checkCommandOutput(po, 21, "CWWKF1516E", null); //Platform not determined
 	Log.exiting(c, METHOD_NAME);
     }
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallVersionlessServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallVersionlessServerTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.install.featureUtility.fat;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.websphere.simplicity.ProgramOutput;
+import com.ibm.websphere.simplicity.log.Log;
+
+public class InstallVersionlessServerTest extends FeatureUtilityToolTest {
+    private static final Class<?> c = InstallVersionlessServerTest.class;
+
+    @BeforeClass
+    public static void beforeClassSetup() throws Exception {
+	final String methodName = "beforeClassSetup";
+        Log.entering(c, methodName);
+        /* Enable tests only if running on a zOS machine, otherwise skip class */
+        Assume.assumeTrue(!isZos);
+	deleteFeaturesAndLafilesFolders("beforeClassSetup");
+	replaceWlpProperties("24.0.0.8");
+        Log.exiting(c, methodName);
+    }
+
+    @Before
+    public void beforeSetUp() throws Exception {
+	copyFileToMinifiedRoot("etc", "publish/propertyFiles/publishRepoOverrideProps/featureUtility.properties");
+	writeToProps(minifiedRoot + "/etc/featureUtility.properties", "featureLocalRepo", mavenLocalRepo2);
+    }
+
+    @After
+    public void afterCleanUp() throws Exception {
+	deleteFeaturesAndLafilesFolders("afterCleanUp");
+	deleteUsrExtFolder("afterCleanUp");
+	deleteEtcFolder("afterCleanUp");
+    }
+
+	@AfterClass
+	public static void cleanUp() throws Exception {
+		if (!isZos) {
+			resetOriginalWlpProps();
+		}
+	}
+
+    
+    /**
+     * Test the install of versionless with bogus platform name xxx from maven central. Should throw expected platform name not found
+     *
+     * @throws Exception
+     */
+    @Ignore
+    @Test
+    public void testVersionlessWithBadPlatformFeatures() throws Exception {
+	final String METHOD_NAME = "testVersionlessWithBadPlatformFeatures";
+	Log.entering(c, METHOD_NAME);
+
+	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessBadPlatform/server.xml");
+	
+	String[] param1s = { "installServerFeatures", "serverX", "--verify=skip", "--verbose" };
+	
+	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+
+	checkCommandOutput(po, 21, "CWWKF1515E", null); //UnKnown platform error
+	Log.exiting(c, METHOD_NAME);
+    }
+    
+    /**
+     * Test the install of versionless with no platform defined. Should throw expected platform can't be determined error
+     *
+     * @throws Exception
+     */
+    @Ignore
+    @Test
+    public void testVersionlessWithNoPlatformFeatures() throws Exception {
+	final String METHOD_NAME = "testVersionlessWithNoPlatformFeatures";
+	Log.entering(c, METHOD_NAME);
+
+	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessNoPlatform/server.xml");
+
+	String[] param1s = { "installServerFeatures", "serverX", "--verify=skip", "--verbose" };
+	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+
+	checkCommandOutput(po, 21, "CWWKF1516E", null); //Platform not determined
+	Log.exiting(c, METHOD_NAME);
+    }
+
+     /**
+     * Test the install of versionless with  platform name. install servlet-6.0 feature
+     *
+     * @throws Exception
+     */
+    @Ignore
+    @Test
+    public void testVersionlessWithPlatformFeatures() throws Exception {
+	final String METHOD_NAME = "testVersionlessWithPlatformFeatures";
+	Log.entering(c, METHOD_NAME);
+
+	copyFileToMinifiedRoot("usr/servers/serverX", "publish/tmp/versionlessWithPlatform/server.xml");
+	
+	String[] param1s = { "installServerFeatures", "serverX", "--verify=skip", "--verbose" };
+	String[] filesList = { "/lib/features/com.ibm.websphere.appserver.servlet-6.0.mf" };
+	
+	ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
+
+	checkCommandOutput(po, 0, null, filesList); //Should have servlet-6.0
+	Log.exiting(c, METHOD_NAME);
+    }
+
+    
+
+}

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessBadPlatform/server.xml
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessBadPlatform/server.xml
@@ -4,7 +4,7 @@
     <!-- Enable features -->
     <featureManager>
 	   <platform>xxx</platform>
-	   <feature>servlet</feature>
+	   <feature>jsp</feature>
     </featureManager>
 </server>
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessBadPlatform/server.xml
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessBadPlatform/server.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+	   <platform>xxx</platform>
+	   <feature>servlet</feature>
+    </featureManager>
+</server>
+

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessNoPlatform/server.xml
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessNoPlatform/server.xml
@@ -3,7 +3,6 @@
 
     <!-- Enable features -->
     <featureManager>
-	   <platform>jakartaee-10.0</platform>
 	   <feature>servlet</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessWithPlatform/server.xml
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessWithPlatform/server.xml
@@ -3,7 +3,7 @@
 
     <!-- Enable features -->
     <featureManager>
-        <platform>jakartaee-10.0</platform>
+        <platform>javaee-6.0</platform>
 	   <feature>servlet</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessWithPlatform/server.xml
+++ b/dev/com.ibm.ws.install.featureUtility_fat/publish/tmp/versionlessWithPlatform/server.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <platform>jakartaee-10.0</platform>
+	   <feature>servlet</feature>
+    </featureManager>
+</server>
+

--- a/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
+++ b/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
@@ -951,7 +951,7 @@ ERROR_INAUTHENTIC_PUBLIC_KEY.useraction=If the public key is a local file, make 
 
 ERROR_MISSING_PLATFORM_NAME=CWWKF1515E: The {0} platform couldn't be found. No versionless features can be installed.
 ERROR_MISSING_PLATFORM_NAME.explanation=The platform name that is specified by the configuration or environment variable wasn't found.
-ERROR_MISSING_PLATFORM_NAME.useraction=Check the spelling of the platform name-version.
+ERROR_MISSING_PLATFORM_NAME.useraction=Check the spelling of the platform name and version, for example, microProfile-6.1.
 
 ERROR_NO_DERIVED_PLATFORM=CWWKF1516E: Platform couldn't be determined, the following versionless features won't be installed: {0}.
 ERROR_NO_DERIVED_PLATFORM.explanation=Platform was not set, or couldn't be derived from existing versioned features. 

--- a/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
+++ b/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
@@ -955,5 +955,5 @@ ERROR_MISSING_PLATFORM_NAME.useraction=Check the spelling of the platform name a
 
 ERROR_NO_DERIVED_PLATFORM=CWWKF1516E: The platform couldn't be determined. The following versionless features can't be installed: {0}.
 ERROR_NO_DERIVED_PLATFORM.explanation= The platform was not set or couldn't be derived from existing versioned features. 
-ERROR_NO_DERIVED_PLATFORM.useraction=Add platform for versionless features
+ERROR_NO_DERIVED_PLATFORM.useraction=Add a platform for versionless features.
 

--- a/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
+++ b/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
@@ -950,7 +950,7 @@ ERROR_INAUTHENTIC_PUBLIC_KEY.explanation=The public key might have changed.
 ERROR_INAUTHENTIC_PUBLIC_KEY.useraction=If the public key is a local file, make sure to provide the correct file.
 
 ERROR_MISSING_PLATFORM_NAME=CWWKF1515E: The {0} platform couldn't be found. No versionless features can be installed.
-ERROR_MISSING_PLATFORM_NAME.explanation=The platform name passed by the config or Env Var wasn't found.
+ERROR_MISSING_PLATFORM_NAME.explanation=The platform name that is specified by the configuration or environment variable wasn't found.
 ERROR_MISSING_PLATFORM_NAME.useraction=Check the spelling of the platform name-version.
 
 ERROR_NO_DERIVED_PLATFORM=CWWKF1516E: Platform couldn't be determined, the following versionless features won't be installed: {0}.

--- a/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
+++ b/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
@@ -953,7 +953,7 @@ ERROR_MISSING_PLATFORM_NAME=CWWKF1515E: The {0} platform couldn't be found. No v
 ERROR_MISSING_PLATFORM_NAME.explanation=The platform name that is specified by the configuration or environment variable wasn't found.
 ERROR_MISSING_PLATFORM_NAME.useraction=Check the spelling of the platform name and version, for example, microProfile-6.1.
 
-ERROR_NO_DERIVED_PLATFORM=CWWKF1516E: Platform couldn't be determined, the following versionless features won't be installed: {0}.
+ERROR_NO_DERIVED_PLATFORM=CWWKF1516E: The platform couldn't be determined. The following versionless features can't be installed: {0}.
 ERROR_NO_DERIVED_PLATFORM.explanation=Platform was not set, or couldn't be derived from existing versioned features. 
 ERROR_NO_DERIVED_PLATFORM.useraction=Add platform for versionless features
 

--- a/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
+++ b/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
@@ -949,7 +949,7 @@ ERROR_INAUTHENTIC_PUBLIC_KEY=CWWKF1514E: The {0} public key ID does not match th
 ERROR_INAUTHENTIC_PUBLIC_KEY.explanation=The public key might have changed. 
 ERROR_INAUTHENTIC_PUBLIC_KEY.useraction=If the public key is a local file, make sure to provide the correct file.
 
-ERROR_MISSING_PLATFORM_NAME=CWWKF1515E: The platform {0} couldn't be found, no versionless features will be installed.
+ERROR_MISSING_PLATFORM_NAME=CWWKF1515E: The {0} platform couldn't be found. No versionless features can be installed.
 ERROR_MISSING_PLATFORM_NAME.explanation=The platform name passed by the config or Env Var wasn't found.
 ERROR_MISSING_PLATFORM_NAME.useraction=Check the spelling of the platform name-version.
 

--- a/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
+++ b/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
@@ -949,11 +949,15 @@ ERROR_INAUTHENTIC_PUBLIC_KEY=CWWKF1514E: The {0} public key ID does not match th
 ERROR_INAUTHENTIC_PUBLIC_KEY.explanation=The public key might have changed. 
 ERROR_INAUTHENTIC_PUBLIC_KEY.useraction=If the public key is a local file, make sure to provide the correct file.
 
-ERROR_MISSING_PLATFORM_NAME=CWWKF1515E: The {0} platform couldn't be found. No versionless features can be installed.
+ERROR_MISSING_PLATFORM_NAME=CWWKF1515E: The {0} platform couldn't be found.
 ERROR_MISSING_PLATFORM_NAME.explanation=The platform name that is specified by the configuration or environment variable wasn't found.
 ERROR_MISSING_PLATFORM_NAME.useraction=Check the spelling of the platform name and version, for example, microProfile-6.1.
 
 ERROR_NO_DERIVED_PLATFORM=CWWKF1516E: The platform couldn't be determined. The following versionless features can't be installed: {0}.
 ERROR_NO_DERIVED_PLATFORM.explanation= The platform was not set or couldn't be derived from existing versioned features. 
 ERROR_NO_DERIVED_PLATFORM.useraction=Add a platform for versionless features.
+
+LOG_INSTALL_WITH_PLATFORM=CWWKF1314I: Installing using the following platforms: {0}.
+LOG_INSTALL_WITH_PLATFORM.explanation=The specified platform versions was used to resolve versionless features.
+LOG_INSTALL_WITH_PLATFORM.useraction=No action is required.
 

--- a/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
+++ b/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
@@ -949,3 +949,11 @@ ERROR_INAUTHENTIC_PUBLIC_KEY=CWWKF1514E: The {0} public key ID does not match th
 ERROR_INAUTHENTIC_PUBLIC_KEY.explanation=The public key might have changed. 
 ERROR_INAUTHENTIC_PUBLIC_KEY.useraction=If the public key is a local file, make sure to provide the correct file.
 
+ERROR_MISSING_PLATFORM_NAME=CWWKF1515E: The platform {0} couldn't be found, no versionless features will be installed.
+ERROR_MISSING_PLATFORM_NAME.explanation=The platform name passed by the config or Env Var wasn't found.
+ERROR_MISSING_PLATFORM_NAME.useraction=Check the spelling of the platform name-version.
+
+ERROR_NO_DERIVED_PLATFORM=CWWKF1516E: Platform couldn't be determined, the following versionless features won't be installed: {0}.
+ERROR_NO_DERIVED_PLATFORM.explanation=Platform was not set, or couldn't be derived from existing versioned features. 
+ERROR_NO_DERIVED_PLATFORM.useraction=Add platform for versionless features
+

--- a/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
+++ b/dev/com.ibm.ws.install/resources/com/ibm/ws/install/internal/resources/InstallKernel.nlsprops
@@ -954,6 +954,6 @@ ERROR_MISSING_PLATFORM_NAME.explanation=The platform name that is specified by t
 ERROR_MISSING_PLATFORM_NAME.useraction=Check the spelling of the platform name and version, for example, microProfile-6.1.
 
 ERROR_NO_DERIVED_PLATFORM=CWWKF1516E: The platform couldn't be determined. The following versionless features can't be installed: {0}.
-ERROR_NO_DERIVED_PLATFORM.explanation=Platform was not set, or couldn't be derived from existing versioned features. 
+ERROR_NO_DERIVED_PLATFORM.explanation= The platform was not set or couldn't be derived from existing versioned features. 
 ERROR_NO_DERIVED_PLATFORM.useraction=Add platform for versionless features
 

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ExceptionUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ExceptionUtils.java
@@ -715,25 +715,14 @@ public class ExceptionUtils {
                 sb.append(Messages.INSTALL_KERNEL_MESSAGES.getMessage("ERROR_MISSING_PLATFORM_NAME", missing)).append("\n");
             }
         }
-        String missingFeatures = createMissingFeatureString(e.getTopLevelFeaturesNotResolved());
         if (!e.getMissingBasePlatforms().isEmpty()) {
-            sb.append(Messages.INSTALL_KERNEL_MESSAGES.getMessage("ERROR_NO_DERIVED_PLATFORM", missingFeatures)).append("\n");
+            for (Map.Entry<String, Set<String>> noPlatformVersionless : e.getMissingBasePlatforms().entrySet()) {
+                sb.append(Messages.INSTALL_KERNEL_MESSAGES.getMessage("ERROR_NO_DERIVED_PLATFORM", noPlatformVersionless.getValue())).append("\n");
+            }
         }
 
         String msg = sb.toString();
         return msg;
-    }
-
-    /**
-     * @param collection
-     * @return
-     */
-    protected static String createMissingFeatureString(Collection<String> missingFeatures) {
-        StringBuilder sb = new StringBuilder();
-        for (String missing : missingFeatures) {
-            sb.append(missing).append(" ");
-        }
-        return sb.toString().trim();
     }
 
     /**

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallKernelMap.java
@@ -1052,8 +1052,10 @@ public class InstallKernelMap implements Map {
             data.put(InstallConstants.ACTION_RESULT, ERROR);
             InstallException ie = ExceptionUtils.create(e, e.getTopLevelFeaturesNotResolved(), (File) data.get(InstallConstants.RUNTIME_INSTALL_DIR), false, isOpenLiberty,
                                                         isFeatureUtility);
-            data.put(InstallConstants.ACTION_ERROR_MESSAGE, ie.getMessage());
-            data.put(InstallConstants.ACTION_EXCEPTION_STACKTRACE, ExceptionUtils.stacktraceToString(ie));
+            if (ie != null) {
+                data.put(InstallConstants.ACTION_ERROR_MESSAGE, ie.getMessage());
+                data.put(InstallConstants.ACTION_EXCEPTION_STACKTRACE, ExceptionUtils.stacktraceToString(ie));
+            }
         } catch (InstallException e) {
             data.put(InstallConstants.ACTION_RESULT, ERROR);
             data.put(InstallConstants.ACTION_ERROR_MESSAGE, e.getMessage());

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
@@ -284,15 +284,6 @@ public class RepositoryResolutionException extends RepositoryException {
     public String getMessage() {
         StringBuilder sb = new StringBuilder();
 
-        if (!getMissingPlatforms().isEmpty()) {
-            for (String missing : getMissingPlatforms()) {
-                sb.append("Platform: ").append(missing).append(" couldn't be found, no versionless features will be resolved").append("\n");
-            }
-        }
-        if (getResolvedPlatforms().isEmpty() && getMissingPlatforms().isEmpty()) {
-            sb.append("Platform couldn't be determined, no versionless features will be resolved").append("\n");
-        }
-
         for (String missing : getTopLevelFeaturesNotResolved()) {
             sb.append("Top level feature not resolved: resource=").append(missing).append("\n");
         }
@@ -373,6 +364,7 @@ public class RepositoryResolutionException extends RepositoryException {
 
     /**
      * This states the target platforms that were used during the resolution
+     *
      * @return the resolvedPlatforms
      */
     public Set<String> getResolvedPlatforms() {
@@ -381,6 +373,7 @@ public class RepositoryResolutionException extends RepositoryException {
 
     /**
      * This describes missspelled or unknown platform names, official names are collected by the feature metadata
+     *
      * @return the missingPlatforms
      */
     public Set<String> getMissingPlatforms() {
@@ -389,6 +382,7 @@ public class RepositoryResolutionException extends RepositoryException {
 
     /**
      * This describes base platforms like "jakartaee" that are not derived, either by passed platform values, or by other included versioned features
+     *
      * @return the missingBasePlatforms
      */
     public List<String> getMissingBasePlatforms() {

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolutionException.java
@@ -15,7 +15,6 @@ package com.ibm.ws.repository.resolver;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -44,7 +43,7 @@ public class RepositoryResolutionException extends RepositoryException {
     private final Map<String, Collection<Chain>> featureConflicts;
     private Set<String> resolvedPlatforms;
     private Set<String> missingPlatforms;
-    private List<String> missingBasePlatforms;
+    private Map<String, Set<String>> missingBasePlatforms;
 
     /**
      * @param cause
@@ -79,7 +78,7 @@ public class RepositoryResolutionException extends RepositoryException {
     public RepositoryResolutionException(ResolutionException cause, Collection<String> topLevelFeaturesNotResolved, Collection<String> allRequirementsNotFound,
                                          Collection<ProductRequirementInformation> missingProductInformation, Collection<MissingRequirement> allRequirementsResourcesNotFound,
                                          Map<String, Collection<Chain>> featureConflicts, Set<String> resolvedPlatforms, Set<String> missingPlatforms,
-                                         List<String> missingBasePlatforms) {
+                                         Map<String, Set<String>> missingBasePlatforms) {
         super(cause);
         this.topLevelFeaturesNotResolved = topLevelFeaturesNotResolved;
         this.allRequirementsNotFound = allRequirementsNotFound;
@@ -381,11 +380,12 @@ public class RepositoryResolutionException extends RepositoryException {
     }
 
     /**
-     * This describes base platforms like "jakartaee" that are not derived, either by passed platform values, or by other included versioned features
+     * This describes a Map of base platforms like "jakartaee" (associated with versionless features) that are not derived, either by passed platform values, or by other included
+     * versioned features
      *
      * @return the missingBasePlatforms
      */
-    public List<String> getMissingBasePlatforms() {
+    public Map<String, Set<String>> getMissingBasePlatforms() {
         return missingBasePlatforms;
     }
 

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -149,6 +149,10 @@ public class RepositoryResolver {
      * returns if versionless features are part of the resolution - used to skip extra processing
      */
     boolean includesVersionless;
+    /**
+     * Map of unresolved base platforms, and the associated passed versionless features
+     */
+    Map<String, Set<String>> missingBasePlatforms;
 
     /**
      * <p>
@@ -501,6 +505,7 @@ public class RepositoryResolver {
         missingRequirements = new ArrayList<>();
         resolverRepository = null;
         featureConflicts = new HashMap<>();
+        missingBasePlatforms = new HashMap<>();
         resolvedPlatforms = new HashSet<>();
         missingPlatforms = new HashSet<>();
         includesVersionless = false;
@@ -572,6 +577,7 @@ public class RepositoryResolver {
             includesVersionless = true;
             resolvedPlatforms = result.getResolvedPlatforms();
             missingPlatforms = result.getMissingPlatforms();
+            missingBasePlatforms = result.getNoPlatformVersionless();
         }
 
         for (String name : result.getResolvedFeatures()) {
@@ -997,25 +1003,6 @@ public class RepositoryResolver {
             && (!includesVersionless || ((!resolvedPlatforms.isEmpty()) && (missingPlatforms.isEmpty())))) {
             // Everything went fine!
             return;
-        }
-
-        List<String> missingBasePlatforms = new ArrayList<String>();
-
-        // Versionless features can't be resolved if a corresponding platform is not derived, making the choice ambiguous, and the feature won't be included in the resolved list.  -  will gather the associated platform unable to target.
-        if (includesVersionless) {
-            for (String name : missingTopLevelRequirements) {
-                ProvisioningFeatureDefinition feature = resolverRepository.getFeature(name);
-                if (feature != null && feature.isVersionless()) {
-                    List<ProvisioningFeatureDefinition> featureChildren = resolverRepository.findAllPossibleVersions(feature);
-                    if (!featureChildren.isEmpty()) {
-                        ProvisioningFeatureDefinition firstChild = featureChildren.get(0);
-                        String plat = firstChild.getPlatformName();
-                        if (plat != null) {//This will add just the platform name without version
-                            missingBasePlatforms.add(resolverRepository.getFeatureBaseName(plat));
-                        }
-                    }
-                }
-            }
         }
 
         Set<ProductRequirementInformation> missingProductInformation = new HashSet<>();


### PR DESCRIPTION
This PR has changes reacting to results coming from the installServer Action possibly including versionless / platforms in the server.xml.

2 new Messages have been added explaining issues with bad platform names and the possibility no platform could be determined with the collection of passed features.

The existing messages in place take care of other scenarios like feature not found, resoltion problems etc...  so no change there.

2 new tests were also added that look for the new messages, The fat tests in general were restructured to use one of two repo's, the later is a new copy containing versionless features - Versionless tests are using the new local repo.