### PR TITLE
Disable telemetry monitor jdbc test on Java 8

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/ConnectionPoolMetricsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/ConnectionPoolMetricsTest.java
@@ -28,6 +28,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
@@ -35,6 +36,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 11)
 public class ConnectionPoolMetricsTest extends BaseTestClass {
 
 	private static Class<?> c = ConnectionPoolMetricsTest.class;


### PR DESCRIPTION
The test uses jdbc-4.3 which requires Java 11

Follow on work for #29361 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

