### PR TITLE
JAX-WS: Timeout added for SSL Tests

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/SSLTestCommon.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/SSLTestCommon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/SSLTestCommon.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/usernametoken/SSLTestCommon.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -124,7 +124,7 @@ public class SSLTestCommon {
         server.waitForStringInLog("port " + portNumber, 60 * 1000); // 1 minute
         server.waitForStringInLog("port " + portNumberSecure, 60 * 1000); // 1 minute
 
-        assertNotNull("SSL Service is not ready.", server.waitForStringInLog("CWWKO0219I.*ssl"));
+        assertNotNull("SSL Service is not ready.", server.waitForStringInLog("CWWKO0219I.*ssl", 60 * 1000)); // 1 minute
 
         //portNumber = "9085" ;
         untClientUrl = "http://localhost:" + portNumber


### PR DESCRIPTION
- [x]  I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x]  If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify release bug label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x]  If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Timeout added to resolve `junit.framework.AssertionFailedError: SSL Service is not ready.` issue. 
