### PR TITLE
Revert "small thread pool on startup for better large config start performance"

### DIFF
--- a/dev/com.ibm.ws.threading/bnd.bnd
+++ b/dev/com.ibm.ws.threading/bnd.bnd
@@ -73,8 +73,7 @@ instrument.classesExcludes: com/ibm/ws/threading/internal/resources/*.class
 	com.ibm.ws.kernel.boot;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest,\
 	io.openliberty.threading.virtual;version=latest,\
-	io.openliberty.threading.virtual.internal;version=latest,\
-	com.ibm.ws.kernel.feature.common;version=latest
+	io.openliberty.threading.virtual.internal;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -46,7 +46,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.boot.internal.KernelUtils;
-import com.ibm.ws.kernel.feature.ServerStarted;
 import com.ibm.ws.kernel.service.util.AvailableProcessorsListener;
 import com.ibm.ws.kernel.service.util.CpuInfo;
 import com.ibm.ws.threading.ThreadQuiesce;
@@ -75,23 +74,6 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
      * maximize throughput.
      */
     ThreadPoolController threadPoolController = null;
-
-    /**
-     * Receive notification when server start completes
-     */
-
-    @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL)
-    protected synchronized void setServerStarted(ServerStarted serverStarted) {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(tc, ": server start complete.");
-        }
-        threadPoolController.startupCompleted();
-    }
-
-    @Trivial
-    protected void unsetServerStarted(ServerStarted serverStarted) {
-        // No action required.
-    }
 
     /**
      * The thread pool name.

--- a/dev/com.ibm.ws.threading/test/com/ibm/ws/threading/internal/ExecutorServiceImplTest.java
+++ b/dev/com.ibm.ws.threading/test/com/ibm/ws/threading/internal/ExecutorServiceImplTest.java
@@ -70,13 +70,6 @@ public class ExecutorServiceImplTest {
         executorService.activate(componentConfig);
         ThreadPoolExecutor executor = executorService.getThreadPool();
 
-        // first check for startupPoolSize, which defaults to 6
-        Assert.assertEquals(6, executor.getCorePoolSize());
-        Assert.assertEquals(6, executor.getMaximumPoolSize());
-
-        // then tell the server that startup has completed
-        executorService.setServerStarted(null);
-        // and check for the expected core/max sizes based on earlier config
         Assert.assertEquals(10, executor.getCorePoolSize());
         Assert.assertEquals(10, executor.getMaximumPoolSize());
 


### PR DESCRIPTION
This reverts commit 74bbce917f76b3f80c336f3ef25f599ca3615c16.


- [x ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Reverting only the thread pool changes from PR28638 (leaving kernel re-org intact) because SOE revealed problems with thread pool hang resolution on zOS and Mac platforms. 