### PR TITLE
Update FeatureList and EsaResourceImpl for Java 23

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -93,7 +93,7 @@ public class FeatureList {
             addJVM(possibleJavaVersions, "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
             addJVM(possibleJavaVersions, "21", "20", "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
-            addJVM(possibleJavaVersions, "22", "21", "20", "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
+            addJVM(possibleJavaVersions, "23", "22", "21", "20", "19", "18", "17", "16", "15", "14", "13", "12", "11", "10", "9", "1.8", "1.7", "1.6", "1.5", "1.4", "1.3", "1.2", "1.1");
 
             List<GenericMetadata> mostGeneralRange = ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=1.7))\"");
 
@@ -107,7 +107,7 @@ public class FeatureList {
             eeToCapability.put("JavaSE-11", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=11))\""));
             eeToCapability.put("JavaSE-17", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=17))\""));
             eeToCapability.put("JavaSE-21", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=21))\""));
-            eeToCapability.put("JavaSE-22", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=22))\""));
+            eeToCapability.put("JavaSE-23", ManifestHeaderProcessor.parseCapabilityString("osgi.ee; filter:=\"(&(osgi.ee=JavaSE)(version=23))\""));
         }
 
         gaBuild = isGABuild();

--- a/dev/com.ibm.ws.repository.parsers/test-resources/esa/esaJsonOnly/com.ibm.websphere.appserver.jsp-2.3.esa.json
+++ b/dev/com.ibm.ws.repository.parsers/test-resources/esa/esaJsonOnly/com.ibm.websphere.appserver.jsp-2.3.esa.json
@@ -53,7 +53,7 @@
                     "io.openliberty.org.eclipse.jdt.core.java11_1.0.92.jar: (&(osgi.ee=JavaSE)(version=11))",
                     "com.ibm.ws.org.apache.taglibs.standard_1.0.92.jar: (&(osgi.ee=JavaSE)(version=1.8))"
                 ],
-                "versionDisplayString": "Java SE 17, Java SE 21, Java SE 22"
+                "versionDisplayString": "Java SE 17, Java SE 21, Java SE 23"
             },
             "links": [
                 {

--- a/dev/com.ibm.ws.repository.parsers/test-resources/reference/com.ibm.websphere.appserver.anno-1.0.esa.json
+++ b/dev/com.ibm.ws.repository.parsers/test-resources/reference/com.ibm.websphere.appserver.anno-1.0.esa.json
@@ -47,7 +47,7 @@
             "rawRequirements":[
                 "com.ibm.ws.anno_1.0.9.jar: (&(osgi.ee=JavaSE)(version>=1.6))"
             ],
-            "versionDisplayString":"Java SE 8, Java SE 11, Java SE 17, Java SE 21, Java SE 22"
+            "versionDisplayString":"Java SE 8, Java SE 11, Java SE 17, Java SE 21, Java SE 23"
         },
         "links":[
             {

--- a/dev/com.ibm.ws.repository.parsers/test-resources/reference/com.ibm.websphere.appserver.jsp-2.3.esa.json
+++ b/dev/com.ibm.ws.repository.parsers/test-resources/reference/com.ibm.websphere.appserver.jsp-2.3.esa.json
@@ -53,7 +53,7 @@
                     "io.openliberty.org.eclipse.jdt.core.java11_1.0.92.jar: (&(osgi.ee=JavaSE)(version=11))",
                     "com.ibm.ws.org.apache.taglibs.standard_1.0.92.jar: (&(osgi.ee=JavaSE)(version=1.8))"
                 ],
-                "versionDisplayString": "Java SE 17, Java SE 21, Java SE 22"
+                "versionDisplayString": "Java SE 17, Java SE 21, Java SE 23"
             },
             "links": [
                 {

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/resources/internal/EsaResourceImpl.java
@@ -234,10 +234,10 @@ public class EsaResourceImpl extends RepositoryResourceImpl implements EsaResour
             return;
         }
 
-        String minJava21 = "Java SE 21, Java SE 22";
-        String minJava17 = "Java SE 17, Java SE 21, Java SE 22";
-        String minJava11 = "Java SE 11, Java SE 17, Java SE 21, Java SE 22";
-        String minJava8 = "Java SE 8, Java SE 11, Java SE 17, Java SE 21, Java SE 22";
+        String minJava21 = "Java SE 21, Java SE 23";
+        String minJava17 = "Java SE 17, Java SE 21, Java SE 23";
+        String minJava11 = "Java SE 11, Java SE 17, Java SE 21, Java SE 23";
+        String minJava8 = "Java SE 8, Java SE 11, Java SE 17, Java SE 21, Java SE 23";
 
         // The min version should have been validated when the ESA was constructed
         // so checking for the version string should be safe


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Update FeatureList and EsaResourceImpl to add Java 23.

Previous version for reference -> https://github.com/OpenLiberty/open-liberty/pull/27590

This PR should not be merged until after the GM build is cut for the release prior to the release that we plan to support Java 23.