### PR TITLE
Allow mixed connection manager pools

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
@@ -167,14 +167,18 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
     public void addObserver(Observer observer) {
         super.addObserver(observer);
         if (countObservers() > 1) {
-//            super.deleteObserver(observer);
             AbstractConnectionFactoryService cfSvc = (AbstractConnectionFactoryService) observer;
             Object[] params = new Object[] { CONNECTION_MANAGER, name, cfSvc.getConfigElementName() };
+			// TODO - After adding additional automated testing to ensure the working behavior is valid, we may decide to remove this warning/failure,
+			// since customers may already be successfully using a mixed connection pool with ignore or warn.
             RuntimeException failure = connectorSvc.ignoreWarnOrFail(tc, null, UnsupportedOperationException.class, "CARDINALITY_ERROR_J2CA8040", params);
-            if (failure != null)
+            if (failure != null) {
+                super.deleteObserver(observer); // only delete observer if throwing exception
                 throw failure;
+            }
+            this.pm.mixedConnectionPool = true; // set mixedConnectionPool to true for added trace information in the poolmanager.
         }
-    }
+	}
 
     /**
      * Create and initialize the connection manager/pool configuration

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -167,7 +167,7 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
     public void addObserver(Observer observer) {
         super.addObserver(observer);
         if (countObservers() > 1) {
-            super.deleteObserver(observer);
+//            super.deleteObserver(observer);
             AbstractConnectionFactoryService cfSvc = (AbstractConnectionFactoryService) observer;
             Object[] params = new Object[] { CONNECTION_MANAGER, name, cfSvc.getConfigElementName() };
             RuntimeException failure = connectorSvc.ignoreWarnOrFail(tc, null, UnsupportedOperationException.class, "CARDINALITY_ERROR_J2CA8040", params);

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectorServiceImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectorServiceImpl.java
@@ -189,9 +189,13 @@ public class ConnectorServiceImpl extends ConnectorService {
                     Tr.debug(tc, "ignoring error: " + msgKey, objs);
                 return null;
             case WARN:
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(tc, "warning error: " + msgKey, objs);
                 Tr.warning(tc, msgKey, objs);
                 return null;
             case FAIL:
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(tc, "fail error: " + msgKey, objs);
                 try {
                     if (throwable != null && exceptionClassToRaise.isInstance(throwable))
                         return exceptionClassToRaise.cast(throwable);

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManager.java
@@ -76,6 +76,7 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
     protected static final String alertResourceBundleName = "com.ibm.ws.j2c.resources.J2CAMessages";
 
     final String nl = CommonFunction.nl;
+    protected boolean mixedConnectionPool = false;
 
     final ConnectorServiceImpl connectorSvc;
     protected J2CGlobalConfigProperties gConfigProps;
@@ -1076,6 +1077,9 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
             sbuff.append(nl);
             sbuff.append(" Connection Request Information = ");
             sbuff.append(requestInfo);
+            if (mixedConnectionPool) {
+                Tr.debug(this, tc, "Mixed connection pool, using managed connection factory " + managedConnectionFactory);
+            }
             Tr.debug(this, tc, sbuff.toString());
             Tr.debug(this, tc, "reserve(), Pool contents ==> " + this.toString2(1));
 

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
@@ -1314,6 +1314,159 @@ public class ConfigTest extends FATServletClient {
     }
 
     /**
+     * Use two data sources using same connection manager with onError warn.
+     *
+     * This test is depended on which data source is used first.
+     *
+     * Checks to see if the right connections are being matched.
+     *
+     * testOnErrorWorkingTwoDSorderA uses order
+     * 1. lookup jdbc/dsfat11amixedpoolderby
+     * 2. lookup jdbc/dsfat11bmixedpoolderby
+     *
+     * related test
+     *
+     * testOnErrorWorkingTwoDSorderB uses the reverse order
+     * 1. lookup jdbc/dsfat11bmixedpoolderby
+     * 2. lookup jdbc/dsfat11amixedpoolderby
+     *
+     * @throws Throwable if it fails.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testOnErrorWorkingTwoDSorderA() throws Throwable {
+        String method = "testOnErrorWorkingTwoDSorderA";
+        Log.info(c, method, "Executing " + method);
+
+        restartServer(); // order depended test, need to restart server.
+        String onErrorString = "WARN";
+        String originalonErrorValue = setonErrorValue(method, onErrorString); // ensure WARN is used
+        Log.info(c, method, "originalonErrorValue=" + originalonErrorValue);
+
+        try {
+            runTest(basicfat, "testOnErrorWorkingTwoDSorderA");
+        } catch (Throwable x) {
+            System.out.println("Failure during " + method + " with the following config:");
+            ServerConfiguration config = server.getServerConfiguration();
+            System.out.println(config);
+            throw x;
+        }
+
+        List<String> messages = server.findStringsInLogs("J2CA8040E");
+        if (messages.isEmpty())
+            throw new Exception("Did not find J2CA8040E for multiple dataSources (dsfat11amixedpoolderby and dsfat11bmixedpoolderby) using same connectionManager.");
+        else
+            Log.info(c, method, "Found expected: " + messages);
+    }
+
+    /**
+     * Use two data sources using same connection manager with onError warn.
+     *
+     * This test is depended on which data source is used first.
+     *
+     * Checks to see if the right connections are being matched.
+     *
+     * testOnErrorWorkingTwoDSorderB uses the order
+     * 1. lookup jdbc/dsfat11bmixedpoolderby
+     * 2. lookup jdbc/dsfat11amixedpoolderby
+     *
+     * related test
+     *
+     * testOnErrorWorkingTwoDSorderA uses the reverse order
+     * 1. lookup jdbc/dsfat11amixedpoolderby
+     * 2. lookup jdbc/dsfat11bmixedpoolderby
+     *
+     * @throws Throwable if it fails.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testOnErrorWorkingTwoDSorderB() throws Throwable {
+        String method = "testOnErrorWorkingTwoDSorderB";
+        Log.info(c, method, "Executing " + method);
+
+        restartServer(); // order depended test, need to restart server.
+        String onErrorString = "WARN";
+        String originalonErrorValue = setonErrorValue(method, onErrorString); // ensure WARN is used
+        Log.info(c, method, "originalonErrorValue=" + originalonErrorValue);
+
+        try {
+            runTest(basicfat, "testOnErrorWorkingTwoDSorderB");
+        } catch (Throwable x) {
+            System.out.println("Failure during " + method + " with the following config:");
+            ServerConfiguration config = server.getServerConfiguration();
+            System.out.println(config);
+            throw x;
+        }
+
+        List<String> messages = server.findStringsInLogs("J2CA8040E");
+        if (messages.isEmpty())
+            throw new Exception("Did not find J2CA8040E for multiple dataSources (dsfat11amixedpoolderby and dsfat11bmixedpoolderby) using same connectionManager.");
+        else
+            Log.info(c, method, "Found expected: " + messages);
+    }
+
+    /**
+     * Restart the server with the required database configuration.
+     *
+     * @throws Exception
+     */
+    private void restartServer() throws Exception {
+        try {
+            server.stopServer(ALLOWED_MESSAGES);
+            //Get driver type
+            server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
+            server.addEnvVar("ANON_DRIVER", "driver" + DatabaseContainerType.valueOf(testContainer).ordinal() + ".jar");
+            server.addEnvVar("DB_USER", testContainer.getUsername());
+            server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
+
+        } finally {
+            server.startServer();
+        }
+    }
+
+    /**
+     * The variable onError used in server.xml can have some interesting behaviors.
+     *
+     * The default when its not set in server.xml is WARN.
+     *
+     * This method can help to set onError to FAIL, WARN, or IGNORE only if the value is
+     * exists in the server.xml.
+     *
+     * The return value can be null if its not set in server.xml, otherwise, if required, it will return
+     * the original value to be able to reset onError back to its original state at the end
+     * of the test. An alternative to resetting the value is restarting the server
+     *
+     * @param method
+     * @param onErrorString
+     * @throws Exception
+     * @throws Throwable
+     */
+
+    private String setonErrorValue(String method, String onErrorString) throws Exception, Throwable {
+        ServerConfiguration config = server.getServerConfiguration();
+        String originalValue = null;
+        Variable onError = null;
+        for (Variable variable : config.getVariables())
+            if (variable.getName().equals("onError"))
+                onError = variable;
+        if (onError != null) {
+            originalValue = onError.getValue();
+            onError.setValue(onErrorString);
+
+            try {
+                updateServerConfig(config, EMPTY_EXPR_LIST);
+            } catch (Throwable x) {
+                Log.info(c, method, "Failure during " + method + " with the following config:");
+                Log.info(c, method, config.toString());
+                throw x;
+            }
+        } else {
+            Log.info(c, method, "Variable onError not set in server.xml, onError defaults to WARN");
+        }
+        return originalValue;
+    }
+
+    /**
      * Update the data source configuration while the server is running.
      * Uses <file> element
      *

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
@@ -172,6 +172,16 @@
     <dataSource id="dsfat11derby" jndiName="jdbc/dsfat11" jdbcDriverRef="Derby" connectionManagerRef="conMgr5" badProperty="badValue1" isolationLevel="TRANSACTION_READ_UNCOMMITTED" queryTimeout="11s" syncQueryTimeoutWithTransactionTimeout="false">
       <properties.derby.embedded databaseName="${shared.resource.dir}/data/derbyfat" createDatabase="create" badVendorProperty="badValue2" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
+    
+	<!-- This Derby-only datasource for expanded mixed pool testing and the current J2CA8040E behavior -->
+    <connectionManager id="conMgr5mixedpool"/>
+    <dataSource id="dsfat11amixedpoolderby" jndiName="jdbc/dsfat11amixedpoolderby" jdbcDriverRef="Derby" connectionManagerRef="conMgr5mixedpool" isolationLevel="TRANSACTION_READ_UNCOMMITTED" queryTimeout="14s" syncQueryTimeoutWithTransactionTimeout="false">
+      <properties.derby.embedded databaseName="${shared.resource.dir}/data/derbyfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+    </dataSource>
+    <dataSource id="dsfat11bmixedpoolderby" jndiName="jdbc/dsfat11bmixedpoolderby" jdbcDriverRef="Derby" connectionManagerRef="conMgr5mixedpool" isolationLevel="TRANSACTION_READ_UNCOMMITTED" queryTimeout="15s" syncQueryTimeoutWithTransactionTimeout="false">
+      <properties.derby.embedded databaseName="${shared.resource.dir}/data/derbyfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+    </dataSource>
+
  
     <!-- This is a Derby-only data source -->
     <dataSource id="dsfat12derby" jndiName="jdbc/dsfat12" containerAuthDataRef="derbyAuth2" jdbcDriverRef="Derby" >


### PR DESCRIPTION
Currently when connection factories and datasources are created a one to one relationship is expected and the J2CA8040E is thrown if <variable name="onError" value="FAIL"/> or a warning message when <variable name="onError" value="WARN"/>.

The FAIL path worked as expected with the second connection factory or datasource not being created.   But with WARN, the second connection factory or datasource is created.   Because the connection manager objects are created and by design the connection manager pools can handle a mixed pool environment.

I have completed some testing and believe at this time we may be able to remove this restriction in increments with this first change that keeps the behavior the same, but adds observers for the additional connection factories or datasources using the same connection managers. 

Follow on tests will need to be added to make sure the behavior is as expected and the full removal of the J2CA8040E may be completed