### PR TITLE
Fix EJB FAT Jakarta RepeatAction FFDC

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/BndErrorTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/BndErrorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2023 IBM Corporation and others.
+ * Copyright (c) 2007, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -278,7 +278,7 @@ public class BndErrorTest extends AbstractTest {
     @ExpectedFFDC(repeatAction = RepeatOnErrorEE8.ID_FAIL,
                   value = { "javax.ejb.EJBException", "com.ibm.ws.container.service.state.StateChangeException" })
     @ExpectedFFDC(repeatAction = { RepeatOnErrorEE9.ID_FAIL, RepeatOnErrorEE10.ID_FAIL },
-                  value = { "javax.ejb.EJBException", "com.ibm.ws.container.service.state.StateChangeException" })
+                  value = { "jakarta.ejb.EJBException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testNamepsaceInBindingName() throws Exception {
         testHelper(19, "CNTR0339W:.*ejblocal:local:ejb/myBean", false);
     }


### PR DESCRIPTION
Test incorrectly identified "javax" exception in FFDC for Jakarta repeat action - fixed.

This break was caused by @jhanders34's change in #28907 to no longer transform exceptions if they are assigned to a specific repeat action.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

