### PR TITLE
Remove some magic numbers from failover tests

### DIFF
--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/test-applications/transaction/src/web/FailoverServlet.java
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/test-applications/transaction/src/web/FailoverServlet.java
@@ -28,8 +28,6 @@ import java.util.Set;
 
 import javax.annotation.Resource;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import javax.transaction.xa.XAResource;
 
@@ -39,6 +37,8 @@ import com.ibm.tx.jta.ut.util.TxTestUtils;
 import com.ibm.tx.jta.ut.util.XAResourceFactoryImpl;
 import com.ibm.tx.jta.ut.util.XAResourceImpl;
 import com.ibm.tx.jta.ut.util.XAResourceInfoFactory;
+import com.informix.database.ConnectionManager;
+import com.informix.jdbcx.IfxConstants.TestType;
 
 import componenttest.app.FATServlet;
 
@@ -49,113 +49,109 @@ public class FailoverServlet extends FATServlet {
     @Resource(lookup = "jdbc/tranlogDataSource")
     private DataSource ds;
 
-    private enum TestType {
-        STARTUP, RUNTIME, DUPLICATE_RESTART, DUPLICATE_RUNTIME, HALT, CONNECT, LEASE
-    };
-
     /**
      * Lookup string that allows character digit lookup by index value.
      * ie _digits[9] == '9' etc.
      */
     private final static String _digits = "0123456789abcdef";
 
-    public void setupForRecoverableFailover(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForRecoverableFailover() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForRecoverableFailover");
-        setupTestParameters(request, response, TestType.RUNTIME, -4498, 12, 1);
+        setupTestParameters(TestType.RUNTIME, -4498, 12, 1);
         System.out.println("FAILOVERSERVLET: setupForRecoverableFailover complete");
     }
 
-    public void setupForRecoverableFailureMultipleRetries(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForRecoverableFailureMultipleRetries() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForRecoverableFailureMultipleRetries");
-        setupTestParameters(request, response, TestType.RUNTIME, -4498, 12, 5); // Can fail up to 5 times
+        setupTestParameters(TestType.RUNTIME, -4498, 12, 5); // Can fail up to 5 times
         System.out.println("FAILOVERSERVLET: setupForRecoverableFailureMultipleRetries complete");
     }
 
-    public void setupForNonRecoverableFailover(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForNonRecoverableFailover() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForNonRecoverableFailover");
-        setupTestParameters(request, response, TestType.RUNTIME, -3, 12, 1);
+        setupTestParameters(TestType.RUNTIME, -3, 12, 1);
         System.out.println("FAILOVERSERVLET: setupForNonRecoverableFailover complete");
     }
 
-    public void setupForNonRecoverableBatchFailover(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForNonRecoverableBatchFailover() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForNonRecoverableBatchFailover");
-        setupTestParameters(request, response, TestType.RUNTIME, -33, 12, 1);
+        setupTestParameters(TestType.RUNTIME, -33, 12, 1);
         System.out.println("FAILOVERSERVLET: setupForNonRecoverableBatchFailover complete");
     }
 
-    public void setupForConnectFailover(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForConnectFailover() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForConnectFailover");
-        setupTestParameters(request, response, TestType.CONNECT, 0, 0, 1);
+        setupTestParameters(TestType.CONNECT, 0, 0, 1);
         System.out.println("FAILOVERSERVLET: setupForConnectFailover complete");
     }
 
-    public void setupForMultiConnectFailover(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForMultiConnectFailover() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForConnectFailover");
-        setupTestParameters(request, response, TestType.CONNECT, 0, 0, 3);
+        setupTestParameters(TestType.CONNECT, 0, 0, 3);
         System.out.println("FAILOVERSERVLET: setupForConnectFailover complete");
     }
 
-    public void setupForStartupFailover(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForStartupFailover() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForStartupFailover");
-        setupTestParameters(request, response, TestType.STARTUP, -4498, 6, 1);
+        setupTestParameters(TestType.STARTUP, -4498, 6, 1);
         System.out.println("FAILOVERSERVLET: setupForStartupFailover complete");
     }
 
-    public void setupForNonRecoverableStartupFailover(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForNonRecoverableStartupFailover() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForNonRecoverableStartupFailover");
-        setupTestParameters(request, response, TestType.STARTUP, -3, 6, 1);
+        setupTestParameters(TestType.STARTUP, -3, 6, 1);
         System.out.println("FAILOVERSERVLET: setupForNonRecoverableStartupFailover complete");
     }
 
-    public void setupForEarlyNonRecoverableStartupFailover(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForEarlyNonRecoverableStartupFailover() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForNonRecoverableStartupFailover");
-        setupTestParameters(request, response, TestType.STARTUP, -3, 0, 1);
+        setupTestParameters(TestType.STARTUP, -3, 0, 1);
         System.out.println("FAILOVERSERVLET: setupForNonRecoverableStartupFailover complete");
     }
 
-    public void setupForDuplicationRestart(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForDuplicationRestart() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForDuplicationRestart");
-        setupTestParameters(request, response, TestType.DUPLICATE_RESTART, 0, 10, 1);
+        setupTestParameters(TestType.DUPLICATE_RESTART, 0, 10, 1);
         System.out.println("FAILOVERSERVLET: setupForDuplicationRestart complete");
     }
 
-    public void setupForDuplicationRuntime(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForDuplicationRuntime() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForDuplicationRuntime");
-        setupTestParameters(request, response, TestType.DUPLICATE_RUNTIME, 0, 10, 1);
+        setupTestParameters(TestType.DUPLICATE_RUNTIME, 0, 10, 1);
         System.out.println("FAILOVERSERVLET: setupForDuplicationRuntime complete");
     }
 
-    public void setupForHalt(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForHalt() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForHalt");
-        setupTestParameters(request, response, TestType.HALT, 0, 12, 1); // set the ioperation to the duplicate test value + 2
+        setupTestParameters(TestType.HALT, 0, 12, 1); // set the ioperation to the duplicate test value + 2
         System.out.println("FAILOVERSERVLET: setupForHalt complete");
     }
 
-    public void setupForLeaseUpdate(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForLeaseUpdate() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForLeaseUpdate");
-        setupTestParameters(request, response, TestType.LEASE, 0, 770, 1); // 770 interpreted as lease update
+        setupTestParameters(TestType.LEASE, 0, 770, 1); // 770 interpreted as lease update
         System.out.println("FAILOVERSERVLET: setupForLeaseUpdate complete");
     }
 
-    public void setupForLeaseDelete(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForLeaseDelete() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForLeaseDelete");
-        setupTestParameters(request, response, TestType.LEASE, 0, 771, 1); // 771 interpreted as lease delete
+        setupTestParameters(TestType.LEASE, 0, 771, 1); // 771 interpreted as lease delete
         System.out.println("FAILOVERSERVLET: setupForLeaseDelete complete");
     }
 
-    public void setupForLeaseClaim(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForLeaseClaim() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForLeaseClaim");
-        setupTestParameters(request, response, TestType.LEASE, 0, 772, 1); // 772 interpreted as lease claim
+        setupTestParameters(TestType.LEASE, 0, 772, 1); // 772 interpreted as lease claim
         System.out.println("FAILOVERSERVLET: setupForLeaseClaim complete");
     }
 
-    public void setupForLeaseGet(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void setupForLeaseGet() throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupForLeaseGet");
-        setupTestParameters(request, response, TestType.LEASE, 0, 773, 1); // 773 interpreted as lease get
+        setupTestParameters(TestType.LEASE, 0, 773, 1); // 773 interpreted as lease get
         System.out.println("FAILOVERSERVLET: setupForLeaseGet complete");
     }
 
-    private void setupTestParameters(HttpServletRequest request, HttpServletResponse response, TestType testType,
+    private void setupTestParameters(TestType testType,
                                      int thesqlcode, int operationToFail, int numberOfFailures) throws Exception {
         System.out.println("FAILOVERSERVLET: drive setupTestParameters");
 
@@ -165,7 +161,7 @@ public class FailoverServlet extends FATServlet {
         // Allow a retry if the first attempt to set up the table fails.
         while (!setupDone && retries < 2) {
             try {
-                setupHATable(request, response, testType, thesqlcode, operationToFail, numberOfFailures);
+                setupHATable(testType, thesqlcode, operationToFail, numberOfFailures);
                 setupDone = true;
             } catch (Exception ex) {
                 System.out.println("FAILOVERSERVLET: caught exception in testSetup: " + ex);
@@ -177,26 +173,39 @@ public class FailoverServlet extends FATServlet {
             throw exToThrow;
     }
 
-    private void setupHATable(HttpServletRequest request, HttpServletResponse response, TestType testType,
+    private void setupHATable(TestType testType,
                               int thesqlcode, int operationToFail, int numberOfFailures) throws Exception {
-        System.out.println("FAILOVERSERVLET: drive setupHATable");
 
         try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
-            try {
-                System.out.println("FAILOVERSERVLET: drop hatable");
-                stmt.executeUpdate("drop table hatable");
-            } catch (SQLException x) {
-                // didn't exist
-            }
 
-            System.out.println("FAILOVERSERVLET: create hatable");
-            stmt.executeUpdate(
-                               "create table hatable (testtype int not null primary key, failingoperation int, numberoffailures int, simsqlcode int)");
-            // was col2 varchar(20)
-            System.out.println("FAILOVERSERVLET: insert row into hatable - type" + testType.ordinal()
-                               + ", operationtofail: " + operationToFail + ", sqlcode: " + thesqlcode);
-            stmt.executeUpdate("insert into hatable values (" + testType.ordinal() + ", " + operationToFail + ", " + numberOfFailures + ", "
-                               + thesqlcode + ")"); // was -4498
+            String q;
+            int ret = 0;
+            boolean isOracle = ConnectionManager.dbProductName.toLowerCase().contains("oracle");
+            boolean isDerby = ConnectionManager.dbProductName.toLowerCase().contains("derby");
+            if (isOracle || isDerby) {
+                q = "drop table hatable";
+            } else {
+                q = "drop table if exists hatable";
+            }
+            try {
+                ret = stmt.executeUpdate(q);
+            } catch (SQLException e) {
+                if (isOracle) {
+                    // table might not have existed
+                    if (942 != e.getErrorCode()) {
+                        throw e;
+                    }
+                }
+            }
+            System.out.println("FAILOVERSERVLET: " + q + " - " + ret);
+
+            q = "create table hatable (testtype int not null primary key, failingoperation int, numberoffailures int, simsqlcode int)";
+            ret = stmt.executeUpdate(q);
+            System.out.println("FAILOVERSERVLET: " + q + " - " + ret);
+
+            q = "insert into hatable values (" + testType.ordinal() + ", " + operationToFail + ", " + numberOfFailures + ", " + thesqlcode + ")";
+            ret = stmt.executeUpdate(q);
+            System.out.println("FAILOVERSERVLET: " + q + " - " + ret);
 
             // UserTransaction Commit
             con.setAutoCommit(false);
@@ -206,7 +215,7 @@ public class FailoverServlet extends FATServlet {
         }
     }
 
-    public void dropHATable(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void dropHATable() throws Exception {
         System.out.println("FAILOVERSERVLET: drive dropHATable");
 
         try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
@@ -225,7 +234,7 @@ public class FailoverServlet extends FATServlet {
         }
     }
 
-    public void dropStaleRecoveryLogTables(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void dropStaleRecoveryLogTables() throws Exception {
         System.out.println("FAILOVERSERVLET: drive dropStaleRecoveryLogTables");
 
         try (Connection con = getConnection(); Statement stmt = con.createStatement()) {
@@ -258,7 +267,7 @@ public class FailoverServlet extends FATServlet {
      * @throws Exception
      *             if an error occurs.
      */
-    public void driveTransactions(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void driveTransactions() throws Exception {
         System.out.println("FAILOVERSERVLET: driveTransactions");
 
         // Set the test parameters
@@ -269,7 +278,7 @@ public class FailoverServlet extends FATServlet {
             System.out.println("FAILOVERSERVLET: drive the Performance Test, resources: " + resources + ", batchSize: "
                                + batchSize);
 
-            simulateTransactions(request, response, batchSize, resources);
+            simulateTransactions(batchSize, resources);
 
         } catch (Exception e) {
             System.out.println("FAILOVERSERVLET: EXCEPTION: " + e);
@@ -277,7 +286,7 @@ public class FailoverServlet extends FATServlet {
         }
     }
 
-    public void driveSixTransactions(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void driveSixTransactions() throws Exception {
         System.out.println("FAILOVERSERVLET: driveSixTransactions");
 
         // Set the test parameters
@@ -288,7 +297,7 @@ public class FailoverServlet extends FATServlet {
             System.out.println("FAILOVERSERVLET: drive the Performance Test, resources: " + resources + ", batchSize: "
                                + batchSize);
 
-            simulateTransactions(request, response, batchSize, resources);
+            simulateTransactions(batchSize, resources);
 
         } catch (Exception e) {
             System.out.println("FAILOVERSERVLET: EXCEPTION: " + e);
@@ -297,7 +306,7 @@ public class FailoverServlet extends FATServlet {
 
     }
 
-    public void driveTransactionsWithFailure(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void driveTransactionsWithFailure() throws Exception {
         System.out.println("FAILOVERSERVLET: driveTransactionsWithFailure");
 
         // Set the test parameters
@@ -309,7 +318,7 @@ public class FailoverServlet extends FATServlet {
             System.out.println("FAILOVERSERVLET: drive a batch of transactions, resources: " + resources + ", batchSize: "
                                + batchSize);
 
-            simulateTransactions(request, response, batchSize, resources);
+            simulateTransactions(batchSize, resources);
             System.out.println("FAILOVERSERVLET: failed to throw SystemException");
             throw new Exception();
         } catch (javax.transaction.SystemException sysex) {
@@ -320,7 +329,7 @@ public class FailoverServlet extends FATServlet {
         }
     }
 
-    private void simulateTransactions(HttpServletRequest request, HttpServletResponse response, int batchSize, int resources) throws Exception {
+    private void simulateTransactions(int batchSize, int resources) throws Exception {
         final ExtendedTransactionManager tm = TransactionManagerFactory.getTransactionManager();
 
         System.out.println("FAILOVERSERVLET: Starting simulateTransactions");
@@ -356,8 +365,7 @@ public class FailoverServlet extends FATServlet {
 
     }
 
-    public void checkForDuplicates(HttpServletRequest request,
-                                   HttpServletResponse response) throws Exception {
+    public void checkForDuplicates() throws Exception {
         Set<List<Number>> resultSet;
         List<Number> row;
 
@@ -399,8 +407,7 @@ public class FailoverServlet extends FATServlet {
         }
     }
 
-    public void insertStaleLease(HttpServletRequest request,
-                                 HttpServletResponse response) throws Exception {
+    public void insertStaleLease() throws Exception {
 
         try (Connection con = getConnection()) {
             con.setAutoCommit(false);
@@ -524,8 +531,7 @@ public class FailoverServlet extends FATServlet {
         }
     }
 
-    public void setupRec007(HttpServletRequest request,
-                            HttpServletResponse response) throws Exception {
+    public void setupRec007() throws Exception {
         final ExtendedTransactionManager tm = TransactionManagerFactory.getTransactionManager();
         XAResourceImpl.clear();
         final Serializable xaResInfo1 = XAResourceInfoFactory.getXAResourceInfo(0);

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/test-bundles/ifxlib/src/com/informix/jdbcx/IfxConstants.java
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/test-bundles/ifxlib/src/com/informix/jdbcx/IfxConstants.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.informix.jdbcx;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class IfxConstants {
+    public enum TestType {
+        STARTUP,
+        RUNTIME,
+        DUPLICATE_RESTART,
+        DUPLICATE_RUNTIME,
+        HALT,
+        CONNECT,
+        LEASE;
+
+        private static final Map<Integer, TestType> _map = new HashMap<Integer, TestType>();
+        static {
+            for (TestType testType : TestType.values()) {
+                _map.put(testType.ordinal(), testType);
+            }
+        }
+
+        public static TestType from(int ordinal) {
+            return _map.get(ordinal);
+        }
+    };
+}

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/test-bundles/ifxlib/src/com/informix/jdbcx/IfxPooledConnection.java
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/test-bundles/ifxlib/src/com/informix/jdbcx/IfxPooledConnection.java
@@ -21,6 +21,8 @@ import javax.sql.ConnectionEventListener;
 import javax.sql.PooledConnection;
 import javax.sql.StatementEventListener;
 
+import com.informix.jdbcx.IfxConstants.TestType;
+
 public class IfxPooledConnection implements PooledConnection {
     PooledConnection wrappedPooledConn = null;
     Connection unwrappedConnection = null;
@@ -95,131 +97,142 @@ public class IfxPooledConnection implements PooledConnection {
                 System.out.println("SIMHADB: Execute a query to see if we can find the table");
                 rsBasic = stmt.executeQuery("SELECT testtype, failingoperation, numberoffailures, simsqlcode" + " FROM hatable");
                 if (rsBasic.next()) {
-                    int testTypeInt = rsBasic.getInt(1);
-                    System.out.println("SIMHADB: Stored column testtype is: " + testTypeInt);
+                    final TestType testType = TestType.from(rsBasic.getInt(1));
+                    System.out.println("SIMHADB: Stored column testtype is: " + testType);
                     int failingOperation = rsBasic.getInt(2);
                     System.out.println("SIMHADB: Stored column failingoperation is: " + failingOperation);
                     int numberOfFailuresInt = rsBasic.getInt(3);
                     System.out.println("SIMHADB: Stored column numberoffailures is: " + numberOfFailuresInt);
                     int simsqlcodeInt = rsBasic.getInt(4);
                     System.out.println("SIMHADB: Stored column simsqlcode is: " + simsqlcodeInt);
-                    if (testTypeInt == 0) // Test Failover at startup
-                    {
-                        // We abuse the failovervalInt parameter. If it is set to
-                        // 999, then we will
-                        // not enable the failover function, so that the server can
-                        // safely shut
-                        // down. But we reset the column, so that next time (on
-                        // startup) failover
-                        // will be enabled
-                        if (failingOperation == 999) {
-                            IfxConnectionPoolDataSource.setTestingFailoverAtRuntime(false);
-                            IfxConnection.setFailoverEnabled(false);
-                            System.out.println("SIMHADB: update HATABLE with faoloverval 0");
-                            stmt.executeUpdate("update hatable set failingoperation = 0 where testtype = 0");
-                            theConn.commit();
-                            System.out.println("SIMHADB: HATABLE committed");
-                            System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
-                            IfxConnection.setSimSQLCode(simsqlcodeInt);
-                        } else {
-                            if (!IfxConnectionPoolDataSource.isTestingFailoverAtRuntime()) {
-                                System.out.println(
-                                                   "SIMHADB: Already set to test failover at startup, we don't want to change settings");
-                            } else {
-                                System.out.println("SIMHADB: Test failover at startup, make settings");
-                                IfxConnection.setFailoverValue(failingOperation);
-                                IfxConnection.setQueryFailoverEnabled(true);
-                                IfxConnectionPoolDataSource.setTestingFailoverAtRuntime(true);
-                                IfxConnection.setQueryFailoverCounter(0);
-
+                    switch (testType) {
+                        case STARTUP:
+                            // We abuse the failovervalInt parameter. If it is set to
+                            // 999, then we will
+                            // not enable the failover function, so that the server can
+                            // safely shut
+                            // down. But we reset the column, so that next time (on
+                            // startup) failover
+                            // will be enabled
+                            if (failingOperation == 999) {
+                                IfxConnectionPoolDataSource.setTestingFailoverAtRuntime(false);
+                                IfxConnection.setFailoverEnabled(false);
+                                System.out.println("SIMHADB: update HATABLE with faoloverval 0");
+                                stmt.executeUpdate("update hatable set failingoperation = 0 where testtype = 0");
+                                theConn.commit();
+                                System.out.println("SIMHADB: HATABLE committed");
                                 System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
                                 IfxConnection.setSimSQLCode(simsqlcodeInt);
+                            } else {
+                                if (!IfxConnectionPoolDataSource.isTestingFailoverAtRuntime()) {
+                                    System.out.println(
+                                                       "SIMHADB: Already set to test failover at startup, we don't want to change settings");
+                                } else {
+                                    System.out.println("SIMHADB: Test failover at startup, make settings");
+                                    IfxConnection.setFailoverValue(failingOperation);
+                                    IfxConnection.setQueryFailoverEnabled(true);
+                                    IfxConnectionPoolDataSource.setTestingFailoverAtRuntime(true);
+                                    IfxConnection.setQueryFailoverCounter(0);
+
+                                    System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
+                                    IfxConnection.setSimSQLCode(simsqlcodeInt);
+                                }
                             }
-                        }
-                    } else if (testTypeInt == 1) // Test Failover at runtime
-                    {
-                        IfxConnection.setFailoverEnabled(true);
-                        IfxConnection.setFailoverCounter(0);
+                            break;
 
-                        System.out.println(
-                                           "SIMHADB: Test failover at runtime, Stored column failoverval is: " + failingOperation);
-                        if (failingOperation > 0)
-                            IfxConnection.setFailoverValue(failingOperation);
-                        System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
-                        IfxConnection.setSimSQLCode(simsqlcodeInt);
+                        case RUNTIME:
+                            IfxConnection.setFailoverEnabled(true);
+                            IfxConnection.setFailoverCounter(0);
 
-                        if (numberOfFailuresInt > 1) {
-                            IfxConnection.setFailingRetries(numberOfFailuresInt);
-                            IfxConnection.setFailingRetryCounter(0);
-                        }
-                    } else if (testTypeInt == 2)// Test duplication in the recovery logs
-                    {
-                        IfxConnection.setDuplicationEnabled(true); // Set this so that we will check in IfxPreparedStatement.eExecuteBatch()to see if we should be duplicating rows.
-                        IfxConnection.setDuplicateCounter(0); // Count the number of executeBatch() calls we have made
+                            System.out.println(
+                                               "SIMHADB: Test failover at runtime, Stored column failoverval is: " + failingOperation);
+                            if (failingOperation > 0)
+                                IfxConnection.setFailoverValue(failingOperation);
+                            System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
+                            IfxConnection.setSimSQLCode(simsqlcodeInt);
 
-                        // Also enable a halt
-                        IfxConnection.setHaltEnabled(true);
-                        System.out.println(
-                                           "SIMHADB: Test duplication at runtime, Stored column failoverval is: " + failingOperation);
-                        if (failingOperation > 0)
-                            IfxConnection.setFailoverValue(failingOperation); //  When the duplicateCounter reaches this value we'll start collecting duplicate rows
-                        System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
-                        IfxConnection.setSimSQLCode(simsqlcodeInt);
-                    } else if (testTypeInt == 3)// Test duplication at runtime
-                    {
-                        IfxConnection.setDuplicationEnabled(true);
-                        IfxConnection.setDuplicateCounter(0);
+                            if (numberOfFailuresInt > 1) {
+                                IfxConnection.setFailingRetries(numberOfFailuresInt);
+                                IfxConnection.setFailingRetryCounter(0);
+                            }
+                            break;
 
-                        System.out.println(
-                                           "SIMHADB: Test duplication at runtime, Stored column failoverval is: " + failingOperation);
-                        if (failingOperation > 0)
-                            IfxConnection.setFailoverValue(failingOperation);
-                        System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
-                        IfxConnection.setSimSQLCode(simsqlcodeInt);
-                    } else if (testTypeInt == 4)// Test "halt" - used as control for duplication test
-                    {
-                        IfxConnection.setHaltEnabled(true);
-                        IfxConnection.setHaltCounter(0);
+                        case DUPLICATE_RESTART:
+                            IfxConnection.setDuplicationEnabled(true); // Set this so that we will check in IfxPreparedStatement.eExecuteBatch()to see if we should be duplicating rows.
+                            IfxConnection.setDuplicateCounter(0); // Count the number of executeBatch() calls we have made
 
-                        System.out.println(
-                                           "SIMHADB: Test halt at runtime, Stored column failoverval is: " + failingOperation);
-                        if (failingOperation > 0)
-                            IfxConnection.setFailoverValue(failingOperation);
-                        System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
-                        IfxConnection.setSimSQLCode(simsqlcodeInt);
-                    } else if (testTypeInt == 5)// Special case of failure at connection, throw an exception here
-                    {
-                        // Dependent on number of connection attempts, reset _areParametersSet
-                        if (_connectAttempts < numberOfFailuresInt)
-                            _areParametersSet = false;
+                            // Also enable a halt
+                            IfxConnection.setHaltEnabled(true);
+                            System.out.println(
+                                               "SIMHADB: Test duplication at runtime, Stored column failoverval is: " + failingOperation);
+                            if (failingOperation > 0)
+                                IfxConnection.setFailoverValue(failingOperation); //  When the duplicateCounter reaches this value we'll start collecting duplicate rows
+                            System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
+                            IfxConnection.setSimSQLCode(simsqlcodeInt);
+                            break;
 
-                        if (_areParametersSet) {
-                            // Last time through, need to update hatable to avoid interference with subsequent tests
-                            System.out.println("SIMHADB: update HATABLE with testtype = 99");
-                            stmt.executeUpdate("update hatable set testtype = 99 where testtype = 5");
-                        }
+                        case DUPLICATE_RUNTIME:
+                            IfxConnection.setDuplicationEnabled(true);
+                            IfxConnection.setDuplicateCounter(0);
 
-                        String sqlReason = "Generated internally";
-                        String sqlState = "Generated reason";
-                        int reasonCode = -777;
+                            System.out.println(
+                                               "SIMHADB: Test duplication at runtime, Stored column failoverval is: " + failingOperation);
+                            if (failingOperation > 0)
+                                IfxConnection.setFailoverValue(failingOperation);
+                            System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
+                            IfxConnection.setSimSQLCode(simsqlcodeInt);
+                            break;
 
-                        System.out.println("SIMHADB: sqlcode set to: " + reasonCode);
-                        // if reason code is "-3" then exception is non-transient, otherwise it is transient
-                        SQLException sqlex = new SQLException(sqlReason, sqlState, reasonCode);
+                        case HALT:
+                            IfxConnection.setHaltEnabled(true);
+                            IfxConnection.setHaltCounter(0);
 
-                        throw sqlex;
-                    } else if (testTypeInt == 6) { // Lease Log tests
-                        // We abuse the failovervalInt parameter.
-                        // 770 - lease update test
-                        if (failingOperation == 770) {
-                            IfxConnection.setTestingLeaselogUpdateFlag(true);
-                        } else if (failingOperation == 771) {
-                            IfxConnection.setTestingLeaselogDeleteFlag(true);
-                        } else if (failingOperation == 772) {
-                            IfxConnection.setTestingLeaselogClaimFlag(true);
-                        } else if (failingOperation == 773) {
-                            IfxConnection.setTestingLeaselogGetFlag(true);
-                        }
+                            System.out.println(
+                                               "SIMHADB: Test halt at runtime, Stored column failoverval is: " + failingOperation);
+                            if (failingOperation > 0)
+                                IfxConnection.setFailoverValue(failingOperation);
+                            System.out.println("SIMHADB: Set simsqlcode to: " + simsqlcodeInt);
+                            IfxConnection.setSimSQLCode(simsqlcodeInt);
+                            break;
+
+                        case CONNECT:
+                            // Dependent on number of connection attempts, reset _areParametersSet
+                            if (_connectAttempts < numberOfFailuresInt)
+                                _areParametersSet = false;
+
+                            if (_areParametersSet) {
+                                // Last time through, need to update hatable to avoid interference with subsequent tests
+                                System.out.println("SIMHADB: update HATABLE with testtype = 99");
+                                stmt.executeUpdate("update hatable set testtype = 99 where testtype = 5");
+                            }
+
+                            String sqlReason = "Generated internally";
+                            String sqlState = "Generated reason";
+                            int reasonCode = -777;
+
+                            System.out.println("SIMHADB: sqlcode set to: " + reasonCode);
+                            // if reason code is "-3" then exception is non-transient, otherwise it is transient
+                            SQLException sqlex = new SQLException(sqlReason, sqlState, reasonCode);
+
+                            throw sqlex;
+
+                        case LEASE:
+                            // We abuse the failovervalInt parameter.
+                            // 770 - lease update test
+                            if (failingOperation == 770) {
+                                IfxConnection.setTestingLeaselogUpdateFlag(true);
+                            } else if (failingOperation == 771) {
+                                IfxConnection.setTestingLeaselogDeleteFlag(true);
+                            } else if (failingOperation == 772) {
+                                IfxConnection.setTestingLeaselogClaimFlag(true);
+                            } else if (failingOperation == 773) {
+                                IfxConnection.setTestingLeaselogGetFlag(true);
+                            }
+                            break;
+
+                        default:
+                            System.out.println("SIMHADB: unknown test type");
+                            break;
                     }
                 } else {
                     System.out.println("SIMHADB: Empty result set");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #29135
#build
#spawn.fullfat.buckets=com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes