### PR TITLE
require PageRequest for CursoredPage

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -73,15 +73,15 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
         EntityManager em = queryInfo.entityInfo.builder.createEntityManager();
         try {
             String jpql = cursor.isEmpty() ? queryInfo.jpql : //
-                            isForward ? queryInfo.jpqlAfterKeyset : //
-                                            queryInfo.jpqlBeforeKeyset;
+                            isForward ? queryInfo.jpqlAfterCursor : //
+                                            queryInfo.jpqlBeforeCursor;
 
             @SuppressWarnings("unchecked")
             TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, queryInfo.entityInfo.entityClass);
             queryInfo.setParameters(query, args);
 
             if (cursor.isPresent())
-                queryInfo.setKeysetParameters(query, cursor.get());
+                queryInfo.setParametersFromCursor(query, cursor.get());
 
             query.setFirstResult(firstResult);
             query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1)); // extra position is for knowing whether to expect another page
@@ -271,7 +271,7 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
         int maxPageSize = pageRequest.size();
         int endingResultIndex = Math.min(maxPageSize, results.size()) - 1; // CURSOR_PREVIOUS that reads a partial page can have a next page
 
-        return PageRequest.afterCursor(Cursor.forKey(queryInfo.getKeysetValues(results.get(endingResultIndex))),
+        return PageRequest.afterCursor(Cursor.forKey(queryInfo.getCursorValues(results.get(endingResultIndex))),
                                        pageRequest.page() == Long.MAX_VALUE ? Long.MAX_VALUE : pageRequest.page() + 1,
                                        maxPageSize,
                                        pageRequest.requestTotal());
@@ -284,7 +284,7 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
                                              "true result of CursoredPage.hasPrevious before attempting this method."); // TODO NLS
 
         // Decrement page number by 1 unless it would go below 1.
-        return PageRequest.beforeCursor(Cursor.forKey(queryInfo.getKeysetValues(results.get(0))),
+        return PageRequest.beforeCursor(Cursor.forKey(queryInfo.getCursorValues(results.get(0))),
                                         pageRequest.page() == 1 ? 1 : pageRequest.page() - 1,
                                         pageRequest.size(),
                                         pageRequest.requestTotal());

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -55,11 +55,15 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
     @FFDCIgnore(Exception.class)
     CursoredPageImpl(QueryInfo queryInfo, PageRequest pageRequest, Object[] args) {
 
+        if (pageRequest == null)
+            PageImpl.missingPageRequest(queryInfo);
+
         this.args = args;
         this.queryInfo = queryInfo;
-        this.pageRequest = pageRequest == null ? PageRequest.ofSize(100) : pageRequest;
+        this.pageRequest = pageRequest;
         this.isForward = this.pageRequest.mode() != PageRequest.Mode.CURSOR_PREVIOUS;
-        Optional<PageRequest.Cursor> keysetCursor = this.pageRequest.cursor();
+
+        Optional<PageRequest.Cursor> cursor = this.pageRequest.cursor();
 
         int maxPageSize = this.pageRequest.size();
         int firstResult = this.pageRequest.mode() == PageRequest.Mode.OFFSET //
@@ -68,7 +72,7 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
 
         EntityManager em = queryInfo.entityInfo.builder.createEntityManager();
         try {
-            String jpql = keysetCursor.isEmpty() ? queryInfo.jpql : //
+            String jpql = cursor.isEmpty() ? queryInfo.jpql : //
                             isForward ? queryInfo.jpqlAfterKeyset : //
                                             queryInfo.jpqlBeforeKeyset;
 
@@ -76,16 +80,18 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
             TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, queryInfo.entityInfo.entityClass);
             queryInfo.setParameters(query, args);
 
-            if (keysetCursor.isPresent())
-                queryInfo.setKeysetParameters(query, keysetCursor.get());
+            if (cursor.isPresent())
+                queryInfo.setKeysetParameters(query, cursor.get());
 
             query.setFirstResult(firstResult);
             query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1)); // extra position is for knowing whether to expect another page
 
             results = query.getResultList();
 
-            // Keyset pagination involves reversing the ORDER BY to obtain the previous page, but the entries
-            // on the page will also be in reverse order, so we need to reverse again to correct that
+            // Cursor-based pagination in the previous page direction is implemented
+            // by reversing the ORDER BY to obtain the previous page. A side-effect
+            // of that is that the resulting entries for the page are reversed,
+            // so we need to reverse again to correct that.
             if (!isForward)
                 for (int size = results.size(), i = 0, j = size - (size > maxPageSize ? 2 : 1); i < j; i++, j--)
                     Collections.swap(results, i, j);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -163,14 +163,14 @@ public class QueryInfo {
     String jpql;
 
     /**
-     * JPQL for a find query after a keyset. Otherwise null.
+     * JPQL for a find query after a cursor. Otherwise null.
      */
-    String jpqlAfterKeyset;
+    String jpqlAfterCursor;
 
     /**
-     * JPQL for a find query before a keyset. Otherwise null.
+     * JPQL for a find query before a cursor. Otherwise null.
      */
-    String jpqlBeforeKeyset;
+    String jpqlBeforeCursor;
 
     /**
      * For counting the total number of results across all pages.
@@ -458,6 +458,24 @@ public class QueryInfo {
         }
 
         return q;
+    }
+
+    /**
+     * Raises an error because the number of cursor elements does not match the
+     * number of sort parameters.
+     *
+     * @param cursor cursor
+     */
+    @Trivial
+    private void cursorSizeMismatchError(PageRequest.Cursor cursor) {
+        List<String> keyTypes = new ArrayList<>();
+        for (int i = 0; i < cursor.size(); i++)
+            keyTypes.add(cursor.get(i) == null ? null : cursor.get(i).getClass().getName());
+
+        throw new MappingException("The cursor with element types " + keyTypes +
+                                   " cannot be used with sort criteria of " + sorts +
+                                   " because they have different numbers of elements. The cursor size is " + cursor.size() +
+                                   " and the sort criteria size is " + sorts.size() + "."); // TODO NLS
     }
 
     /**
@@ -789,6 +807,71 @@ public class QueryInfo {
     }
 
     /**
+     * Generates the queries for before/after a cursor and populates them into the
+     * query information.
+     * Example conditions to add for cursor next of (lastName, firstName, ssn):
+     * AND ((o.lastName > ?5)
+     * _ OR (o.lastName = ?5 AND o.firstName > ?6)
+     * _ OR (o.lastName = ?5 AND o.firstName = ?6 AND o.ssn > ?7) )
+     *
+     * @param q    query up to the WHERE clause, if present
+     * @param fwd  ORDER BY clause in forward page direction.
+     *                 Null if forward page direction is not needed.
+     * @param prev ORDER BY clause in previous page direction.
+     *                 Null if previous page direction is not needed.
+     */
+    void generateCursorQueries(StringBuilder q, StringBuilder fwd, StringBuilder prev) {
+        int numSorts = sorts.size();
+        String paramPrefix = paramNames == null ? "?" : ":cursor";
+        StringBuilder a = fwd == null ? null : new StringBuilder(200).append(hasWhere ? " AND (" : " WHERE (");
+        StringBuilder b = prev == null ? null : new StringBuilder(200).append(hasWhere ? " AND (" : " WHERE (");
+        String o_ = entityVar_;
+        for (int i = 0; i < numSorts; i++) {
+            if (a != null)
+                a.append(i == 0 ? "(" : " OR (");
+            if (b != null)
+                b.append(i == 0 ? "(" : " OR (");
+            for (int s = 0; s <= i; s++) {
+                Sort<?> sort = sorts.get(s);
+                String name = sort.property();
+                boolean asc = sort.isAscending();
+                boolean lower = sort.ignoreCase();
+                if (a != null)
+                    if (lower) {
+                        a.append(s == 0 ? "LOWER(" : " AND LOWER(").append(o_).append(name).append(')');
+                        a.append(s < i ? '=' : (asc ? '>' : '<'));
+                        a.append("LOWER(").append(paramPrefix).append(paramCount + 1 + s).append(')');
+                    } else {
+                        a.append(s == 0 ? "" : " AND ").append(o_).append(name);
+                        a.append(s < i ? '=' : (asc ? '>' : '<'));
+                        a.append(paramPrefix).append(paramCount + 1 + s);
+                    }
+                if (b != null)
+                    if (lower) {
+                        b.append(s == 0 ? "LOWER(" : " AND LOWER(").append(o_).append(name).append(')');
+                        b.append(s < i ? '=' : (asc ? '<' : '>'));
+                        b.append("LOWER(").append(paramPrefix).append(paramCount + 1 + s).append(')');
+                    } else {
+                        b.append(s == 0 ? "" : " AND ").append(o_).append(name);
+                        b.append(s < i ? '=' : (asc ? '<' : '>'));
+                        b.append(paramPrefix).append(paramCount + 1 + s);
+                    }
+            }
+            if (a != null)
+                a.append(')');
+            if (b != null)
+                b.append(')');
+        }
+        if (a != null)
+            jpqlAfterCursor = new StringBuilder(q).append(a).append(')').append(fwd).toString();
+        if (b != null)
+            jpqlBeforeCursor = new StringBuilder(q).append(b).append(')').append(prev).toString();
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "forward & previous cursor queries", jpqlAfterCursor, jpqlBeforeCursor);
+    }
+
+    /**
      * Generates JQPL for deletion by id, for find-and-delete repository operations.
      */
     private String generateDeleteById() {
@@ -858,75 +941,13 @@ public class QueryInfo {
     }
 
     /**
-     * Generates the before/after keyset queries and populates them into the query information.
-     * Example conditions to add for forward keyset of (lastName, firstName, ssn):
-     * AND ((o.lastName > ?5)
-     * _ OR (o.lastName = ?5 AND o.firstName > ?6)
-     * _ OR (o.lastName = ?5 AND o.firstName = ?6 AND o.ssn > ?7) )
-     *
-     * @param q    query up to the WHERE clause, if present
-     * @param fwd  ORDER BY clause in forward page direction. Null if forward page direction is not needed.
-     * @param prev ORDER BY clause in previous page direction. Null if previous page direction is not needed.
-     */
-    void generateKeysetQueries(StringBuilder q, StringBuilder fwd, StringBuilder prev) {
-        int numKeys = sorts.size();
-        String paramPrefix = paramNames == null ? "?" : ":keyset";
-        StringBuilder a = fwd == null ? null : new StringBuilder(200).append(hasWhere ? " AND (" : " WHERE (");
-        StringBuilder b = prev == null ? null : new StringBuilder(200).append(hasWhere ? " AND (" : " WHERE (");
-        String o_ = entityVar_;
-        for (int i = 0; i < numKeys; i++) {
-            if (a != null)
-                a.append(i == 0 ? "(" : " OR (");
-            if (b != null)
-                b.append(i == 0 ? "(" : " OR (");
-            for (int k = 0; k <= i; k++) {
-                Sort<?> keyInfo = sorts.get(k);
-                String name = keyInfo.property();
-                boolean asc = keyInfo.isAscending();
-                boolean lower = keyInfo.ignoreCase();
-                if (a != null)
-                    if (lower) {
-                        a.append(k == 0 ? "LOWER(" : " AND LOWER(").append(o_).append(name).append(')');
-                        a.append(k < i ? '=' : (asc ? '>' : '<'));
-                        a.append("LOWER(").append(paramPrefix).append(paramCount + 1 + k).append(')');
-                    } else {
-                        a.append(k == 0 ? "" : " AND ").append(o_).append(name);
-                        a.append(k < i ? '=' : (asc ? '>' : '<'));
-                        a.append(paramPrefix).append(paramCount + 1 + k);
-                    }
-                if (b != null)
-                    if (lower) {
-                        b.append(k == 0 ? "LOWER(" : " AND LOWER(").append(o_).append(name).append(')');
-                        b.append(k < i ? '=' : (asc ? '<' : '>'));
-                        b.append("LOWER(").append(paramPrefix).append(paramCount + 1 + k).append(')');
-                    } else {
-                        b.append(k == 0 ? "" : " AND ").append(o_).append(name);
-                        b.append(k < i ? '=' : (asc ? '<' : '>'));
-                        b.append(paramPrefix).append(paramCount + 1 + k);
-                    }
-            }
-            if (a != null)
-                a.append(')');
-            if (b != null)
-                b.append(')');
-        }
-        if (a != null)
-            jpqlAfterKeyset = new StringBuilder(q).append(a).append(')').append(fwd).toString();
-        if (b != null)
-            jpqlBeforeKeyset = new StringBuilder(q).append(b).append(')').append(prev).toString();
-
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(this, tc, "forward & previous keyset queries", jpqlAfterKeyset, jpqlBeforeKeyset);
-    }
-
-    /**
      * Generates the JPQL ORDER BY clause. This method is common between the OrderBy annotation and keyword.
      */
     private void generateOrderBy(StringBuilder q) {
-        boolean needsKeysetQueries = CursoredPage.class.equals(multiType);
+        boolean needsCursorQueries = CursoredPage.class.equals(multiType);
 
-        StringBuilder fwd = needsKeysetQueries ? new StringBuilder(100) : q; // forward page order
-        StringBuilder prev = needsKeysetQueries ? new StringBuilder(100) : null; // previous page order
+        StringBuilder fwd = needsCursorQueries ? new StringBuilder(100) : q; // forward page order
+        StringBuilder prev = needsCursorQueries ? new StringBuilder(100) : null; // previous page order
 
         boolean first = true;
         for (Sort<?> sort : sorts) {
@@ -934,15 +955,15 @@ public class QueryInfo {
             fwd.append(first ? " ORDER BY " : ", ");
             generateSort(fwd, sort, true);
 
-            if (needsKeysetQueries) {
+            if (needsCursorQueries) {
                 prev.append(first ? " ORDER BY " : ", ");
                 generateSort(prev, sort, false);
             }
             first = false;
         }
 
-        if (needsKeysetQueries) {
-            generateKeysetQueries(q, fwd, prev);
+        if (needsCursorQueries) {
+            generateCursorQueries(q, fwd, prev);
             q.append(fwd);
         }
     }
@@ -1287,8 +1308,11 @@ public class QueryInfo {
      * For most properties, this will be of a form such as o.name or LOWER(o.name) DESC or ...
      *
      * @param q             builder for the JPQL query.
-     * @param Sort          sort criteria for a single attribute (name must already be converted to a valid entity attribute name).
-     * @param sameDirection indicate to append the Sort in the normal direction. Otherwise reverses it (for keyset pagination in previous page direction).
+     * @param Sort          sort criteria for a single attribute (name must already
+     *                          be converted to a valid entity attribute name).
+     * @param sameDirection indicate to append the Sort in the normal direction.
+     *                          Otherwise reverses it (for cursor pagination in the
+     *                          previous page direction).
      * @return the same builder for the JPQL query.
      */
     @Trivial
@@ -1571,35 +1595,37 @@ public class QueryInfo {
     }
 
     /**
-     * Obtains keyset cursor values for the specified entity.
+     * Obtains cursor values for the specified entity.
      *
      * @param entity the entity.
-     * @return keyset cursor values, ordering according to the sort criteria.
+     * @return cursor values, ordering according to the sort criteria.
      */
     @Trivial
-    Object[] getKeysetValues(Object entity) {
+    Object[] getCursorValues(Object entity) {
         if (!entityInfo.getType().isInstance(entity))
-            throw new MappingException("Unable to obtain keyset values from the " +
+            throw new MappingException("Unable to obtain a cursor from the " +
                                        (entity == null ? null : entity.getClass().getName()) +
-                                       " type query result. Queries that use keyset pagination must return results of the same type as the entity type, which is " +
+                                       " result that is returned by the " + method.getName() +
+                                       " method of the " + method.getDeclaringClass().getName() +
+                                       " repository. Queries that use cursor-based pagination must return results of the same type as the entity type, which is " +
                                        entityInfo.getType().getName() + "."); // TODO NLS
-        ArrayList<Object> keyValues = new ArrayList<>();
-        for (Sort<?> keyInfo : sorts)
+        ArrayList<Object> cursorValues = new ArrayList<>();
+        for (Sort<?> sort : sorts)
             try {
-                List<Member> accessors = entityInfo.attributeAccessors.get(keyInfo.property());
+                List<Member> accessors = entityInfo.attributeAccessors.get(sort.property());
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "getKeysetValues for " + entity, accessors);
+                    Tr.debug(this, tc, "getCursorValues for " + entity, accessors);
                 Object value = entity;
                 for (Member accessor : accessors)
                     if (accessor instanceof Method)
                         value = ((Method) accessor).invoke(value);
                     else
                         value = ((Field) accessor).get(value);
-                keyValues.add(value);
+                cursorValues.add(value);
             } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException x) {
                 throw new DataException(x instanceof InvocationTargetException ? x.getCause() : x);
             }
-        return keyValues.toArray();
+        return cursorValues.toArray();
     }
 
     /**
@@ -1753,7 +1779,7 @@ public class QueryInfo {
             } else {
                 if (methodTypeAnno != null) {
                     // Query by Parameters
-                    q = initQueryByParameters(methodTypeAnno, countPages); // keyset queries before orderby
+                    q = initQueryByParameters(methodTypeAnno, countPages);
                 } else {
                     // Query by Method Name
                     q = initQueryByMethodName(countPages);
@@ -2516,23 +2542,6 @@ public class QueryInfo {
     }
 
     /**
-     * Raises an error because the number of keyset keys does not match the number of sort parameters.
-     *
-     * @param keysetCursor keyset cursor
-     */
-    @Trivial
-    private void keysetSizeMismatchError(PageRequest.Cursor keysetCursor) {
-        List<String> keyTypes = new ArrayList<>();
-        for (int i = 0; i < keysetCursor.size(); i++)
-            keyTypes.add(keysetCursor.get(i) == null ? null : keysetCursor.get(i).getClass().getName());
-
-        throw new MappingException("The keyset cursor with key types " + keyTypes +
-                                   " cannot be used with sort criteria of " + sorts +
-                                   " because they have different numbers of elements. The keyset size is " + keysetCursor.size() +
-                                   " and the sort criteria size is " + sorts.size() + "."); // TODO NLS
-    }
-
-    /**
      * Parses and handles the text between find___By or find___OrderBy or find___ of a repository method.
      * Currently this is only "First" or "First#" and entity property names to select.
      * "Distinct" is reserved for future use.
@@ -2710,64 +2719,6 @@ public class QueryInfo {
     }
 
     /**
-     * Sets query parameters from keyset values.
-     *
-     * @param query        the query
-     * @param keysetCursor keyset values
-     * @throws Exception if an error occurs
-     */
-    void setKeysetParameters(jakarta.persistence.Query query, PageRequest.Cursor keysetCursor) throws Exception {
-        int paramNum = paramCount; // set to position before the first keyset parameter
-        if (paramNames == null) // positional parameters
-            for (int i = 0; i < keysetCursor.size(); i++) {
-                Object value = keysetCursor.get(i);
-                if (entityInfo.idClassAttributeAccessors != null && entityInfo.idType.isInstance(value)) {
-                    for (Member accessor : entityInfo.idClassAttributeAccessors.values()) {
-                        Object v = accessor instanceof Field ? ((Field) accessor).get(value) : ((Method) accessor).invoke(value);
-                        if (++paramNum - paramCount > sorts.size())
-                            keysetSizeMismatchError(keysetCursor);
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                            Tr.debug(this, tc, "set keyset parameter ?" + paramNum + ' ' + value.getClass().getName() + "-->" +
-                                               (v == null ? null : v.getClass().getSimpleName()));
-                        query.setParameter(paramNum, v);
-                    }
-                } else {
-                    if (++paramNum - paramCount > sorts.size())
-                        keysetSizeMismatchError(keysetCursor);
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "set keyset parameter ?" + paramNum + ' ' +
-                                           (value == null ? null : value.getClass().getSimpleName()));
-                    query.setParameter(paramNum, value);
-                }
-            }
-        else // named parameters
-            for (int i = 0; i < keysetCursor.size(); i++) {
-                Object value = keysetCursor.get(i);
-                if (entityInfo.idClassAttributeAccessors != null && entityInfo.idType.isInstance(value)) {
-                    for (Member accessor : entityInfo.idClassAttributeAccessors.values()) {
-                        Object v = accessor instanceof Field ? ((Field) accessor).get(value) : ((Method) accessor).invoke(value);
-                        if (++paramNum - paramCount > sorts.size())
-                            keysetSizeMismatchError(keysetCursor);
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                            Tr.debug(this, tc, "set keyset parameter :keyset" + paramNum + ' ' + value.getClass().getName() + "-->" +
-                                               (v == null ? null : v.getClass().getSimpleName()));
-                        query.setParameter("keyset" + paramNum, v);
-                    }
-                } else {
-                    if (++paramNum - paramCount > sorts.size())
-                        keysetSizeMismatchError(keysetCursor);
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "set keyset parameter :keyset" + paramNum + ' ' +
-                                           (value == null ? null : value.getClass().getSimpleName()));
-                    query.setParameter("keyset" + paramNum, value);
-                }
-            }
-
-        if (sorts.size() > paramNum - paramCount) // not enough keyset values
-            keysetSizeMismatchError(keysetCursor);
-    }
-
-    /**
      * Sets the query parameter at the specified position to a value from the entity,
      * obtained via the accessor methods.
      *
@@ -2834,6 +2785,64 @@ public class QueryInfo {
                 }
             }
         }
+    }
+
+    /**
+     * Sets query parameters from cursor element values.
+     *
+     * @param query  the query
+     * @param cursor the cursor
+     * @throws Exception if an error occurs
+     */
+    void setParametersFromCursor(jakarta.persistence.Query query, PageRequest.Cursor cursor) throws Exception {
+        int paramNum = paramCount; // position before that of first cursor element
+        if (paramNames == null) // positional parameters
+            for (int i = 0; i < cursor.size(); i++) {
+                Object value = cursor.get(i);
+                if (entityInfo.idClassAttributeAccessors != null && entityInfo.idType.isInstance(value)) {
+                    for (Member accessor : entityInfo.idClassAttributeAccessors.values()) {
+                        Object v = accessor instanceof Field ? ((Field) accessor).get(value) : ((Method) accessor).invoke(value);
+                        if (++paramNum - paramCount > sorts.size())
+                            cursorSizeMismatchError(cursor);
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                            Tr.debug(this, tc, "set [cursor] ?" + paramNum + ' ' + value.getClass().getName() + "-->" +
+                                               (v == null ? null : v.getClass().getSimpleName()));
+                        query.setParameter(paramNum, v);
+                    }
+                } else {
+                    if (++paramNum - paramCount > sorts.size())
+                        cursorSizeMismatchError(cursor);
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "set [cursor] ?" + paramNum + ' ' +
+                                           (value == null ? null : value.getClass().getSimpleName()));
+                    query.setParameter(paramNum, value);
+                }
+            }
+        else // named parameters
+            for (int i = 0; i < cursor.size(); i++) {
+                Object value = cursor.get(i);
+                if (entityInfo.idClassAttributeAccessors != null && entityInfo.idType.isInstance(value)) {
+                    for (Member accessor : entityInfo.idClassAttributeAccessors.values()) {
+                        Object v = accessor instanceof Field ? ((Field) accessor).get(value) : ((Method) accessor).invoke(value);
+                        if (++paramNum - paramCount > sorts.size())
+                            cursorSizeMismatchError(cursor);
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                            Tr.debug(this, tc, "set [cursor] :cursor" + paramNum + ' ' + value.getClass().getName() + "-->" +
+                                               (v == null ? null : v.getClass().getSimpleName()));
+                        query.setParameter("cursor" + paramNum, v);
+                    }
+                } else {
+                    if (++paramNum - paramCount > sorts.size())
+                        cursorSizeMismatchError(cursor);
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "set [cursor] :cursor" + paramNum + ' ' +
+                                           (value == null ? null : value.getClass().getSimpleName()));
+                    query.setParameter("cursor" + paramNum, value);
+                }
+            }
+
+        if (sorts.size() > paramNum - paramCount) // not enough cursor elements
+            cursorSizeMismatchError(cursor);
     }
 
     /**
@@ -3047,8 +3056,8 @@ public class QueryInfo {
         q.entityVar_ = entityVar_;
         q.hasWhere = hasWhere;
         q.jpql = jpql;
-        q.jpqlAfterKeyset = jpqlAfterKeyset;
-        q.jpqlBeforeKeyset = jpqlBeforeKeyset;
+        q.jpqlAfterCursor = jpqlAfterCursor;
+        q.jpqlBeforeCursor = jpqlBeforeCursor;
         q.jpqlCount = jpqlCount;
         q.jpqlDelete = jpqlDelete; // TODO jpqlCount and jpqlDelete could potentially be combined because you will never need both at once
         q.maxResults = maxResults;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -854,7 +854,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                         Class<?> multiType = queryInfo.multiType;
 
                         if (CursoredPage.class.equals(multiType)) {
-                            returnValue = new CursoredPageImpl<>(queryInfo, limit == null ? pagination : toPageRequest(limit), args);
+                            returnValue = new CursoredPageImpl<>(queryInfo, pagination, args);
                         } else if (Page.class.equals(multiType)) {
                             returnValue = new PageImpl<>(queryInfo, limit == null ? pagination : toPageRequest(limit), args);
                         } else if (pagination != null && !PageRequest.Mode.OFFSET.equals(pagination.mode())) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -839,10 +839,11 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             }
 
                             if (pagination == null || pagination.mode() == PageRequest.Mode.OFFSET) {
-                                queryInfo = queryInfo.withJPQL(q.append(order).toString(), sortList); // offset pagination can be a starting point for keyset pagination
+                                // offset pagination can be a starting point for cursor pagination
+                                queryInfo = queryInfo.withJPQL(q.append(order).toString(), sortList);
                             } else { // CURSOR_NEXT or CURSOR_PREVIOUS
                                 queryInfo = queryInfo.withJPQL(null, sortList);
-                                queryInfo.generateKeysetQueries(q, forward ? order : null, forward ? null : order);
+                                queryInfo.generateCursorQueries(q, forward ? order : null, forward ? null : order);
                             }
                         }
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2941,31 +2941,21 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * A repository might define a method that returns a keyset-aware page without specifying a PageRequest,
-     * specifying the sort criteria separately.
+     * A repository might attempt to define a method that returns a CursoredPage
+     * without specifying a PageRequest. This is not supported by the spec.
+     * Expect UnsupportedOperationException.
      */
     @Test
     public void testKeysetWithoutPageRequest() {
-        // This is not a recommended pattern. Testing to see how it is handled.
-        CursoredPage<Prime> page = primes.findByNumberIdBetweenAndBinaryDigitsNotNull(30L, 40L, Sort.asc(ID));
-        assertEquals(31L, page.content().get(0).numberId);
-
-        // Obtain PageRequest for previous entries from the CursoredPage
-        PageRequest pagination = page.previousPageRequest().size(5);
-        page = primes.findByNumberIdBetween(0L, 40L, pagination);
-        assertIterableEquals(List.of(13L, 17L, 19L, 23L, 29L),
-                             page.stream()
-                                             .map(p -> p.numberId)
-                                             .collect(Collectors.toList()));
-
-        pagination = page.previousPageRequest();
-        page = primes.findByNumberIdBetween(0L, 40L, pagination);
-        assertIterableEquals(List.of(2L, 3L, 5L, 7L, 11L),
-                             page.stream()
-                                             .map(p -> p.numberId)
-                                             .collect(Collectors.toList()));
-
-        assertEquals(false, page.hasPrevious());
+        CursoredPage<Prime> page;
+        try {
+            page = primes.findByNumberIdBetweenAndBinaryDigitsNotNull(30L, //
+                                                                      40L, //
+                                                                      Sort.asc(ID));
+            fail("Able to obtain CursoredPage without a PageRequest: " + page);
+        } catch (UnsupportedOperationException x) {
+            // pass
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2294,11 +2294,11 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Access pages in a forward direction while entities are being added and removed,
-     * using a keyset to avoid duplicates.
+     * Access pages in the next page direction while entities are being added and
+     * removed, using a cursor to avoid duplicates.
      */
     @Test
-    public void testKeysetForwardPagination() {
+    public void testCursorNext() {
         packages.deleteAll();
 
         packages.saveAll(List.of(new Package(114, 14.0f, 90.0f, 15.0f, "package#114"), // page1
@@ -2330,7 +2330,7 @@ public class DataTestServlet extends FATServlet {
         // should not appear on next page because we already read up to length 18.0:
         packages.save(new Package(117, 17.0f, 23.0f, 12.0f, "package#117"));
 
-        // should appear on next page because length 20.0 is beyond the keyset value of 18.0:
+        // should appear on next page because length 20.0 is beyond the cursor value of 18.0:
         packages.save(new Package(120, 20.0f, 23.0f, 12.0f, "package#120"));
 
         // Page 2
@@ -2342,7 +2342,8 @@ public class DataTestServlet extends FATServlet {
         // remove some entries that we already read:
         packages.deleteByIdIn(List.of(116, 118, 120, 122, 124));
 
-        // should appear on next page because length 22.0 matches the keyset value and width 70.0 is beyond the keyset value:
+        // should appear on next page because length 22.0 matches the cursor value
+        // and width 70.0 is beyond the cursor value:
         packages.save(new Package(130, 22.0f, 70.0f, 67.0f, "package#130"));
 
         // Page 3
@@ -2399,9 +2400,10 @@ public class DataTestServlet extends FATServlet {
         assertIterableEquals(List.of(114, 144, 133, 151),
                              page.stream().map(pkg -> pkg.id).collect(Collectors.toList()));
 
-        packages.saveAll(List.of(new Package(128, 28.0f, 45.0f, 53.0f, "package#128"), // comes after the keyset values, should be included in next page
-                                 new Package(153, 53.0f, 45.0f, 28.0f, "package#153") // comes before the keyset values, should not be on next page
-        ));
+        packages.saveAll(List.of(// comes after the cursor values, should be included in next page
+                                 new Package(128, 28.0f, 45.0f, 53.0f, "package#128"),
+                                 // comes before the cursor values, should not be on next page
+                                 new Package(153, 53.0f, 45.0f, 28.0f, "package#153")));
 
         // Page 2
         page = packages.findByHeightGreaterThan(10.0f, page.nextPageRequest());
@@ -2462,11 +2464,12 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Access pages in a forward direction, but delete the remaining entries before accessing the next page.
-     * Expect the next page to be empty, and next/previous PageRequest from the empty page to be null.
+     * Access pages in the next page direction, but delete the remaining entries
+     * before accessing the next page. Expect the next page to be empty, and the
+     * next/previous PageRequest from the empty page to be null.
      */
     @Test
-    public void testKeysetForwardPaginationNextPageEmptyAfterDeletion() {
+    public void testCursorNextPageEmptyAfterDeletion() {
         packages.deleteAll();
 
         packages.saveAll(List.of(new Package(440, 40.0f, 44.0f, 40.0f, "package#440"), // page1
@@ -2498,17 +2501,17 @@ public class DataTestServlet extends FATServlet {
         assertEquals(0, page.numberOfElements());
         assertEquals(false, page.hasContent());
 
-        // An empty page lacks keyset values from which to request next/previous pages
+        // An empty page lacks cursor values from which to request next/previous pages
         assertEquals(false, page.hasNext());
         assertEquals(false, page.hasPrevious());
     }
 
     /**
-     * Obtain keyset cursors from a page of results and use them to obtain pages in forward
-     * and reverse directions.
+     * Obtain cursors from a page of results and use them to obtain pages in the
+     * next page and previous page directions.
      */
     @Test
-    public void testKeysetPaginationWithCursor() {
+    public void testCursorPagination() {
         // Expected order for OrderByEvenDescSumOfBitsDescNumberAsc:
         // num binary sum even?
         // 2,  10,     1, true
@@ -2564,10 +2567,10 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Access pages in reverse direction using a keyset.
+     * Access pages in the previous page direction using a cursor.
      */
     @Test
-    public void testKeysetPreviousPages() {
+    public void testCursorPrevious() {
         packages.deleteAll();
 
         packages.saveAll(List.of(new Package(210, 10.0f, 50.0f, 55.0f, "package#210"), // page 1
@@ -2629,26 +2632,26 @@ public class DataTestServlet extends FATServlet {
         // 240, 40.0f, 21.0f, 42.0f
 
         PageRequest.Cursor cursor = new PageRequest.Cursor() {
-            private final List<Object> keysetValues = List.of(21.0f, 42.0f, 240);
+            private final List<Object> cursorElements = List.of(21.0f, 42.0f, 240);
 
             @Override
             public List<?> elements() {
-                return keysetValues;
+                return cursorElements;
             }
 
             @Override
             public Object get(int index) {
-                return keysetValues.get(index);
+                return cursorElements.get(index);
             }
 
             @Override
             public int size() {
-                return keysetValues.size();
+                return cursorElements.size();
             }
 
             @Override
             public String toString() {
-                return "Custom cursor of " + keysetValues;
+                return "Custom cursor of " + cursorElements;
             }
         };
 
@@ -2765,11 +2768,11 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Access pages in reverse direction while entities are being added and removed,
-     * using a keyset to avoid duplicates.
+     * Access pages in the previous page direction while entities are being added
+     * and removed, using a cursor to avoid duplicates.
      */
     @Test
-    public void testKeysetReversePaginationWithUpdates() {
+    public void testCursorPreviousWithUpdates() {
         packages.deleteAll();
 
         // using @OrderBy width descending, height ascending, id descending:
@@ -2903,50 +2906,29 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * A repository might define a method that returns a keyset-aware page with a Limit parameter.
+     * A repository might attempt to define a method that returns a CursoredPage
+     * without specifying a PageRequest and attempt to use a Limit parameter
+     * instead. This is not supported by the spec.
+     * Expect UnsupportedOperationException.
      */
     @Test
-    public void testKeysetWithLimit() {
-        // This is not a recommended pattern. Testing to see how it is handled.
-        CursoredPage<Prime> page = primes.findByNumberIdBetween(15L, 45L, Limit.of(5));
-
-        assertEquals(1L, page.pageRequest().page());
-        assertEquals(5L, page.numberOfElements());
-        assertEquals(5L, page.pageRequest().size());
-        assertEquals(1L, page.pageRequest().page());
-        assertEquals(2L, page.totalPages());
-        assertEquals(8L, page.totalElements());
-
-        assertIterableEquals(List.of(17L, 19L, 23L, 29L, 31L),
-                             page.stream()
-                                             .map(p -> p.numberId)
-                                             .collect(Collectors.toList()));
-
-        assertIterableEquals(Collections.EMPTY_LIST,
-                             primes.findByNumberIdBetween(15L, 45L, page.previousPageRequest()));
-
-        page = primes.findByNumberIdBetween(15L, 45L, page.nextPageRequest());
-
-        assertEquals(3L, page.numberOfElements());
-        assertEquals(5L, page.pageRequest().size());
-        assertEquals(2L, page.pageRequest().page());
-        assertEquals(2L, page.totalPages());
-        assertEquals(8L, page.totalElements());
-        assertEquals(false, page.hasNext());
-
-        assertIterableEquals(List.of(37L, 41L, 43L),
-                             page.stream()
-                                             .map(p -> p.numberId)
-                                             .collect(Collectors.toList()));
+    public void testLacksPageRequestUseLimitInstead() {
+        CursoredPage<Prime> page;
+        try {
+            page = primes.findByNumberIdBetween(15L, 45L, Limit.of(5));
+            fail("Able to obtain CursoredPage without a PageRequest: " + page);
+        } catch (UnsupportedOperationException x) {
+            // pass
+        }
     }
 
     /**
      * A repository might attempt to define a method that returns a CursoredPage
-     * without specifying a PageRequest. This is not supported by the spec.
-     * Expect UnsupportedOperationException.
+     * without specifying a PageRequest and attempt to use a Sort parameter instead.
+     * This is not supported by the spec. Expect UnsupportedOperationException.
      */
     @Test
-    public void testKeysetWithoutPageRequest() {
+    public void testLacksPageRequestUseSortInstead() {
         CursoredPage<Prime> page;
         try {
             page = primes.findByNumberIdBetweenAndBinaryDigitsNotNull(30L, //
@@ -4572,8 +4554,8 @@ public class DataTestServlet extends FATServlet {
 
     /**
      * When sort criteria is specified statically via the Query annotation and
-     * dynamically via Sorts from keyset pagination, the static sort criteria is applied
-     * before the dynamic sort criteria.
+     * dynamically via Sorts from cursor-based pagination, the static sort criteria
+     * is applied before the dynamic sort criteria.
      */
     @Test
     public void testSortCriteriaOfOrderByAnnoTakesPrecedenceOverPaginationSortsOnCustomQueryUsingCursorPagination() {
@@ -4630,11 +4612,11 @@ public class DataTestServlet extends FATServlet {
 
     /**
      * When sort criteria is specified statically via the OrderBy keyword and
-     * dynamically via Sorts from keyset pagination, the static sort criteria is applied
-     * before the dynamic sort criteria.
+     * dynamically via Sorts from cursor-based pagination, the static sort criteria
+     * is applied before the dynamic sort criteria.
      */
     @Test
-    public void testSortCriteriaOfOrderByKeywordTakesPrecedenceOverKeysetPaginationSorts() {
+    public void testSortCriteriaOfOrderByKeywordTakesPrecedenceOverCursorPaginationSorts() {
 
         PageRequest pagination = PageRequest.ofSize(6).withoutTotal();
         CursoredPage<Prime> page1 = primes.findByNumberIdLessThanOrderByEvenAscSumOfBitsAsc(52L, pagination,
@@ -4919,10 +4901,11 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Obtain total counts of number of elements and pages when keyset pagination is used.
+     * Obtain total counts of number of elements and pages when cursor-based
+     * pagination is used.
      */
     @Test
-    public void testTotalCountsWithKeysetPagination() {
+    public void testTotalCountsWithCursorPagination() {
         CursoredPage<Prime> page3 = primes.findByNumberIdBetween(3L, 50L, PageRequest.ofPage(3)
                         .size(5)
                         .beforeCursor(Cursor.forKey(47L)));
@@ -4952,7 +4935,7 @@ public class DataTestServlet extends FATServlet {
         // In this case, the 14 elements are across 4 pages, not 3,
         // because the first and last pages ended up being partial.
         // But that doesn't become known until the first or last page is read.
-        // This is one of many reasons why keyset pagination documents that
+        // This is one of many reasons why CursoredPage documents that
         // page counts are inaccurate and cannot be relied upon.
         assertEquals(3L, page4.totalPages());
         assertEquals(14L, page4.totalElements());

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -111,6 +111,7 @@ public interface Primes {
 
     Prime findByNumberIdBetween(long min, long max);
 
+    // Unsupported pattern: lacks PageRequest parameter.
     @OrderBy("numberId")
     CursoredPage<Prime> findByNumberIdBetween(long min, long max, Limit limit);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -119,7 +119,8 @@ public interface Primes {
 
     List<Prime> findByNumberIdBetween(long min, long max, Sort<?>... orderBy);
 
-    CursoredPage<Prime> findByNumberIdBetweenAndBinaryDigitsNotNull(long min, long max, Sort<?>... orderBy); // Lacks PageRequest
+    // Unsupported pattern: lacks PageRequest parameter.
+    CursoredPage<Prime> findByNumberIdBetweenAndBinaryDigitsNotNull(long min, long max, Sort<?>... orderBy);
 
     CursoredPage<Prime> findByNumberIdBetweenAndEvenFalse(long min, long max, PageRequest pagination, Order<Prime> order);
 

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -561,11 +561,12 @@ public class DataExperimentalServlet extends FATServlet {
     }
 
     /**
-     * Use keyset pagination with the OrderBy annotation on a composite id that is defined by an IdClass attribute.
-     * Also use named parameters, which means the keyset portion of the query will also need to use named parameters.
+     * Use cursor-based pagination with the OrderBy annotation on a composite id
+     * that is defined by an IdClass attribute. Also use named parameters, which
+     * means the cursor portion of the query will also need to use named parameters.
      */
     @Test
-    public void testIdClassOrderByAnnotationWithKeysetPaginationAndNamedParameters() {
+    public void testIdClassOrderByAnnotationWithCursorPaginationAndNamedParameters() {
         PageRequest pagination = PageRequest.ofSize(2);
 
         CursoredPage<Town> page1 = towns.sizedWithin(100000, 1000000, pagination);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1789,10 +1789,11 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Use keyset pagination with the OrderBy annotation on a composite id that is defined by an IdClass attribute.
+     * Use cursor-based pagination with the OrderBy annotation on a composite id
+     * that is defined by an IdClass attribute.
      */
     @Test
-    public void testIdClassOrderByAnnotationWithKeysetPagination() {
+    public void testIdClassOrderByAnnotationWithCursorPagination() {
         PageRequest pagination = PageRequest
                         .ofSize(3)
                         .withoutTotal()
@@ -1821,10 +1822,11 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Use keyset pagination with the OrderBy query-by-method pattern on a composite id that is defined by an IdClass attribute.
+     * Use cursor-based pagination with the OrderBy query-by-method pattern on a
+     * composite id that is defined by an IdClass attribute.
      */
     @Test
-    public void testIdClassOrderByNamePatternWithKeysetPagination() {
+    public void testIdClassOrderByNamePatternWithCursorPagination() {
         PageRequest pagination = PageRequest.ofSize(5).withoutTotal();
 
         CursoredPage<City> slice1 = cities.findByStateNameNotNull(pagination, Order.by());
@@ -1864,11 +1866,12 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Use keyset pagination with the OrderBy query-by-method pattern in descending direction
-     * on a composite id that is defined by an IdClass attribute.
+     * Use cursor-based pagination with the OrderBy query-by-method pattern in
+     * descending direction on a composite id that is defined by an IdClass
+     * attribute.
      */
     @Test
-    public void testIdClassOrderByNamePatternWithKeysetPaginationDescending() {
+    public void testIdClassOrderByNamePatternWithCursorPaginationDescending() {
         PageRequest pagination = PageRequest.ofSize(3)
                         .withTotal()
                         .afterCursor(Cursor.forKey(CityId.of("Springfield", "Tennessee")));
@@ -1901,10 +1904,11 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Use keyset pagination with the pagination sort criteria on a composite id that is defined by an IdClass attribute.
+     * Use cursor-based pagination with the pagination sort criteria on a
+     * composite id that is defined by an IdClass attribute.
      */
     @Test
-    public void testIdClassOrderByPaginationWithKeyset() {
+    public void testIdClassOrderByPaginationWithCursor() {
         // ascending:
         Order<City> asc = Order.by(Sort.asc(ID));
         PageRequest pagination = PageRequest.ofSize(5);
@@ -2476,7 +2480,7 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(false, it.hasNext());
         assertEquals(false, it.hasNext());
 
-        // Iterator with keyset pagination:
+        // Iterator with cursor-based pagination:
         try {
             it = tariffs.findByLeviedAgainstLessThanOrderByKeyDesc("M", PageRequest.ofSize(2)
                             .afterCursor(Cursor.forKey(t8key)));
@@ -2485,7 +2489,8 @@ public class DataJPATestServlet extends FATServlet {
             // expected
         }
 
-        // Iterator with keyset pagination obtaining pages in the previous page direction
+        // Iterator with cursor-based pagination obtaining pages in the
+        // previous page direction
         try {
             it = tariffs.findByLeviedAgainstLessThanOrderByKeyDesc("M", PageRequest.ofSize(2)
                             .beforeCursor(Cursor.forKey(t2key)));


### PR DESCRIPTION
Repository methods that return CursoredPage must provide a PageRequest parameters. They should not be able to use other parameters, such Limit and Sort in place of it. This PR updates code to ensure a helpful error is raised and updates tests to check for it. Also, this PR updates both code and tests to switch from outdated keyset terminology over to cursor-based pagination in order to align with the Jakarta Data spec.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
