### PR TITLE
small thread pool on startup for better large config start performance

### DIFF
--- a/dev/com.ibm.ws.threading/bnd.bnd
+++ b/dev/com.ibm.ws.threading/bnd.bnd
@@ -73,7 +73,8 @@ instrument.classesExcludes: com/ibm/ws/threading/internal/resources/*.class
 	com.ibm.ws.kernel.boot;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest,\
 	io.openliberty.threading.virtual;version=latest,\
-	io.openliberty.threading.virtual.internal;version=latest
+	io.openliberty.threading.virtual.internal;version=latest,\
+	com.ibm.ws.kernel.feature.common;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -46,6 +46,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.boot.internal.KernelUtils;
+import com.ibm.ws.kernel.feature.ServerStarted;
 import com.ibm.ws.kernel.service.util.AvailableProcessorsListener;
 import com.ibm.ws.kernel.service.util.CpuInfo;
 import com.ibm.ws.threading.ThreadQuiesce;
@@ -74,6 +75,23 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
      * maximize throughput.
      */
     ThreadPoolController threadPoolController = null;
+
+    /**
+     * Receive notification when server start completes
+     */
+
+    @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL)
+    protected synchronized void setServerStarted(ServerStarted serverStarted) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+            Tr.event(tc, ": server start complete.");
+        }
+        threadPoolController.startupCompleted();
+    }
+
+    @Trivial
+    protected void unsetServerStarted(ServerStarted serverStarted) {
+        // No action required.
+    }
 
     /**
      * The thread pool name.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ThreadPoolController.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ThreadPoolController.java
@@ -356,11 +356,39 @@ public final class ThreadPoolController {
     private static final int deepQueuePoolIncrementMultiple;
 
     /**
+     * Pool size on initial startup, until "ready to run" - after the server reports that it has
+     * started, the pool size will be set to coreThreads and will auto-adjust as usual
+     */
+    private static final int startupPoolSize;
+
+    /**
+     * When server and app startup reports that it has started, this will be set "true" so
+     * that if the thread pool is recreated due to a config action, the new pool will not use
+     * startupPoolSize but rather will use coreThreads and maxThreads.
+     */
+    private static boolean initialStartupCompleted = false;
+
+    /**
      * Read in applicable system properties, use defaults if the property is not present
      * These system properties will not be documented, and are intended for diagnostic and/or
      * triage use by support.
      */
     static {
+        String tpcStartupPoolSize = getSystemProperty("tpcStartupPoolSize");
+        if (tpcStartupPoolSize == null) {
+            startupPoolSize = 6;
+        } else {
+            int cfgStartupPoolSize = Integer.parseInt(tpcStartupPoolSize);
+            if (cfgStartupPoolSize == -1) {
+                // escape - don't run startupPoolSize logic
+                initialStartupCompleted = true;
+                startupPoolSize = -1;
+            } else {
+                // make sure startupPoolSize is not set to be less than less than MINIMUM_POOL_SIZE
+                startupPoolSize = Math.max(ExecutorServiceImpl.MINIMUM_POOL_SIZE, cfgStartupPoolSize);
+            }
+        }
+
         String tpcResetDistroStdDevEwmaRatio = getSystemProperty("tpcResetDistroStdDevEwmaRatio");
         resetDistroStdDevEwmaRatio = (tpcResetDistroStdDevEwmaRatio == null) ? 0.10 : Double.parseDouble(tpcResetDistroStdDevEwmaRatio);
 
@@ -673,14 +701,26 @@ public final class ThreadPoolController {
         this.currentMinimumPoolSize = this.coreThreads;
         this.maxThreads = pool.getMaximumPoolSize();
         this.threadRange = this.maxThreads - this.coreThreads;
-        setPoolSize(coreThreads);
+        if (!initialStartupCompleted) {
+            // make sure pool size during startup is not greater than maxThreads
+            setPoolSize(Math.min(startupPoolSize, this.maxThreads));
+            // controller cycle only needs to run during startup to monitor for possible hang condition,
+            // and checking for hang is only useful if increasing the pool size is permitted
+            if (startupPoolSize < maxThreads) {
+                activeTask = new IntervalTask(this);
+                timer.schedule(activeTask, interval, interval);
+            }
+        } else {
+            setPoolSize(coreThreads);
+            if (coreThreads != maxThreads) {
+                // start controller cycle
+                activeTask = new IntervalTask(this);
+                timer.schedule(activeTask, interval, interval);
+            }
+        }
+
         targetPoolSize = coreThreads;
         resetStatistics(true);
-        // nothing to do if core == max
-        if (coreThreads < maxThreads) {
-            activeTask = new IntervalTask(this);
-            timer.schedule(activeTask, interval, interval);
-        }
         numberCpus = CpuInfo.getAvailableProcessors().get();
         /**
          * if coreThreads has been configured to a small value, we will use the
@@ -713,6 +753,31 @@ public final class ThreadPoolController {
 
         if (tc.isEventEnabled()) {
             reportSystemProperties();
+        }
+    }
+
+    /**
+     * Switch to regular pool sizing after startup completes
+     */
+    void startupCompleted() {
+        // if pool hung during startup, we will already have moved out of startup
+        // pool size mode, so check that first
+        if (!initialStartupCompleted) {
+            initialStartupCompleted = true;
+            setPoolSize(coreThreads);
+            // no need to run the controller cycle if there will be no pool size changes
+            if (coreThreads < maxThreads) {
+                if (activeTask == null) {
+                    activeTask = new IntervalTask(this);
+                    timer.schedule(activeTask, interval, interval);
+                }
+            } else {
+                // fixed pool size, cancel the controller cycle if it is running
+                if (activeTask != null) {
+                    activeTask.cancel();
+                    activeTask = null;
+                }
+            }
         }
     }
 
@@ -1338,7 +1403,7 @@ public final class ThreadPoolController {
 
         // we can't even think about adjusting the pool size until the underlying executor has aggressively
         // grown the pool to the coreThreads value, so if that hasn't happened yet we should just bail
-        if (poolSize < coreThreads) {
+        if (poolSize < coreThreads && initialStartupCompleted) {
             return "poolSize < coreThreads";
         }
 
@@ -1349,7 +1414,20 @@ public final class ThreadPoolController {
         long deltaTime = Math.max(currentTime - lastTimerPop, interval);
         long deltaCompleted = completedWork - previousCompleted;
         double throughput = 1000.0 * deltaCompleted / deltaTime;
+
         try {
+            // check for hang during server/app startup
+            if (!initialStartupCompleted) {
+                if (deltaCompleted <= 0) {
+                    // startup has hung - switch to post-startup mode to allow hang resolution to work
+                    initialStartupCompleted = true;
+                    setPoolSize(coreThreads);
+                    poolSize = threadPool.getPoolSize();
+                } else {
+                    return "server startup in progress";
+                }
+            }
+
             queueDepth = threadPool.getQueue().size();
             boolean queueEmpty = (queueDepth <= 0);
             // Count the number of consecutive times we've seen an empty queue

--- a/dev/com.ibm.ws.threading/test/com/ibm/ws/threading/internal/ExecutorServiceImplTest.java
+++ b/dev/com.ibm.ws.threading/test/com/ibm/ws/threading/internal/ExecutorServiceImplTest.java
@@ -70,6 +70,13 @@ public class ExecutorServiceImplTest {
         executorService.activate(componentConfig);
         ThreadPoolExecutor executor = executorService.getThreadPool();
 
+        // first check for startupPoolSize, which defaults to 6
+        Assert.assertEquals(6, executor.getCorePoolSize());
+        Assert.assertEquals(6, executor.getMaximumPoolSize());
+
+        // then tell the server that startup has completed
+        executorService.setServerStarted(null);
+        // and check for the expected core/max sizes based on earlier config
         Assert.assertEquals(10, executor.getCorePoolSize());
         Assert.assertEquals(10, executor.getMaximumPoolSize());
 


### PR DESCRIPTION
- [x ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Starting a large Liberty configuration (many large complex applications) can lead to contention for resources shared among the applications. Keeping the thread pool small during server/application startup can significantly reduce both startup duration and cpu used during startup.

This PR sets a small startup pool size, which is fixed until server/application startup completes (or the timeout is reached). After startup is complete, the pool size is set to coreThreads and allowed to vary based on coreThreads/maxThreads tuning (if any).
