### PR TITLE
Jakarta Data recreates for Eclipselink issues

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/.classpath
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/jpabootstrap/src"/>
 	<classpathentry kind="src" path="test-applications/helpers/DatabaseManagement/src"/>
+	<classpathentry kind="src" path="test-applications/jakartadata/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/bnd.bnd
@@ -16,7 +16,8 @@ bVersion=1.0
 src: \
     fat/src,\
     test-applications/helpers/DatabaseManagement/src,\
-    test-applications/jpabootstrap/src
+    test-applications/jpabootstrap/src,\
+    test-applications/jakartadata/src
 
 fat.project: true
 tested.features: databaseRotation, persistence-3.2, persistencecontainer-3.2, servlet-6.1

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.ws.jpa.jpa32.JPABootstrapTest;
+import com.ibm.ws.jpa.jpa32.JakartaDataRecreateTest;
 
 import componenttest.containers.TestContainerSuite;
 import componenttest.rules.repeater.RepeatTests;
@@ -28,6 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
 @RunWith(Suite.class)
 @SuiteClasses({
                 JPABootstrapTest.class,
+                JakartaDataRecreateTest.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JakartaDataRecreateTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JakartaDataRecreateTest.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jpa.jpa32;
 
@@ -28,66 +25,62 @@ import com.ibm.ws.jpa.FATSuite;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
-import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.PrivHelper;
-import jpabootstrap.web.TestJPABootstrapServlet;
+import io.openliberty.jpa.data.tests.web.JakartaDataRecreateServlet;
 
 /**
- * Verify that the JPA Runtime Integration can parse the supported JPA Spec levels of persistence.xml.
+ * Recreate issues found during development of Jakarta Data with EclipseLink
+ * using pure Jakarta Persistence.
  *
+ * These tests should be contributed back to EclipseLink as these issues are resovled.
  */
 @RunWith(FATRunner.class)
-@Mode(TestMode.LITE)
 @MinimumJavaLevel(javaLevel = 17)
-public class JPABootstrapTest extends FATServletClient {
-    public static final String APP_NAME = "jpabootstrap";
-    public static final String SERVLET = "TestJPABootstrap";
+public class JakartaDataRecreateTest {
+    public static final String APP_NAME = "jakartadata";
+    public static final String SERVLET = "JakartaDataRecreate";
     public static final String SPECLEVEL = "3.2";
 
-    @Server("JPABootstrapFATServer")
-    @TestServlets({
-                    @TestServlet(servlet = TestJPABootstrapServlet.class, path = APP_NAME + "_" + SPECLEVEL + "/" + SERVLET)
-    })
-    public static LibertyServer server1;
+    @Server("JakartaDataRecreateServer")
+    @TestServlet(servlet = JakartaDataRecreateServlet.class, path = APP_NAME + "_" + SPECLEVEL + "/" + SERVLET)
+    public static LibertyServer server;
 
     public static final JdbcDatabaseContainer<?> testContainer = FATSuite.testContainer;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server1, PrivHelper.JAXB_PERMISSION);
+        PrivHelper.generateCustomPolicy(server, PrivHelper.JAXB_PERMISSION);
 
         //Get driver name
-        server1.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
+        server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
 
         //Setup server DataSource properties
-        DatabaseContainerUtil.setupDataSourceProperties(server1, testContainer);
+        DatabaseContainerUtil.setupDataSourceProperties(server, testContainer);
 
         createApplication(SPECLEVEL);
-        server1.startServer();
+        server.startServer();
     }
 
     private static void createApplication(String specLevel) throws Exception {
         final String resPath = "test-applications/" + APP_NAME + "/resources/jpa-" + specLevel + "/web/";
 
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + "_" + specLevel + ".war");
-        app.addPackage("jpabootstrap.web");
-        app.addPackage("jpabootstrap.entity");
+        app.addPackage("io.openliberty.jpa.data.tests.models");
+        app.addPackage("io.openliberty.jpa.data.tests.web");
         app.merge(ShrinkWrap.create(GenericArchive.class).as(ExplodedImporter.class).importDirectory(resPath).as(GenericArchive.class),
                   "/",
                   Filters.includeAll());
-        ShrinkHelper.exportDropinAppToServer(server1, app);
+        ShrinkHelper.exportDropinAppToServer(server, app);
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.stopServer("CWWJP9991W",
-                           "Missing PostgreSQL10JsonPlatform"); // Generated with postgres db, since we don't include the postgres plugin);
+        server.stopServer("CWWJP9991W",
+                          "Missing PostgreSQL10JsonPlatform"); // Generated with postgres db, since we don't include the postgres plugin);
     }
+
 }

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JakartaDataRecreateTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JakartaDataRecreateTest.java
@@ -80,6 +80,7 @@ public class JakartaDataRecreateTest {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer("CWWJP9991W",
+                          "WTRN0074E: Exception caught from before_completion synchronization operation", // RuntimeException test, expected
                           "Missing PostgreSQL10JsonPlatform"); // Generated with postgres db, since we don't include the postgres plugin);
     }
 

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/publish/servers/JPABootstrapFATServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/publish/servers/JPABootstrapFATServer/bootstrap.properties
@@ -12,4 +12,4 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 # Test requires JPA trace to be enabled, do not disable!
-traceSpecification=JPA=all
+com.ibm.ws.logging.trace.specification==JPA=all

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/publish/servers/JakartaDataRecreateServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/publish/servers/JakartaDataRecreateServer/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+# Test requires JPA trace to be enabled, do not disable!
+traceSpecification=JPA=all

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/publish/servers/JakartaDataRecreateServer/bootstrap.properties
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/publish/servers/JakartaDataRecreateServer/bootstrap.properties
@@ -12,4 +12,4 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 # Test requires JPA trace to be enabled, do not disable!
-traceSpecification=JPA=all
+com.ibm.ws.logging.trace.specification=*=info:JPA=all:eclipselink=all

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/publish/servers/JakartaDataRecreateServer/server.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/publish/servers/JakartaDataRecreateServer/server.xml
@@ -1,0 +1,46 @@
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server description="new server">
+
+	<featureManager>
+		<feature>persistence-3.2</feature>
+		<feature>servlet-6.1</feature>
+		<!-- DO NOT ADD data-1.0 feature -->
+	    <feature>componenttest-2.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    <dataSource id="DefaultDataSource" fat.modify="true">
+        <jdbcDriver libraryRef="JDBCLib"/>
+    	<properties.derby.embedded databaseName="memory:ds1" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu" />
+    </dataSource>
+
+    <library id="JDBCLib">
+        <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
+    </library>
+
+    <!-- JDBC driver -->
+    <javaPermission codebase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
+
+    <!-- Permission needed for Postgres driver -->
+    <javaPermission className="java.util.PropertyPermission" name="org.postgresql.forceBinary" actions="read"/>
+    
+    <!-- Permission needed for SQLServer driver -->
+    <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+
+    <!-- Permission needed for Oracle driver -->
+    <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />
+
+    <!-- File read write permissions -->
+    <javaPermission className="java.util.PropertyPermission" name="user.dir" actions="read"/>
+    <javaPermission className="java.io.FilePermission" name="files/timertestoutput.txt" actions="read,write"/>
+    <javaPermission className="java.io.FilePermission" name="files" actions="write"/>
+    
+</server>

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/resources/jpa-3.2/web/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/resources/jpa-3.2/web/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd"
+        version="3.2">
+
+    <persistence-unit name="RecreatePersistenceUnit">
+    	<properties>
+			<!-- EclipseLink should create the database schema automatically -->
+			<property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create" />
+		</properties>
+    </persistence-unit>
+</persistence>

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/resources/jpa-3.2/web/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/resources/jpa-3.2/web/WEB-INF/classes/META-INF/persistence.xml
@@ -21,7 +21,8 @@
     <persistence-unit name="RecreatePersistenceUnit">
     	<properties>
 			<!-- EclipseLink should create the database schema automatically -->
-			<property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create" />
+			<property name="jakarta.persistence.schema-generation.database.action" value="create" />
+			<property name="eclipselink.logging.parameters" value="true"/>
 		</properties>
     </persistence-unit>
 </persistence>

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Account.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Account.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat_jpa
+ */
+@Entity
+public class Account {
+
+    @EmbeddedId
+    public AccountId accountId;
+
+    public double balance;
+
+    public String bankName;
+
+    public boolean checking;
+
+    public String owner;
+
+    public static Account of(long accountNum, long routingNum, String bankName, boolean checking, double balance, String owner) {
+        Account inst = new Account();
+        inst.accountId = AccountId.of(accountNum, routingNum);
+        inst.bankName = bankName;
+        inst.checking = checking;
+        inst.balance = balance;
+        inst.owner = owner;
+        return inst;
+    }
+
+    @Override
+    public String toString() {
+        return bankName + ' ' + accountId + " $" + balance + " owned by " + owner + (checking ? " with checking" : "");
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/AccountId.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/AccountId.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class AccountId {
+
+    public long accountNum;
+    public long routingNum;
+
+    public AccountId() {
+    }
+
+    public AccountId(long accountNum, long routingNum) {
+        this.accountNum = accountNum;
+        this.routingNum = routingNum;
+    }
+
+    public static AccountId of(long accountNum, long routingNum) {
+        return new AccountId(accountNum, routingNum);
+    }
+
+    @Override
+    public String toString() {
+        return "AccountId:" + accountNum + ":" + routingNum;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/AsciiCharacter.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/AsciiCharacter.java
@@ -1,6 +1,12 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package io.openliberty.jpa.data.tests.models;
 
 import java.io.Serializable;

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/AsciiCharacter.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/AsciiCharacter.java
@@ -1,0 +1,77 @@
+/**
+ *
+ */
+package io.openliberty.jpa.data.tests.models;
+
+import java.io.Serializable;
+
+/**
+ * Recreate from Jakarta Data TCK
+ */
+@jakarta.persistence.Entity
+public class AsciiCharacter implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @jakarta.persistence.Id
+    private long id;
+
+    private int numericValue;
+
+    private String hexadecimal;
+
+    private char thisCharacter;
+
+    private boolean isControl;
+
+    public static AsciiCharacter of(int numericValue) {
+        AsciiCharacter inst = new AsciiCharacter();
+        inst.id = numericValue;
+        inst.numericValue = numericValue;
+        inst.hexadecimal = Integer.toHexString(numericValue);
+        inst.thisCharacter = (char) numericValue;
+        inst.isControl = Character.isISOControl(inst.thisCharacter);
+
+        return inst;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getNumericValue() {
+        return numericValue;
+    }
+
+    public void setNumericValue(int numericValue) {
+        this.numericValue = numericValue;
+    }
+
+    public String getHexadecimal() {
+        return hexadecimal;
+    }
+
+    public void setHexadecimal(String hexadecimal) {
+        this.hexadecimal = hexadecimal;
+    }
+
+    public char getThisCharacter() {
+        return thisCharacter;
+    }
+
+    public void setThisCharacter(char thisCharacter) {
+        this.thisCharacter = thisCharacter;
+    }
+
+    public boolean isControl() {
+        return isControl;
+    }
+
+    public void setControl(boolean isControl) {
+        this.isControl = isControl;
+    }
+
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Box.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Box.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+/**
+ * Recreate from Jakarta Data TCK
+ */
+@jakarta.persistence.Entity
+public class Box {
+    @jakarta.persistence.Id
+    public String boxIdentifier;
+
+    public int length;
+
+    public int width;
+
+    public int height;
+
+    public static Box of(String id, int length, int width, int height) {
+        Box box = new Box();
+        box.boxIdentifier = id;
+        box.length = length;
+        box.width = width;
+        box.height = height;
+        return box;
+    }
+
+    @Override
+    public String toString() {
+        return "Box@" + Integer.toHexString(hashCode()) + ":" + length + "x" + width + "x" + height + ":" + boxIdentifier;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Business.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Business.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat_jpa
+ */
+@Entity
+public class Business {
+
+    public String name;
+
+    @GeneratedValue
+    @Id
+    public int id;
+
+    @Embedded
+    public Location location;
+
+    public static Business of(float latitude, float longitude, String city, String state, int zip,
+                              int houseNum, String streetName, String streetDir, String name) {
+        Business inst = new Business();
+        Street street = new Street(streetName, streetDir);
+        Address address = new Address(city, state, zip, houseNum, street);
+
+        inst.name = name;
+        inst.location = new Location(address, latitude, longitude);
+
+        return inst;
+    }
+
+    @Embeddable
+    public static class Location {
+
+        @Embedded
+        public Address address;
+
+        @Column(columnDefinition = "DECIMAL(8,5) NOT NULL")
+        public float latitude;
+
+        @Column(columnDefinition = "DECIMAL(8,5) NOT NULL")
+        public float longitude;
+
+        public Location() {
+        }
+
+        public Location(Address address, float latitude, float longitude) {
+            this.address = address;
+            this.latitude = latitude;
+            this.longitude = longitude;
+        }
+    }
+
+    @Embeddable
+    public static class Address {
+
+        public String city;
+
+        public int houseNum;
+
+        public String state;
+
+        @Embedded
+        public Street street;
+
+        public int zip;
+
+        public Address() {
+        }
+
+        Address(String city, String state, int zip, int houseNum, Street street) {
+            this.city = city;
+            this.state = state;
+            this.zip = zip;
+            this.houseNum = houseNum;
+            this.street = street;
+        }
+    }
+
+    @Embeddable
+    public static class Street {
+
+        public String direction;
+
+        @Column(name = "STREETNAME")
+        public String name;
+
+        public Street() {
+        }
+
+        public Street(String name, String direction) {
+            this.name = name;
+            this.direction = direction;
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/City.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/City.java
@@ -1,6 +1,12 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package io.openliberty.jpa.data.tests.models;
 
 import java.util.Set;
@@ -11,7 +17,7 @@ import jakarta.persistence.IdClass;
 import jakarta.persistence.Version;
 
 /**
- *
+ * Recreate from io.openliberty.data.internal_fat_jpa
  */
 @Entity
 @IdClass(CityId.class)
@@ -31,14 +37,13 @@ public class City {
     @Id
     public String stateName;
 
-    public City() {
-    }
-
-    City(String name, String state, int population, Set<Integer> areaCodes) {
-        this.name = name;
-        this.stateName = state;
-        this.population = population;
-        this.areaCodes = areaCodes;
+    public static City of(String name, String state, int population, Set<Integer> areaCodes) {
+        City inst = new City();
+        inst.name = name;
+        inst.stateName = state;
+        inst.population = population;
+        inst.areaCodes = areaCodes;
+        return inst;
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/City.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/City.java
@@ -1,0 +1,48 @@
+/**
+ *
+ */
+package io.openliberty.jpa.data.tests.models;
+
+import java.util.Set;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Version;
+
+/**
+ *
+ */
+@Entity
+@IdClass(CityId.class)
+public class City {
+    // TODO uncomment to reproduce EclipseLink bug with selecting an attribute that is a collection type.
+    //@ElementCollection(fetch = FetchType.EAGER)
+    public Set<Integer> areaCodes;
+
+    @Version
+    long changeCount;
+
+    @Id
+    public String name;
+
+    public int population;
+
+    @Id
+    public String stateName;
+
+    public City() {
+    }
+
+    City(String name, String state, int population, Set<Integer> areaCodes) {
+        this.name = name;
+        this.stateName = state;
+        this.population = population;
+        this.areaCodes = areaCodes;
+    }
+
+    @Override
+    public String toString() {
+        return "City of " + name + ", " + stateName + " pop " + population + " in " + areaCodes + " v" + changeCount;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/City.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/City.java
@@ -11,7 +11,9 @@ package io.openliberty.jpa.data.tests.models;
 
 import java.util.Set;
 
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Version;
@@ -22,8 +24,7 @@ import jakarta.persistence.Version;
 @Entity
 @IdClass(CityId.class)
 public class City {
-    // TODO uncomment to reproduce EclipseLink bug with selecting an attribute that is a collection type.
-    //@ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.EAGER)
     public Set<Integer> areaCodes;
 
     @Version

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/CityId.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/CityId.java
@@ -1,6 +1,12 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package io.openliberty.jpa.data.tests.models;
 
 import java.io.Serializable;

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/CityId.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/CityId.java
@@ -1,0 +1,56 @@
+/**
+ *
+ */
+package io.openliberty.jpa.data.tests.models;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ *
+ */
+public class CityId implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public String name;
+
+    private String stateName;
+
+    public CityId() {
+    }
+
+    public CityId(String name, String state) {
+        this.name = name;
+        this.stateName = state;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        CityId c;
+        return CityId.class.equals(o.getClass()) &&
+               Objects.equals(name, (c = (CityId) o).name) &&
+               Objects.equals(stateName, c.stateName);
+    }
+
+    public String getStateName() {
+        return stateName;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, stateName);
+    }
+
+    public static CityId of(String name, String state) {
+        return new CityId(name, state);
+    }
+
+    public void setStateName(String v) {
+        stateName = v;
+    }
+
+    @Override
+    public String toString() {
+        return name + ", " + stateName;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Coordinate.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Coordinate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import java.util.UUID;
+
+/**
+ * Recreate from Jakarta Data TCK
+ */
+@jakarta.persistence.Entity
+public class Coordinate {
+    @jakarta.persistence.Id
+    public UUID id;
+
+    public double x;
+
+    public float y;
+
+    public static Coordinate of(String id, double x, float y) {
+        Coordinate c = new Coordinate();
+        c.id = UUID.nameUUIDFromBytes(id.getBytes());
+        c.x = x;
+        c.y = y;
+        return c;
+    }
+
+    @Override
+    public String toString() {
+        return "Coordinate@" + Integer.toHexString(hashCode()) + "(" + x + "," + y + ")" + ":" + id;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/DemographicInfo.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/DemographicInfo.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat_jpa
+ */
+@Entity
+public class DemographicInfo {
+
+    @Column
+    public Instant collectedOn;
+
+    @GeneratedValue
+    @Id
+    public BigInteger id;
+
+    @Column
+    public BigDecimal publicDebt;
+
+    @Column
+    public BigDecimal intragovernmentalDebt;
+
+    @Column
+    public BigInteger numFullTimeWorkers;
+
+    public static DemographicInfo of(int year, int month, int day,
+                                     long numFullTimeWorkers,
+                                     double intragovernmentalDebt, double publicDebt) {
+        DemographicInfo inst = new DemographicInfo();
+        inst.collectedOn = ZonedDateTime.of(year, month, day, 12, 0, 0, 0, ZoneId.of("America/New_York")).toInstant();
+        inst.numFullTimeWorkers = BigInteger.valueOf(numFullTimeWorkers);
+        inst.intragovernmentalDebt = BigDecimal.valueOf(intragovernmentalDebt);
+        inst.publicDebt = BigDecimal.valueOf(publicDebt);
+        return inst;
+    }
+
+    @Override
+    public String toString() {
+        return "DemographicInfo from " + collectedOn;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Item.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Item.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat_exp
+ */
+@Entity
+public class Item {
+    public String description;
+
+    public String name;
+
+    @Id
+    @GeneratedValue
+    public UUID pk; // Do not add Id to this name. It should be detectable based on type alone.
+
+    public float price;
+
+    public long version;
+
+    public static Item of(String description, String name, float price) {
+        Item inst = new Item();
+        inst.description = description;
+        inst.name = name;
+        inst.price = price;
+        return inst;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Line.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Line.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat
+ * Instead of using house, use this simpler Entity
+ */
+@Entity
+public class Line {
+    @GeneratedValue
+    @Id
+    public Long id;
+
+    @Embedded
+    @AttributeOverrides({
+                          @AttributeOverride(name = "x", column = @Column(name = "x_A")),
+                          @AttributeOverride(name = "y", column = @Column(name = "y_A"))
+    })
+    @Column
+    public Point pointA;
+
+    @Embedded
+    @AttributeOverrides({
+                          @AttributeOverride(name = "x", column = @Column(name = "x_B")),
+                          @AttributeOverride(name = "y", column = @Column(name = "y_B"))
+    })
+    @Column
+
+    public Point pointB;
+
+    @Embeddable
+    public static class Point {
+
+        public int x;
+
+        public int y;
+
+        public static Point of(int x, int y) {
+            Point inst = new Point();
+            inst.x = x;
+            inst.y = y;
+            return inst;
+        }
+
+        @Override
+        public String toString() {
+            return "Point [x=" + x + ", y=" + y + "]";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Point other = (Point) obj;
+            return x == other.x && y == other.y;
+        }
+
+    }
+
+    public static Line of(int x1, int y1, int x2, int y2) {
+        Line inst = new Line();
+        inst.pointA = Point.of(x1, y1);
+        inst.pointB = Point.of(x2, y2);
+        return inst;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/NaturalNumber.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/NaturalNumber.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import java.io.Serializable;
+
+/**
+ * Recreate from Jakarta Data TCK
+ */
+@jakarta.persistence.Entity
+public class NaturalNumber implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public enum NumberType {
+        ONE, PRIME, COMPOSITE
+    }
+
+    @jakarta.persistence.Id
+    private long id; //AKA the value
+
+    private boolean isOdd;
+
+    private Short numBitsRequired;
+
+    private NumberType numType; // enum of ONE | PRIME | COMPOSITE
+
+    private long floorOfSquareRoot;
+
+    public static NaturalNumber of(int value) {
+        boolean isOne = value == 1;
+        boolean isOdd = value % 2 == 1;
+        long sqrRoot = squareRoot(value);
+        boolean isPrime = isOdd ? isPrime(value, sqrRoot) : (value == 2);
+
+        NaturalNumber inst = new NaturalNumber();
+        inst.id = value;
+        inst.isOdd = isOdd;
+        inst.numBitsRequired = bitsRequired(value);
+        inst.numType = isOne ? NumberType.ONE : isPrime ? NumberType.PRIME : NumberType.COMPOSITE;
+        inst.floorOfSquareRoot = sqrRoot;
+
+        return inst;
+    }
+
+    private static Short bitsRequired(int value) {
+        return (short) (Math.floor(Math.log(value) / Math.log(2)) + 1);
+    }
+
+    private static long squareRoot(int value) {
+        return (long) Math.floor(Math.sqrt(value));
+    }
+
+    private static boolean isPrime(int value, long largestPossibleFactor) {
+        if (value == 1)
+            return false;
+
+        for (int i = 2; i <= largestPossibleFactor; i++) {
+            if (value % i == 0)
+                return false;
+        }
+        return true;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public boolean isOdd() {
+        return isOdd;
+    }
+
+    public void setOdd(boolean isOdd) {
+        this.isOdd = isOdd;
+    }
+
+    public Short getNumBitsRequired() {
+        return numBitsRequired;
+    }
+
+    public void setNumBitsRequired(Short numBitsRequired) {
+        this.numBitsRequired = numBitsRequired;
+    }
+
+    public NumberType getNumType() {
+        return numType;
+    }
+
+    public void setNumType(NumberType numType) {
+        this.numType = numType;
+    }
+
+    public long getFloorOfSquareRoot() {
+        return floorOfSquareRoot;
+    }
+
+    public void setFloorOfSquareRoot(long floorOfSquareRoot) {
+        this.floorOfSquareRoot = floorOfSquareRoot;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Package.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Package.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat
+ */
+@Entity
+public class Package {
+
+    public String description;
+
+    @Id
+    public int id;
+
+    public float height;
+
+    public float length;
+
+    public float width;
+
+    public static Package of(int id, float length, float width, float height, String description) {
+        Package inst = new Package();
+        inst.id = id;
+        inst.length = length;
+        inst.width = width;
+        inst.height = height;
+        inst.description = description;
+        return inst;
+    }
+
+    @Override
+    public String toString() {
+        return "Package id=" + id + "; L=" + length + "; W=" + width + "; H=" + height + " " + description;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Person.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Person.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat
+ */
+@Entity
+public class Person {
+
+    @Id
+    public long ssn_id;
+
+    public String firstName;
+
+    public String lastName;
+
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Prime.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Prime.java
@@ -1,6 +1,12 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package io.openliberty.jpa.data.tests.models;
 
 import java.util.ArrayList;

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Prime.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Prime.java
@@ -1,0 +1,50 @@
+/**
+ *
+ */
+package io.openliberty.jpa.data.tests.models;
+
+import java.util.ArrayList;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat
+ */
+@Entity
+public class Prime {
+    public String binaryDigits;
+
+    public boolean even;
+
+    public String hex;
+
+    public String name;
+
+    @Id
+    public long numberId;
+
+    public String romanNumeral;
+
+    public ArrayList<String> romanNumeralSymbols;
+
+    public int sumOfBits;
+
+    public static Prime of(long number, String romanNumeral, String name) {
+        Prime inst = new Prime();
+        inst.binaryDigits = Long.toBinaryString(number);
+        inst.even = number % 2 == 0;
+        inst.hex = Long.toHexString(number);
+        inst.name = name;
+        inst.romanNumeral = romanNumeral;
+        inst.numberId = number;
+        inst.sumOfBits = Long.bitCount(number);
+        if (romanNumeral != null) {
+            inst.romanNumeralSymbols = new ArrayList<>(romanNumeral.length());
+            for (int i = 0; i < romanNumeral.length(); i++)
+                inst.romanNumeralSymbols.add(romanNumeral.substring(i, i + 1));
+        }
+
+        return inst;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Product.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Product.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat
+ */
+@Entity
+public class Product {
+    public String description;
+
+    public String name;
+
+    @Id
+    @GeneratedValue
+    public UUID pk;
+
+    public float price;
+
+    @Version
+    public long version;
+
+    public static Product of(String description, String name, float price) {
+        Product inst = new Product();
+        inst.name = name;
+        inst.description = description;
+        inst.price = price;
+        return inst;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/PurchaseOrder.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/PurchaseOrder.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat_jpa
+ */
+@Entity(name = "Orders") // overrides the default name PurchaseOrder
+public class PurchaseOrder {
+
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Id
+    public UUID id;
+
+    public String purchasedBy;
+
+    public float total;
+
+    @Version
+    public int versionNum;
+
+    public static PurchaseOrder of(String purchasedBy, float total) {
+        PurchaseOrder inst = new PurchaseOrder();
+        inst.purchasedBy = purchasedBy;
+        inst.total = total;
+        return inst;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Rebate.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Rebate.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+//
+// Recreate from io.openliberty.data.internal_fat_jpa
+//
+//public record Rebate(
+//                Integer id, // TODO use @GeneratedValue
+//                double amount,
+//                String customerId,
+//                LocalTime purchaseMadeAt,
+//                LocalDate purchaseMadeOn,
+//                Rebate.Status status,
+//                LocalDateTime updatedAt,
+//                Integer version) { // TODO rename to something other than version, and use @Version
+//    public static enum Status {
+//        DENIED, SUBMITTED, VERIFIED, PAID
+//    }
+//}
+
+@Entity
+public class Rebate {
+
+    @Id
+    @GeneratedValue
+    public Integer id;
+
+    public double amount;
+
+    public String customerId;
+
+    public LocalTime purchaseMadeAt;
+
+    public LocalDate purchaseMadeOn;
+
+    public Rebate.Status status;
+
+    public LocalDateTime updatedAt;
+
+    @Version
+    Integer version;
+
+    public static Rebate of(double amount, String customerId, LocalTime purchaseMadeAt, LocalDate purchaseMadeOn, Status status, LocalDateTime updatedAt, int version) {
+        Rebate inst = new Rebate();
+        inst.amount = amount;
+        inst.customerId = customerId;
+        inst.purchaseMadeAt = purchaseMadeAt;
+        inst.purchaseMadeOn = purchaseMadeOn;
+        inst.status = status;
+        inst.updatedAt = updatedAt;
+        inst.version = version;
+
+        return inst;
+    }
+
+    public static enum Status {
+        DENIED, SUBMITTED, VERIFIED, PAID
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Reciept.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Reciept.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat
+ * Record -> Class
+ */
+@Entity
+public class Reciept {
+
+    @Id
+    public long purchaseId;
+
+    public String customer;
+
+    public float total;
+
+    public static Reciept of(long purchaseId, String customer, float total) {
+        Reciept inst = new Reciept();
+        inst.purchaseId = purchaseId;
+        inst.customer = customer;
+        inst.total = total;
+        return inst;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Segment.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Segment.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat_jpa
+ *
+ * The problem here is with the entity itself
+ * TODO: uncomment @Entity
+ * TODO: remove constructor from Point
+ */
+//@Entity
+public class Segment {
+
+    @GeneratedValue
+    @Id
+    public Long id;
+
+    @Embedded
+    @Column(nullable = false)
+    public Point pointA;
+
+    @Embedded
+    @Column(nullable = false)
+    public Point pointB;
+
+    @Embeddable
+    public static record Point(int x, int y) {
+        /**
+         * Recreate
+         * Exception Description: The instance creation method [io.openliberty.jpa.data.tests.models.Segment$Point.&lt;Default Constructor&gt;],
+         * with no parameters, does not exist, or is not accessible.
+         */
+        public Point() {
+            this(0, 0);
+        }
+    }
+
+    public static Segment of(int x1, int y1, int x2, int y2) {
+        Segment inst = new Segment();
+        inst.pointA = new Point(x1, y1);
+        inst.pointB = new Point(x2, y2);
+        return inst;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Triangle.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Triangle.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import java.util.Arrays;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat_jpa
+ */
+@Entity
+public class Triangle {
+
+    @Basic(optional = false)
+    @GeneratedValue
+    @Id
+    public Integer distinctKey;
+
+    @Basic(optional = true)
+    public Byte hypotenuse;
+
+    @Basic(optional = false)
+    public short perimeter;
+
+    @Basic(optional = false)
+    public Short sameLengthSides; // 0, 2, or 3
+
+    @Basic(optional = false)
+    public byte[] sides;
+
+    public static Triangle of(byte side1, byte side2, byte side3) {
+        Triangle inst = new Triangle();
+        inst.perimeter = (short) (side1 + side2 + side3);
+        inst.sides = new byte[] { side1, side2, side3 };
+        inst.sameLengthSides = side1 == side2 && side2 == side3 ? (short) 3 //
+                        : side1 == side2 || side2 == side3 || side1 == side3 ? (short) 2 //
+                                        : 0;
+        byte longest = 0;
+        byte[] others = new byte[2];
+        int i = 0;
+
+        for (byte s : inst.sides)
+            if (s > longest) {
+                if (longest > 0)
+                    others[i++] = longest;
+                longest = s;
+            } else if (s <= 0) {
+                throw new IllegalArgumentException("side " + s);
+            } else {
+                others[i++] = s;
+            }
+
+        inst.hypotenuse = longest * longest == others[0] * others[0] + others[1] * others[1] ? longest : null;
+
+        return inst;
+    }
+
+    @Override
+    public String toString() {
+        return "Triangle#" + distinctKey + " sides " + Arrays.toString(sides) + ", "
+               + sameLengthSides + "of same length, perimeter " + perimeter + ", hypotenuse " + hypotenuse;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -9,14 +9,21 @@
  *******************************************************************************/
 package io.openliberty.jpa.data.tests.web;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.UUID;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
+import io.openliberty.jpa.data.tests.models.Coordinate;
+import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.servlet.annotation.WebServlet;
+import jakarta.transaction.UserTransaction;
 
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/JakartaDataRecreate")
@@ -25,9 +32,51 @@ public class JakartaDataRecreateServlet extends FATServlet {
     @PersistenceContext(unitName = "RecreatePersistenceUnit")
     private EntityManager em;
 
+    @Resource
+    private UserTransaction tx;
+
     @Test
     public void alwaysPasses() {
         assertTrue(true);
+    }
+
+    @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28912")
+    public void testOLGH28912() throws Exception {
+        Coordinate original = Coordinate.of("testOLGH28912", 10, 15f);
+        UUID id = original.id;
+        Coordinate result;
+
+        tx.begin();
+
+        try {
+            em.persist(original);
+
+            em.createQuery("UPDATE Coordinate SET x = :newX, y = y / :yDivisor WHERE id = :id") //FAILURE PARSING QUERY HERE
+                            .setParameter("newX", 11)
+                            .setParameter("yDivisor", 5)
+                            .setParameter("id", id)
+                            .executeUpdate();
+
+            result = em.createQuery("SELECT Coordinate WHERE id = :id", Coordinate.class)
+                            .setParameter("id", id)
+                            .getSingleResult();
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+
+            /*
+             * Recreated
+             * java.lang.IllegalArgumentException: An exception occurred while creating a query in EntityManager:
+             * Exception Description: Syntax error parsing [UPDATE Coordinate SET x = :newX, y = y / :yDivisor WHERE id = :id].
+             * [37, 38] The left expression is not an arithmetic expression.
+             */
+            throw e;
+        }
+
+        assertEquals(id, result.id);
+        assertEquals(11, result.x, 0.001);
+        assertEquals(5f, result.y, 0.001);
     }
 
 }

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.web;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.servlet.annotation.WebServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/JakartaDataRecreate")
+public class JakartaDataRecreateServlet extends FATServlet {
+
+    @PersistenceContext(unitName = "RecreatePersistenceUnit")
+    private EntityManager em;
+
+    @Test
+    public void alwaysPasses() {
+        assertTrue(true);
+    }
+
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -32,6 +32,7 @@ import io.openliberty.jpa.data.tests.models.Person;
 import io.openliberty.jpa.data.tests.models.Prime;
 import io.openliberty.jpa.data.tests.models.Rebate;
 import io.openliberty.jpa.data.tests.models.Rebate.Status;
+import io.openliberty.jpa.data.tests.models.Segment;
 import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -380,6 +381,21 @@ public class JakartaDataRecreateServlet extends FATServlet {
         }
 
         assertEquals(4, primes.size());
+    }
+
+    @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/29117")
+    public void testOLGH29117() throws Exception {
+        Segment unitRadius = Segment.of(0, 0, 0, 1);
+
+        tx.begin();
+        try {
+            em.persist(unitRadius);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        }
     }
 
 }

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jpabootstrap/src/jpabootstrap/web/TestJPABootstrapServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jpabootstrap/src/jpabootstrap/web/TestJPABootstrapServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,7 @@
 package jpabootstrap.web;
 
 import org.junit.Assert;
+import org.junit.Test;
 
 import componenttest.app.FATServlet;
 import jakarta.annotation.Resource;
@@ -31,6 +32,7 @@ public class TestJPABootstrapServlet extends FATServlet {
     @Resource
     private UserTransaction tx;
 
+    @Test
     public void testPersistenceUnitBootstrap() throws Exception {
         tx.begin();
         SimpleTestEntity entity = new SimpleTestEntity();

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
-import static componenttest.annotation.SkipIfSysProp.DB_DB2;
 import static componenttest.annotation.SkipIfSysProp.DB_Oracle;
 import static componenttest.annotation.SkipIfSysProp.DB_Postgres;
 import static componenttest.annotation.SkipIfSysProp.DB_SQLServer;

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import static componenttest.annotation.SkipIfSysProp.DB_DB2;
 import static componenttest.annotation.SkipIfSysProp.DB_Oracle;
 import static componenttest.annotation.SkipIfSysProp.DB_Postgres;
 import static componenttest.annotation.SkipIfSysProp.DB_SQLServer;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/City.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/City.java
@@ -20,7 +20,7 @@ import jakarta.persistence.IdClass;
 import jakarta.persistence.Version;
 
 /**
- * Recreate from io.openliberty.data.internal_fat_jpa
+ *
  */
 @Entity
 @IdClass(CityId.class)

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/City.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/City.java
@@ -20,7 +20,7 @@ import jakarta.persistence.IdClass;
 import jakarta.persistence.Version;
 
 /**
- *
+ * Recreate from io.openliberty.data.internal_fat_jpa
  */
 @Entity
 @IdClass(CityId.class)

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2142,8 +2142,12 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(1L, accounts.countByOwnerAndBalanceBetween("Laura TestLiteralDouble", 331.159, 331.161));
 
-        Account account = accounts.findByAccountId(id);
-        assertEquals(331.16, account.balance, 0.001);
+        // TODO Enable the following once fixed,
+        //Account account = accounts.findByAccountId(id);
+        //assertEquals(331.16, account.balance, 0.001);
+        // Failure is:
+        // Caused by: java.lang.NullPointerException: Cannot read field "index" because "key" is null
+        // at org.eclipse.persistence.internal.sessions.ArrayRecord.get(ArrayRecord.java:139) ...
 
         assertEquals(2L, accounts.deleteByOwnerEndsWith("TestLiteralDouble"));
     }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2142,12 +2142,8 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(1L, accounts.countByOwnerAndBalanceBetween("Laura TestLiteralDouble", 331.159, 331.161));
 
-        // TODO Enable the following once fixed,
-        //Account account = accounts.findByAccountId(id);
-        //assertEquals(331.16, account.balance, 0.001);
-        // Failure is:
-        // Caused by: java.lang.NullPointerException: Cannot read field "index" because "key" is null
-        // at org.eclipse.persistence.internal.sessions.ArrayRecord.get(ArrayRecord.java:139) ...
+        Account account = accounts.findByAccountId(id);
+        assertEquals(331.16, account.balance, 0.001);
 
         assertEquals(2L, accounts.deleteByOwnerEndsWith("TestLiteralDouble"));
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Start recreating Jakarta Data issues from #28366
- Recreates are using Jakarta Persistence only
- This will allow the JPA team:
  - To verify solutions to resolve these issues
  - Commit tests back to the EclipseLink project
  - Better understand these issues in the context of JPA (without Jakarta Data syntax)

Fixes #29202