### PR TITLE
temporarily disabled test of record as embeddable of unannotated entity

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -115,6 +115,9 @@ public class DataTestServlet extends FATServlet {
     Packages packages;
 
     @Inject
+    Participants participants;
+
+    @Inject
     People people;
 
     @Inject
@@ -3638,6 +3641,30 @@ public class DataTestServlet extends FATServlet {
         assertEquals(true, receipts.deleteByTotalLessThan(1000000.0f));
 
         assertEquals(0L, receipts.count());
+    }
+
+    /**
+     * Test an unannotated entity that has an attribute which is a Java record,
+     * which should be inferred to be an embeddable, such that queries and sorting
+     * can be performed on the attributes of the embeddable.
+     */
+    @Test
+    public void testRecordAsEmbeddable() {
+        participants.remove("TestRecordAsEmbeddable");
+
+        participants.add(Participant.of("Steve", "TestRecordAsEmbeddable", 1),
+                         Participant.of("Sarah", "TestRecordAsEmbeddable", 2),
+                         Participant.of("Simon", "TestRecordAsEmbeddable", 3),
+                         Participant.of("Samantha", "TestRecordAsEmbeddable", 4));
+
+        assertEquals("Simon", participants.getFirstName(3).orElseThrow());
+
+        assertEquals(List.of("Samantha", "Sarah", "Simon", "Steve"),
+                     participants.withSurname("TestRecordAsEmbeddable")
+                                     .map(p -> p.name.first())
+                                     .collect(Collectors.toList()));
+
+        assertEquals(4L, participants.remove("TestRecordAsEmbeddable"));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -498,6 +498,16 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Use a repository method that performs a JDQL query using the String
+     * concatenation operator ||.
+     */
+    @Test
+    public void testConcatenationOperator() {
+        assertEquals(List.of("thirty-one", "twenty-three", "thirteen", "three", "two"),
+                     primes.concatAndMatch("%It%", Sort.desc(ID)));
+    }
+
+    /**
      * Count the number of matching entries in the database using query by method name.
      */
     @Test
@@ -2896,6 +2906,16 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Use a repository method that performs a JDQL query using LEFT function
+     * to obtain the beginning of a String value.
+     */
+    @Test
+    public void tesLeftFunction() {
+        assertEquals(List.of("seven", "seventeen"),
+                     primes.matchLeftSideOfName("seven"));
+    }
+
+    /**
      * Intermix two different types of entities in the same transaction.
      */
     @Test
@@ -4044,6 +4064,17 @@ public class DataTestServlet extends FATServlet {
                                              .map(o -> o.a)
                                              .sorted()
                                              .collect(Collectors.toList()));
+    }
+
+    /**
+     * Use a repository method that performs a JDQL query using RIGHT function
+     * to obtain the end of a String value.
+     */
+    @Test
+    public void testRightFunction() {
+        assertEquals(List.of("thirty-seven", "thirteen", "seventeen",
+                             "seven", "nineteen", "eleven"),
+                     primes.matchRightSideOfName("en"));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participant.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participant.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+/**
+ * An unannotated entity with a record attribute that should
+ * be interpreted as an embeddable.
+ */
+public class Participant {
+
+    public Integer id;
+
+    public Name name;
+
+    //public static record Name(String first, String last) {
+    //}
+    // TODO switch to the above and remove the following once 29117 is fixed
+    public static class Name {
+        public String first, last;
+
+        public Name() {
+        }
+
+        public Name(String first, String last) {
+            this.first = first;
+            this.last = last;
+        }
+
+        public String first() {
+            return first;
+        }
+
+        public String last() {
+            return last;
+        }
+    }
+
+    public static Participant of(String firstName, String lastName, int id) {
+        Participant p = new Participant();
+        p.id = id;
+        p.name = new Name(firstName, lastName);
+        return p;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participants.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participants.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import jakarta.data.repository.By;
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for an unannotated entity with a record attribute
+ * that should be interpreted as an embeddable.
+ */
+@Repository
+public interface Participants extends DataRepository<Participant, Integer> {
+
+    @Insert
+    void add(Participant... p);
+
+    @Query("SELECT name.first WHERE id = ?1")
+    Optional<String> getFirstName(int id);
+
+    @Delete
+    long remove(@By("name.last") String lastName);
+
+    @Find
+    @OrderBy("name.first")
+    @OrderBy("id")
+    Stream<Participant> withSurname(@By("name.last") String lastName);
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -52,6 +52,9 @@ public interface Primes {
     @Query("SELECT (num.name) FROM Prime As num")
     Page<String> all(Sort<Prime> sort, PageRequest pagination);
 
+    @Query("SELECT name WHERE numberId < 35 AND romanNumeral || name LIKE :pattern")
+    List<String> concatAndMatch(String pattern, Sort<?> sort);
+
     Integer countByNumberIdBetween(long first, long last);
 
     @Asynchronous
@@ -226,6 +229,16 @@ public interface Primes {
 
     @Query("SELECT o.numberId FROM Prime o WHERE (o.name = ?1 OR o.numberId=:num)")
     Collection<Long> matchAnyWithMixedUsageOfPositionalAndNamed(String name, long num);
+
+    @Query("SELECT name WHERE numberId < 50 AND LEFT(name, LENGTH(:s)) = :s")
+    @OrderBy("name")
+    List<String> matchLeftSideOfName(@Param("s") String searchFor);
+
+    @Query("SELECT name" +
+           " WHERE numberId < 40" +
+           "   AND RIGHT(name, LENGTH(:searchFor)) = :searchFor" +
+           " ORDER BY name DESC")
+    List<String> matchRightSideOfName(String searchFor);
 
     @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), COUNT(o.numberId), AVG(o.numberId) FROM Prime o WHERE o.numberId < ?1")
     Deque<Double> minMaxSumCountAverageDeque(long numBelow);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Rating.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Rating.java
@@ -36,9 +36,9 @@ public record Rating(
             this.email = email;
         }
     }
-    // TODO switch the above class to the following record after JPA 3.2 adds support for records as embeddables
+    // TODO switch the above class to the following record after 29117 is fixed
     //public static record Reviewer(
-    //                String firstName,
+    //                String firstName, // TODO nested record embeddable for Name(first, last) ?
     //                String lastName,
     //                String email) {
     //}


### PR DESCRIPTION
Test scenario where the JPA 3.2 feature for records as embeddables is used to define a Java record attribute under an unannotated entity. Temporarily disabled because the Java record as Embeddabble function isn't working in EcilpseLink yet.

This PR also adds tests for the || (concatenation) operator and the LEFT and RIGHT functions that are new in Persistence 3.2 and part of Jakarta Data Query Language.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".