### PR TITLE
Set and export JAVA_HOME when not set.

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -548,6 +548,7 @@ serverEnvAndJVMOptions()
   fi
 
   # Determine location of Java Platform Module System (JPMS) modules directory
+  # Set JAVA_HOME if it is not already set.
   if [ -z "${JAVA_HOME}" ]; then
 
     # JAVA_HOME not set.  Locate java using the PATH.
@@ -555,6 +556,10 @@ serverEnvAndJVMOptions()
     if [ -n "${JAVA_PATH}" ] ; then
 
       REAL_JAVA_PATH=$(findRealPath "${JAVA_PATH}")
+      JAVA_HOME=$(dirname "${REAL_JAVA_PATH}")/..
+      # The "exit" will cause JAVA_HOME to be unset in the unlikely case that JAVA_HOME is not a directory
+      JAVA_HOME="$(unset CDPATH; cd "${JAVA_HOME}" || exit; pwd)"
+      export JAVA_HOME
 
       if [ -n "${REAL_JAVA_PATH}" ]; then
          JPMS_MODULE_FILE_LOCATION=$(dirname "$(dirname "${REAL_JAVA_PATH}")")/lib/modules


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #28947" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


When JAVA_HOME is not set, we find the java executable by searching the path.   Once we find the executable, we know JAVA_HOME should be the grandparent of the executable.  