### PR TITLE
Fix EJB timer FAT verification 2

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.np_fat/test-applications/NpTimersWeb.war/src/com/ibm/ws/ejbcontainer/timer/np/web/AbstractAnnotationTxServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np_fat/test-applications/NpTimersWeb.war/src/com/ibm/ws/ejbcontainer/timer/np/web/AbstractAnnotationTxServlet.java
@@ -630,7 +630,14 @@ public abstract class AbstractAnnotationTxServlet extends AbstractServlet {
     public void testCreateIntervalDurationTimer() {
         svExpiredTimerInfos.clear();
 
-        long startTime = System.nanoTime();
+        // The tested timer is scheduled based on Date (currentTimeMillis), which due to
+        // inaccuracy may appear slightly in the past, causing the timers to run sooner
+        // than anticipated. So, while using nanoTime to calculate duration may be more
+        // accurate, that does not account for the first timeout being scheduled in the
+        // past. Therefore, the test will calculate duration using both nanoTime and
+        // currentTimeMillis and use the larger value for verification.
+        long startTimeNano = System.nanoTime();
+        long startTimeMillis = System.currentTimeMillis();
         try {
             ivBean.executeTest(TstName.TEST_INTERVAL_TIMER_DURATION);
         } catch (EJBException ex) {
@@ -640,7 +647,9 @@ public abstract class AbstractAnnotationTxServlet extends AbstractServlet {
         // sleep long enough for initial wait time + two intervals
         long minimumDuration = AnnotationTxLocal.DURATION + AnnotationTxLocal.INTERVAL + AnnotationTxLocal.INTERVAL;
         ivBean.waitForTimer(AnnotationTxLocal.MAX_WAIT_TIME);
-        long actualDuration = TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+        long actualDurationNano = TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTimeNano, TimeUnit.NANOSECONDS);
+        long actualDurationMillis = System.currentTimeMillis() - startTimeMillis;
+        long actualDuration = Math.max(actualDurationNano, actualDurationMillis);
 
         ivBean.clearAllTimers();
 
@@ -649,7 +658,8 @@ public abstract class AbstractAnnotationTxServlet extends AbstractServlet {
             assertEquals("Unexpected timer invoked (bad info)",
                          AnnotationTxLocal.INTERVAL_INFO, info);
         }
-        assertTrue("Timers ran too quickly; minimum=" + minimumDuration + ", actual=" + actualDuration, actualDuration >= minimumDuration);
+        assertTrue("Timers ran too quickly; minimum=" + minimumDuration + ", actualNano=" + actualDurationNano + ", actualMillis=" + actualDurationMillis,
+                   actualDuration >= minimumDuration);
     }
 
     /**


### PR DESCRIPTION
Account for inaccuracy of Date() time when verifying timers
- Same issue as fixed previously in a similar test method : [PR 28025](https://github.com/OpenLiberty/open-liberty/pull/28025)
- Prior test was based on Date(), whereas current test is for "duration", but "duration" is just based on Date(), so same fix needs to be applied to both tests.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

