### PR TITLE
Add reactive features to Telemetry MP50 repeats

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/TelemetryActions.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/TelemetryActions.java
@@ -13,15 +13,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.FeatureSet;
-import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatActions;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.rules.repeater.EE7FeatureReplacementAction;
 import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.FeatureSet;
 import componenttest.rules.repeater.JakartaEEAction;
-
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions;
+import componenttest.rules.repeater.RepeatTests;
 
 public class TelemetryActions {
     public static final String MP14_MPTEL11_ID = MicroProfileActions.MP14_ID + "_MPTEL11";
@@ -29,7 +28,7 @@ public class TelemetryActions {
     public static final String MP50_MPTEL11_ID = MicroProfileActions.MP50_ID + "_MPTEL11";
 
     //Telemetry 2.0 repeats should not start with "MicroProfile_xx" as RepeatTestFilter uses startsWith() which makes them indisinguishable to mpTelemetry-1.1 in tests
-    public static final String MP14_MPTEL20_ID = EE7FeatureReplacementAction.ID + "_MPTEL20_MicroProfile_14"; 
+    public static final String MP14_MPTEL20_ID = EE7FeatureReplacementAction.ID + "_MPTEL20_MicroProfile_14";
     public static final String MP41_MPTEL20_ID = EE8FeatureReplacementAction.ID + "_MPTEL20_MicroProfile_41";
     public static final String MP50_MPTEL20_ID = JakartaEEAction.EE9_ACTION_ID + "_MPTEL20_MicroProfile_50";
 
@@ -43,10 +42,14 @@ public class TelemetryActions {
 
     public static final FeatureSet MP50_MPTEL11 = MicroProfileActions.MP50
                     .addFeature("mpTelemetry-1.1")
+                    .addFeature("mpReactiveMessaging-3.0")
+                    .addFeature("mpReactiveStreams-3.0")
                     .build(MP50_MPTEL11_ID);
 
     public static final FeatureSet MP50_MPTEL20 = MicroProfileActions.MP50
                     .addFeature("mpTelemetry-2.0")
+                    .addFeature("mpReactiveMessaging-3.0")
+                    .addFeature("mpReactiveStreams-3.0")
                     .build(MP50_MPTEL20_ID);
 
     public static final FeatureSet MP41_MPTEL20 = MicroProfileActions.MP41
@@ -58,7 +61,8 @@ public class TelemetryActions {
                     .build(MP14_MPTEL20_ID);
 
     //All MicroProfile Telemetry FeatureSets - must be descending order
-    private static final FeatureSet[] ALL_MPTEL_SETS_ARRAY = { MicroProfileActions.MP61, MicroProfileActions.MP60, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11, MP50_MPTEL11, MP41_MPTEL11, MP14_MPTEL11, MP50_MPTEL20, MP41_MPTEL20, MP14_MPTEL20};
+    private static final FeatureSet[] ALL_MPTEL_SETS_ARRAY = { MicroProfileActions.MP61, MicroProfileActions.MP60, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11,
+                                                               MP50_MPTEL11, MP41_MPTEL11, MP14_MPTEL11, MP50_MPTEL20, MP41_MPTEL20, MP14_MPTEL20 };
     private static final List<FeatureSet> ALL_MPTEL_SETS_LIST = Arrays.asList(ALL_MPTEL_SETS_ARRAY);
 
     /**
@@ -66,18 +70,19 @@ public class TelemetryActions {
      * <p>
      * The returned FeatureReplacementAction can then be configured further
      *
-     * @param server     the server to repeat on
+     * @param server the server to repeat on
      * @param featureSet the featureSet to repeat with
      * @return a FeatureReplacementAction
      */
     public static FeatureReplacementAction repeatFor(String server, FeatureSet featureSet) {
         return RepeatActions.forFeatureSet(ALL_MPTEL_SETS_LIST, featureSet, new String[] { server }, TestMode.FULL);
     }
+
     /**
      * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in FULL.
      *
-     * @param server           The server to repeat on
-     * @param firstFeatureSet  The first FeatureSet
+     * @param server The server to repeat on
+     * @param firstFeatureSet The first FeatureSet
      * @param otherFeatureSets The other FeatureSets
      * @return a RepeatTests instance
      */
@@ -88,10 +93,10 @@ public class TelemetryActions {
     /**
      * Get a RepeatTests instance for the given FeatureSets. The first FeatureSet will be run in LITE mode. The others will be run in the mode specified.
      *
-     * @param server                   The server to repeat on
+     * @param server The server to repeat on
      * @param otherFeatureSetsTestMode The mode to run the other FeatureSets
-     * @param firstFeatureSet          The first FeatureSet
-     * @param otherFeatureSets         The other FeatureSets
+     * @param firstFeatureSet The first FeatureSet
+     * @param otherFeatureSets The other FeatureSets
      * @return a RepeatTests instance
      */
     public static RepeatTests repeat(String server, TestMode otherFeatureSetsTestMode, FeatureSet firstFeatureSet, FeatureSet... otherFeatureSets) {


### PR DESCRIPTION
Fixes `ReactiveMessageThatTriggersClientTest` where one of the repeats ran without the reactive features enabled.

I initially wanted to add `mpReactiveMessaging-3.0` and `mpReactiveStreams-3.0` to `MicroProfileActions.MP50`, but they were removed from there in #28956 [TE: because MP50 allows Java 8 but RM requires Java 11]

Fixes RTC300893

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
