### PR TITLE
Extra trace for wait timeout

### DIFF
--- a/dev/com.ibm.ws.wsat.common/src/com/ibm/ws/wsat/common/impl/WSATParticipant.java
+++ b/dev/com.ibm.ws.wsat.common/src/com/ibm/ws/wsat/common/impl/WSATParticipant.java
@@ -115,7 +115,7 @@ public class WSATParticipant extends WSATEndpoint implements Serializable {
         if (timeoutMills <= 0) {
             while (!responseList.contains(state)) {
                 if (TC.isDebugEnabled()) {
-                    Tr.debug(TC, "Waiting 1 second for state (" + state + ") to be one of (" + joinParticipantStates(responses) + ")");
+                    Tr.debug(TC, "Waiting 1 second for state [" + state + "] to be one of " + Arrays.toString(responses));
                 }
                 try {
                     wait(1000);
@@ -127,10 +127,14 @@ public class WSATParticipant extends WSATEndpoint implements Serializable {
             while (Instant.now().compareTo(expiry) < 0 && !responseList.contains(state)) {
                 final long waitTime = expiry.minusMillis(Instant.now().toEpochMilli()).toEpochMilli();
                 if (TC.isDebugEnabled()) {
-                    Tr.debug(TC, "Waiting " + waitTime + " milliseconds for state (" + state + ") to be one of (" + joinParticipantStates(responses) + ")");
+                    Tr.debug(TC, "Waiting " + waitTime + " milliseconds for state [" + state + "] to be one of " + Arrays.toString(responses));
                 }
                 try {
-                    wait(waitTime);
+                    if (waitTime > 0) {
+                        wait(waitTime);
+                    } else {
+                        break;
+                    }
                 } catch (InterruptedException e) {
                 }
             }
@@ -141,25 +145,6 @@ public class WSATParticipant extends WSATEndpoint implements Serializable {
             Tr.exit(TC, "waitResponse", ret);
         }
         return ret;
-    }
-
-    /**
-     * @param responses
-     * @return
-     */
-    @Trivial
-    private String joinParticipantStates(WSATParticipantState[] states) {
-        if (states == null) {
-            return "";
-        }
-
-        final StringBuffer sb = new StringBuffer("" + states[0]);
-
-        for (int i = 1; i < states.length; i++) {
-            sb.append("," + states[i]);
-        }
-
-        return sb.toString();
     }
 
     /*


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

#build
#spawn.fullfat.buckets=com.ibm.ws.wsat.common_fat,com.ibm.ws.wsat.concurrent_fat,com.ibm.ws.wsat.migration_fat.1,com.ibm.ws.wsat.migration_fat.2,com.ibm.ws.wsat.migration_fat.3,com.ibm.ws.wsat.migration_fat.4,com.ibm.ws.wsat.migration_fat.5,com.ibm.ws.wsat.migration_fat.6,com.ibm.ws.wsat.migration_fat.7,com.ibm.ws.wsat.recovery_fat.lps,com.ibm.ws.wsat.recovery_fat.multi.1,com.ibm.ws.wsat.recovery_fat.multi.2,com.ibm.ws.wsat.recovery_fat.multi.3,com.ibm.ws.wsat.recovery_fat.multi.4,com.ibm.ws.wsat.recovery_fat.multi.5,com.ibm.ws.wsat.recovery_fat.multi.6,com.ibm.ws.wsat.recovery_fat.multi.7,com.ibm.ws.wsat.recovery_fat.multi.8,com.ibm.ws.wsat.recovery_fat.multi.9,com.ibm.ws.wsat.recovery_fat.single.1,com.ibm.ws.wsat.recovery_fat.single.2,com.ibm.ws.wsat_fat.assertion,com.ibm.ws.wsat_fat.db,com.ibm.ws.wsat_fat.db_optional,com.ibm.ws.wsat_fat.dbs,com.ibm.ws.wsat_fat.dbs_optional,com.ibm.ws.wsat_fat.multi,com.ibm.ws.wsat_fat.multi.misroute,com.ibm.ws.wsat_fat.ssl.misroute,com.ibm.ws.wsat_fat.ssl