### PR TITLE
adjust workaround for EclipseLink issue so that we can run more of the test

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -251,6 +251,9 @@ public class DataJPATestServlet extends FATServlet {
         demographics.write(new DemographicInfo(2004, 4, 30, 114520000, 2974811477645.08, 4158978012936.35));
         demographics.write(new DemographicInfo(2003, 4, 30, 113320000, 2757535748111.21, 3702844997678.07));
         demographics.write(new DemographicInfo(2002, 4, 30, 112700000, 2582340471146.16, 3402336886067.70));
+
+        // TODO remove this workaround for intermittent issue triggered by test ordering once 28078 is fixed
+        testLiteralDouble();
     }
 
     /**
@@ -2128,10 +2131,10 @@ public class DataJPATestServlet extends FATServlet {
      * Use a repository method with a Query that hard codes a literal for a double value in E notation,
      * as is done in an example within the spec.
      */
-    @Test
+    // enable once 28078 is fixed @Test
     public void testLiteralDouble() {
         // Clear out data before test
-        accounts.deleteByOwnerEndsWith("testLiteralDouble");
+        accounts.deleteByOwnerEndsWith("TestLiteralDouble");
 
         accounts.create(new Account(1006520, 28002, "Think Bank", true, 21.04, "Lester TestLiteralDouble"));
         accounts.create(new Account(2003291, 28002, "Think Bank", true, 331.01, "Laura TestLiteralDouble"));

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2142,12 +2142,8 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(1L, accounts.countByOwnerAndBalanceBetween("Laura TestLiteralDouble", 331.159, 331.161));
 
-        // TODO Enable the following once fixed,
-        //Account account = accounts.findByAccountId(id);
-        //assertEquals(331.16, account.balance, 0.001);
-        // Failure is:
-        // Caused by: java.lang.NullPointerException: Cannot read field "index" because "key" is null
-        // at org.eclipse.persistence.internal.sessions.ArrayRecord.get(ArrayRecord.java:139) ...
+        Account account = accounts.findByAccountId(id);
+        assertEquals(331.16, account.balance, 0.001);
 
         assertEquals(2L, accounts.deleteByOwnerEndsWith("TestLiteralDouble"));
     }


### PR DESCRIPTION
This does not resolve #28078 , which turned out to be test ordering dependent, but works around it in a better way so that the entire testLiteralDouble can run as long is it runs before testEmbeddedId.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".