### PR TITLE
Fix `TelemetryAttributesTest`

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAttributesTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAttributesTest.java
@@ -51,7 +51,8 @@ public class TelemetryAttributesTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
-                        .addClasses(ResourceServlet.class);
+                        .addClasses(ResourceServlet.class)
+                        .addAsManifestResource(TelemetryAttributesTest.class.getResource("permissions-TelemetryAttributesTest.xml"), "permissions.xml");
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
         server.addEnvVar("OTEL_SDK_DISABLED", "false");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/ResourceServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/ResourceServlet.java
@@ -48,7 +48,7 @@ public class ResourceServlet extends FATServlet {
         //Values come from https://github.com/open-telemetry/semantic-conventions-java/blob/release/v1.26.0/semconv/src/main/java/io/opentelemetry/semconv/ResourceAttributes.java
         osNameMap.put("windows", "windows");
         osNameMap.put("linux", "linux");
-        osNameMap.put("mac", "mac");
+        osNameMap.put("mac", "darwin");
         osNameMap.put("netbsd", "netbsd");
         osNameMap.put("openbsd", "openbsd");
         osNameMap.put("dragonflybsd", "dragonflybsd");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/permissions-TelemetryAttributesTest.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/permissions-TelemetryAttributesTest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+	version="7">
+	<!-- Permissions needed to use InetAddress.getLocalHost to resolve local hostname -->
+	<permission>
+		<class-name>java.net.SocketPermission</class-name>
+		<name>*</name>
+		<actions>resolve</actions>
+	</permission>
+</permissions>


### PR DESCRIPTION
- Fix the expected value of `os.type` on Mac
- Give test permissions to resolve hostnames to allow it to correctly get the expected local hostname
  - On most systems `InetAddress.getLocalHost()` seems to return something with a canoncial hostname of `localhost` which can be resolved using the default permissions, but on some systems we seem to be seeing different values depending on whether Java 2 security is enabled. The `InetAddress.getLocalHost()` javadoc suggests this is possible.
  - I've given it permission to resolve all names, we could instead get the expected hostname in the test process before starting the server, but the difference does not seem important and adding the permission is eaiser.

Fixes RTC 301130 (which turned out to be two separate issues)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".