### PR TITLE
fix os.type value for z/os

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/ResourceServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/telemetry/ResourceServlet.java
@@ -55,7 +55,7 @@ public class ResourceServlet extends FATServlet {
         osNameMap.put("hp-ux", "hpux");
         osNameMap.put("aix", "aix");
         osNameMap.put("solaris", "solaris");
-        osNameMap.put("z/os", "z/os");
+        osNameMap.put("z/os", "z_os");
     }
 
     @Test


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #29383

os.type for z/os should be `z_os`
See https://opentelemetry.io/docs/specs/semconv/attributes-registry/os/