### PR TITLE
versionless features fix errors CWWKF0054E and CWWKF0055E

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -780,10 +780,10 @@ public class FeatureResolverImpl implements FeatureResolver {
                     if(versionedFeature == null || versionedFeature.getVisibility() != Visibility.PUBLIC || versionedFeature.getPlatformName() == null){
                         continue;
                     }
-                    platformBase = parseName(versionedFeature.getPlatformName());
-                    String compatibilityBase = selectionContext.getCompatibilityBaseName(platformBase);
+
+                    platformBase = selectionContext.getCompatibilityBaseName(parseName(versionedFeature.getPlatformName()));
                     
-                    if(multiplePlatforms.contains(compatibilityBase)){
+                    if(multiplePlatforms.contains(platformBase)){
                         hasMultiplePlatforms = true;
                         break;
                     }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureRepository.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureRepository.java
@@ -423,22 +423,22 @@ public final class FeatureRepository implements FeatureResolver.Repository {
      * 
      * @return String platformBaseName
      */
-    public String getPlatformForVersionlessFeature(String versionlessFeatureName){
+    public Set<String> getPlatformsForVersionlessFeature(String versionlessFeatureName){
         ProvisioningFeatureDefinition versionlessFeature = getFeature(versionlessFeatureName);
+        Set<String> platforms = new HashSet<String>();
+
 
         if (versionlessFeature != null && versionlessFeature.isVersionless()) {
             for (ProvisioningFeatureDefinition child : findAllPossibleVersions(versionlessFeature)) {
                 if(child == null){
                     continue;
                 }
-                String plat = child.getPlatformName();
-                if(plat != null && plat.indexOf("-") != -1){
-                    return getFeatureBaseName(plat);
-                }
+                platforms.addAll(child.getPlatformNames());
+                
             }
         }
 
-        return null;
+        return platforms;
     }
 
     /**
@@ -534,7 +534,7 @@ public final class FeatureRepository implements FeatureResolver.Repository {
      * @param nameAndVersion the feature symbolic name
      * @return the feature symbolic name with any version stripped
      */
-    private String getFeatureBaseName(String nameAndVersion) {
+    public String getFeatureBaseName(String nameAndVersion) {
         int dashPosition = nameAndVersion.lastIndexOf('-');
         if (dashPosition != -1) {
             return nameAndVersion.substring(0, dashPosition);


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

If a platform is specified, the CWWKF0055E error should not get spit out. The CWWKF0054E error should consistently get spit out of a versionless feature does not have a version for the resolved platform.