### PR TITLE
 record as IdClass

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -14,7 +14,9 @@ package io.openliberty.data.internal.persistence;
 
 import static jakarta.data.repository.By.ID;
 
-import java.lang.reflect.Field;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.lang.reflect.Member;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -106,7 +108,6 @@ public abstract class EntityManagerBuilder {
                 Queue<List<Member>> relationAccessors = new LinkedList<>();
                 Class<?> recordClass = getRecordClass(entityType.getJavaType());
                 Class<?> idType = null;
-                SortedMap<String, Member> idClassAttributeAccessors = null;
                 String versionAttrName = null;
 
                 for (Attribute<?, ?> attr : entityType.getAttributes()) {
@@ -205,6 +206,7 @@ public abstract class EntityManagerBuilder {
                     }
                 }
 
+                SortedMap<String, Member> idClassAttributeAccessors = null;
                 if (!entityType.hasSingleIdAttribute()) {
                     // Per JavaDoc, the above means there is an IdClass.
                     // An EclipseLink extension that allows an Id on an embeddable of an entity
@@ -216,14 +218,7 @@ public abstract class EntityManagerBuilder {
                         if (idClassAttributes != null) {
                             attributeNames.remove(ID);
                             idType = idClassType.getJavaType();
-                            idClassAttributeAccessors = new TreeMap<>();
-                            for (SingularAttribute<?, ?> attr : idClassAttributes) {
-                                Member entityMember = attr.getJavaMember();
-                                Member idClassMember = entityMember instanceof Field //
-                                                ? idType.getField(entityMember.getName()) //
-                                                : idType.getMethod(entityMember.getName());
-                                idClassAttributeAccessors.put(attr.getName().toLowerCase(), idClassMember);
-                            }
+                            idClassAttributeAccessors = getIdClassAccessors(idType, idClassAttributes);
                         }
                     }
                 }
@@ -267,6 +262,35 @@ public abstract class EntityManagerBuilder {
      * @throws UnsupportedOperationException if the DataSource cannot be obtained from the EntityManager.
      */
     public abstract DataSource getDataSource();
+
+    @FFDCIgnore(NoSuchFieldException.class)
+    private static final SortedMap<String, Member> getIdClassAccessors(Class<?> idType,
+                                                                       Set<SingularAttribute<?, ?>> idClassAttributes) //
+                    throws IntrospectionException, NoSuchFieldException, NoSuchMethodException, SecurityException {
+        SortedMap<String, Member> accessors = new TreeMap<>();
+        boolean isIdClassRecord = idType.isRecord();
+        for (SingularAttribute<?, ?> attr : idClassAttributes) {
+            String entityAttrName = attr.getName();
+            Member idClassMember = null;;
+            if (isIdClassRecord)
+                idClassMember = idType.getMethod(entityAttrName);
+            else
+                try {
+                    idClassMember = idType.getField(entityAttrName);
+                } catch (NoSuchFieldException x) {
+                    for (PropertyDescriptor pd : Introspector.getBeanInfo(idType).getPropertyDescriptors())
+                        if (entityAttrName.equals(pd.getName())) {
+                            idClassMember = pd.getReadMethod();
+                            break;
+                        }
+                    if (idClassMember == null)
+                        throw x;
+                }
+
+            accessors.put(entityAttrName.toLowerCase(), idClassMember);
+        }
+        return accessors;
+    }
 
     /**
      * Returns the record class that corresponds to the specified generated entity class.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1184,33 +1184,41 @@ public class QueryInfo {
                 }
 
                 if (singleAttributeName == null) {
-                    // Construct new instance for record or IdClass
-                    q.append("SELECT NEW ").append(singleType.getName()).append('(');
-                    RecordComponent[] recordComponents;
-                    boolean first = true;
-                    if ((recordComponents = singleType.getRecordComponents()) != null)
-                        for (RecordComponent component : recordComponents) {
-                            String name = component.getName();
-                            q.append(first ? "" : ", ").append(o_).append(name);
-                            first = false;
-                        }
-                    else if (entityInfo.idClassAttributeAccessors != null && singleType.equals(entityInfo.idType))
-                        // TODO determine correct order of idClass attributes for constructor (possibly based on type?)
-                        // instead of guessing they are alphabetized?
-                        for (String idClassAttributeName : entityInfo.idClassAttributeAccessors.keySet()) {
-                            String name = entityInfo.getAttributeName(idClassAttributeName, true);
-                            q.append(first ? "" : ", ").append(o_).append(name);
-                            first = false;
-                        }
-                    else
-                        throw new MappingException("The " + method.getName() + " method of the " +
-                                                   method.getDeclaringClass().getName() + " repository specifies the " +
-                                                   singleType.getName() + " result type, which is not convertible from the " +
-                                                   entityInfo.entityClass.getName() + " entity type. A repository method " +
-                                                   "result type must be the entity type, an entity attribute type, or a " +
-                                                   "Java record with attribute names that are a subset of the entity attribute names, " +
-                                                   "or the Query annotation must be used to construct the result type with JPQL."); // TODO NLS
-                    q.append(')');
+                    // TODO enable this once #29073 is fixed
+                    //if (entityInfo.idClassAttributeAccessors != null && singleType.equals(entityInfo.idType)) {
+                    //    // IdClass
+                    //    q.append("SELECT ID(THIS)");
+                    // } else
+                    {
+                        // Construct new instance for record
+                        q.append("SELECT NEW ").append(singleType.getName()).append('(');
+                        RecordComponent[] recordComponents;
+                        boolean first = true;
+                        if ((recordComponents = singleType.getRecordComponents()) != null)
+                            for (RecordComponent component : recordComponents) {
+                                String name = component.getName();
+                                q.append(first ? "" : ", ").append(o_).append(name);
+                                first = false;
+                            }
+                        // TODO remove else block once #29073 is fixed
+                        else if (entityInfo.idClassAttributeAccessors != null && singleType.equals(entityInfo.idType))
+                            // The following guess of alphabetic order is not valid in most cases, but the
+                            // whole code block that will be removed before GA, so there is no reason to correct it.
+                            for (String idClassAttributeName : entityInfo.idClassAttributeAccessors.keySet()) {
+                                String name = entityInfo.getAttributeName(idClassAttributeName, true);
+                                q.append(first ? "" : ", ").append(o_).append(name);
+                                first = false;
+                            }
+                        else
+                            throw new MappingException("The " + method.getName() + " method of the " +
+                                                       method.getDeclaringClass().getName() + " repository specifies the " +
+                                                       singleType.getName() + " result type, which is not convertible from the " +
+                                                       entityInfo.entityClass.getName() + " entity type. A repository method " +
+                                                       "result type must be the entity type, an entity attribute type, or a " +
+                                                       "Java record with attribute names that are a subset of the entity attribute names, " +
+                                                       "or the Query annotation must be used to construct the result type with JPQL."); // TODO NLS
+                        q.append(')');
+                    }
                 } else {
                     q.append("SELECT ").append(o_).append(singleAttributeName);
                 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CityId.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CityId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 package test.jakarta.data.jpa.web;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Id class for City entity.
@@ -20,15 +21,39 @@ public class CityId implements Serializable {
 
     public String name;
 
-    public String stateName;
+    private String stateName;
+
+    public CityId() {
+    }
 
     public CityId(String name, String state) {
         this.name = name;
         this.stateName = state;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        CityId c;
+        return CityId.class.equals(o.getClass()) &&
+               Objects.equals(name, (c = (CityId) o).name) &&
+               Objects.equals(stateName, c.stateName);
+    }
+
+    public String getStateName() {
+        return stateName;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, stateName);
+    }
+
     public static CityId of(String name, String state) {
         return new CityId(name, state);
+    }
+
+    public void setStateName(String v) {
+        stateName = v;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCard.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCard.java
@@ -28,15 +28,7 @@ public class CreditCard {
         AmericanExtravagance, Discrooger, MonsterCard, Feesa
     }
 
-    public static class CardId {
-        public Issuer issuer;
-        public long number;
-
-        public CardId(Issuer issuer, long number) {
-            this.issuer = issuer;
-            this.number = number;
-        }
-
+    public static record CardId(Issuer issuer, long number) {
         @Override
         public String toString() {
             return issuer + " card #" + number;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -657,7 +657,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, ids.hasNext());
         id = ids.next();
-        assertEquals("South Dakota", id.stateName);
+        assertEquals("South Dakota", id.getStateName());
         if (supportsOrderByForUpdate)
             assertEquals("Aberdeen", id.name);
         // else order is unknown, but at least must be one of the city names that we added and haven't removed yet
@@ -665,7 +665,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, ids.hasNext());
         id = ids.next();
-        assertEquals("South Dakota", id.stateName);
+        assertEquals("South Dakota", id.getStateName());
         if (supportsOrderByForUpdate)
             assertEquals("Brookings", id.name);
         // else order is unknown, but at least must be one of the city names that we added and haven't removed yet
@@ -673,7 +673,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, ids.hasNext());
         id = ids.next();
-        assertEquals("South Dakota", id.stateName);
+        assertEquals("South Dakota", id.getStateName());
         if (supportsOrderByForUpdate)
             assertEquals("Mitchell", id.name);
         // else order is unknown, but at least must be one of the city names that we added and haven't removed yet
@@ -683,14 +683,14 @@ public class DataJPATestServlet extends FATServlet {
 
         Order<City> orderByPopulation = supportsOrderByForUpdate ? Order.by(Sort.asc("population")) : Order.by();
         id = cities.deleteFirstByStateName("South Dakota", orderByPopulation).orElseThrow();
-        assertEquals("South Dakota", id.stateName);
+        assertEquals("South Dakota", id.getStateName());
         if (supportsOrderByForUpdate)
             assertEquals("Spearfish", id.name);
         // else order is unknown, but at least must be one of the city names that we added and haven't removed yet
         assertEquals("Found " + id, true, cityNames.remove(id.name));
 
         id = cities.deleteByStateName("South Dakota", Limit.of(1));
-        assertEquals("South Dakota", id.stateName);
+        assertEquals("South Dakota", id.getStateName());
         assertEquals("Found " + id, true, cityNames.remove(id.name));
 
         List<CityId> some = cities.deleteSome("South Dakota", Limit.of(2));
@@ -698,12 +698,12 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, ids.hasNext());
         id = ids.next();
-        assertEquals("South Dakota", id.stateName);
+        assertEquals("South Dakota", id.getStateName());
         assertEquals("Found " + id, true, cityNames.remove(id.name));
 
         assertEquals(true, ids.hasNext());
         id = ids.next();
-        assertEquals("South Dakota", id.stateName);
+        assertEquals("South Dakota", id.getStateName());
         assertEquals("Found " + id, true, cityNames.remove(id.name));
 
         assertEquals(false, ids.hasNext());
@@ -714,7 +714,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, ids.hasNext());
         id = ids.next();
-        assertEquals("South Dakota", id.stateName);
+        assertEquals("South Dakota", id.getStateName());
         assertEquals("Found " + id, true, cityNames.remove(id.name));
 
         assertEquals(false, ids.hasNext());
@@ -741,15 +741,15 @@ public class DataJPATestServlet extends FATServlet {
 
         CityId id = ids.next();
         assertEquals("Davenport", id.name);
-        assertEquals("Iowa", id.stateName);
+        assertEquals("Iowa", id.getStateName());
 
         id = ids.next();
         assertEquals("Iowa City", id.name);
-        assertEquals("Iowa", id.stateName);
+        assertEquals("Iowa", id.getStateName());
 
         id = ids.next();
         assertEquals("Sioux City", id.name);
-        assertEquals("Iowa", id.stateName);
+        assertEquals("Iowa", id.getStateName());
 
         removed = cities.deleteByStateName("Iowa");
 
@@ -1905,7 +1905,7 @@ public class DataJPATestServlet extends FATServlet {
         // single result
         CityId cityId = cities.findFirstByNameOrderByPopulationDesc("Springfield");
         assertEquals("Springfield", cityId.name);
-        assertEquals("Missouri", cityId.stateName);
+        assertEquals("Missouri", cityId.getStateName());
 
         // Stream result
         assertIterableEquals(List.of("Springfield, Oregon",


### PR DESCRIPTION
As of Jakarta Persistence 3.2, a record can be used as the IdClass.
Add this ability to Jakarta Data.
This PR also adds the ability for an IdClass to identify components of the id via accessor methods rather than fields.
Also, we should be able to use `ID(THIS)` to select the id when using IdClass, but it's broken in EclipseLink.  I added some commented-out code to enable once that is fixed.