### PR TITLE
concurrencyPolicy with virtual=true

### DIFF
--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -45,3 +45,7 @@ runIfQueueFull.desc=Applies when using the <execute> or <submit> methods. Indica
 
 startTimeout=Start timeout
 startTimeout.desc=Specifies the maximum amount of time that may elapse between the task submission and the task start. By default, tasks do not time out. If both a maximum wait for enqueue and a start timeout are enabled, configure the start timeout to be larger than the maximum wait for enqueue. When the start timeout is updated while in use, the new start timeout value applies to tasks submitted after the update occurs.
+
+virtual=Use virtual threads
+virtual.desc=Requests the use of virtual threads for tasks that do not run inline. \
+Java 21 or higher is a prerequisite of configuring this value to true.

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2023 IBM Corporation and others.
+    Copyright (c) 2017,2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@
   <AD id="runIfQueueFull"    type="Boolean" default="false" name="%runIfQueueFull" description="%runIfQueueFull.desc"/>
   <AD id="service.ranking"   type="Integer" default="0" name="internal" description="internal use only"/>
   <AD id="startTimeout"      type="String"  ibm:type="duration" required="false" name="%startTimeout" description="%startTimeout.desc"/>
-  <AD id="virtual"           type="Boolean" default="false" name="internal" description="internal use only"/>
+  <AD id="virtual"           type="Boolean" default="false" ibm:beta="true" name="%virtual" description="%virtual.desc"/>
  </OCD>
 
 </metatype:MetaData>

--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/l10n/metatype.properties
@@ -70,3 +70,7 @@ onError.desc=Determines the action to take in response to configuration errors. 
 onError.FAIL=Fail when incorrect configuration is encountered.
 onError.IGNORE=Ignore incorrect configuration.
 onError.WARN=Issue a warning for incorrect configuration.
+
+virtual=Use virtual threads
+virtual.desc=Determines whether the ManagedThreadFactory creates virtual threads. \
+Java 21 or higher is a prerequisite of configuring this value to true.

--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
@@ -95,7 +95,7 @@
   <AD id="maxPriority"                        type="Integer" required="false" max="10" min="1" name="%maxPriority" description="%maxPriority.desc"/>
   <AD id="qualifiers"                         type="String"  required="false" cardinality="-1000" name="internal" description="internal use only"/>
   <AD id="service.ranking"                    type="Integer" default="-1000" name="internal" description="internal use only"/>
-  <AD id="virtual"                            type="Boolean" default="false" name="internal" description="internal use only"/>
+  <AD id="virtual"                            type="Boolean" default="false" ibm:beta="true" name="%virtual" description="%virtual.desc"/>
   <AD id="javaCompDefaultName"                type="String"  required="false" name="internal" description="internal use only" />  
  </OCD>
 

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/PolicyAndExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/PolicyAndExecutor.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.internal;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrency.policy.ConcurrencyPolicy;
+import com.ibm.ws.threading.PolicyExecutor;
+
+/**
+ * Pair of ConcurrencyPolicy and PolicyExecutor.
+ */
+@Trivial
+class PolicyAndExecutor {
+    final PolicyExecutor executor;
+    final ConcurrencyPolicy policy;
+
+    PolicyAndExecutor(ConcurrencyPolicy policy, PolicyExecutor executor) {
+        this.policy = policy;
+        this.executor = executor;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        PolicyAndExecutor o;
+        return other instanceof PolicyAndExecutor && //
+               (o = (PolicyAndExecutor) other).policy == policy && //
+               o.executor == executor;
+    }
+
+    @Override
+    public int hashCode() {
+        return (executor == null ? 0 : executor.hashCode()) + //
+               (policy == null ? 0 : policy.hashCode());
+    }
+
+    /**
+     * Returns a String of the form:
+     * [ConcurrencyPolicyImpl@87654321, PolicyExecutorImpl@12345678]
+     */
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder(61).append('[');
+        if (policy == null)
+            b.append("null");
+        else
+            b.append(policy.getClass().getName()).append('@') //
+                            .append(Integer.toHexString(policy.hashCode()));
+        b.append(", ");
+        if (policy == null)
+            b.append("null");
+        else
+            b.append(executor.getClass().getName()).append('@')//
+                            .append(Integer.toHexString(executor.hashCode()));
+        b.append("]");
+        return b.toString();
+    }
+}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ScheduledTask.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ScheduledTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -712,7 +712,7 @@ public class ScheduledTask<T> implements Callable<T>, ScheduledCustomExecutorTas
     @Override
     @Trivial
     public Executor getExecutor() {
-        return managedExecSvc.policyExecutor.getVirtualThreadExecutor(); // null if virtual=false
+        return managedExecSvc.getNormalPolicyExecutor().getVirtualThreadExecutor(); // null if virtual=false
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -69,8 +69,8 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
         String longRunning = execProps.get("jakarta.enterprise.concurrent.LONGRUNNING_HINT");
         if (longRunning == null)
             longRunning = execProps.get("javax.enterprise.concurrent.LONGRUNNING_HINT");;
-        PolicyExecutor executor = Boolean.parseBoolean(longRunning) ? managedExecutor.longRunningPolicyExecutorRef.get() : null;
-        this.policyExecutor = executor == null ? managedExecutor.policyExecutor : executor;
+        PolicyExecutor executor = Boolean.parseBoolean(longRunning) ? managedExecutor.getLongRunningPolicyExecutor() : null;
+        this.policyExecutor = executor == null ? managedExecutor.getNormalPolicyExecutor() : executor;
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta/server.xml
@@ -76,6 +76,10 @@
                                    concurrencyPolicyRef="max2virtual">
   </managedScheduledExecutorService>
 
+  <managedThreadFactory id="virtualThreadFactory" jndiName="concurrent/virtualThreadFactory"
+                        virtual="true">
+  </managedThreadFactory>
+
   <!-- needed by ForkJoinPool, which the test application uses -->
   <javaPermission codebase="${server.config.dir}/apps/ConcurrencyTestApp.ear" className="java.lang.RuntimePermission" name="modifyThread"/>
 

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/publish/servers/com.ibm.ws.concurrent.fat.jakarta/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021,2022 IBM Corporation and others.
+    Copyright (c) 2021,2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -37,6 +37,8 @@
     <fileset dir="${server.config.dir}/lib" include="location-utils.jar,stat-utils.jar"/>
   </library>
 
+  <concurrencyPolicy id="max2virtual" max="2" maxQueueSize="3" virtual="true"/>
+
   <contextService id="AppContext" jndiName="concurrent/appContext">
     <classloaderContext/>
     <jeeMetadataContext/>
@@ -47,6 +49,10 @@
     <contextService>
       <jeeMetadataContext/>
     </contextService>
+  </managedExecutorService>
+
+  <managedExecutorService id="virtualExec1" jndiName="concurrent/virtualExec1"
+                          concurrencyPolicyRef="max2virtual">
   </managedExecutorService>
 
   <!-- Do not use directly. Tests must only use this through its nested contextService. -->
@@ -64,6 +70,10 @@
 
   <managedScheduledExecutorService id="executor4" jndiName="concurrent/executor4" contextServiceRef="AppContext">
     <concurrencyPolicy max="4" maxQueueSize="4"/>
+  </managedScheduledExecutorService>
+
+  <managedScheduledExecutorService id="virtualExec2" jndiName="concurrent/virtualExec2"
+                                   concurrencyPolicyRef="max2virtual">
   </managedScheduledExecutorService>
 
   <!-- needed by ForkJoinPool, which the test application uses -->

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -216,6 +216,12 @@ public class ConcurrencyTestServlet extends FATServlet {
 
     @Resource(lookup = "java:app/concurrent/lowPriorityThreads")
     ManagedThreadFactory lowPriorityThreads;
+
+    @Resource(name = "java:comp/env/concurrent/virtualExec1Ref", lookup = "concurrent/virtualExec1")
+    ManagedExecutorService virtualExecutor1;
+
+    @Resource(name = "java:module/env/concurrent/virtualExec2Ref", lookup = "concurrent/virtualExec2")
+    ManagedScheduledExecutorService virtualExecutor2;
 
     //Do not use for any other tests
     @EJB
@@ -3105,6 +3111,130 @@ public class ConcurrencyTestServlet extends FATServlet {
             String message = x.getMessage();
             if (message == null || !message.contains("CWWKC1204E") || !message.contains("Timestamp") || !message.contains("ZipCode"))
                 throw x;
+        }
+    }
+
+    /**
+     * Use server-defined ManagedExecutorService and ManagedScheduledExecutorService
+     * resources that are configured to share a concurrency policy that specifies
+     * to run on virtual threads. In Java 21+, it should run on virtual threads.
+     * Prior to Java 21, this must result in an error because virtual threads are
+     * not available.
+     */
+    @Test
+    public void testVirtualThreadedExecutors() throws Exception {
+        String version = System.getProperty("java.version");
+        System.out.println("java.version is \"" + version + "\"");
+        boolean supportsVirtualThreads = Integer.parseInt(version.substring(0, version.indexOf('.'))) >= 21;
+
+        if (supportsVirtualThreads) {
+            CountDownLatch twoStarted = new CountDownLatch(2);
+            CountDownLatch blocker = new CountDownLatch(1);
+
+            try {
+                Future<String> future1 = virtualExecutor1.submit(() -> {
+                    twoStarted.countDown();
+                    InitialContext.doLookup("java:comp/env/concurrent/virtualExec1Ref");
+                    assertEquals(true, blocker.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+                    return Thread.currentThread().toString();
+                });
+
+                Future<String> future2 = virtualExecutor2.submit(() -> {
+                    twoStarted.countDown();
+                    InitialContext.doLookup("java:module/env/concurrent/virtualExec2Ref");
+                    assertEquals(true, blocker.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+                    return Thread.currentThread().toString();
+                });
+
+                // max=2 allows 2 to run at once
+                assertEquals(true, twoStarted.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+                // maxQueueSize=3 allows 3 more to queue
+                Future<String> future3 = virtualExecutor1.submit(() -> {
+                    return Thread.currentThread().toString();
+                });
+
+                Future<String> future4 = virtualExecutor2.submit(() -> {
+                    return Thread.currentThread().toString();
+                });
+
+                Future<String> future5 = virtualExecutor1.submit(() -> {
+                    return Thread.currentThread().toString();
+                });
+
+                try {
+                    Future<String> future6 = virtualExecutor2.submit(() -> {
+                        return Thread.currentThread().getName();
+                    });
+                    fail("6th task should not be allowed. " + future6);
+                } catch (RejectedExecutionException x) {
+                    // expected, no more queue positions are available
+                }
+
+                try {
+                    future3.get(100, TimeUnit.MILLISECONDS);
+                    fail("3rd task should not run yet with max=2.");
+                } catch (TimeoutException x) {
+                    // expected, concurrency is limited to max of 2
+                }
+
+                try {
+                    future4.get(4, TimeUnit.MILLISECONDS);
+                    fail("4th task should not run yet with max=2.");
+                } catch (TimeoutException x) {
+                    // expected, concurrency is limited to max of 2
+                }
+
+                try {
+                    future5.get(5, TimeUnit.MILLISECONDS);
+                    fail("5th task should not run yet with max=2.");
+                } catch (TimeoutException x) {
+                    // expected, concurrency is limited to max of 2
+                }
+
+                blocker.countDown();
+
+                String thread1name = future1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+                assertEquals(thread1name, true, thread1name.startsWith("VirtualThread["));
+
+                String thread2name = future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+                assertEquals(thread2name, true, thread2name.startsWith("VirtualThread["));
+
+                String thread3name = future3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+                assertEquals(thread3name, true, thread3name.startsWith("VirtualThread["));
+
+                String thread4name = future4.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+                assertEquals(thread4name, true, thread4name.startsWith("VirtualThread["));
+
+                String thread5name = future5.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+                assertEquals(thread5name, true, thread5name.startsWith("VirtualThread["));
+            } finally {
+                blocker.countDown();
+            }
+        } else {
+            try {
+                Future<String> future = virtualExecutor1.submit(() -> {
+                    return Thread.currentThread().toString();
+                });
+                fail("ManagedExecutorService must reject virtual=true prior to Java 21. Instead: " + future);
+            } catch (IllegalArgumentException x) {
+                if (x.getMessage().indexOf("virtual") >= 0)
+                    ; // expected that virtual=true is not allowed prior to Java 21
+                else
+                    throw x;
+            }
+
+            try {
+                Future<String> future = virtualExecutor2.submit(() -> {
+                    return Thread.currentThread().toString();
+                });
+                fail("ManagedScheduledExecutorService must reject virtual=true prior to Java 21. Instead: " + future);
+            } catch (IllegalArgumentException x) {
+                if (x.getMessage().indexOf("virtual") >= 0)
+                    ; // expected that virtual=true is not allowed prior to Java 21
+                else
+                    throw x;
+            }
         }
     }
 

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/publish/servers/com.ibm.ws.concurrent.fat.jakarta.ee11/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/publish/servers/com.ibm.ws.concurrent.fat.jakarta.ee11/server.xml
@@ -13,6 +13,7 @@
 <server>
 
   <featureManager>
+    <!-- Do not add CDI. The concurrent feature must be able to run without it. -->
     <feature>componenttest-2.0</feature>
     <feature>concurrent-3.1</feature>
     <feature>jndi-1.0</feature>

--- a/dev/com.ibm.ws.concurrent_fat_schedasync/publish/servers/com.ibm.ws.concurrent.fat.schedasync/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_schedasync/publish/servers/com.ibm.ws.concurrent.fat.schedasync/server.xml
@@ -24,12 +24,4 @@
 
   <application location="SchedAsyncWeb.war"/>
 
-  <!--  TODO remove this once virtual=true can be sent in through ManagedExecutorDefinition -->
-  <managedExecutorService jndiName="concurrent/temp-max-2-executor">
-    <concurrencyPolicy max="2" virtual="true"/>
-    <contextService>
-      <classloaderContext/>
-      <jeeMetadataContext/>
-    </contextService>
-  </managedExecutorService>
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_schedasync/test-applications/SchedAsyncWeb/src/test/concurrency/schedasync/web/SchedAsyncTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_schedasync/test-applications/SchedAsyncWeb/src/test/concurrency/schedasync/web/SchedAsyncTestServlet.java
@@ -27,9 +27,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import jakarta.annotation.Resource;
 import jakarta.enterprise.concurrent.ContextServiceDefinition;
-import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
@@ -42,10 +41,10 @@ import componenttest.app.FATServlet;
 @ContextServiceDefinition(name = "java:app/concurrent/app-context",
                           propagated = APPLICATION,
                           unchanged = ALL_REMAINING)
-//@ManagedExecutorDefinition(name = "java:module/concurrent/max-2-executor",
-//                           context = "java:app/concurrent/app-context",
-//                           maxAsync = 2,
-//                           virtual = true)
+@ManagedExecutorDefinition(name = "java:module/concurrent/max-2-executor",
+                           context = "java:app/concurrent/app-context",
+                           maxAsync = 2,
+                           virtual = true)
 @SuppressWarnings("serial")
 @WebServlet("/*")
 public class SchedAsyncTestServlet extends FATServlet {
@@ -53,10 +52,6 @@ public class SchedAsyncTestServlet extends FATServlet {
      * Maximum number of nanoseconds to wait for a task to finish.
      */
     private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
-
-    // TODO remove this once virtual=true is honored on @ManagedExecutorDefinition
-    @Resource(name = "java:module/concurrent/max-2-executor", lookup = "concurrent/temp-max-2-executor")
-    ManagedExecutorService temp;
 
     private static LinkedBlockingQueue<long[]> afterSixSeconds3Times = new LinkedBlockingQueue<>();
     private static final AtomicInteger afterSixSeconds3TimesCount = new AtomicInteger();
@@ -253,27 +248,28 @@ public class SchedAsyncTestServlet extends FATServlet {
         Set<Thread> uniqueThreads = new HashSet<>();
         Thread th;
 
-        // TODO update thread name assertions to check for the JNDI name once we are actually using the ManagedExecutorDefinition
-        // Example name: managedExecutorService[java:module/concurrent/max-2-executor]/concurrencyPolicy:4
+        String prefix = "application[SchedAsyncWeb]/module[SchedAsyncWeb.war]/" +
+                        "managedExecutorService[java:module/concurrent/max-2-executor]/" +
+                        "concurrencyPolicy:";
 
         assertNotNull(th = everyFourSecondsVirtualThreads.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        assertEquals(true, th.isVirtual());
-        assertEquals(true, th.getName().startsWith("managedExecutorService["));
+        assertEquals(th.toString(), true, th.isVirtual());
+        assertEquals(th.getName(), true, th.getName().startsWith(prefix));
         uniqueThreads.add(th);
 
         assertNotNull(th = everyFourSecondsVirtualThreads.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        assertEquals(true, th.isVirtual());
-        assertEquals(true, th.getName().startsWith("managedExecutorService["));
+        assertEquals(th.toString(), true, th.isVirtual());
+        assertEquals(th.getName(), true, th.getName().startsWith(prefix));
         uniqueThreads.add(th);
 
         assertNotNull(th = everyFourSecondsVirtualThreads.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        assertEquals(true, th.isVirtual());
-        assertEquals(true, th.getName().startsWith("managedExecutorService["));
+        assertEquals(th.toString(), true, th.isVirtual());
+        assertEquals(th.getName(), true, th.getName().startsWith(prefix));
         uniqueThreads.add(th);
 
         assertNotNull(th = everyFourSecondsVirtualThreads.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
-        assertEquals(true, th.isVirtual());
-        assertEquals(true, th.getName().startsWith("managedExecutorService["));
+        assertEquals(th.toString(), true, th.isVirtual());
+        assertEquals(th.getName(), true, th.getName().startsWith(prefix));
         uniqueThreads.add(th);
 
         assertEquals(null, everyFourSecondsVirtualThreads.poll());

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutorProvider.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutorProvider.java
@@ -74,9 +74,12 @@ public class PolicyExecutorProvider implements ServerQuiesceListener {
      * @throws NullPointerException  if the specified identifier is null
      */
     public PolicyExecutor create(Map<String, Object> props) {
-        PolicyExecutor executor = new PolicyExecutorImpl((ExecutorServiceImpl) libertyThreadPool, (String) props.get("config.displayId"), null, policyExecutors, virtualThreadOps);
-        executor.updateConfig(props);
-        return executor;
+        return new PolicyExecutorImpl( //
+                        (ExecutorServiceImpl) libertyThreadPool, //
+                        (String) props.get("config.displayId"), //
+                        policyExecutors, //
+                        virtualThreadOps, //
+                        props);
     }
 
     /**


### PR DESCRIPTION
managedExecutorService and managedScheduledExecutorService configured with a concurrencyPolicy that has virtual=true to create virtual threads.
Also, managedThreadFactory configured with virtual=true to create virtual threads.
Also, the PR removes a workaround from schedasync bucket adding coverage of app-defined ManagedExecutorDefinition that uses virtual threads with scheduled asynchronous methods.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
