### PR TITLE
Performance improvements for feature list utility

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/metatype/MetaTypeHelper.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/metatype/MetaTypeHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,13 +24,13 @@ public class MetaTypeHelper {
     public static final List<String> parseValue(String value) {
         List<String> values = new ArrayList<String>();
         StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < value.length(); i++) {
+        for (int i = 0, valueLength = value.length(); i < valueLength; i++) {
             char ch = value.charAt(i);
             if (ch == ',') {
                 values.add(builder.toString());
-                builder.delete(0, builder.length());
+                builder.setLength(0);
             } else if (ch == '\\') {
-                if (i + 1 < value.length()) {
+                if (i + 1 < valueLength) {
                     // add next
                     builder.append(value.charAt(++i));
                 } else {

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/schema/SchemaMetaTypeParser.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/schema/SchemaMetaTypeParser.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -81,6 +81,20 @@ public class SchemaMetaTypeParser {
     public static final String PROP_EXT = ".properties";
     private static final ResourceBundle _msgs = ResourceBundle.getBundle(XMLConfigConstants.NLS_PROPS);
 
+    private static final Map<String, Integer> typeMap = new HashMap<>();
+
+    static {
+        typeMap.put("long", AttributeDefinition.LONG);
+        typeMap.put("double", AttributeDefinition.DOUBLE);
+        typeMap.put("float", AttributeDefinition.FLOAT);
+        typeMap.put("integer", AttributeDefinition.INTEGER);
+        typeMap.put("byte", AttributeDefinition.BYTE);
+        typeMap.put("char", AttributeDefinition.CHARACTER);
+        typeMap.put("boolean", AttributeDefinition.BOOLEAN);
+        typeMap.put("short", AttributeDefinition.SHORT);
+        typeMap.put("password", AttributeDefinition.PASSWORD);
+    }
+
     private final XMLInputFactory inputFactory;
     private final List<MetaTypeInformationSpecification> metatypeList;
     MetaTypeInformationSpecification metatype = null;
@@ -99,9 +113,9 @@ public class SchemaMetaTypeParser {
 
     /**
      * Constructor.
-     * 
+     *
      * @param generatorOptions The user options wrapper.
-     * @param prodJars The Map of bundle jars organized by product (core, usr, prodExt1, prodExt2 ...)
+     * @param prodJars         The Map of bundle jars organized by product (core, usr, prodExt1, prodExt2 ...)
      */
     public SchemaMetaTypeParser(Locale locale, Map<String, List<File>> prodJars) {
         inputFactory = DesignatedXMLInputFactory.newInstance();
@@ -114,7 +128,7 @@ public class SchemaMetaTypeParser {
      * Since we don't have have the luxury of OSGi framework getting the OCDs for us,
      * we need to look up all the metatype.xml files from each jar manually and
      * construct a metatypeinformation which will be passed to SchemaWriter
-     * 
+     *
      * @param jars
      * @return StreamSource containing all the metatype XMLs
      */
@@ -165,7 +179,8 @@ public class SchemaMetaTypeParser {
         return metatypeList;
     }
 
-    private void parse(InputStream metatypeXML, JarFile jarFile, boolean generateNewMetatype, Map<String, URL> metatypePropMap, String productName) throws XMLStreamException, IOException {
+    private void parse(InputStream metatypeXML, JarFile jarFile, boolean generateNewMetatype, Map<String, URL> metatypePropMap,
+                       String productName) throws XMLStreamException, IOException {
 
         XMLStreamReader xmlStreamReader = inputFactory.createXMLStreamReader(metatypeXML);
         DepthAwareXMLStreamReader parser = new DepthAwareXMLStreamReader(xmlStreamReader);
@@ -229,7 +244,7 @@ public class SchemaMetaTypeParser {
 
     private void warning(String message, Object... args) {
         // Don't generate an error when this is being run by the mbean. Not all
-        // bundles may be included by a running server. 
+        // bundles may be included by a running server.
         String msg = message;
         try {
             msg = _msgs.getString(message);
@@ -245,7 +260,7 @@ public class SchemaMetaTypeParser {
 
     /**
      * Tries to generate the correct metatype properties location according to locale
-     * 
+     *
      * @param metatypeName
      * @return a String with the correct metatype properties location
      */
@@ -459,7 +474,7 @@ public class SchemaMetaTypeParser {
     }
 
     /**
-     * 
+     *
      * @param xmlStreamReader
      * @return
      */
@@ -484,29 +499,7 @@ public class SchemaMetaTypeParser {
      * @return
      */
     private int parseType(String type) {
-        type = type.toLowerCase();
-        if (type.equals("long")) {
-            return AttributeDefinition.LONG;
-        } else if (type.equals("double")) {
-            return AttributeDefinition.DOUBLE;
-        } else if (type.equals("float")) {
-            return AttributeDefinition.FLOAT;
-        } else if (type.equals("integer")) {
-            return AttributeDefinition.INTEGER;
-        } else if (type.equals("byte")) {
-            return AttributeDefinition.BYTE;
-        } else if (type.equals("char")) {
-            return AttributeDefinition.CHARACTER;
-        } else if (type.equals("boolean")) {
-            return AttributeDefinition.BOOLEAN;
-        } else if (type.equals("short")) {
-            return AttributeDefinition.SHORT;
-        } else if (type.equals("password")) {
-            return AttributeDefinition.PASSWORD;
-        } else {
-            //defaults to string at least that's what SchemaWriter does
-            return AttributeDefinition.STRING;
-        }
+        //defaults to string at least that's what SchemaWriter does
+        return typeMap.getOrDefault(type.toLowerCase(), AttributeDefinition.STRING);
     }
-
 }

--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/DefaultConfigurationList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/DefaultConfigurationList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -62,6 +62,7 @@ public class DefaultConfigurationList {
 
     private static final String DEFAULT_INSTANCE = "defaultInstance";
     private static final String PROVIDING_FEATURES = "providingFeatures";
+    private static final XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
 
     private final Map<String, ProvisioningFeatureDefinition> features;
     private final FeatureListOptions options;
@@ -174,7 +175,7 @@ public class DefaultConfigurationList {
 
                 ZipEntry defaultConfigFile = jar.getEntry(fileFilter);
                 if (defaultConfigFile != null) {
-                    this.reader = XMLInputFactory.newInstance().createXMLStreamReader(jar.getInputStream(defaultConfigFile));
+                    this.reader = xmlInputFactory.createXMLStreamReader(jar.getInputStream(defaultConfigFile));
 
                     // Parse the config into a list of top level elements. 
                     parseConfig(elements, existing, notExisting);

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
@@ -771,7 +771,9 @@ public class FeatureDefinitionUtils {
                 List<NameValuePair> data = ManifestHeaderProcessor.parseExportString(contents);
                 result = new ArrayList<FeatureResource>(data.size());
                 Set<String> preventDups = new HashSet<>();
-                for (NameValuePair content : data) {
+
+                for (int idx = 0, size = data.size(); idx < size; ++idx) {
+                    NameValuePair content = data.get(idx);
                     if (preventDups.add(content.getName())) {
                         result.add(new FeatureResourceImpl(content.getName(), content.getAttributes(), iAttr.bundleRepositoryType, iAttr.featureName, iAttr.activationType));
                     }
@@ -781,10 +783,11 @@ public class FeatureDefinitionUtils {
             }
 
             if (type != null) {
-                Collection<FeatureResource> unfiltered = result;
+                List<FeatureResource> unfiltered = result;
 
                 result = new ArrayList<FeatureResource>();
-                for (FeatureResource resource : unfiltered) {
+                for (int idx = 0, size = unfiltered.size(); idx < size; idx++) {
+                    FeatureResource resource = unfiltered.get(idx);
                     if (resource.isType(type)) {
                         result.add(resource);
                     }


### PR DESCRIPTION
- Get XMLInputFactory instance once and store statically instead of getting a new one each time in DefaultConfigurationList
- Update to use List.get() method instead of using an Iterator in FeatureDefinitionUtils
- Cache MetaTypeInformationSpecification per bundle to avoid parsing the same bundle multiple times in FeatureList.  This is the critical change in this PR
- Update to not get the value length over and over and use StringBuilder.setLength() instead of StringBuilder.delete() in MetaTypeHelper
- Use a Map to get the AttributeDefinition value instead of calling equals 9 times potentially in parseType() method in SchemaMetaTypeParser

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
