### PR TITLE
Adding translation metatype properties

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_cs.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_cs.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_de.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_de.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_es.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_es.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_fr.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_fr.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_hu.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_hu.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_it.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_it.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_ja.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_ja.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_ko.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_ko.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_pl.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_pl.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_pt_BR.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_pt_BR.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_ro.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_ro.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_ru.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_ru.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_zh.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_zh.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_zh_TW.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/resources/OSGI-INF/l10n/metatype_zh_TW.properties
@@ -1,0 +1,9 @@
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+mpTelemetryLogging=MicroProfile Telemetry 2.0
+mpTelemetryLogging.desc=MicroProfile Telemetry Logging gathers data from various sources and forwards the data to the configured MicroProfile Telemetry Log Exporter.
+
+source=Source
+source.desc=Specifies a list of comma-separated sources for the MicroProfile Telemetry. Valid values for the source attribute are message, trace, and ffdc.


### PR DESCRIPTION
Having the translations files are required when introducing new metatype.properties files.

Original PR: #29108 