### PR TITLE
Fix test bug when java.version = 23-ea

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/test-applications/ConcurrencyTestWeb/src/test/jakarta/concurrency/web/ConcurrencyTestServlet.java
@@ -3129,11 +3129,8 @@ public class ConcurrencyTestServlet extends FATServlet {
      */
     @Test
     public void testVirtualThreadedExecutors() throws Exception {
-        String version = System.getProperty("java.version");
-        System.out.println("java.version is \"" + version + "\"");
-        int dot = version.indexOf('.');
-        String major = dot < 0 ? version : version.substring(0, dot);
-        boolean supportsVirtualThreads = Integer.parseInt(major) >= 21;
+        System.out.println("Runtime.version() is \"" + Runtime.version().toString() + "\"");
+        boolean supportsVirtualThreads = Runtime.version().feature() >= 21;
 
         if (supportsVirtualThreads) {
             CountDownLatch twoStarted = new CountDownLatch(2);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes test bug where `java.version = 23-ea` is not correctly parsed.