### PR TITLE
Avoid re-activation of CacheServiceImpl when the server config is updated after checkpoint 

### DIFF
--- a/dev/io.openliberty.checkpoint_fat_jcache_hazelcast/publish/servers/io.openliberty.jcache.internal.fat.provider.in.app.1/server.xml
+++ b/dev/io.openliberty.checkpoint_fat_jcache_hazelcast/publish/servers/io.openliberty.jcache.internal.fat.provider.in.app.1/server.xml
@@ -44,7 +44,7 @@
 	<cacheManager id="CacheManager">
 
 		<properties
-			hazelcast.config.location="file:${shared.resource.dir}/hazelcast/${hazelcast.config.file}" />
+			hazelcast.config.location="${uri_location}" />
 
 		<cachingProvider
 			jCacheLibraryRef="HazelcastLib" commonLibraryRef="CustomLoginLib" />

--- a/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/Activator.java
+++ b/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/Activator.java
@@ -45,7 +45,7 @@ import io.openliberty.checkpoint.spi.CheckpointPhase;
  */
 public class Activator implements BundleActivator, ServiceTrackerCustomizer<Condition, Boolean>, ConfigurationListener, RuntimeUpdateListener {
     public static final String CACHE_MANAGER_CONFIG_CONDITION = "jcache.cachemanager.config";
-    private static final Set<String> pids = new HashSet<>(Arrays.asList("io.openliberty.jcache.cachemanager", "io.openliberty.jcache.cachingprovider"));
+    private static final Set<String> pids = new HashSet<>(Arrays.asList("io.openliberty.jcache.cachemanager", "io.openliberty.jcache.cachingprovider", "io.openliberty.jcache.cache"));
     private final AtomicReference<ServiceRegistration<Condition>> conditionReg = new AtomicReference<>();
     volatile ServiceTracker<Condition, Boolean> runningConditionTracker;
     volatile BundleContext bc;

--- a/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/Activator.java
+++ b/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/Activator.java
@@ -44,7 +44,7 @@ import io.openliberty.checkpoint.spi.CheckpointPhase;
  *
  */
 public class Activator implements BundleActivator, ServiceTrackerCustomizer<Condition, Boolean>, ConfigurationListener, RuntimeUpdateListener {
-    public static final String CACHE_MANAGER_CONFIG_CONDITION = "jcache.cachemanager.config";
+    public static final String CACHE_CONFIG_CONDITION = "jcache.cache.config";
     private static final Set<String> pids = new HashSet<>(Arrays.asList("io.openliberty.jcache.cachemanager", "io.openliberty.jcache.cachingprovider", "io.openliberty.jcache.cache"));
     private final AtomicReference<ServiceRegistration<Condition>> conditionReg = new AtomicReference<>();
     volatile ServiceTracker<Condition, Boolean> runningConditionTracker;
@@ -128,7 +128,7 @@ public class Activator implements BundleActivator, ServiceTrackerCustomizer<Cond
                 reg.unregister();
             }
             return bc.registerService(Condition.class, Condition.INSTANCE,
-                                      FrameworkUtil.asDictionary(Collections.singletonMap(Condition.CONDITION_ID, CACHE_MANAGER_CONFIG_CONDITION)));
+                                      FrameworkUtil.asDictionary(Collections.singletonMap(Condition.CONDITION_ID, CACHE_CONFIG_CONDITION)));
         });
     }
 }

--- a/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/CacheManagerServiceImpl.java
+++ b/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/CacheManagerServiceImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package io.openliberty.jcache.internal;
 
-import static io.openliberty.jcache.internal.Activator.CACHE_MANAGER_CONFIG_CONDITION;
+import static io.openliberty.jcache.internal.Activator.CACHE_CONFIG_CONDITION;
 import static org.osgi.service.component.annotations.ConfigurationPolicy.REQUIRE;
 
 import java.io.IOException;
@@ -285,7 +285,7 @@ public class CacheManagerServiceImpl implements CacheManagerService {
         this.scheduledExecutorService = null;
     }
 
-    @Reference(name = "configCondition", service = Condition.class, target = "(" + Condition.CONDITION_ID + "=" + CACHE_MANAGER_CONFIG_CONDITION + ")")
+    @Reference(name = "configCondition", service = Condition.class, target = "(" + Condition.CONDITION_ID + "=" + CACHE_CONFIG_CONDITION + ")")
     protected void setConfigCondition(Condition configCondition) {
         // do nothing; this is just a reference that we use to force the component to recycle
     }

--- a/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/CacheServiceImpl.java
+++ b/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/CacheServiceImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package io.openliberty.jcache.internal;
 
-import static io.openliberty.jcache.internal.Activator.CACHE_MANAGER_CONFIG_CONDITION;
+import static io.openliberty.jcache.internal.Activator.CACHE_CONFIG_CONDITION;
 import static org.osgi.service.component.annotations.ConfigurationPolicy.REQUIRE;
 
 import java.io.ByteArrayInputStream;
@@ -334,7 +334,7 @@ public class CacheServiceImpl implements CacheService {
         this.serializationService = null;
     }
     
-    @Reference(name = "configCondition", service = Condition.class, target = "(" + Condition.CONDITION_ID + "=" + CACHE_MANAGER_CONFIG_CONDITION + ")")
+    @Reference(name = "configCondition", service = Condition.class, target = "(" + Condition.CONDITION_ID + "=" + CACHE_CONFIG_CONDITION + ")")
     protected void setConfigCondition(Condition configCondition) {
         // do nothing; this is just a reference that we use to force the component to recycle
     }

--- a/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/CacheServiceImpl.java
+++ b/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/CacheServiceImpl.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.jcache.internal;
 
+import static io.openliberty.jcache.internal.Activator.CACHE_MANAGER_CONFIG_CONDITION;
 import static org.osgi.service.component.annotations.ConfigurationPolicy.REQUIRE;
 
 import java.io.ByteArrayInputStream;
@@ -37,8 +38,10 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.condition.Condition;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -82,11 +85,7 @@ public class CacheServiceImpl implements CacheService {
 
     @Activate
     public void activate(Map<String, Object> configProps) {
-        /*
-         * Retrieve the id and cache name from the configuration properties.
-         */
-        this.id = (String) configProps.get(KEY_ID);
-        this.cacheName = (String) configProps.get(KEY_CACHE_NAME);
+        processConfiguration(configProps);
         /*
          * Schedule a task to initialize the cache in the background. This will
          * alleviate delays on the first request to the cache.
@@ -101,6 +100,19 @@ public class CacheServiceImpl implements CacheService {
                 }
             }, 0, TimeUnit.SECONDS);
         });
+    }
+
+    private void processConfiguration(Map<String, Object> configProps) {
+        /*
+         * Retrieve the id and cache name from the configuration properties.
+         */
+        this.id = (String) configProps.get(KEY_ID);
+        this.cacheName = (String) configProps.get(KEY_CACHE_NAME);
+    }
+
+    @Modified
+    public void modified(Map<String, Object> configProps) {
+        processConfiguration(configProps);
     }
 
     @Deactivate
@@ -320,6 +332,11 @@ public class CacheServiceImpl implements CacheService {
 
     public void unsetSerializationService(SerializationService serializationService) {
         this.serializationService = null;
+    }
+    
+    @Reference(name = "configCondition", service = Condition.class, target = "(" + Condition.CONDITION_ID + "=" + CACHE_MANAGER_CONFIG_CONDITION + ")")
+    protected void setConfigCondition(Condition configCondition) {
+        // do nothing; this is just a reference that we use to force the component to recycle
     }
 
     @Override

--- a/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/CachingProviderService.java
+++ b/dev/io.openliberty.jcache.internal/src/io/openliberty/jcache/internal/CachingProviderService.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package io.openliberty.jcache.internal;
 
-import static io.openliberty.jcache.internal.Activator.CACHE_MANAGER_CONFIG_CONDITION;
+import static io.openliberty.jcache.internal.Activator.CACHE_CONFIG_CONDITION;
 import static org.osgi.service.component.annotations.ConfigurationPolicy.REQUIRE;
 
 import java.util.HashSet;
@@ -261,7 +261,7 @@ public class CachingProviderService {
         this.classLoadingService = null;
     }
 
-    @Reference(name = "configCondition", service = Condition.class, target = "(" + Condition.CONDITION_ID + "=" + CACHE_MANAGER_CONFIG_CONDITION + ")")
+    @Reference(name = "configCondition", service = Condition.class, target = "(" + Condition.CONDITION_ID + "=" + CACHE_CONFIG_CONDITION + ")")
     protected void setConfigCondition(Condition configCondition) {
         // do nothing; this is just a reference that we use to force the component to recycle
     }


### PR DESCRIPTION
Fixes #https://github.com/OpenLiberty/open-liberty/issues/29306

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
