### PR TITLE
Fix oidc spnego FATs - bouncyCastle jar issue

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,8 @@ dependencies {
                'org.apache.httpcomponents:httpclient:4.1.2',
                'org.apache.httpcomponents:httpcore:4.1.2',
                project(':io.openliberty.org.apache.commons.logging'), // 1.2 (was 1.1.1)
-               project(':com.ibm.ws.org.apache.commons.lang3') // 3.8 (was ????)
+               project(':com.ibm.ws.org.apache.commons.lang3'), // 3.8 (was ????)
+               project(':com.ibm.ws.security.spnego.fat.common')
 }
 
 /******************************************************************

--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ dependencies {
                project(':com.ibm.ws.security.jaas.common'),
                project(':com.ibm.ws.security.oauth.oidc_fat.common'),
                project(':io.openliberty.org.apache.xercesImpl'),
+               project(':com.ibm.ws.security.spnego.fat.common'),
                'jtidy:jtidy:4aug2000r7-dev',
                'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
                'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',


### PR DESCRIPTION
Follow up change to https://github.com/OpenLiberty/open-liberty/pull/29011

Fixes RTC Defect 300701

Using the `io.openliberty.org.bouncycastle.bcprov-jdk18on.jar` wrapper project for the BC jars was causing an issue for the apache.sshd lib when running on certain JDK levels
```
com.ibm.ws.security.spnego.fat.FATSuite:org.apache.sshd.common.SshException: DefaultAuthFuture[ssh-connection]: Failed (NoSuchProviderException) to execute: JCE cannot authenticate the provider BC
    at org.apache.sshd.common.future.AbstractSshFuture.lambda$verifyResult$1(AbstractSshFuture.java:132)
    ...
Caused by: java.util.jar.JarException: file: .../dev/autoFVT/fattest.simplicity/lib/io.openliberty.org.bouncycastle.bcprov-jdk18on.jar has unsigned entries - org/bouncycastle/LICENSE.class
```