### PR TITLE
Ignore start failure when test has already passed

### DIFF
--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/fat/src/tests/FailoverTest2.java
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/fat/src/tests/FailoverTest2.java
@@ -426,10 +426,15 @@ public class FailoverTest2 extends FailoverTest {
         Log.info(this.getClass(), method, "set timeout");
         server.setServerStartTimeout(START_TIMEOUT);
 
-        FATUtils.startServers(runner, server);
+        try {
+            // Don't care whether this actually starts a server
+            FATUtils.startServers(runner, server);
+        } catch (Exception e) {
+        }
 
         // Should see a message like
         // WTRN0108I: Have recovered from SQLException when opening SQL RecoveryLog
+        server.resetLogMarks();
         assertNotNull("No warning message signifying failover", server.waitForStringInTrace("Have recovered from SQLException when claiming local recovery logs"));
     }
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

#build
#spawn.fullfat.buckets=com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.sqlserver.2