### PR TITLE
Improve arquillian error messages for Data TCK

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -746,6 +746,7 @@ public class TCKRunner {
         Log.entering(c, "genericResolveJarPath", new Object[] { jarName, wlpPathName });
         String dev = wlpPathName + "/dev/";
         String api = dev + "api/";
+        String thirdParty = api + "third-party/";
         String apiStable = api + "stable/";
         String apiSpec = api + "spec/";
         String lib = wlpPathName + "/lib/";
@@ -754,6 +755,7 @@ public class TCKRunner {
         places.add(apiStable);
         places.add(apiSpec);
         places.add(lib);
+        places.add(thirdParty);
 
         String jarPath = null;
         for (String dir : places) {

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/platform/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/platform/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-	~ Copyright (c) 2022, 2023 IBM Corporation and others. All rights reserved. 
+	~ Copyright (c) 2022, 2024 IBM Corporation and others. All rights reserved. 
 	~ This program and the accompanying materials are made available under the 
 	~ terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	~ and is available at 
@@ -72,7 +72,15 @@
 			<scope>system</scope>
 			<systemPath>${io.openliberty.data.internal}</systemPath>
 		</dependency>
-
+		<!-- impl - persistence - internal bundle -->
+		<!-- Necessary to avoid ClassNotFoundException from Arquillian -->
+		<dependency>
+			<groupId>io.openliberty.jakarta.persistence</groupId>
+			<artifactId>jakarta.persistence-impl</artifactId>
+			<version>3.2</version>
+			<scope>system</scope>
+			<systemPath>${io.openliberty.persistence.3.2.thirdparty}</systemPath>
+		</dependency>
 		<!-- The Liberty Arquillian plugin -->
 		<dependency>
 			<groupId>io.openliberty.arquillian</groupId>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Avoid `ClassNotFoundError` when Arquillian reports an error thrown by eclipselink
