### PR TITLE
Ignore `FirstX` keyword for delete queries

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2246,7 +2246,6 @@ public class QueryInfo {
                                                             " return type is not supported for the " + methodName +
                                                             " repository method."); // TODO NLS
                 type = Type.FIND_AND_DELETE;
-                parseDeleteBy(by);
                 q = generateSelectClause().append(" FROM ").append(entityInfo.name).append(' ').append(o);
                 jpqlDelete = generateDeleteById();
             } else { // DELETE
@@ -2412,20 +2411,6 @@ public class QueryInfo {
                                    " cannot be used with sort criteria of " + sorts +
                                    " because they have different numbers of elements. The keyset size is " + keysetCursor.size() +
                                    " and the sort criteria size is " + sorts.size() + "."); // TODO NLS
-    }
-
-    /**
-     * Parses and handles the text between delete___By of a repository method.
-     * Currently this is only "First" or "First#".
-     *
-     * @param by index of first occurrence of "By" in the method name. -1 if "By" is absent.
-     */
-    private void parseDeleteBy(int by) {
-        String methodName = method.getName();
-        if (methodName.regionMatches(6, "First", 0, 5)) {
-            int endBefore = by == -1 ? methodName.length() : by;
-            parseFirst(11, endBefore);
-        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1286,13 +1286,13 @@ public class DataTestServlet extends FATServlet {
         remaining.addAll(Set.of(80008, 80080, 80081, 80088));
 
         Sort<Package> sort = supportsOrderByForUpdate ? Sort.desc("width") : null;
-        Integer id = packages.deleteFirst(sort).orElseThrow();
+        Integer id = packages.delete1(Limit.of(1), sort).orElseThrow();
         if (supportsOrderByForUpdate)
             assertEquals(Integer.valueOf(80080), id);
         assertEquals("Found " + id + "; expected one of " + remaining, true, remaining.remove(id));
 
         Sort<?>[] sorts = supportsOrderByForUpdate ? new Sort[] { Sort.desc("height"), Sort.asc("length") } : null;
-        int[] ids = packages.deleteFirst2(sorts);
+        int[] ids = packages.delete2(Limit.of(2), sorts);
         assertEquals(Arrays.toString(ids), 2, ids.length);
         if (supportsOrderByForUpdate) {
             assertEquals(80081, ids[0]);
@@ -1302,7 +1302,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals("Found " + ids[1] + "; expected one of " + remaining, true, remaining.remove(ids[1]));
 
         // should have only 1 remaining
-        ids = packages.deleteFirst2(sorts);
+        ids = packages.delete2(Limit.of(2), sorts);
         assertEquals(Arrays.toString(ids), 1, ids.length);
         assertEquals(remaining.iterator().next(), Integer.valueOf(ids[0]));
     }
@@ -1320,21 +1320,21 @@ public class DataTestServlet extends FATServlet {
         Sort<Package> sort = Sort.asc("id");
 
         try {
-            long[] deleted = packages.deleteFirst3(sort);
+            long[] deleted = packages.delete3(Limit.of(3), sort);
             fail("Deleted with return type of long[]: " + Arrays.toString(deleted) + " even though the id type is int.");
         } catch (MappingException x) {
             // expected
         }
 
         try {
-            List<String> deleted = packages.deleteFirst4(sort);
+            List<String> deleted = packages.delete4(Limit.of(4), sort);
             fail("Deleted with return type of List<String>: " + deleted + " even though the id type is int.");
         } catch (MappingException x) {
             // expected
         }
 
         try {
-            Collection<Number> deleted = packages.deleteFirst5(sort);
+            Collection<Number> deleted = packages.delete5(Limit.of(5), sort);
             fail("Deleted with return type of Collection<Number>: " + deleted + " even though the id type is int.");
         } catch (MappingException x) {
             // expected
@@ -1377,7 +1377,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals("Found " + p.id + "; expected one of " + remaining, true, remaining.remove(p.id));
 
         Sort<?>[] sorts = supportsOrderByForUpdate ? new Sort[] { Sort.desc("height"), Sort.asc("length") } : null;
-        LinkedList<?> deletesList = packages.deleteFirst2ByHeightLessThan(8.0f, sorts);
+        LinkedList<?> deletesList = packages.delete2ByHeightLessThan(8.0f, Limit.of(2), sorts);
         assertEquals("Deleted " + deletesList, 2, deletesList.size());
         Package p0 = (Package) deletesList.get(0);
         Package p1 = (Package) deletesList.get(1);
@@ -3446,7 +3446,7 @@ public class DataTestServlet extends FATServlet {
                                      .collect(Collectors.toList()));
 
         assertEquals(List.of("Impreza", "HR-V"),
-                     vehicles.deleteFirst2FoundOrderByPriceAscVinIdAsc()
+                     vehicles.deleteFoundOrderByPriceAscVinIdAsc(Limit.of(2))
                                      .stream()
                                      .map(v -> v.model)
                                      .collect(Collectors.toList()));

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -634,6 +634,34 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Query by method name with deleteFirstX prefix - ensure First keywork is ignored
+     */
+    @Test
+    public void testDeleteIgnoresFirstKeywork() {
+        packages.deleteAll(); //cleanup before test
+
+        packages.save(new Package(10001, 10.0f, 13.0f, 4.0f, "testDeleteIgnoresFirstKeywork#10001"));
+        packages.save(new Package(10002, 11.0f, 12.4f, 4.0f, "testDeleteIgnoresFirstKeywork#10002"));
+        packages.save(new Package(10003, 12.0f, 11.0f, 4.0f, "testDeleteIgnoresFirstKeywork#10003"));
+        packages.save(new Package(10004, 13.0f, 10.0f, 4.0f, "testDeleteIgnoresFirstKeywork#10004"));
+
+        try {
+            Optional<Package> pkg = packages.deleteFirst();
+            fail("Expected packages.deleteFirst() to ignore the 'first' keyword and fail to return a signular result.");
+        } catch (NonUniqueResultException e) {
+            // pass
+        }
+
+        Package pkg = packages.deleteFirst5ByWidthLessThan(11.0f);
+        assertEquals(10004, pkg.id);
+
+        List<Package> pkgs = packages.deleteFirst2();
+        assertEquals(3, pkgs.size());
+
+        assertEquals(0, packages.deleteAll()); //cleanup after test
+    }
+
+    /**
      * Parameter-based query with the Delete annotation.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -62,6 +62,12 @@ public interface Packages extends BasicRepository<Package, Integer> {
 
     Collection<Number> delete5(Limit limit, Sort<Package> sort); // invalid return type is not the entity or id
 
+    List<Package> deleteFirst2(); // 'first2' should be ignored and this should delete all entities
+
+    Package deleteFirst5ByWidthLessThan(float maxWidth); // 'first5' should be ignored and the number of results should be limited by the condition
+
+    Optional<Package> deleteFirst(); // 'first' should be ignored and this should delete all entities (expect failure since the result will be non-unique)
+
     @Delete
     Object[] destroy(Limit limit, Sort<Package> sort);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -50,17 +50,17 @@ public interface Packages extends BasicRepository<Package, Integer> {
     @Query("DELETE FROM Package")
     int deleteEverything();
 
-    Optional<Integer> deleteFirst(Sort<Package> sort);
+    Optional<Integer> delete1(Limit limit, Sort<Package> sort);
 
-    int[] deleteFirst2(Sort<?>... sorts);
+    int[] delete2(Limit limit, Sort<?>... sorts);
 
-    LinkedList<?> deleteFirst2ByHeightLessThan(float maxHeight, Sort<?>... sorts);
+    LinkedList<?> delete2ByHeightLessThan(float maxHeight, Limit limit, Sort<?>... sorts);
 
-    long[] deleteFirst3(Sort<Package> sort); // invalid return type is not the entity or id
+    long[] delete3(Limit limit, Sort<Package> sort); // invalid return type is not the entity or id
 
-    List<String> deleteFirst4(Sort<Package> sort); // invalid return type is not the entity or id
+    List<String> delete4(Limit limit, Sort<Package> sort); // invalid return type is not the entity or id
 
-    Collection<Number> deleteFirst5(Sort<Package> sort); // invalid return type is not the entity or id
+    Collection<Number> delete5(Limit limit, Sort<Package> sort); // invalid return type is not the entity or id
 
     @Delete
     Object[] destroy(Limit limit, Sort<Package> sort);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import jakarta.data.Limit;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
@@ -36,7 +37,7 @@ public interface Vehicles {
 
     List<Vehicle> deleteAll();
 
-    List<Vehicle> deleteFirst2FoundOrderByPriceAscVinIdAsc();
+    List<Vehicle> deleteFoundOrderByPriceAscVinIdAsc(Limit limit);
 
     boolean exists();
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -57,9 +57,9 @@ public interface Cities {
 
     CityId deleteByStateName(String state, Limit limitOf1);
 
-    Optional<CityId> deleteFirstByStateName(String state, Order<City> sorts);
+    Optional<CityId> delete1ByStateName(String state, Limit limit, Order<City> sorts);
 
-    Iterable<CityId> deleteFirst3ByStateName(String state, Order<City> sorts);
+    Iterable<CityId> delete3ByStateName(String state, Limit limit, Order<City> sorts);
 
     @Delete
     List<CityId> deleteSome(@By("stateName") String state,

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -652,7 +652,7 @@ public class DataJPATestServlet extends FATServlet {
         }
 
         Order<City> orderByCityName = supportsOrderByForUpdate ? Order.by(Sort.asc("name")) : Order.by();
-        Iterator<CityId> ids = cities.deleteFirst3ByStateName("South Dakota", orderByCityName).iterator();
+        Iterator<CityId> ids = cities.delete3ByStateName("South Dakota", Limit.of(3), orderByCityName).iterator();
         CityId id;
 
         assertEquals(true, ids.hasNext());
@@ -682,7 +682,7 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(false, ids.hasNext());
 
         Order<City> orderByPopulation = supportsOrderByForUpdate ? Order.by(Sort.asc("population")) : Order.by();
-        id = cities.deleteFirstByStateName("South Dakota", orderByPopulation).orElseThrow();
+        id = cities.delete1ByStateName("South Dakota", Limit.of(1), orderByPopulation).orElseThrow();
         assertEquals("South Dakota", id.getStateName());
         if (supportsOrderByForUpdate)
             assertEquals("Spearfish", id.name);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #29112 
