### PR TITLE
Config runtime ignores metrics

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
@@ -52,7 +52,9 @@ tested.features:\
   expressionlanguage-4.0,\
   pages-3.0,\
   jsp-2.3,\
-  el-3.0
+  el-3.0,\
+  expressionlanguage-6.0,\
+  pages-4.0
 
 -buildpath: \
 	com.ibm.ws.componenttest;version=latest,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -36,6 +36,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
                 TelemetryConfigSystemPropTest.class,
                 TelemetryConfigEnvOnlyTest.class,
                 TelemetryConfigNullTest.class,
+                TelemetryConfigRuntimeModeIgnoresMPConfigTest.class,
                 TelemetryServiceNameTest.class,
                 TelemetryShimTest.class,
                 TelemetryLoggingExporterTest.class,

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigRuntimeModeIgnoresMPConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigRuntimeModeIgnoresMPConfigTest.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.LoggingServlet;
+
+/**
+ * This test verifies that a property set in META-INF/microprofile-config.properties
+ * is ignored even if there is no corresponding property in the system properties or env
+ */
+@RunWith(FATRunner.class)
+public class TelemetryConfigRuntimeModeIgnoresMPConfigTest extends FATServletClient {
+
+    public static final String APP_NAME = "TelemetryServletTestApp";
+    public static final String SERVER_NAME = "Telemetry10IgnoreMPConfig";
+
+    @TestServlets({
+                    @TestServlet(contextRoot = APP_NAME, servlet = LoggingServlet.class)
+    })
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    //This test will break in app mode, which is the only mode before OTel 2.0
+    @ClassRule
+    public static RepeatTests r = FATSuite.allMPRepeatsWithMPTel20OrLater(SERVER_NAME);
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        server.addEnvVar("OTEL_SDK_DISABLED", "false");
+        server.addEnvVar("OTEL_TRACES_EXPORTER", "logging");
+
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addClasses(LoggingServlet.class)
+                        //If this nonsense config is implemented line 86 will fail.
+                        .addAsResource(new StringAsset("otel.attribute.value.length.limit=1"),
+                                       "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
+        server.startServer();
+    }
+
+    @Test
+    public void testConsole() throws Exception {
+        server.setMarkToEndOfLog();
+
+        runTest(server, APP_NAME + "/LoggingServlet", "testLoggingExporter");
+
+        //The exporter should not give this error message
+        assertNull(server.verifyStringNotInLogUsingMark("Failed to export spans", 1000));
+
+        //Checks for span output in logs
+        assertNotNull(server.waitForStringInLogUsingMark("io.opentelemetry.exporter.logging.LoggingSpanExporter"));
+        assertNotNull(server.waitForStringInLogUsingMark("'testSpan' : .* \\[tracer: logging-exporter-test:1.0.0\\]"));
+        assertNotNull(server.waitForStringInLogUsingMark("GET /TelemetryServletTestApp/LoggingServle.*url.query=testMethod=testLoggingExporter"));
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10IgnoreMPConfig/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10IgnoreMPConfig/bootstrap.properties
@@ -1,0 +1,1 @@
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10IgnoreMPConfig/jvm.options
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10IgnoreMPConfig/jvm.options
@@ -1,0 +1,1 @@
+-Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10IgnoreMPConfig/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10IgnoreMPConfig/server.xml
@@ -1,0 +1,19 @@
+<server description="Telemetry10Servlet">
+
+    <include location="../fatTestPorts.xml" />
+
+    <featureManager>
+        <feature>servlet-6.0</feature>
+        <feature>pages-3.1</feature>
+        <feature>mpTelemetry-1.0</feature>
+        <feature>componentTest-2.0</feature>
+    </featureManager>
+
+    <application type="war" location="TelemetryServletTestApp.war">
+        <classloader apiTypeVisibility="+third-party" />
+    </application>
+
+    <!-- For HttpURLConnection -->
+    <javaPermission className="java.net.URLPermission" name="http://localhost:-/-" actions="GET:" />
+    <javaPermission className="java.util.PropertyPermission" name="jaxws.http.autoredirect" actions="read"/>
+</server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Associated with #27108 - this is part of the FAT testing, we add a test that verifies that we do not process microprofile config properties when the runtime mode is enabled.