### PR TITLE
Versionless Caching tests pass on non-linux operating systems

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessCachingTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessCachingTest.java
@@ -301,6 +301,7 @@ public class VersionlessCachingTest {
         // There are some ASCII - EBCDIC issues that would have to be worked out for Z/OS.
         if (!OS.contains("linux") && !OS.contains("mac os")) {
             System.out.println("Returning.  Test not valid on " + OS);
+            TEST_PASSED = true;
             return;
         }
 
@@ -374,6 +375,7 @@ public class VersionlessCachingTest {
         // There are some ASCII - EBCDIC issues that would have to be worked out for Z/OS.
         if (!OS.contains("linux") && !OS.contains("mac os")) {
             System.out.println("Returning.  Test not valid on " + OS);
+            TEST_PASSED = true;
             return;
         }
 
@@ -433,6 +435,7 @@ public class VersionlessCachingTest {
         // There are some ASCII - EBCDIC issues that would have to be worked out for Z/OS.
         if (!OS.contains("linux") && !OS.contains("mac os")) {
             System.out.println("Returning.  Test not valid on " + OS);
+            TEST_PASSED = true;
             return;
         }
 
@@ -490,6 +493,7 @@ public class VersionlessCachingTest {
         // There are some ASCII - EBCDIC issues that would have to be worked out for Z/OS.
         if (!OS.contains("linux") && !OS.contains("mac os")) {
             System.out.println("Returning.  Test not valid on " + OS);
+            TEST_PASSED = true;
             return;
         }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Veersionless caching tests don't auto fail on non-linux and non-mac operating systems.