### PR TITLE
requirements around primary entity

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -192,7 +192,7 @@ public class QueryInfo {
     /**
      * Repository method to which this query information pertains.
      */
-    final Method method;
+    public final Method method;
 
     /**
      * The type of data structure that returns multiple results for this query.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
@@ -36,33 +36,6 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
 
     private final String persistenceUnitRef;
 
-    // TODO this should be removed because the spec did not add the ability to use
-    // a resource access method with a qualifier to configure the EntityManager.
-    public PUnitEMBuilder(DataProvider provider,
-                          ClassLoader repositoryClassLoader,
-                          EntityManagerFactory emf,
-                          Set<Class<?>> entityTypes) {
-        super(provider, repositoryClassLoader);
-        this.emf = emf;
-        this.persistenceUnitRef = emf.toString();
-
-        try {
-            collectEntityInfo(entityTypes);
-        } catch (RuntimeException x) {
-            for (Class<?> entityClass : entityTypes)
-                entityInfoMap.computeIfAbsent(entityClass, EntityInfo::newFuture).completeExceptionally(x);
-            throw x;
-        } catch (Exception x) {
-            for (Class<?> entityClass : entityTypes)
-                entityInfoMap.computeIfAbsent(entityClass, EntityInfo::newFuture).completeExceptionally(x);
-            throw new RuntimeException(x);
-        } catch (Error x) {
-            for (Class<?> entityClass : entityTypes)
-                entityInfoMap.computeIfAbsent(entityClass, EntityInfo::newFuture).completeExceptionally(x);
-            throw x;
-        }
-    }
-
     /**
      * Obtains entity manager instances from a persistence unit reference /
      * EntityManagerFactory.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/validation/EntityValidatorImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/validation/EntityValidatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -87,7 +87,7 @@ public class EntityValidatorImpl implements EntityValidator {
     public <T> void validateParameters(T object, Method method, Object[] args) {
         Set<ConstraintViolation<Object>> violations = methodValidator.validateParameters(object, method, args);
         if (violations != null && !violations.isEmpty())
-            throw new ConstraintViolationException(violations); // TODO better message? Ensure that message includes at least the first violation.
+            throw new ConstraintViolationException(violations);
     }
 
     /**
@@ -102,6 +102,6 @@ public class EntityValidatorImpl implements EntityValidator {
     public <T> void validateReturnValue(T object, Method method, Object returnValue) {
         Set<ConstraintViolation<Object>> violations = methodValidator.validateReturnValue(object, method, returnValue);
         if (violations != null && !violations.isEmpty())
-            throw new ConstraintViolationException(violations); // TODO better message? Ensure that message includes at least the first violation.
+            throw new ConstraintViolationException(violations);
     }
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/People.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/People.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
 
 /**
@@ -20,5 +21,7 @@ import jakarta.data.repository.Repository;
  * to be discovered another way.
  */
 @Repository
-public interface People extends CustomRepository<Person, Long> {
+public interface People extends //
+                CustomRepository<Person, Long>, //
+                DataRepository<Person, Long> {
 }

--- a/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/DDLGenTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/DDLGenTestServlet.java
@@ -91,6 +91,12 @@ public class DDLGenTestServlet extends FATServlet {
         Part.Identifier nonmatching = new Part.Identifier("EI3155-T", "Acme");
         assertEquals(false, parts.findById(nonmatching).isPresent());
 
-        parts.deleteAll(List.of(part1, part2, part3));
+        assertEquals(true, parts.findById(part1.id()).isPresent());
+
+        parts.deleteById(part1.id());
+
+        assertEquals(false, parts.findById(part1.id()).isPresent());
+
+        parts.deleteAll(List.of(part2, part3));
     }
 }


### PR DESCRIPTION
Improve implementation of requirements for detecting the primary entity class, so that we always obtain it first from the type parameter of a built-in repository supertype.  Also improve the proposed error message that tells users how to correct it when a primary entity type is needed but missing. We should be able to identify the repository and repository method that requires it along with the recommended action for correcting.  This also cover various TODO comments in code and adds a test case for an embedded id being used for a delete query.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
