### PR TITLE
reject ZonedDateTime attribute

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
-import static jakarta.data.repository.By.ID;
-
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -24,14 +22,12 @@ import java.time.ZonedDateTime;
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.concurrent.CompletableFuture;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 import jakarta.data.exceptions.MappingException;
@@ -41,7 +37,6 @@ import jakarta.persistence.Inheritance;
  * Entity information
  */
 public class EntityInfo {
-    private static final TraceComponent tc = Tr.register(EntityInfo.class);
 
     /**
      * Suffix for generated record class names. The name used for a generated
@@ -60,6 +55,12 @@ public class EntityInfo {
 
     // lower case attribute name --> properly cased/qualified JPQL attribute name
     final Map<String, String> attributeNames;
+
+    // names of attributes to use for entity update.
+    // excludes id and version.
+    // excludes inner relation attributes, such as location.address when there is also a location.address.zipcode
+    // TODO updates (and probably deletes) of entities with an embeddable id is not implemented yet.
+    final SortedSet<String> attributeNamesForEntityUpdate;
 
     // properly cased/qualified JPQL attribute name --> type
     final SortedMap<String, Class<?>> attributeTypes;
@@ -87,6 +88,7 @@ public class EntityInfo {
                Class<?> recordClass,
                Map<String, List<Member>> attributeAccessors,
                Map<String, String> attributeNames,
+               SortedSet<String> attributeNamesForUpdate,
                SortedMap<String, Class<?>> attributeTypes,
                Map<String, Class<?>> collectionElementTypes,
                Map<Class<?>, List<String>> relationAttributeNames,
@@ -99,6 +101,7 @@ public class EntityInfo {
         this.entityClass = entityClass;
         this.attributeAccessors = attributeAccessors;
         this.attributeNames = attributeNames;
+        this.attributeNamesForEntityUpdate = attributeNamesForUpdate;
         this.attributeTypes = attributeTypes;
         this.collectionElementTypes = collectionElementTypes;
         this.relationAttributeNames = relationAttributeNames;
@@ -142,37 +145,6 @@ public class EntityInfo {
 
     Collection<String> getAttributeNames() {
         return attributeNames.values();
-    }
-
-    /**
-     * Returns the list of entity attribute names, suitable for use in JPQL, when updating an entity.
-     * This excludes the id and version. It also excludes embeddable and relation attribute names,
-     * but leaves the outermost name (for example, removes location.address, but preserves location.address.cityName).
-     * TODO The above is for embeddables. Decide what to do for relations other than embeddable.
-     * TODO It's inefficient to keep recomputing this. Consider doing it just once, maybe in EntityDefiner
-     * where we can build the list correctly from the start rather than later excluding. Maybe the pre-computed list
-     * can be null when there are relation attributes to indicate that update by entity isn't supported for that type of entity.
-     * TODO updates (and probably deletes) to entities with an embeddable id is not implemented yet.
-     *
-     * @return list of entity attribute names.
-     */
-    LinkedHashSet<String> getAttributeNamesForEntityUpdate() {
-        LinkedHashSet<String> names = new LinkedHashSet<>(attributeNames.size());
-
-        for (String name : attributeTypes.keySet())
-            names.add(name);
-
-        names.remove(ID);
-        names.remove(attributeNames.get(ID));
-        names.remove(versionAttributeName);
-
-        for (String name : attributeTypes.keySet()) {
-            int ldot = name.lastIndexOf('.');
-            if (ldot > 0)
-                names.remove(name.substring(0, ldot));
-        }
-
-        return names;
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1406,7 +1406,7 @@ public class QueryInfo {
                             .append(" SET ");
 
             boolean first = true;
-            for (String name : entityInfo.getAttributeNamesForEntityUpdate()) {
+            for (String name : entityInfo.attributeNamesForEntityUpdate) {
                 if (first)
                     first = false;
                 else

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -1672,7 +1673,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
         String jpql = queryInfo.jpql;
         EntityInfo entityInfo = queryInfo.entityInfo;
-        LinkedHashSet<String> attrsToUpdate = entityInfo.getAttributeNamesForEntityUpdate();
+        Set<String> attrsToUpdate = entityInfo.attributeNamesForEntityUpdate;
 
         int versionParamIndex = attrsToUpdate.size() + 2;
         Object version = null;
@@ -1697,7 +1698,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
         // parameters for entity attributes to update:
 
         int p = 0;
-        for (String attrName : entityInfo.getAttributeNamesForEntityUpdate())
+        for (String attrName : attrsToUpdate)
             QueryInfo.setParameter(++p, update, e,
                                    entityInfo.attributeAccessors.get(attrName));
 


### PR DESCRIPTION
ZonedDateTime, which is not part of the Data or Persistence spec, produces unexpected behavior in EclipseLink, where we see different values being read back from the database than were written.  Explicitly reject the use of ZonedDateTime as unsupported to protect users and so that we have the flexibility to add it back in later if it is added to the spec and/or is implemented better in EclipseLink.

Also, this PR addresses a TODO comment to replace some inefficient code in the EntityInfo class.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".