### PR TITLE
Fix intermittent hang in client tests for Java 22+ (298672,300720)

### DIFF
--- a/dev/com.ibm.ws.security.client_fat/publish/clients/ProgrammaticLoginTestClient/client.jvm.options
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/ProgrammaticLoginTestClient/client.jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djava.security.auth.login.config=${client.config.dir}/resources/security/jaas/wsjaas_client.conf
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
 -Djdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/java2Client/client.jvm.options
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/java2Client/client.jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djava.security.auth.login.config=${client.config.dir}/resources/security/jaas/wsjaas_client.conf
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
 -Djdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/javacolonClientInjection/client.jvm.options
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/javacolonClientInjection/client.jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djava.security.auth.login.config=${client.config.dir}/resources/security/jaas/wsjaas_client.conf
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
 -Djdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/myFileMonitorClient/client.jvm.options
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/myFileMonitorClient/client.jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djava.security.auth.login.config=${client.config.dir}/resources/security/jaas/wsjaas_client.conf
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
 -Djdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/mySSLAutoAcceptClient/client.jvm.options
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/mySSLAutoAcceptClient/client.jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djava.security.auth.login.config=${client.config.dir}/resources/security/jaas/wsjaas_client.conf
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
 -Djdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/mySSLCmdClient/client.jvm.options
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/mySSLCmdClient/client.jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djava.security.auth.login.config=${client.config.dir}/resources/security/jaas/wsjaas_client.conf
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
 -Djdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/mySSLPromptClient/client.jvm.options
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/mySSLPromptClient/client.jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djava.security.auth.login.config=${client.config.dir}/resources/security/jaas/wsjaas_client.conf
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
 -Djdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/mySSLTestClient/client.jvm.options
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/mySSLTestClient/client.jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djava.security.auth.login.config=${client.config.dir}/resources/security/jaas/wsjaas_client.conf
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
 -Djdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/myTestClient/client.jvm.options
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/myTestClient/client.jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djava.security.auth.login.config=${client.config.dir}/resources/security/jaas/wsjaas_client.conf
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
 -Djdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/noDefaultKeyClient/bootstrap.properties
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/noDefaultKeyClient/bootstrap.properties
@@ -21,7 +21,3 @@ logService=all
 
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
-
-#In JDK22, the console no longer returns null when there is no console
-#Using java.base restores the existing console behavior from previous JDK versions. 
-jdk.console=java.base

--- a/dev/com.ibm.ws.security.client_fat/publish/clients/noDefaultKeyClient/client.jvm.options
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/noDefaultKeyClient/client.jvm.options
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,6 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 
--Djava.security.auth.login.config=${client.config.dir}/resources/security/jaas/wsjaas_client.conf
+#In JDK22, the console no longer returns null when there is no console
+#Using java.base restores the existing console behavior from previous JDK versions. 
 -Djdk.console=java.base


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

In Java 22+, there was a change to the System.console() method.
```
System.console() now returns a Console object when the standard streams are redirected or connected to a virtual terminal. In prior releases, System.console() returned null for these cases.
```
In the security client tests, in Java 22+, a null is no longer returned when there is no console for input.  This intermittently causes some of the client test to hang waiting for user input.

For more reference see:
https://www.oracle.com/java/technologies/javase/22-relnote-issues.html#Remaining (look for `JLine As The Default Console Provider`)

or this enhancement -> [JDK-8308591](https://bugs.openjdk.org/browse/JDK-8308591)


[Associated PR](https://github.com/OpenLiberty/open-liberty/pull/28104)