### PR TITLE
Add versionless features for MicroProfile standalone features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpContextPropagation-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpContextPropagation-1.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.internal.versionless.mpContextPropagation-1.0
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.internal.mpVersion-1.0; ibm.tolerates:="1.2,1.3,1.4,2.0,2.1,2.2,3.0,3.2,3.3", \
+  com.ibm.websphere.appserver.mpContextPropagation-1.0
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpContextPropagation-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpContextPropagation-1.2.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.internal.versionless.mpContextPropagation-1.2
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.internal.mpVersion-4.0; ibm.tolerates:="4.1", \
+  com.ibm.websphere.appserver.mpContextPropagation-1.2
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpContextPropagation-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpContextPropagation-1.3.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.internal.versionless.mpContextPropagation-1.3
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.internal.mpVersion-5.0; ibm.tolerates:="6.0,6.1,7.0", \
+  io.openliberty.mpContextPropagation-1.3
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpGraphQL-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpGraphQL-1.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.internal.versionless.mpGraphQL-1.0
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.internal.mpVersion-3.3; ibm.tolerates:="4.0,4.1", \
+  com.ibm.websphere.appserver.mpGraphQL-1.0
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpGraphQL-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpGraphQL-2.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.internal.versionless.mpGraphQL-2.0
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.internal.mpVersion-5.0; ibm.tolerates:="6.0,6.1,7.0", \
+  io.openliberty.mpGraphQL-2.0
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpReactiveMessaging-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpReactiveMessaging-1.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.internal.versionless.mpReactiveMessaging-1.0
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.internal.mpVersion-1.4; ibm.tolerates:="2.0,2.1,2.2,3.0,3.2,3.3", \
+  com.ibm.websphere.appserver.mpReactiveMessaging-1.0
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpReactiveMessaging-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpReactiveMessaging-3.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.internal.versionless.mpReactiveMessaging-3.0
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.internal.mpVersion-5.0; ibm.tolerates:="6.0,6.1,7.0", \
+  io.openliberty.mpReactiveMessaging-3.0
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpReactiveStreams-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpReactiveStreams-1.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.internal.versionless.mpReactiveStreams-1.0
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.internal.mpVersion-1.0; ibm.tolerates:="1.2,1.3,1.4,2.0,2.1,2.2,3.0,3.2,3.3", \
+  com.ibm.websphere.appserver.mpReactiveStreams-1.0
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpReactiveStreams-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.mpReactiveStreams-3.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.internal.versionless.mpReactiveStreams-3.0
+visibility=private
+singleton=true
+-features= \
+  io.openliberty.internal.mpVersion-5.0; ibm.tolerates:="6.0,6.1,7.0", \
+  io.openliberty.mpReactiveStreams-3.0
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.0/com.ibm.websphere.appserver.mpContextPropagation-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.0/com.ibm.websphere.appserver.mpContextPropagation-1.0.feature
@@ -15,3 +15,4 @@ IBM-API-Package: \
   com.ibm.ws.microprofile.contextpropagation.1.0
 kind=ga
 edition=core
+WLP-Platform: microProfile-1.0,microProfile-1.2,microProfile-1.3,microProfile-1.4,microProfile-2.0,microProfile-2.1,microProfile-2.2,microProfile-3.0,microProfile-3.2,microProfile-3.3

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.2/com.ibm.websphere.appserver.mpContextPropagation-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.2/com.ibm.websphere.appserver.mpContextPropagation-1.2.feature
@@ -15,3 +15,4 @@ IBM-API-Package: \
   com.ibm.ws.microprofile.contextpropagation.1.0
 kind=ga
 edition=core
+WLP-Platform: microProfile-4.0,microProfile-4.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.3/io.openliberty.mpContextPropagation-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.3/io.openliberty.mpContextPropagation-1.3.feature
@@ -16,3 +16,4 @@ IBM-API-Package: \
   com.ibm.ws.microprofile.contextpropagation.1.0
 kind=ga
 edition=core
+WLP-Platform: microProfile-5.0,microProfile-6.0,microProfile-6.1,microProfile-7.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/io.openliberty.versionless.mpContextPropagation.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/io.openliberty.versionless.mpContextPropagation.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.versionless.mpContextPropagation
+visibility=public
+IBM-ShortName: mpContextPropagation
+Subsystem-Name: mpContextPropagation
+-features=io.openliberty.internal.versionless.mpContextPropagation-1.0; ibm.tolerates:="1.2,1.3"
+kind=ga
+edition=core
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for versionless mpContextPropagation

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_cs.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_cs.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Tato funkce umo\u017e\u0148uje podporu pro bezverzovou mpContextPropagation

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_de.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_de.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Dieses Feature aktiviert die Unterst\u00fctzung f\u00fcr mpContextPropagation ohne Versionssteuerung

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_es.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_es.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Esta caracter\u00edstica habilita el soporte para mpContextPropagation sin versi\u00f3n

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_fr.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_fr.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Cette fonction active la prise en charge de mpContextPropagation sans version

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_hu.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_hu.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Ez a szolg\u00e1ltat\u00e1s t\u00e1mogatja a verzi\u00f3n\u00e9lk\u00fcli mpContextPropagation t\u00e1mogat\u00e1st

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_it.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_it.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Questa funzione abilita il supporto per mpContextPropagation senza versione

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_ja.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_ja.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u3053\u306e\u30d5\u30a3\u30fc\u30c1\u30e3\u30fc\u306f\u3001\u30d0\u30fc\u30b8\u30e7\u30f3\u306e\u306a\u3044 mpContextPropagation \u306e\u30b5\u30dd\u30fc\u30c8\u3092\u6709\u52b9\u306b\u3057\u307e\u3059\u3002

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_ko.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_ko.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\uc774 \uae30\ub2a5\uc740 \ubc84\uc804\uc774 \uc5c6\ub294 mpContextPropagation \uc5d0 \ub300\ud55c \uc9c0\uc6d0\uc744 \uc0ac\uc6a9 \uac00\ub2a5\ud558\uac8c \ud569\ub2c8\ub2e4.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_pl.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_pl.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Ten sk\u0142adnik umo\u017cliwia obs\u0142ug\u0119 konsoli mpContextPropagation bez wersji.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_pt_BR.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_pt_BR.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Esse recurso ativa o suporte para mpContextPropagation sem vers\u00e3o

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_ro.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_ro.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Aceast\u0103 caracteristic\u0103 permite suport pentru versionless mpContextPropagation

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_ru.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_ru.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u042d\u0442\u0430 \u0444\u0443\u043d\u043a\u0446\u0438\u044f \u043f\u043e\u0437\u0432\u043e\u043b\u044f\u0435\u0442 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0442\u044c \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0443 \u0432\u0435\u0440\u0441\u0438\u0439 mpContextPropagation\u0441 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u043e\u0439 \u0432\u0435\u0440\u0441\u0438\u0439.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_zh.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_zh.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u6b64\u529f\u80fd\u90e8\u4ef6\u652f\u6301\u65e0\u7248\u672c mpContextPropagation

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_zh_TW.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation/resources/l10n/io.openliberty.versionless.mpContextPropagation_zh_TW.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u9019\u9805\u7279\u6027\u53ef\u652f\u63f4\u7121\u7248\u672c\u5316 mpContextPropagation

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
@@ -26,3 +26,4 @@ Subsystem-Name: MicroProfile GraphQL 1.0
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
+WLP-Platform: microProfile-3.3,microProfile-4.0,microProfile-4.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-2.0/io.openliberty.mpGraphQL-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-2.0/io.openliberty.mpGraphQL-2.0.feature
@@ -27,3 +27,4 @@ Subsystem-Name: MicroProfile GraphQL 2.0
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
+WLP-Platform: microProfile-5.0,microProfile-6.0,microProfile-6.1,microProfile-7.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/io.openliberty.versionless.mpGraphQL.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/io.openliberty.versionless.mpGraphQL.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.versionless.mpGraphQL
+visibility=public
+IBM-ShortName: mpGraphQL
+Subsystem-Name: mpGraphQL
+-features=io.openliberty.internal.versionless.mpGraphQL-1.0; ibm.tolerates:="2.0"
+kind=ga
+edition=core
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for versionless mpGraphQL

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_cs.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_cs.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Tato funkce umo\u017e\u0148uje podporu pro bezverzovou mpGraphQL

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_de.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_de.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Dieses Feature aktiviert die Unterst\u00fctzung f\u00fcr mpGraphQL ohne Versionssteuerung

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_es.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_es.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Esta caracter\u00edstica habilita el soporte para mpGraphQL sin versi\u00f3n

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_fr.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_fr.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Cette fonction active la prise en charge de mpGraphQL sans version

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_hu.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_hu.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Ez a szolg\u00e1ltat\u00e1s t\u00e1mogatja a verzi\u00f3n\u00e9lk\u00fcli mpGraphQL t\u00e1mogat\u00e1st

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_it.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_it.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Questa funzione abilita il supporto per mpGraphQL senza versione

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_ja.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_ja.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u3053\u306e\u30d5\u30a3\u30fc\u30c1\u30e3\u30fc\u306f\u3001\u30d0\u30fc\u30b8\u30e7\u30f3\u306e\u306a\u3044 mpGraphQL \u306e\u30b5\u30dd\u30fc\u30c8\u3092\u6709\u52b9\u306b\u3057\u307e\u3059\u3002

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_ko.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_ko.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\uc774 \uae30\ub2a5\uc740 \ubc84\uc804\uc774 \uc5c6\ub294 mpGraphQL \uc5d0 \ub300\ud55c \uc9c0\uc6d0\uc744 \uc0ac\uc6a9 \uac00\ub2a5\ud558\uac8c \ud569\ub2c8\ub2e4.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_pl.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_pl.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Ten sk\u0142adnik umo\u017cliwia obs\u0142ug\u0119 konsoli mpGraphQL bez wersji.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_pt_BR.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_pt_BR.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Esse recurso ativa o suporte para mpGraphQL sem vers\u00e3o

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_ro.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_ro.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Aceast\u0103 caracteristic\u0103 permite suport pentru versionless mpGraphQL

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_ru.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_ru.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u042d\u0442\u0430 \u0444\u0443\u043d\u043a\u0446\u0438\u044f \u043f\u043e\u0437\u0432\u043e\u043b\u044f\u0435\u0442 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0442\u044c \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0443 \u0432\u0435\u0440\u0441\u0438\u0439 mpGraphQL\u0441 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u043e\u0439 \u0432\u0435\u0440\u0441\u0438\u0439.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_zh.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_zh.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u6b64\u529f\u80fd\u90e8\u4ef6\u652f\u6301\u65e0\u7248\u672c mpGraphQL

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_zh_TW.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL/resources/l10n/io.openliberty.versionless.mpGraphQL_zh_TW.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u9019\u9805\u7279\u6027\u53ef\u652f\u63f4\u7121\u7248\u672c\u5316 mpGraphQL

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging-1.0/com.ibm.websphere.appserver.mpReactiveMessaging-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging-1.0/com.ibm.websphere.appserver.mpReactiveMessaging-1.0.feature
@@ -27,3 +27,4 @@ Subsystem-Name: MicroProfile Reactive Messaging 1.0
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
+WLP-Platform: microProfile-1.4,microProfile-2.0,microProfile-2.1,microProfile-2.2,microProfile-3.0,microProfile-3.2,microProfile-3.3

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging-3.0/io.openliberty.mpReactiveMessaging-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging-3.0/io.openliberty.mpReactiveMessaging-3.0.feature
@@ -28,3 +28,4 @@ kind=ga
 edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
+WLP-Platform: microProfile-5.0,microProfile-6.0,microProfile-6.1,microProfile-7.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/io.openliberty.versionless.mpReactiveMessaging.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/io.openliberty.versionless.mpReactiveMessaging.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.versionless.mpReactiveMessaging
+visibility=public
+IBM-ShortName: mpReactiveMessaging
+Subsystem-Name: mpReactiveMessaging
+-features=io.openliberty.internal.versionless.mpReactiveMessaging-1.0; ibm.tolerates:="3.0"
+kind=ga
+edition=core
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for versionless mpReactiveMessaging

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_cs.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_cs.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Tato funkce umo\u017e\u0148uje podporu pro bezverzovou mpReactiveMessaging

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_de.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_de.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Dieses Feature aktiviert die Unterst\u00fctzung f\u00fcr mpReactiveMessaging ohne Versionssteuerung

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_es.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_es.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Esta caracter\u00edstica habilita el soporte para mpReactiveMessaging sin versi\u00f3n

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_fr.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_fr.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Cette fonction active la prise en charge de mpReactiveMessaging sans version

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_hu.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_hu.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Ez a szolg\u00e1ltat\u00e1s t\u00e1mogatja a verzi\u00f3n\u00e9lk\u00fcli mpReactiveMessaging t\u00e1mogat\u00e1st

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_it.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_it.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Questa funzione abilita il supporto per mpReactiveMessaging senza versione

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_ja.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_ja.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u3053\u306e\u30d5\u30a3\u30fc\u30c1\u30e3\u30fc\u306f\u3001\u30d0\u30fc\u30b8\u30e7\u30f3\u306e\u306a\u3044 mpReactiveMessaging \u306e\u30b5\u30dd\u30fc\u30c8\u3092\u6709\u52b9\u306b\u3057\u307e\u3059\u3002

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_ko.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_ko.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\uc774 \uae30\ub2a5\uc740 \ubc84\uc804\uc774 \uc5c6\ub294 mpReactiveMessaging \uc5d0 \ub300\ud55c \uc9c0\uc6d0\uc744 \uc0ac\uc6a9 \uac00\ub2a5\ud558\uac8c \ud569\ub2c8\ub2e4.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_pl.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_pl.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Ten sk\u0142adnik umo\u017cliwia obs\u0142ug\u0119 konsoli mpReactiveMessaging bez wersji.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_pt_BR.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_pt_BR.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Esse recurso ativa o suporte para mpReactiveMessaging sem vers\u00e3o

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_ro.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_ro.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Aceast\u0103 caracteristic\u0103 permite suport pentru versionless mpReactiveMessaging

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_ru.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_ru.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u042d\u0442\u0430 \u0444\u0443\u043d\u043a\u0446\u0438\u044f \u043f\u043e\u0437\u0432\u043e\u043b\u044f\u0435\u0442 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0442\u044c \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0443 \u0432\u0435\u0440\u0441\u0438\u0439 mpReactiveMessaging\u0441 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u043e\u0439 \u0432\u0435\u0440\u0441\u0438\u0439.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_zh.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_zh.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u6b64\u529f\u80fd\u90e8\u4ef6\u652f\u6301\u65e0\u7248\u672c mpReactiveMessaging

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_zh_TW.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveMessaging/resources/l10n/io.openliberty.versionless.mpReactiveMessaging_zh_TW.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u9019\u9805\u7279\u6027\u53ef\u652f\u63f4\u7121\u7248\u672c\u5316 mpReactiveMessaging

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams-1.0/com.ibm.websphere.appserver.mpReactiveStreams-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams-1.0/com.ibm.websphere.appserver.mpReactiveStreams-1.0.feature
@@ -23,3 +23,4 @@ IBM-API-Package: \
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
+WLP-Platform: microProfile-1.0,microProfile-1.2,microProfile-1.3,microProfile-1.4,microProfile-2.0,microProfile-2.1,microProfile-2.2,microProfile-3.0,microProfile-3.2,microProfile-3.3

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams-3.0/io.openliberty.mpReactiveStreams-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams-3.0/io.openliberty.mpReactiveStreams-3.0.feature
@@ -24,3 +24,4 @@ kind=ga
 edition=core
 WLP-Activation-Type: parallel
 WLP-InstantOn-Enabled: true
+WLP-Platform: microProfile-5.0,microProfile-6.0,microProfile-6.1,microProfile-7.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/io.openliberty.versionless.mpReactiveStreams.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/io.openliberty.versionless.mpReactiveStreams.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.versionless.mpReactiveStreams
+visibility=public
+IBM-ShortName: mpReactiveStreams
+Subsystem-Name: mpReactiveStreams
+-features=io.openliberty.internal.versionless.mpReactiveStreams-1.0; ibm.tolerates:="3.0"
+kind=ga
+edition=core
+WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for versionless mpReactiveStreams

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_cs.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_cs.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Tato funkce umo\u017e\u0148uje podporu pro bezverzovou mpReactiveStreams

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_de.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_de.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Dieses Feature aktiviert die Unterst\u00fctzung f\u00fcr mpReactiveStreams ohne Versionssteuerung

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_es.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_es.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Esta caracter\u00edstica habilita el soporte para mpReactiveStreams sin versi\u00f3n

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_fr.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_fr.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Cette fonction active la prise en charge de mpReactiveStreams sans version

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_hu.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_hu.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Ez a szolg\u00e1ltat\u00e1s t\u00e1mogatja a verzi\u00f3n\u00e9lk\u00fcli mpReactiveStreams t\u00e1mogat\u00e1st

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_it.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_it.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Questa funzione abilita il supporto per mpReactiveStreams senza versione

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_ja.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_ja.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u3053\u306e\u30d5\u30a3\u30fc\u30c1\u30e3\u30fc\u306f\u3001\u30d0\u30fc\u30b8\u30e7\u30f3\u306e\u306a\u3044 mpReactiveStreams \u306e\u30b5\u30dd\u30fc\u30c8\u3092\u6709\u52b9\u306b\u3057\u307e\u3059\u3002

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_ko.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_ko.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\uc774 \uae30\ub2a5\uc740 \ubc84\uc804\uc774 \uc5c6\ub294 mpReactiveStreams \uc5d0 \ub300\ud55c \uc9c0\uc6d0\uc744 \uc0ac\uc6a9 \uac00\ub2a5\ud558\uac8c \ud569\ub2c8\ub2e4.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_pl.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_pl.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Ten sk\u0142adnik umo\u017cliwia obs\u0142ug\u0119 konsoli mpReactiveStreams bez wersji.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_pt_BR.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_pt_BR.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Esse recurso ativa o suporte para mpReactiveStreams sem vers\u00e3o

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_ro.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_ro.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=Aceast\u0103 caracteristic\u0103 permite suport pentru versionless mpReactiveStreams

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_ru.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_ru.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u042d\u0442\u0430 \u0444\u0443\u043d\u043a\u0446\u0438\u044f \u043f\u043e\u0437\u0432\u043e\u043b\u044f\u0435\u0442 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0442\u044c \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0443 \u0432\u0435\u0440\u0441\u0438\u0439 mpReactiveStreams\u0441 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u043e\u0439 \u0432\u0435\u0440\u0441\u0438\u0439.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_zh.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_zh.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u6b64\u529f\u80fd\u90e8\u4ef6\u652f\u6301\u65e0\u7248\u672c mpReactiveStreams

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_zh_TW.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpReactiveStreams/resources/l10n/io.openliberty.versionless.mpReactiveStreams_zh_TW.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=\u9019\u9805\u7279\u6027\u53ef\u652f\u63f4\u7121\u7248\u672c\u5316 mpReactiveStreams


### PR DESCRIPTION
- Adds versionless features mpContextPropagation, mpGraphQL, mpReactiveMessaging, and mpReactiveStreams to start with the microProfile-x.y platforms that they work with
- Updated tests to support the new versionless features and added additional validation for platforms.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".