### PR TITLE
WS-AT fails when downstream server is non-Liberty

### DIFF
--- a/dev/com.ibm.ws.wsat.common/src/com/ibm/ws/wsat/service/WSATUtil.java
+++ b/dev/com.ibm.ws.wsat.common/src/com/ibm/ws/wsat/service/WSATUtil.java
@@ -29,18 +29,27 @@ import com.ibm.ws.jaxws.wsat.Constants;
 public class WSATUtil {
     private static final TraceComponent TC = Tr.register(WSATUtil.class);
 
-    public static EndpointReferenceType createEpr(String hostname, String... recoveryIds) {
+    public static EndpointReferenceType createEpr(String hostname) {
         EndpointReferenceType epr = new EndpointReferenceType();
         AttributedURIType uri = new AttributedURIType();
         uri.setValue(hostname);
         epr.setAddress(uri);
-        ReferenceParametersType para = new ReferenceParametersType();
+        epr.setReferenceParameters(new ReferenceParametersType());
+        return epr;
+    }
 
-        if (recoveryIds.length > 0 && recoveryIds[0] != null) {
-            para.getAny().add(new JAXBElement<String>(Constants.WS_WSAT_REC_REF, String.class, recoveryIds[0]));
+    public static EndpointReferenceType createEpr(String hostname, String globalId, String recoveryId) {
+        EndpointReferenceType epr = WSATUtil.createEpr(hostname);
+
+        final ReferenceParametersType para = epr.getReferenceParameters();
+
+        if (recoveryId != null && !recoveryId.isEmpty()) {
+            para.getAny().add(new JAXBElement<String>(Constants.WS_WSAT_REC_REF, String.class, recoveryId));
+        }
+        if (globalId != null && !globalId.isEmpty()) {
+            para.getAny().add(new JAXBElement<String>(Constants.WS_WSAT_CTX_REF, String.class, globalId));
         }
 
-        epr.setReferenceParameters(para);
         return epr;
     }
 

--- a/dev/com.ibm.ws.wsat.webservice/src/com/ibm/ws/wsat/interceptor/CoorContextOutInterceptor.java
+++ b/dev/com.ibm.ws.wsat.webservice/src/com/ibm/ws/wsat/interceptor/CoorContextOutInterceptor.java
@@ -109,9 +109,10 @@ public class CoorContextOutInterceptor extends AbstractPhaseInterceptor<Message>
                                  + "/"
                                  + WSCoorConstants.COORDINATION_REGISTRATION_ENDPOINT;
 
-                EndpointReferenceType localRegEpr = WSATUtil.createEpr(regHost, tranService != null ? tranService.getRecoveryId() : null);
+                final String recoveryId = tranService != null ? tranService.getRecoveryId() : null;
 
-                WSATContext ctx = WSCoorUtil.getHandlerService().handleClientRequest();
+                final WSATContext ctx = WSCoorUtil.getHandlerService().handleClientRequest();
+                final EndpointReferenceType localRegEpr = WSATUtil.createEpr(regHost, ctx.getId(), recoveryId);
 
                 CoordinationContext cc = WSCoorUtil.createCoordinationContext(ctx, localRegEpr);
                 dataBinding = new JAXBDataBinding(CoordinationContext.class);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #29127
#build
#spawn.fullfat.buckets=com.ibm.ws.wsat.common_fat,com.ibm.ws.wsat.concurrent_fat,com.ibm.ws.wsat.migration_fat.1,com.ibm.ws.wsat.migration_fat.2,com.ibm.ws.wsat.migration_fat.3,com.ibm.ws.wsat.migration_fat.4,com.ibm.ws.wsat.migration_fat.5,com.ibm.ws.wsat.migration_fat.6,com.ibm.ws.wsat.migration_fat.7,com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.multi.5,com.ibm.ws.wsat.recovery_fat.multi.6,com.ibm.ws.wsat.recovery_fat.multi.7,com.ibm.ws.wsat.recovery_fat.single.1,com.ibm.ws.wsat.recovery_fat.single.2,com.ibm.ws.wsat_fat.assertion,com.ibm.ws.wsat_fat.db,com.ibm.ws.wsat_fat.db_optional,com.ibm.ws.wsat_fat.dbs,com.ibm.ws.wsat_fat.dbs_optional,com.ibm.ws.wsat_fat.multi,com.ibm.ws.wsat_fat.multi.misroute,com.ibm.ws.wsat_fat.ssl.misroute,com.ibm.ws.wsat_fat.ssl