### PR TITLE
Ignore start failure when test has already passed

### DIFF
--- a/dev/com.ibm.ws.transaction.recovery_fat.3/fat/src/tests/WaitForRecoveryTest.java
+++ b/dev/com.ibm.ws.transaction.recovery_fat.3/fat/src/tests/WaitForRecoveryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -30,11 +30,9 @@ import com.ibm.ws.transaction.fat.util.FATUtils;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
-import web.WaitForRecoveryServlet;
 
 @RunWith(FATRunner.class)
 public class WaitForRecoveryTest extends FATServletClient {
@@ -43,7 +41,6 @@ public class WaitForRecoveryTest extends FATServletClient {
     public static final String SERVLET_NAME = APP_NAME + "/WaitForRecoveryServlet";
 
     @Server("com.ibm.ws.transaction_waitForRecovery")
-    @TestServlet(servlet = WaitForRecoveryServlet.class, contextRoot = APP_NAME)
     public static LibertyServer server1;
 
     @BeforeClass
@@ -56,7 +53,10 @@ public class WaitForRecoveryTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        FATUtils.stopServers(server1);
+        FATUtils.stopServers(new String[] { "WTRN0075W", "WTRN0076W" }, server1); // Stop the server and indicate the '"WTRN0075W", "WTRN0076W" error messages were expected
+
+        // Clean up XA resource file
+        server1.deleteFileFromLibertyServerRoot("XAResourceData.dat");
     }
 
     @SuppressWarnings("deprecation")
@@ -64,38 +64,38 @@ public class WaitForRecoveryTest extends FATServletClient {
     @ExpectedFFDC(value = { "javax.transaction.xa.XAException" })
     public void testWaitForRecovery() throws Exception {
         final String method = "testBaseRecovery";
-        StringBuilder sb = null;
 
         try {
             // We expect this to fail since it is gonna crash the server
-            sb = runTestWithResponse(server1, SERVLET_NAME, "testRec001");
-            fail(sb.toString());
+            runTest(server1, SERVLET_NAME, "testRec001");
+            fail();
         } catch (IOException e) {
         }
-        Log.info(this.getClass(), method, "testRec001 returned: " + sb);
 
         assertNotNull(server1.getServerName() + " failed to crash", server1.waitForStringInLog(XAResourceImpl.DUMP_STATE));
         server1.resetLogOffsets(); // Dunno how you would do this with log marks
 
-        // Now re-start cloud1
-        ProgramOutput po = server1.startServerAndValidate(false, true, true);
-        if (po.getReturnCode() != 0) {
-            Log.info(this.getClass(), method, po.getCommand() + " returned " + po.getReturnCode());
-            Log.info(this.getClass(), method, "Stdout: " + po.getStdout());
-            Log.info(this.getClass(), method, "Stderr: " + po.getStderr());
-            Exception ex = new Exception("Could not restart the server");
-            Log.error(this.getClass(), "WaitForRecoveryTest", ex);
-            throw ex;
+        try {
+            final ProgramOutput po = server1.startServerAndValidate(false, true, true);
+            if (po.getReturnCode() != 0) {
+                Log.info(this.getClass(), method, po.getCommand() + " returned " + po.getReturnCode());
+                String str = po.getStdout();
+                if (str != null && !str.isEmpty()) {
+                    Log.info(this.getClass(), method, "Stdout: " + str);
+                }
+                str = po.getStderr();
+                if (str != null && !str.isEmpty()) {
+                    Log.info(this.getClass(), method, "Stderr: " + str);
+                }
+                // Not really bothered. Checks below will tell us whether app start waited.
+            }
+        } catch (Exception e) {
         }
 
-        // Server appears to have started ok. Check for key string to see whether recovery has succeeded
+        // Check for key string to see whether recovery has succeeded
         assertNotNull(server1.getServerName() + " did not perform recovery", server1.waitForStringInTraceUsingLastOffset("Performed recovery for " + server1.getServerName()));
+
+        // Check app start happened afterwards
         assertNotNull("App must have started first", server1.waitForStringInTraceUsingLastOffset("Starting application " + APP_NAME));
-
-        // Lastly stop server1
-        FATUtils.stopServers(new String[] { "WTRN0075W", "WTRN0076W" }, server1); // Stop the server and indicate the '"WTRN0075W", "WTRN0076W" error messages were expected
-
-        // Lastly, clean up XA resource file
-        server1.deleteFileFromLibertyServerRoot("XAResourceData.dat");
     }
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

#build
#spawn.fullfat.buckets=com.ibm.ws.transaction.recovery_fat.3