### PR TITLE
Java record as Embeddable not working

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Point.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Point.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Embeddable;
+
+/**
+ * Java record that is used as an Embeddable by the DirectedLineSegment entity.
+ */
+@Embeddable
+public record Point(int x, int y) {
+    // TODO remove once #29117 is fixed
+    public Point() {
+        this(0, 0);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Segment.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Segment.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * Entity with embeddables that are Java records.
+ */
+@Entity
+public class Segment {
+
+    @GeneratedValue
+    @Id
+    public Long id;
+
+    @Embedded
+    @Column(nullable = false)
+    public Point pointA;
+
+    @Embedded
+    @Column(nullable = false)
+    public Point pointB;
+
+    @Override
+    public String toString() {
+        return "Segment#" + id + " (" +
+               pointA.x() + ", " + pointA.y() + ") -> (" +
+               pointB.x() + ", " + pointB.y() + ")";
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Segments.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Segments.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import jakarta.data.Sort;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Param;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
+
+/**
+ * Repository for an entity with embeddables that are Java records.
+ */
+@Repository
+public interface Segments {
+
+    @Save
+    Segment addOrModify(Segment s);
+
+    // starting West of
+    long countByPointAXLessThan(int xExclusiveMax);
+
+    @Query("WHERE pointB.y < :yExclusiveMax ORDER BY pointB.y ASC, id ASC")
+    Stream<Segment> endingSouthOf(int yExclusiveMax);
+
+    @Delete
+    long erase();
+
+    @Query("WHERE (pointA.x - pointB.x) * (pointA.x - pointB.x)" +
+           "    + (pointA.y - pointB.y) * (pointA.y - pointB.y)" +
+           "    > :len * :len")
+    List<Segment> longerThan(@Param("len") int length,
+                                         Sort<?>... sortBy);
+
+    @Delete
+    long removeStartingAt(@By("pointA.x") int x,
+                          @By("pointA.y") int y);
+
+    @Query("SELECT pointB WHERE id=?1")
+    Optional<Point> terminalPoint(long id);
+}


### PR DESCRIPTION
Added tests in Jakarta Data for embeddables being a Java record, but EclipseLink is broken so the tests are disabled for now.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

