### PR TITLE
Ensure fattest.simpliciy jar updates

### DIFF
--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -43,39 +43,43 @@ task assembleBootstrap(type: Copy) {
     filter(ReplaceTokens, tokens: [JAVA_HOME: javaHome])
 }
 
-task assembleBinaryDependencies(type: Copy) {
+task assembleBinaryDependencyJar(type:Copy) {
+	from jar
+	into new File(buildDir, 'lib')
+	exclude 'buildfiles'
+}
+
+task assembleBinaryDependencyProject(type:Copy) {
+	from configurations.projectDependencies
+	into new File(buildDir, 'lib')
+	rename 'com.ibm.ws.common.encoder.jar', 'fattest.encoder.jar'
+}
+
+task assembleBinaryDependencyMaven(type:Copy) {
 	dependsOn ':cnf:copyMavenLibs'
-	
-	into(new File(buildDir, 'lib'))
-	
-	//fattest.simplicity.jar
-	from(jar) {
-	    exclude 'buildfiles'
-	}
-	
-	//Project dependencies
-	from(configurations.projectDependencies) {
-		rename 'com.ibm.ws.common.encoder.jar', 'fattest.encoder.jar'
-	}
-	
-	//Maven dependencies
-	from(cnf.file('mavenlibs')) {
-        include 'infra.buildtasks-core-7.0.2.jar'
-        include 'asm-all-5.2.jar'
-        include 'org.apache.aries.util-*.jar'
-        include 'osgi.core*.jar'
-        include 'jsch-*.jar'
-	}
-	
-	//Transitive dependencies (not from projects)
-	from(sourceSets.main.runtimeClasspath.findAll {
+	from cnf.file('mavenlibs')
+	into new File(buildDir, 'lib')
+	include 'infra.buildtasks-core-7.0.2.jar'
+	include 'asm-all-5.2.jar'
+	include 'org.apache.aries.util-*.jar'
+	include 'osgi.core*.jar'
+	include 'jsch-*.jar'
+}
+
+task assembleBinaryDependencySource(type:Copy) {
+	from sourceSets.main.runtimeClasspath.findAll {
 		it.getAbsolutePath().contains('.m2') ||
 		it.getAbsolutePath().contains('.ibmartifactory') ||
 		it.getAbsolutePath().contains('.ibmdhe')
-	})
-	
-	// Debug task
-	// eachFile { println it.sourcePath }
+	}
+	into new File(buildDir, 'lib')
+}
+
+task assembleBinaryDependencies() {
+	dependsOn assembleBinaryDependencySource
+	dependsOn assembleBinaryDependencyMaven
+	dependsOn assembleBinaryDependencyProject
+	dependsOn assembleBinaryDependencyJar
 }
 
 configurations {
@@ -117,11 +121,11 @@ task extractArquillianSupportJakartaFeature21(type:Sync) {
     }
 }
 
-jar {
+jar { // NOTE: this is called by fat.gradle:autoFVT
     dependsOn assembleBootstrap
     dependsOn extractArquillianSupportFeature
     dependsOn extractArquillianSupportJakartaFeature21
-    finalizedBy assembleBinaryDependencies
+    finalizedBy assembleBinaryDependencyJar
 }
 
 task publishArquillianSupportFeature(type:Copy) {
@@ -135,4 +139,5 @@ task publishArquillianSupportFeature(type:Copy) {
 
 assemble {
     dependsOn publishArquillianSupportFeature
+    dependsOn assembleBinaryDependencies
 }

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -125,7 +125,7 @@ jar { // NOTE: this is called by fat.gradle:autoFVT
     dependsOn assembleBootstrap
     dependsOn extractArquillianSupportFeature
     dependsOn extractArquillianSupportJakartaFeature21
-    finalizedBy assembleBinaryDependencyJar
+    finalizedBy assembleBinaryDependencies
 }
 
 task publishArquillianSupportFeature(type:Copy) {
@@ -139,5 +139,4 @@ task publishArquillianSupportFeature(type:Copy) {
 
 assemble {
     dependsOn publishArquillianSupportFeature
-    dependsOn assembleBinaryDependencies
 }

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -12,6 +12,29 @@
  *******************************************************************************/
 import org.apache.tools.ant.filters.ReplaceTokens
 
+configurations {
+	projectDependencies { transitive = false }
+}
+
+dependencies {
+	projectDependencies project(':com.ibm.websphere.javaee.jaxb.2.2'),
+	                    project(':com.ibm.websphere.javaee.jsonp.1.0'),
+	                    project(':com.ibm.ws.common.encoder'),
+	                    project(':com.ibm.ws.componenttest'),
+	                    project(':com.ibm.ws.jaxb.tools'),
+	                    project(':com.ibm.ws.junit.extensions'),
+	                    project(':com.ibm.ws.logging.core'),
+	                    project(':com.ibm.ws.org.glassfish.json'),
+	                    project(':com.ibm.ws.org.slf4j.api'),
+	                    project(':com.ibm.ws.org.slf4j.simple'),
+	                    project(':io.openliberty.com.fasterxml.jackson'),
+	                    project(':io.openliberty.org.apache.commons.logging'),
+	                    project(':io.openliberty.org.bouncycastle.bcpkix-jdk18on'),
+	                    project(':io.openliberty.org.bouncycastle.bcprov-jdk18on'),
+	                    project(':io.openliberty.org.bouncycastle.bcutil-jdk18on'),
+	                    project(':io.openliberty.org.testcontainers')	               
+}
+
 task assembleBootstrap(type: Copy) {
     inputs.property("javaHome", System.properties.('java.home').replace('\\', '\\\\').replace(':', '\\:'))
     def javaHome = System.properties.('java.home').replace('\\', '\\\\').replace(':', '\\:')
@@ -20,73 +43,39 @@ task assembleBootstrap(type: Copy) {
     filter(ReplaceTokens, tokens: [JAVA_HOME: javaHome])
 }
 
-task assembleBinaryDependencies() {
-    dependsOn ':com.ibm.websphere.javaee.jaxb.2.2:jar'
-    dependsOn ':com.ibm.websphere.javaee.jsonp.1.0:jar'
-    dependsOn ':com.ibm.ws.common.encoder:jar'
-    dependsOn ':com.ibm.ws.componenttest:jar'
-    dependsOn ':com.ibm.ws.jaxb.tools:jar'
-    dependsOn ':com.ibm.ws.junit.extensions:jar'
-    dependsOn ':com.ibm.ws.logging.core:jar'
-    dependsOn ':com.ibm.ws.org.glassfish.json:jar'
-    dependsOn ':com.ibm.ws.org.slf4j.api:jar'
-    dependsOn ':com.ibm.ws.org.slf4j.simple:jar'
-    dependsOn ':io.openliberty.com.fasterxml.jackson:jar'
-    dependsOn ':io.openliberty.org.apache.commons.logging:jar'
-    dependsOn ':io.openliberty.org.bouncycastle.bcpkix-jdk18on:jar'
-    dependsOn ':io.openliberty.org.bouncycastle.bcprov-jdk18on:jar'
-    dependsOn ':io.openliberty.org.bouncycastle.bcutil-jdk18on:jar'
-    dependsOn ':io.openliberty.org.testcontainers:jar'
-    File buildDirLib = new File(buildDir, 'lib')
-    outputs.dir buildDirLib
-    doLast {
-        // Copy maven dependencies of this project into a directory that can be included by the junit
-        // task of every FAT bucket, effectively making all of fattest.simplicty's dependencies transitive
-        sourceSets.main.runtimeClasspath.each {
-            def path = it.getAbsolutePath()
-            if((path.contains('.m2') || path.contains('.ibmartifactory') || path.contains('.ibmdhe')) && 
-               !(new File(buildDirLib, it.getName()).exists())) {
-                copy {
-                    from path
-                    into buildDirLib
-                }
-            }
-        }
-        copy {
-            from new File(project(':com.ibm.websphere.javaee.jaxb.2.2').buildDir, 'com.ibm.websphere.javaee.jaxb.2.2.jar')
-            from new File(project(':com.ibm.websphere.javaee.jsonp.1.0').buildDir, 'com.ibm.websphere.javaee.jsonp.1.0.jar')
-            from new File(project(':com.ibm.ws.componenttest').buildDir, 'com.ibm.ws.componenttest.jar')
-            from new File(project(':com.ibm.ws.jaxb.tools').buildDir, 'com.ibm.ws.jaxb.tools.jar')
-            from new File(project(':com.ibm.ws.junit.extensions').buildDir, 'com.ibm.ws.junit.extensions.jar')
-            from new File(project(':com.ibm.ws.logging.core').buildDir, 'com.ibm.ws.logging.core.jar')
-            from new File(project(':com.ibm.ws.org.glassfish.json').buildDir, 'com.ibm.ws.org.glassfish.json.1.0.jar')
-            from new File(project(':com.ibm.ws.org.slf4j.api').buildDir, 'com.ibm.ws.org.slf4j.api.jar')
-            from new File(project(':com.ibm.ws.org.slf4j.simple').buildDir, 'com.ibm.ws.org.slf4j.simple.jar')
-            from new File(project(':io.openliberty.com.fasterxml.jackson').buildDir, 'io.openliberty.com.fasterxml.jackson.jar')
-            from new File(project(':io.openliberty.org.apache.commons.logging').buildDir, 'io.openliberty.org.apache.commons.logging.jar')
-            from new File(project(':io.openliberty.org.bouncycastle.bcpkix-jdk18on').buildDir, 'io.openliberty.org.bouncycastle.bcpkix-jdk18on.jar')
-            from new File(project(':io.openliberty.org.bouncycastle.bcprov-jdk18on').buildDir, 'io.openliberty.org.bouncycastle.bcprov-jdk18on.jar')
-            from new File(project(':io.openliberty.org.bouncycastle.bcutil-jdk18on').buildDir, 'io.openliberty.org.bouncycastle.bcutil-jdk18on.jar')
-            from new File(project(':io.openliberty.org.testcontainers').buildDir, 'io.openliberty.org.testcontainers.jar')
-            from new File(buildDir, 'fattest.simplicity.jar')
-            into buildDirLib
-        }
-        copy {
-            from cnf.file('mavenlibs')
-            into buildDirLib
-            include 'infra.buildtasks-core-7.0.2.jar'
-            include 'asm-all-5.2.jar'
-            include 'org.apache.aries.util-*.jar'
-            include 'osgi.core*.jar'
-            include 'jsch-*.jar'
-        }
-        copy {
-            from project(':com.ibm.ws.common.encoder').buildDir
-            into buildDirLib
-            include 'com.ibm.ws.common.encoder.jar'
-            rename 'com.ibm.ws.common.encoder.jar', 'fattest.encoder.jar'
-        }
-    }
+task assembleBinaryDependencies(type: Copy) {
+	dependsOn ':cnf:copyMavenLibs'
+	
+	into(new File(buildDir, 'lib'))
+	
+	//fattest.simplicity.jar
+	from(jar) {
+	    exclude 'buildfiles'
+	}
+	
+	//Project dependencies
+	from(configurations.projectDependencies) {
+		rename 'com.ibm.ws.common.encoder.jar', 'fattest.encoder.jar'
+	}
+	
+	//Maven dependencies
+	from(cnf.file('mavenlibs')) {
+        include 'infra.buildtasks-core-7.0.2.jar'
+        include 'asm-all-5.2.jar'
+        include 'org.apache.aries.util-*.jar'
+        include 'osgi.core*.jar'
+        include 'jsch-*.jar'
+	}
+	
+	//Transitive dependencies (not from projects)
+	from(sourceSets.main.runtimeClasspath.findAll {
+		it.getAbsolutePath().contains('.m2') ||
+		it.getAbsolutePath().contains('.ibmartifactory') ||
+		it.getAbsolutePath().contains('.ibmdhe')
+	})
+	
+	// Debug task
+	// eachFile { println it.sourcePath }
 }
 
 configurations {

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -46,7 +46,7 @@ task assembleBootstrap(type: Copy) {
 task assembleBinaryDependencyJar(type:Copy) {
 	from jar
 	into new File(buildDir, 'lib')
-	exclude 'buildfiles'
+	include 'fattest.simplicity.jar'
 }
 
 task assembleBinaryDependencyProject(type:Copy) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- This should fix the issue where switching between branches and running a test bucket doesn't copy the `fattest.simplicy:jar` into `fattest.simplicity/build/libs/lib`
  - This was achieved by using `from jar` in a copy task instead of `from new File(buildDir, 'fattest.simplicity.jar')`
  - Gradle checks what it needs to copy during the configuration stage.  If it sees that fattest.simpliciy.jar exists in both the to and from location it will skip the copy step.
  - When using `from jar` during the configuration stage gradle will check if `:jar` is going to be executed and then knows it needs to execute the copy as well.
- Made sure that this change kept the contents of `fattest.simplicity/build/libs/lib` the same after :clean :build and :clean :assemble
- Also verified performance of change is the same or better

## Before change

### Clean build

BUILD SUCCESSFUL in 34s
201 actionable tasks: 26 executed, 175 up-to-date

BUILD SUCCESSFUL in 32s
201 actionable tasks: 26 executed, 175 up-to-

BUILD SUCCESSFUL in 31s
201 actionable tasks: 26 executed, 175 up-to-date

### Build - no updates

BUILD SUCCESSFUL in 7s
201 actionable tasks: 18 executed, 183 up-to-date

BUILD SUCCESSFUL in 6s
201 actionable tasks: 18 executed, 183 up-to-date

BUILD SUCCESSFUL in 6s
201 actionable tasks: 18 executed, 183 up-to-date

### Build - recompile fattest.simplicity

BUILD SUCCESSFUL in 35s
201 actionable tasks: 21 executed, 180 up-to-date

BUILD SUCCESSFUL in 34s
201 actionable tasks: 21 executed, 180 up-to-date

BUILD SUCCESSFUL in 30s
201 actionable tasks: 21 executed, 180 up-to-date

## After change

### Clean build

BUILD SUCCESSFUL in 32s
204 actionable tasks: 29 executed, 175 up-to-date

BUILD SUCCESSFUL in 32s
204 actionable tasks: 29 executed, 175 up-to-date

BUILD SUCCESSFUL in 32s
204 actionable tasks: 29 executed, 175 up-to-date

### Build - no updates

BUILD SUCCESSFUL in 5s
204 actionable tasks: 18 executed, 186 up-to-date

BUILD SUCCESSFUL in 6s
204 actionable tasks: 18 executed, 186 up-to-date

BUILD SUCCESSFUL in 6s
204 actionable tasks: 18 executed, 186 up-to-date

### Build - recompile fattest.simplicity

BUILD SUCCESSFUL in 30s
204 actionable tasks: 22 executed, 182 up-to-date

BUILD SUCCESSFUL in 33s
204 actionable tasks: 22 executed, 182 up-to-date

BUILD SUCCESSFUL in 31s
204 actionable tasks: 22 executed, 182 up-to-date