### PR TITLE
ensure safe type conversions

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -71,6 +71,13 @@ public class QueryInfo {
     }
 
     /**
+     * Primitive types for numeric values.
+     */
+    static final Set<Class<?>> PRIMITIVE_NUMERIC_TYPES = //
+                    Set.of(long.class, int.class, short.class, byte.class,
+                           double.class, float.class);
+
+    /**
      * Return types for deleteBy that distinguish delete-only from find-and-delete.
      */
     private static final Set<Class<?>> RETURN_TYPES_FOR_DELETE_ONLY = //

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -236,6 +236,170 @@ public class RepositoryImpl<R> implements InvocationHandler {
     }
 
     /**
+     * Converts a value to the type that is required by the repository method
+     * return type.
+     *
+     * @param value     value to convert.
+     * @param queryInfo query information.
+     * @return converted value.
+     */
+    @FFDCIgnore(ArithmeticException.class) // reported to user as chained exception
+    @Trivial
+    private Object convert(Object value, QueryInfo queryInfo) {
+        Class<?> fromType = value.getClass();
+        Class<?> toType = queryInfo.singleType;
+        Exception cause = null;
+
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isDebugEnabled())
+            Tr.debug(this, tc, "convert " + fromType.getSimpleName() +
+                               " to " + toType.getSimpleName());
+
+        if (value instanceof Number &&
+            (QueryInfo.PRIMITIVE_NUMERIC_TYPES.contains(toType) ||
+             Number.class.isAssignableFrom(toType))) {
+            try {
+                if (BigDecimal.class.equals(fromType)) {
+                    BigDecimal v = (BigDecimal) value;
+                    if (long.class.equals(toType) ||
+                        Long.class.equals(toType)) {
+                        return v.longValueExact();
+                    } else if (int.class.equals(toType) ||
+                               Integer.class.equals(toType)) {
+                        return v.intValueExact();
+                    } else if (short.class.equals(toType) ||
+                               Short.class.equals(toType)) {
+                        return v.shortValueExact();
+                    } else if (byte.class.equals(toType) ||
+                               Byte.class.equals(toType)) {
+                        return v.byteValueExact();
+                    } else if (BigInteger.class.equals(toType)) {
+                        return v.toBigIntegerExact();
+                    }
+                } else if (BigInteger.class.equals(fromType)) {
+                    BigInteger v = (BigInteger) value;
+                    if (long.class.equals(toType) ||
+                        Long.class.equals(toType)) {
+                        return v.longValueExact();
+                    } else if (int.class.equals(toType) ||
+                               Integer.class.equals(toType)) {
+                        return v.intValueExact();
+                    } else if (short.class.equals(toType) ||
+                               Short.class.equals(toType)) {
+                        return v.shortValueExact();
+                    } else if (byte.class.equals(toType) ||
+                               Byte.class.equals(toType)) {
+                        return v.byteValueExact();
+                    } else if (BigDecimal.class.equals(toType)) {
+                        return new BigDecimal(v);
+                    }
+                } else if (double.class.equals(fromType) ||
+                           Double.class.equals(fromType)) {
+                    Double v = (Double) value;
+                    if (double.class.equals(toType))
+                        return v;
+                    else if (BigDecimal.class.equals(toType))
+                        return BigDecimal.valueOf(v);
+                } else if (float.class.equals(fromType) ||
+                           Float.class.equals(fromType)) {
+                    Float v = (Float) value;
+                    if (float.class.equals(toType))
+                        return v;
+                    else if (double.class.equals(toType))
+                        return v.doubleValue();
+                    else if (BigDecimal.class.equals(toType))
+                        return BigDecimal.valueOf(v);
+                } else {
+                    Number n = (Number) value;
+                    long v = n.longValue();
+                    if (long.class.equals(toType) ||
+                        Long.class.equals(toType)) {
+                        return v;
+                    } else if (int.class.equals(toType) ||
+                               Integer.class.equals(toType)) {
+                        if (v >= Integer.MIN_VALUE && v <= Integer.MAX_VALUE)
+                            return n.intValue();
+                        else
+                            convertFail(queryInfo.method, fromType,
+                                        Integer.MIN_VALUE, Integer.MAX_VALUE);
+                    } else if (short.class.equals(toType) ||
+                               Short.class.equals(toType)) {
+                        if (v >= Short.MIN_VALUE && v <= Short.MAX_VALUE)
+                            return n.shortValue();
+                        else
+                            convertFail(queryInfo.method, fromType,
+                                        Short.MIN_VALUE, Short.MAX_VALUE);
+                    } else if (byte.class.equals(toType) ||
+                               Byte.class.equals(toType)) {
+                        if (v >= Byte.MIN_VALUE && v <= Byte.MAX_VALUE)
+                            return n.byteValue();
+                        else
+                            convertFail(queryInfo.method, fromType,
+                                        Byte.MIN_VALUE, Byte.MAX_VALUE);
+                    } else if (BigInteger.class.equals(toType)) {
+                        return BigInteger.valueOf(v);
+                    } else if (BigDecimal.class.equals(toType)) {
+                        return BigDecimal.valueOf(v);
+                    } else if (double.class.equals(toType) ||
+                               Double.class.equals(toType)) {
+                        if (Integer.class.equals(fromType) ||
+                            Short.class.equals(fromType) ||
+                            Byte.class.equals(fromType))
+                            return n.doubleValue();
+                    } else if (float.class.equals(toType) ||
+                               Float.class.equals(toType)) {
+                        if (Short.class.equals(fromType) ||
+                            Byte.class.equals(fromType))
+                            return n.floatValue();
+                    }
+                }
+            } catch (ArithmeticException x) {
+                cause = x;
+            }
+        } else if (String.class.equals(toType) ||
+                   CharSequence.class.equals(toType)) {
+            return value.toString();
+        } else if (char.class.equals(toType) ||
+                   Character.class.equals(toType)) {
+            if (value instanceof CharSequence) {
+                CharSequence chars = (CharSequence) value;
+                if (chars.length() == 1)
+                    return chars.charAt(0);
+                else if (chars.isEmpty() && Character.class.equals(toType))
+                    return null;
+            }
+        }
+
+        throw new MappingException("The " + queryInfo.method.getName() + " method of the " +
+                                   queryInfo.method.getDeclaringClass().getName() +
+                                   " repository is unable to convert a " +
+                                   fromType.getName() + " value into a " + toType.getName() +
+                                   " value that is required by the return type of the method.", // TODO NLS
+                        cause);
+    }
+
+    /**
+     * Raises an error for a type conversion failure due to a value being outside of
+     * the specified range.
+     *
+     * @param method   repository method.
+     * @param fromType type from which conversion has failed.
+     * @param min      minimum value for range.
+     * @param max      maximum value for range.
+     * @throws MappingException for the type conversion failure.
+     */
+    private void convertFail(Method method, Class<?> fromType, long min, long max) {
+        Class<?> toType = method.getReturnType();
+        throw new MappingException("The " + method.getName() + " method of the " +
+                                   method.getDeclaringClass().getName() +
+                                   " repository is unable to convert a " +
+                                   fromType.getName() + " value into a " + toType.getName() +
+                                   " value because the value is not within the range of " +
+                                   min + " to " + max + ". A " + toType.getName() +
+                                   " value is required by the return type of the method"); // TODO NLS
+    }
+
+    /**
      * Execute a repository count query.
      *
      * @param em        entity manager.
@@ -1045,7 +1209,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
                                 if (results.isEmpty() && queryInfo.isOptional) {
                                     returnValue = null;
-                                } else if (multiType == null && (entityInfo.entityClass).equals(singleType)) {
+                                } else if (multiType == null && entityInfo.entityClass.equals(singleType)) {
                                     returnValue = oneResult(results);
                                 } else if (multiType != null && multiType.isInstance(results) && (results.isEmpty() || !(results.get(0) instanceof Object[]))) {
                                     returnValue = results;
@@ -1123,31 +1287,25 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                                                    " returned no results. If this is expected, specify a return type of array, List, Optional, Page, CursoredPage, or Stream for the repository method.");
                                 } else { // single result of other type
                                     returnValue = oneResult(results);
-                                    if (returnValue != null && !singleType.isAssignableFrom(returnValue.getClass())) {
-                                        // TODO these conversions are not all safe
-                                        if (double.class.equals(singleType) || Double.class.equals(singleType))
-                                            returnValue = ((Number) returnValue).doubleValue();
-                                        else if (float.class.equals(singleType) || Float.class.equals(singleType))
-                                            returnValue = ((Number) returnValue).floatValue();
-                                        else if (long.class.equals(singleType) || Long.class.equals(singleType))
-                                            returnValue = ((Number) returnValue).longValue();
-                                        else if (int.class.equals(singleType) || Integer.class.equals(singleType))
-                                            returnValue = ((Number) returnValue).intValue();
-                                        else if (short.class.equals(singleType) || Short.class.equals(singleType))
-                                            returnValue = ((Number) returnValue).shortValue();
-                                        else if (byte.class.equals(singleType) || Byte.class.equals(singleType))
-                                            returnValue = ((Number) returnValue).byteValue();
-                                    }
+                                    if (returnValue != null &&
+                                        !singleType.isAssignableFrom(returnValue.getClass()))
+                                        returnValue = convert(returnValue, queryInfo);
                                 }
                             }
                         }
 
-                        if (Optional.class.equals(returnType)) {
+                        if (queryInfo.isOptional) {
                             returnValue = returnValue == null
-                                          || returnValue instanceof Collection && ((Collection<?>) returnValue).isEmpty()
-                                          || returnValue instanceof Page && !((Page<?>) returnValue).hasContent() //
-                                                          ? Optional.empty() : Optional.of(returnValue);
-                        } else if (CompletableFuture.class.equals(returnType) || CompletionStage.class.equals(returnType)) {
+                                          || returnValue instanceof Collection &&
+                                             ((Collection<?>) returnValue).isEmpty()
+                                          || returnValue instanceof Page
+                                             && !((Page<?>) returnValue).hasContent() //
+                                                             ? Optional.empty() //
+                                                             : Optional.of(returnValue);
+                        }
+
+                        if (CompletableFuture.class.equals(returnType) ||
+                            CompletionStage.class.equals(returnType)) {
                             returnValue = CompletableFuture.completedFuture(returnValue);
                         }
                         break;

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -510,6 +510,78 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Use repository methods that convert a long value to other numeric types.
+     */
+    @Test
+    public void testConvertLongValue() throws Exception {
+        assertEquals(47L,
+                     primes.numberAsBigDecimal(47).longValue());
+
+        assertEquals(43L,
+                     primes.numberAsBigInteger(43).orElseThrow().longValue());
+
+        assertEquals((byte) 41,
+                     primes.numberAsByte(41));
+
+        try {
+            byte result = primes.numberAsByte(4021);
+            fail("Should not convert long value 4021 to byte value " + result);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
+
+        assertEquals((byte) 37,
+                     primes.numberAsByteWrapper(37).orElseThrow().byteValue());
+
+        try {
+            Optional<Byte> result = primes.numberAsByteWrapper(4019);
+            fail("Should not convert long value 4019 to Byte value " + result);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
+
+        try {
+            double result = primes.numberAsDouble(4003);
+            fail("Should not convert long value to double value " + result);
+        } catch (MappingException x) {
+            // expected - not convertible
+        }
+
+        try {
+            Optional<Float> result = primes.numberAsFloatWrapper(4001)
+                            .get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+            fail("Should not convert long value to float value " + result);
+        } catch (ExecutionException x) {
+            if (x.getCause() instanceof MappingException)
+                ; // expected - not convertible
+            else
+                throw x;
+        }
+
+        assertEquals(31,
+                     primes.numberAsInt(31));
+
+        assertEquals(29,
+                     primes.numberAsInteger(29L).orElseThrow().intValue());
+
+        assertEquals(23L,
+                     primes.numberAsLong(23));
+
+        assertEquals(19L,
+                     primes.numberAsLongWrapper(19).orElseThrow().longValue());
+
+        assertEquals((short) 4013,
+                     primes.numberAsShort(4013));
+
+        assertEquals((short) 4007,
+                     primes.numberAsShortWrapper(4007).orElseThrow().shortValue());
+
+        assertEquals(false,
+                     primes.numberAsShortWrapper(27).isPresent());
+
+    }
+
+    /**
      * Repository method that returns the count as a BigDecimal value.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static test.jakarta.data.web.Assertions.assertIterableEquals;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.Duration;
 import java.time.Year;
 import java.util.ArrayList;
@@ -508,18 +510,105 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Repository method that returns the count as a BigDecimal value.
+     */
+    @Test
+    public void testCountAsBigDecimal() {
+        assertEquals(BigDecimal.valueOf(14L), primes.countAsBigDecimalByNumberIdLessThan(45));
+    }
+
+    /**
+     * Repository method that returns the count as a BigInteger value.
+     */
+    @Test
+    public void testCountAsBigInteger() {
+        assertEquals(BigInteger.valueOf(13L), primes.countAsBigIntegerByNumberIdLessThan(43));
+    }
+
+    /**
+     * Repository method that returns the count as a boolean value,
+     * which is not an allowed return type. This must raise an error.
+     */
+    @Test
+    public void testCountAsBoolean() {
+        try {
+            boolean count = primes.countAsBooleanByNumberIdLessThan(42);
+            fail("Count queries cannot have a boolean return type: " + count);
+        } catch (MappingException x) {
+            // expected
+        }
+    }
+
+    /**
+     * Repository method that returns the count as a byte value.
+     */
+    @Test
+    public void testCountAsByte() {
+        assertEquals((byte) 12, primes.countAsβyteByNumberIdLessThan(40));
+    }
+
+    /**
+     * Repository method that returns the count as a Byte value.
+     */
+    @Test
+    public void testCountAsByteWrapper() {
+        assertEquals(Byte.valueOf((byte) 10),
+                     primes.countAsβyteWrapperByNumberIdLessThan(30));
+    }
+
+    /**
+     * Repository method that returns the count as an int value.
+     */
+    @Test
+    public void testCountAsInt() {
+        assertEquals(9, primes.countAsIntByNumberIdLessThan(25));
+    }
+
+    /**
      * Count the number of matching entries in the database using query by method name.
      */
     @Test
-    public void testCount() throws ExecutionException, InterruptedException, TimeoutException {
+    public void testCountAsInteger() throws ExecutionException, InterruptedException, TimeoutException {
 
-        assertEquals(15, primes.countByNumberIdLessThan(50));
+        assertEquals(15L, primes.countAsLongByNumberIdLessThan(50));
 
-        assertEquals(Integer.valueOf(0), primes.countByNumberIdBetween(32, 36));
+        assertEquals(Integer.valueOf(0), primes.countAsIntegerByNumberIdBetween(32, 36));
 
-        assertEquals(Integer.valueOf(3), primes.countByNumberIdBetween(40, 50));
+        assertEquals(Integer.valueOf(3), primes.countAsIntegerByNumberIdBetween(40, 50));
 
         assertEquals(Short.valueOf((short) 14), primes.countByNumberIdBetweenAndEvenNot(0, 50, true).get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
+    }
+
+    /**
+     * Repository method that returns the count as a Long value.
+     */
+    @Test
+    public void testCountAsLongWrapper() {
+        assertEquals(Long.valueOf(8L), primes.countAsLongWrapperByNumberIdLessThan(20));
+    }
+
+    /**
+     * Repository method that returns the count as a Number.
+     */
+    @Test
+    public void testCountAsNumber() {
+        assertEquals(7L, primes.countAsNumberByNumberIdLessThan(18).longValue());
+    }
+
+    /**
+     * Repository method that returns the count as a short value.
+     */
+    @Test
+    public void testCountAsShort() {
+        assertEquals((short) 6, primes.countAsShortByNumberIdLessThan(15));
+    }
+
+    /**
+     * Repository method that returns the count as a Short value.
+     */
+    @Test
+    public void testCountAsShortWrapper() {
+        assertEquals(Short.valueOf((short) 5), primes.countAsShortWrapperByNumberIdLessThan(12));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -304,6 +304,43 @@ public interface Primes {
     @OrderBy("numberId")
     Page<Object[]> namesWithHex(long maxNumber, PageRequest pagination);
 
+    @Query("SELECT numberId WHERE numberId=?1")
+    BigDecimal numberAsBigDecimal(long num);
+
+    @Query("SELECT numberId WHERE numberId=:num")
+    Optional<BigInteger> numberAsBigInteger(long num);
+
+    @Query("SELECT numberId WHERE numberId=?1")
+    byte numberAsByte(long num);
+
+    @Query("SELECT numberId WHERE numberId=:n")
+    Optional<Byte> numberAsByteWrapper(@Param("n") long num);
+
+    @Query("SELECT numberId WHERE ID(this)=?1")
+    double numberAsDouble(long num);
+
+    @Asynchronous
+    @Query("SELECT numberId WHERE id(THIS)=?1")
+    CompletableFuture<Optional<Float>> numberAsFloatWrapper(long num);
+
+    @Query("SELECT numberId WHERE Id(This)=?1")
+    int numberAsInt(long num);
+
+    @Query("SELECT numberId WHERE Id(This)=:num")
+    Optional<Integer> numberAsInteger(long num);
+
+    @Query("SELECT numberId WHERE id(this)=?1")
+    long numberAsLong(long num);
+
+    @Query("SELECT numberId WHERE id(this)=:num")
+    Optional<Long> numberAsLongWrapper(long num);
+
+    @Query("SELECT numberId WHERE ID(THIS)=?1")
+    short numberAsShort(long num);
+
+    @Query("SELECT numberId WHERE ID(THIS)=:num")
+    Optional<Short> numberAsShortWrapper(long num);
+
     @Insert
     void persist(Prime... primes);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -14,6 +14,8 @@ package test.jakarta.data.web;
 
 import static jakarta.data.repository.By.ID;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
@@ -55,12 +57,35 @@ public interface Primes {
     @Query("SELECT name WHERE numberId < 35 AND romanNumeral || name LIKE :pattern")
     List<String> concatAndMatch(String pattern, Sort<?> sort);
 
-    Integer countByNumberIdBetween(long first, long last);
+    BigDecimal countAsBigDecimalByNumberIdLessThan(long number);
+
+    BigInteger countAsBigIntegerByNumberIdLessThan(long number);
+
+    // boolean return type is not allowed for count methods
+    boolean countAsBooleanByNumberIdLessThan(long number);
+
+    int countAsIntByNumberIdLessThan(long number);
+
+    Integer countAsIntegerByNumberIdBetween(long first, long last);
+
+    long countAsLongByNumberIdLessThan(long number);
+
+    Long countAsLongWrapperByNumberIdLessThan(long number);
+
+    Number countAsNumberByNumberIdLessThan(long number);
+
+    short countAsShortByNumberIdLessThan(long number);
+
+    Short countAsShortWrapperByNumberIdLessThan(long number);
+
+    // The β symbol is used here because Byte starts with the By keyword
+    byte countAsβyteByNumberIdLessThan(long number);
+
+    // The β symbol is used here because Byte starts with the By keyword
+    Byte countAsβyteWrapperByNumberIdLessThan(long number);
 
     @Asynchronous
     CompletableFuture<Short> countByNumberIdBetweenAndEvenNot(long first, long last, boolean isOdd);
-
-    long countByNumberIdLessThan(long number);
 
     @Find
     Stream<Prime> find(boolean even, int sumOfBits, Limit limit, Sort<?>... sorts);

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -158,9 +158,9 @@ public class DataExperimentalServlet extends FATServlet {
 
         assertEquals(104.99f, items.lowestPrice(), 0.001f);
 
-        assertEquals(200.99f, items.meanPrice(), 0.001f);
+        assertEquals(200.99, items.meanPrice(), 0.001f);
 
-        assertEquals(698.97f, items.totalOfDistinctPrices(), 0.001f);
+        assertEquals(698.97, items.totalOfDistinctPrices(), 0.001f);
 
         // EclipseLink says that multiple distinct attribute are not support at this time,
         // so we are testing this with distinct=false

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Items.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Items.java
@@ -75,7 +75,7 @@ public interface Items {
     float lowestPrice();
 
     @Query("SELECT AVG(price) FROM Item")
-    float meanPrice();
+    double meanPrice();
 
     @Update
     int reduceBy(@By(ID) UUID id,
@@ -102,7 +102,7 @@ public interface Items {
     int total();
 
     @Query("SELECT SUM(DISTINCT price) FROM Item")
-    float totalOfDistinctPrices();
+    double totalOfDistinctPrices();
 
     @Query("UPDATE Item SET price=price/?2, version=version-1 WHERE (pk IN ?1)")
     // TODO switch to annotated parameters once available for conditions

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -34,6 +34,7 @@ import java.time.OffsetDateTime;
 import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -455,6 +456,142 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals("Springfield", list.get(1).name());
         assertEquals("Missouri", list.get(1).stateName());
         assertEquals(Set.of(417), list.get(1).areaCodes());
+    }
+
+    /**
+     * Use repository methods that convert a BigInteger value to other
+     * numeric types.
+     */
+    @Test
+    public void testConvertBigDecimalValue() {
+        ZoneId ET = ZoneId.of("America/New_York");
+        Instant when = ZonedDateTime.of(2024, 4, 30, 12, 0, 0, 0, ET)
+                        .toInstant();
+
+        assertEquals(27480960216618.32,
+                     demographics.publicDebtAsBigDecimal(when)
+                                     .doubleValue(),
+                     1.0);
+
+        try {
+            Optional<BigInteger> i = demographics.publicDebtAsBigInteger(when);
+            // TODO is BigDecimal.toBigIntegerExact() broken?
+            // or are the fractional digits not being included?
+            //fail("Should not convert BigDecimal 27480960216618.32 to BigInteger " + i);
+            assertEquals(27480960216618L,
+                         i.orElseThrow().longValue());
+        } catch (MappingException x) {
+            if (x.getCause() instanceof ArithmeticException)
+                ; // expected - out of range
+            else
+                throw x;
+        }
+
+        try {
+            byte b = demographics.publicDebtAsByte(when);
+            fail("Should not convert BigDecimal 27480960216618.32 to byte " + b);
+        } catch (MappingException x) {
+            if (x.getCause() instanceof ArithmeticException)
+                ; // expected - out of range
+            else
+                throw x;
+        }
+
+        try {
+            Double d = demographics.publicDebtAsDouble(when);
+            fail("Should not convert BigDecimal 27480960216618.32 to Double " + d);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
+
+        try {
+            Optional<Float> f = demographics.publicDebtAsFloat(when);
+            fail("Should not convert BigDecimal 27480960216618.32 to Float " + f);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
+
+        try {
+            int i = demographics.publicDebtAsInt(when);
+            fail("Should not convert BigDecimal 27480960216618.32 to int " + i);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
+
+        try {
+            Long l = demographics.publicDebtAsLong(when);
+            // TODO is BigDecimal.longValueExact() broken?
+            // or are the fractional digits not being included?
+            //fail("Should not convert BigDecimal 27480960216618.32 to Long " + l);
+            assertEquals(Long.valueOf(27480960216618L),
+                         l);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
+
+        try {
+            Optional<Short> s = demographics.publicDebtAsShort(when);
+            fail("Should not convert BigDecimal 27480960216618.32 to Short " + s);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
+    }
+
+    /**
+     * Use repository methods that convert a BigInteger value to other
+     * numeric types.
+     */
+    @Test
+    public void testConvertBigIntegerValue() {
+        ZoneId ET = ZoneId.of("America/New_York");
+        Instant when = ZonedDateTime.of(2024, 4, 30, 12, 0, 0, 0, ET)
+                        .toInstant();
+
+        assertEquals(133809000L,
+                     demographics.numFullTimeWorkersAsBigDecimal(when)
+                                     .orElseThrow()
+                                     .longValueExact());
+
+        assertEquals(133809000L,
+                     demographics.numFullTimeWorkersAsBigInteger(when)
+                                     .longValueExact());
+
+        try {
+            Optional<Byte> b = demographics.numFullTimeWorkersAsByte(when);
+            fail("Should not convert BigInteger 133809000 to byte value " + b);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
+
+        try {
+            Double d = demographics.numFullTimeWorkersAsDouble(when);
+            fail("Should not convert BigInteger 133809000 to Double value " + d);
+        } catch (MappingException x) {
+            // expected - not convertible
+        }
+
+        try {
+            float f = demographics.numFullTimeWorkersAsFloat(when);
+            fail("Should not convert BigInteger 133809000 to float value " + f);
+        } catch (MappingException x) {
+            // expected - not convertible
+        }
+
+        assertEquals(Integer.valueOf(133809000),
+                     demographics.numFullTimeWorkersAsInteger(when)
+                                     .toCompletableFuture()
+                                     .join()
+                                     .orElseThrow());
+
+        assertEquals(133809000L,
+                     demographics.numFullTimeWorkersAsLong(when));
+
+        try {
+            short s = demographics.numFullTimeWorkersAsShort(when);
+            fail("Should not convert BigInteger 133809000 to short value " + s);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
@@ -14,6 +14,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
 import jakarta.data.repository.Find;
@@ -34,6 +36,60 @@ public interface Demographics {
 
     @OrderBy("publicDebt")
     List<DemographicInfo> findByPublicDebtBetween(BigDecimal min, BigDecimal max);
+
+    // Methods with conversion from BigInteger to other types:
+
+    @Query("SELECT numFullTimeWorkers WHERE collectedOn=:when")
+    Optional<BigDecimal> numFullTimeWorkersAsBigDecimal(Instant when);
+
+    @Query("SELECT numFullTimeWorkers WHERE collectedOn=:when")
+    BigInteger numFullTimeWorkersAsBigInteger(Instant when);
+
+    @Query("SELECT numFullTimeWorkers WHERE collectedOn=:when")
+    Optional<Byte> numFullTimeWorkersAsByte(Instant when);
+
+    @Query("SELECT numFullTimeWorkers WHERE collectedOn=:when")
+    Double numFullTimeWorkersAsDouble(Instant when);
+
+    @Query("SELECT numFullTimeWorkers WHERE collectedOn=:when")
+    float numFullTimeWorkersAsFloat(Instant when);
+
+    @Query("SELECT numFullTimeWorkers WHERE collectedOn=:when")
+    CompletionStage<Optional<Integer>> numFullTimeWorkersAsInteger(Instant when);
+
+    @Query("SELECT numFullTimeWorkers WHERE collectedOn=:when")
+    long numFullTimeWorkersAsLong(Instant when);
+
+    @Query("SELECT numFullTimeWorkers WHERE collectedOn=:when")
+    short numFullTimeWorkersAsShort(Instant when);
+
+    // Methods with conversion from BigDecimal to other types:
+
+    @Query("SELECT publicDebt WHERE collectedOn=:when")
+    BigDecimal publicDebtAsBigDecimal(Instant when);
+
+    @Query("SELECT publicDebt WHERE collectedOn=:when")
+    Optional<BigInteger> publicDebtAsBigInteger(Instant when);
+
+    @Query("SELECT publicDebt WHERE collectedOn=:when")
+    byte publicDebtAsByte(Instant when);
+
+    @Query("SELECT publicDebt WHERE collectedOn=:when")
+    Double publicDebtAsDouble(Instant when);
+
+    @Query("SELECT publicDebt WHERE collectedOn=:when")
+    Optional<Float> publicDebtAsFloat(Instant when);
+
+    @Query("SELECT publicDebt WHERE collectedOn=:when")
+    int publicDebtAsInt(Instant when);
+
+    @Query("SELECT publicDebt WHERE collectedOn=:when")
+    Long publicDebtAsLong(Instant when);
+
+    @Query("SELECT publicDebt WHERE collectedOn=:when")
+    Optional<Short> publicDebtAsShort(Instant when);
+
+    // End of type conversion methods
 
     // TODO support for Instant requires JPA 3.2, after which the following can be tried out:
 


### PR DESCRIPTION
Ensure that any type conversion that are made on the count result and single value query results are done safely such that no data is lost.

Also, I found a bug where Optional isn't recognized with a return type, which was inadvertently caught by tests that I wrote for this, so I'm fixing that as well.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".