### PR TITLE
Disable SASL Tests for Java versions >21

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/SaslPlainTests.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/SaslPlainTests.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import componenttest.annotation.MaximumJavaLevel;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -54,6 +55,9 @@ import componenttest.containers.TestContainerSuite;
                 LibertyLoginModuleInvalidTest.class,
                 LibertyLoginModuleSpecialCharsTest.class,
 })
+// The Kafka Client SASL library uses Java Security Manager, which is no longer available as of Java 23
+// This should be removed when the test Kafka client jar is updated to a version that works with Java 23+
+@MaximumJavaLevel(javaLevel = 21)
 public class SaslPlainTests extends TestContainerSuite {
 
     public static final String ADMIN_USER = "admin";


### PR DESCRIPTION
The Kafka Client's SASL code uses the Java security, which as of Java 23 now throws exceptions if used. there is currently no Kafka Client version that does not use Security Manager. To allow for the rest of the RM suite of tests to continue passing without the failing Java 23 build, set the maximum java level to 21.

This limitation should be removed once a suitable client is available and included.

Change should be reverted when #29403 has been resolved

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
