### PR TITLE
SELECT clause on its own

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2286,6 +2286,9 @@ public class QueryInfo {
                 } else {
                     q.append("SELECT").append(selection);
                 }
+                if (fromLen == 0 && whereLen == 0 && orderLen == 0 &&
+                    !Character.isWhitespace(q.charAt(q.length() - 1)))
+                    q.append(' ');
             } else {
                 q = generateSelectClause().append(' ');
             }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4457,7 +4457,37 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Repository method with a SELECT clause but no FROM clause.
+     * Repository method having only a SELECT clause.
+     */
+    @Test
+    public void testSelectClauseOnly() {
+        products.clear();
+
+        assertEquals(List.of(),
+                     List.of(products.names()));
+
+        Product prod1 = new Product();
+        prod1.pk = UUID.nameUUIDFromBytes("TestSelectClauseOnly-1".getBytes());
+        prod1.name = "TestSelectClauseOnly-1";
+        prod1.description = "TestSelectClauseOnly description 1";
+        prod1.price = 18.99f;
+
+        Product prod2 = new Product();
+        prod2.pk = UUID.nameUUIDFromBytes("TestSelectClauseOnly-2".getBytes());
+        prod2.name = "TestSelectClauseOnly-2";
+        prod2.description = "TestSelectClauseOnly description 2";
+        prod2.price = 27.99f;
+
+        products.saveMultiple(prod1, prod2);
+
+        assertEquals(Set.of("TestSelectClauseOnly-1", "TestSelectClauseOnly-2"),
+                     Set.of(products.names()));
+
+        products.clear();
+    }
+
+    /**
+     * Repository method with a SELECT clause and WHERE clause, but no FROM clause.
      */
     @Test
     public void testSelectClauseWithoutFromClause() {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
@@ -54,6 +54,9 @@ public interface Products {
     @Query("UPDATE Product SET price = price - (?2 * price) WHERE name LIKE CONCAT('%', ?1, '%')")
     long putOnSale(String nameContains, float discount);
 
+    @Query("SELECT name")
+    String[] names();
+
     // Custom repository method that combines multiple operations into a single transaction
     @Transactional
     default Product remove(UUID id) {

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2269,6 +2269,61 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Repository method that queries by an Instant attribute and retrieves an
+     * entity that includes the Instant attribute.
+     */
+    // TODO requires #28813 to fix java.time.Instant DateTimeParseException
+    //@Test
+    public void testInstant() {
+        final ZoneId EASTERN = ZoneId.of("America/New_York");
+        final Instant apr_28_2023 = ZonedDateTime.of(2023, 4, 28,
+                                                     12, 0, 0, 0,
+                                                     EASTERN)
+                        .toInstant();
+
+        DemographicInfo info = demographics.read(apr_28_2023).orElseThrow();
+
+        assertEquals(apr_28_2023,
+                     info.collectedOn);
+
+        assertEquals(134060000L,
+                     info.numFullTimeWorkers.longValue());
+
+        assertEquals(6852746625848.93,
+                     info.intragovernmentalDebt.doubleValue(),
+                     0.01);
+
+        assertEquals(24605068022566.94,
+                     info.publicDebt.doubleValue(),
+                     0.01);
+    }
+
+    /**
+     * Repository method that queries by the year component of an Instant attribute.
+     */
+    @Test
+    public void testInstantExtractYear() {
+
+        assertEquals(30189.32,
+                     demographics.publicDebtPerFullTimeWorker(2002)
+                                     .orElseThrow()
+                                     .doubleValue(),
+                     0.01);
+
+        assertEquals(102683.76,
+                     demographics.publicDebtPerFullTimeWorker(2013)
+                                     .orElseThrow()
+                                     .doubleValue(),
+                     0.01);
+
+        assertEquals(205374.53,
+                     demographics.publicDebtPerFullTimeWorker(2024)
+                                     .orElseThrow()
+                                     .doubleValue(),
+                     0.01);
+    }
+
+    /**
      * Use a repository method with a Query that hard codes a literal for a double value in E notation,
      * as is done in an example within the spec.
      */

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
@@ -91,13 +91,17 @@ public interface Demographics {
 
     // End of type conversion methods
 
-    // TODO support for Instant requires JPA 3.2, after which the following can be tried out:
+    @Query("SELECT this.publicDebt / this.numFullTimeWorkers" +
+           "  FROM DemographicInfo" +
+           " WHERE EXTRACT (YEAR FROM this.collectedOn) = ?1")
+    // TODO once #28912 is fixed:
+    //@Query("SELECT publicDebt / numFullTimeWorkers" +
+    //       "  FROM DemographicInfo" +
+    //       " WHERE EXTRACT (YEAR FROM collectedOn) = ?1")
+    Optional<BigDecimal> publicDebtPerFullTimeWorker(int year);
 
-    //@Query("SELECT publicDebt / numFullTimeWorkers FROM DemographicInfo WHERE EXTRACT (YEAR FROM collectedOn) = ?1")
-    //Optional<BigDecimal> publicDebtPerFullTimeWorker(int year);
-
-    //@Find
-    //Optional<DemographicInfo> read(Instant collectedOn);
+    @Find
+    Optional<DemographicInfo> read(Instant collectedOn);
 
     @OrderBy("numFullTimeWorkers")
     @Query("WHERE numFullTimeWorkers >= :min AND numFullTimeWorkers <= :max")


### PR DESCRIPTION
Implement the ability for JDQL to be a SELECT clause only, and test it. This is required by the spec, but there were no test for it prior to this.
Remove some TODOs to cover testing of attributes of type Instant. Then added more TODOs disabling tests further along due to another EclipseLink issue (already reported) that they subsequently run into.
Improve the logging of the stack trace for Resource Accessor Methods with AutoCloseable return types that are used outside the scope of repository default methods (so there is no point for the close to automatically happen).

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
