### PR TITLE
Update FT TCK to 4.1-RC4 and enable tests

### DIFF
--- a/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <microprofile.config.version>3.0.1</microprofile.config.version>
-        <microprofile.faulttolerance.version>4.1-RC2</microprofile.faulttolerance.version>
+        <microprofile.faulttolerance.version>4.1-RC4</microprofile.faulttolerance.version>
         <microprofile.metrics.version>4.0</microprofile.metrics.version>
 
         <arquillian.version>1.7.0.Alpha13</arquillian.version>

--- a/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -130,8 +130,13 @@
                     <include name="testTimeoutMetric"/>
                 </methods>
             </class>
-            <!-- AllAnnotationTelemetryTest excluded until TCK release with #641 is available -->
-            <!-- BulkheadTelemetryTest excluded until TCK release with #641 is available -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.AllAnnotationTelemetryTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.BulkheadTelemetryTest">
+                <methods>
+                    <include name="bulkheadMetricTest"/>
+                    <include name="bulkheadMetricRejectionTest"/>
+                </methods>
+            </class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.CircuitBreakerTelemetryTest"></class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.ClassLevelTelemetryTest"></class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.FallbackTelemetryTest"></class>

--- a/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -14,23 +14,5 @@
         <packages>
             <package name="org.eclipse.microprofile.fault.tolerance.tck.*"/>
         </packages>
-        <!-- Tests excluded until TCK release with #641 is available -->
-        <classes>
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.AllAnnotationTelemetryTest">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.BulkheadTelemetryTest">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.TimeoutTelemetryTest">
-                <methods>
-                    <exclude name="testMetricUnits"/>
-                </methods>
-            </class>
-        </classes>
     </test>
 </suite>


### PR DESCRIPTION
This version of the TCK includes the test changes which match our implementation changes so we can re-enable the tests.

Enables the tests which were disabled in #29216

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
