### PR TITLE
Finalize DatabaseRotation improvements

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/bnd.bnd
@@ -19,7 +19,6 @@ src: \
 	test-applications/timersapp/src
 
 fat.project: true
-tested.features: databaseRotation
 
 # Uncomment to test against alternative databases
 # Options: Derby, Postgres, DB2, Oracle, SQLServer
@@ -28,7 +27,7 @@ tested.features: databaseRotation
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true
 
-tested.features=concurrent-3.0, servlet-6.0
+tested.features: databaseRotation, concurrent-3.0, servlet-6.0
 
 -buildpath: \
 	com.ibm.ws.componenttest.2.0;version=latest,\

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -95,7 +95,7 @@ public class DatabaseContainerFactory {
         Log.info(c, "create", "System property: fat.bucket.db.type is " + dbProperty);
 
         if (!validateDatabaseRotationFeature) {
-            throw new IllegalArgumentException("To use a generic database, the FAT must be opted into database rotation by setting 'testedFeatures: " //
+            throw new IllegalArgumentException("To use a generic database, the FAT must be opted into database rotation by setting 'tested.features: " //
                                                + databaseRotationTestFeature + "' in the FAT project's bnd.bnd file");
         }
 

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -95,9 +95,8 @@ public class DatabaseContainerFactory {
         Log.info(c, "create", "System property: fat.bucket.db.type is " + dbProperty);
 
         if (!validateDatabaseRotationFeature) {
-            // TODO throw this exception once WL is updated
-//            throw new IllegalArgumentException("To use a generic database, the FAT must be opted into database rotation by setting 'testedFeatures: " //
-//                                               + databaseRotationTestFeature + "' in the FAT project's bnd.bnd file");
+            throw new IllegalArgumentException("To use a generic database, the FAT must be opted into database rotation by setting 'testedFeatures: " //
+                                               + databaseRotationTestFeature + "' in the FAT project's bnd.bnd file");
         }
 
         DatabaseContainerType type = null;


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fail test projects that do not correctly declare they are enrolled in DatabaseRotation
