### PR TITLE
Add security headers to platform OpenAPI

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config.openapi/src/com/ibm/ws/rest/handler/config/openapi/ConfigSchemaRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config.openapi/src/com/ibm/ws/rest/handler/config/openapi/ConfigSchemaRESTHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -74,6 +74,9 @@ public class ConfigSchemaRESTHandler implements RESTHandler {
             if (formatParam != null && formatParam.equals("json")) {
                 format = "json";
             }
+
+            response.setResponseHeader("X-Content-Type-Options", "nosniff");
+            response.setResponseHeader("Content-Security-Policy", "default-src 'none'");
 
             if (format.equals("json")) {
                 response.setContentType("application/json");

--- a/dev/com.ibm.ws.rest.handler.validator.openapi/src/com/ibm/ws/rest/handler/validator/openapi/ValidatorSchemaRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator.openapi/src/com/ibm/ws/rest/handler/validator/openapi/ValidatorSchemaRESTHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -91,6 +91,9 @@ public class ValidatorSchemaRESTHandler implements RESTHandler {
             if (formatParam != null && formatParam.equals("json")) {
                 format = "json";
             }
+
+            response.setResponseHeader("X-Content-Type-Options", "nosniff");
+            response.setResponseHeader("Content-Security-Policy", "default-src 'none'");
 
             if (format.equals("json")) {
                 response.setContentType("application/json");

--- a/dev/io.openliberty.rest.handler.config.openapi.2.0/src/io/openliberty/rest/handler/config/openapi20/ConfigSchemaRESTHandler.java
+++ b/dev/io.openliberty.rest.handler.config.openapi.2.0/src/io/openliberty/rest/handler/config/openapi20/ConfigSchemaRESTHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -70,6 +70,9 @@ public class ConfigSchemaRESTHandler implements RESTHandler {
             if ((formatParam != null) && formatParam.equals("json")) {
                 format = "json";
             }
+
+            response.setResponseHeader("X-Content-Type-Options", "nosniff");
+            response.setResponseHeader("Content-Security-Policy", "default-src 'none'");
 
             if (format.equals("json")) {
                 response.setContentType("application/json");

--- a/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/ValidatorSchemaRESTHandler.java
+++ b/dev/io.openliberty.rest.handler.validator.openapi.2.0/src/io/openliberty/rest/handler/validator/openapi20/ValidatorSchemaRESTHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -87,6 +87,9 @@ public class ValidatorSchemaRESTHandler implements RESTHandler {
             if ((formatParam != null) && formatParam.equals("json")) {
                 format = "json";
             }
+
+            response.setResponseHeader("X-Content-Type-Options", "nosniff");
+            response.setResponseHeader("Content-Security-Policy", "default-src 'none'");
 
             if (format.equals("json")) {
                 response.setContentType("application/json");


### PR DESCRIPTION
Add the following headers when returning OpenAPI for platform REST endpoints.

```
X-Content-Type-Options: nosniff
Content-Security-Policy: default-src 'none'
```

Fixes #29165

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

