### PR TITLE
Ignore test failures when there are network errors

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/suite/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/suite/FATSuite.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.microprofile.telemetry.internal.suite;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -32,12 +33,13 @@ import io.openliberty.microprofile.telemetry.internal.tests.JaegerOtelCollectorT
 import io.openliberty.microprofile.telemetry.internal.tests.JaegerOtlpTest;
 import io.openliberty.microprofile.telemetry.internal.tests.JaegerSecureOtelCollectorTest;
 import io.openliberty.microprofile.telemetry.internal.tests.JaegerSecureOtlpTest;
+import io.openliberty.microprofile.telemetry.internal.tests.JvmMetricsOtelCollectorTest;
+import io.openliberty.microprofile.telemetry.internal.tests.MetricsApiOtelCollectorTest;
 import io.openliberty.microprofile.telemetry.internal.tests.TracingNotEnabledTest;
 import io.openliberty.microprofile.telemetry.internal.tests.ZipkinOtelCollectorTest;
 import io.openliberty.microprofile.telemetry.internal.tests.ZipkinTest;
-import io.openliberty.microprofile.telemetry.internal.tests.JvmMetricsOtelCollectorTest;
-import io.openliberty.microprofile.telemetry.internal.tests.MetricsApiOtelCollectorTest;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.connectivity.ConnectionErrorWatcher;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -57,7 +59,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
                 TracingNotEnabledTest.class,
                 JvmMetricsOtelCollectorTest.class,
                 MetricsApiOtelCollectorTest.class,
-                ZipkinOtelCollectorTest.class, 
+                ZipkinOtelCollectorTest.class,
                 ZipkinTest.class,
 
 })
@@ -66,6 +68,9 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
  * Purpose: This suite collects and runs all known good test suites.
  */
 public class FATSuite extends TestContainerSuite {
+
+    @ClassRule
+    public static ConnectionErrorWatcher connectionWatcher = new ConnectionErrorWatcher();
 
     public static RepeatTests allMPRepeats(String serverName) {
         return TelemetryActions.repeat(serverName,

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent129Test.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent129Test.java
@@ -41,8 +41,10 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -87,6 +89,9 @@ public class Agent129Test {
     // so that it can check for any trace IDs not accounted for
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(repeat).around(jaegerContainer);
+
+    @Rule
+    public TestRule ignoreConnectionErrors = FATSuite.connectionWatcher.ignoreConnectivityFailures(server);
 
     private static JaegerQueryClient client;
     private static Set<String> traceIdsUsed;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent210Test.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent210Test.java
@@ -41,8 +41,10 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -88,6 +90,9 @@ public class Agent210Test {
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(repeat).around(jaegerContainer);
 
+    @Rule
+    public TestRule ignoreConnectionErrors = FATSuite.connectionWatcher.ignoreConnectivityFailures(server);
+
     private static JaegerQueryClient client;
     private static Set<String> traceIdsUsed;
 
@@ -103,9 +108,9 @@ public class Agent210Test {
         //The default OTLP protocol has been changed from grpc to http/protobuf in the Java Agent v2.1.0
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_PROTOCOL, "grpc");
 
-        server.addEnvVar("OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_CONTROLLER_TELEMETRY_ENABLED","true"); //otel.instrumentation.common.experimental.controller-telemetry.enabled=true)
+        server.addEnvVar("OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_CONTROLLER_TELEMETRY_ENABLED", "true"); //otel.instrumentation.common.experimental.controller-telemetry.enabled=true)
 
-        server.addEnvVar("OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_VIEW_TELEMETRY_ENABLED","true"); //otel.instrumentation.common.experimental.controller-telemetry.enabled=true)
+        server.addEnvVar("OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_VIEW_TELEMETRY_ENABLED", "true"); //otel.instrumentation.common.experimental.controller-telemetry.enabled=true)
 
         server.addEnvVar("OTEL_METRICS_EXPORTER", "none"); //TO DO: TEST METRICS
         server.addEnvVar("OTEL_LOGS_EXPORTER", "none");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
@@ -37,6 +37,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
@@ -65,6 +66,7 @@ import io.openliberty.microprofile.telemetry.internal.utils.TestUtils;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.connectivity.ConnectionErrorWatcher.ConnectionErrorsRule;
 
 /**
  * Test all the ways the agent can be configured
@@ -86,6 +88,9 @@ public class AgentConfigTest {
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);
+
+    @Rule
+    public static ConnectionErrorsRule ignoreConnectivityFailures = FATSuite.connectionWatcher.ignoreConnectivityFailures(server);
 
     public static JaegerQueryClient client;
 
@@ -129,6 +134,7 @@ public class AgentConfigTest {
 
     @After
     public void ensureStopped() throws Exception {
+        ignoreConnectivityFailures.checkForConnectivityErrors();
         server.stopServer();
     }
 
@@ -237,7 +243,7 @@ public class AgentConfigTest {
      * Skipping for 1.4 and 4.1 as JavaAgent 1.29 currently will not return a span for methods annotated with @withSpan
      * (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10159)
      */
-    @SkipForRepeat({ TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID, TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID})
+    @SkipForRepeat({ TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID, TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID })
     public void testEnableSpecificInstrumentation() throws Exception {
         // Enable only @WithSpan instrumentation
         server.addEnvVar("OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED", "false");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentTest.java
@@ -41,8 +41,10 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -59,6 +61,7 @@ import componenttest.topology.utils.HttpRequest;
 import io.jaegertracing.api_v2.Model.Span;
 import io.openliberty.microprofile.telemetry.internal.apps.agent.AgentSubResource;
 import io.openliberty.microprofile.telemetry.internal.apps.agent.AgentTestResource;
+import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
@@ -86,6 +89,9 @@ public class AgentTest {
     // so that it can check for any trace IDs not accounted for
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(repeat).around(jaegerContainer);
+
+    @Rule
+    public TestRule ignoreConnectionErrors = FATSuite.connectionWatcher.ignoreConnectivityFailures(server);
 
     private static JaegerQueryClient client;
     private static Set<String> traceIdsUsed;

--- a/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/connectivity/ConnectionErrorWatcher.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/connectivity/ConnectionErrorWatcher.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.shared.connectivity;
+
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Ignore test failures which occur due to connectivity errors between liberty and the system collecting spans.
+ * <p>
+ * Test failures of monitored tests will be ignored if there are errors in the server log similar to
+ *
+ * <pre>
+ * WARN io.opentelemetry.exporter.internal.grpc.GrpcExporter - Failed to export spans.
+ * </pre>
+ *
+ * <p>
+ * However, if more than a certain percentage of monitored tests fail in this way, an error will be reported at the end of the suite.
+ * <p>
+ * In the suite class:
+ *
+ * <pre>
+ * &#64;ClassRule
+ * public static TestRule connectionErrorWatcher = new ConnectionErrorWatcher(0.05);
+ * </pre>
+ *
+ * <p>
+ * In the test class:
+ *
+ * <pre>
+ * &#64;Server("MyServer")
+ * public static LibertyServer server;
+ *
+ * &#64;Rule
+ * public TestRule ignoreConnectionErrors = FATSuite.connectionErrorWatcher.ignoreConnectivityFailures(server);
+ * </pre>
+ */
+public class ConnectionErrorWatcher implements TestRule {
+
+    private final List<Failure> failures = new ArrayList<>();
+    private double failureRatioThreshold;
+    private int testsRun = 0;
+    private boolean watcherActive = false;
+
+    /**
+     * Create a new connection error watcher.
+     * <p>
+     * The watcher is created with the default failure ratio threshold of 5%
+     */
+    public ConnectionErrorWatcher() {
+        super();
+        failureRatioThreshold = 0.05;
+    }
+
+    /**
+     * Set the failure threshold ratio.
+     *
+     * If the number of failures divided by the number of tests run with the watcher is greater than the threshold, a failure will be created at the end of the test run.
+     *
+     * @param failureRatioThreshold the threshold ratio
+     */
+    public void withFailureRatioThreshold(double failureRatioThreshold) {
+        this.failureRatioThreshold = failureRatioThreshold;
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    watcherActive = true;
+                    statement.evaluate();
+                } finally {
+                    watcherActive = false;
+                }
+
+                if (failures.size() > testsRun * failureRatioThreshold) {
+                    StringBuilder error = new StringBuilder();
+                    error.append(failures.size()).append("/").append(testsRun)
+                                    .append(" tests failed with connectivity errors in the server logs.\n");
+                    error.append("Test failures:\n");
+                    failures.forEach(f -> {
+                        error.append("  ").append(f.desc.getDisplayName()).append("\n");
+                        error.append("    ").append(f.error.toString());
+                    });
+                    fail(error.toString());
+                }
+            }
+        };
+    }
+
+    /**
+     * Ignore test failures if the server reports connectivity errors.
+     * <p>
+     * The returned value must be assigned to a field and annotated with {@code @Rule} to ignore failures from that class.
+     *
+     * @param server the server whose logs should be checked for errors
+     * @return a test rule which causes test failures to be logged but ignored if there are connectivity errors in the server log
+     */
+    public ConnectionErrorsRule ignoreConnectivityFailures(LibertyServer server) {
+        if (!watcherActive) {
+            throw new IllegalStateException("Connectivity failure ignorer requested when Watcher is not running a suite. ConnectionErrorWatcher should be annotated with @ClassRule on the FATSuite");
+        }
+        return new ConnectionErrorsRule(this, server);
+    }
+
+    /**
+     * Record a test which failed but there were connectivity errors in the logs which may have caused the failure.
+     *
+     * @param description the test description
+     * @param e the error that caused the test to fail
+     */
+    void addFailure(Description description, Throwable e) {
+        if (!watcherActive) {
+            throw new IllegalStateException("Test failure recorded when Watcher is not running a suite. ConnectionErrorWatcher should be annotated with @ClassRule on the FATSuite", e);
+        }
+        failures.add(new Failure(description, e));
+    }
+
+    /**
+     * Record that a test monitored for connection errors has started
+     */
+    void recordTestStart() {
+        if (!watcherActive) {
+            throw new IllegalStateException("Watched test started when Watcher is not running a suite. ConnectionErrorWatcher should be annotated with @ClassRule on the FATSuite");
+        }
+        testsRun++;
+    }
+
+    private static class Failure {
+        private final Description desc;
+        private final Throwable error;
+
+        public Failure(Description desc, Throwable error) {
+            super();
+            this.desc = desc;
+            this.error = error;
+        }
+    }
+
+    /**
+     * A test rule to ignore failures if a server has connectivity errors.
+     * <p>
+     * Instances are created via {@link ConnectionErrorWatcher#ignoreConnectivityFailures(LibertyServer)}.
+     */
+    public class ConnectionErrorsRule implements TestRule {
+
+        private LibertyServer server;
+        private Set<String> initialConnectivityErrors = Collections.emptySet();
+        private final Set<String> finalConnectivityErrors = new HashSet<>();
+
+        private ConnectionErrorsRule(ConnectionErrorWatcher watcher, LibertyServer server) {
+            this.server = server;
+        }
+
+        @Override
+        public Statement apply(Statement statement, Description description) {
+            return new Statement() {
+
+                @Override
+                public void evaluate() throws Throwable {
+                    if (server != null) {
+                        initialConnectivityErrors = new HashSet<>(findConnectivityErrors(server));
+                    }
+                    recordTestStart();
+                    try {
+                        statement.evaluate();
+                    } catch (AssertionError | Exception e) {
+                        if (server != null) {
+                            checkForConnectivityErrors();
+                        }
+                        if (hasNewConnectivityErrors()) {
+                            Log.info(ConnectionErrorWatcher.class, "evaluate",
+                                     "Test " + description.getDisplayName() + " failed but server logs show connectivity errors so the failure is suppressed.");
+                            e.printStackTrace();
+                            addFailure(description, e);
+                            throw new AssumptionViolatedException("Test failed but server log shows connectivity errors");
+                        }
+                        throw e;
+                    } finally {
+                        initialConnectivityErrors = null;
+                    }
+                }
+            };
+        }
+
+        /**
+         * Set the server whose logs should be checked for connectivity errors.
+         * <p>
+         * Only needed for tests where the server isn't known before the test runs.
+         *
+         * @param server the server to check
+         * @throws Exception
+         */
+        public void setServer(LibertyServer server) throws Exception {
+            this.server = server;
+            initialConnectivityErrors = new HashSet<>(findConnectivityErrors(server));
+        }
+
+        /**
+         * Check the server log and record any connectivity errors.
+         * <p>
+         * This method is called automatically at test end, but may need to be called manually if the test cleans up the logs before it ends.
+         *
+         * @throws Exception
+         */
+        public void checkForConnectivityErrors() throws Exception {
+            finalConnectivityErrors.addAll(findConnectivityErrors(server));
+        }
+
+        private boolean hasNewConnectivityErrors() {
+            return finalConnectivityErrors.stream()
+                            .anyMatch(e -> !initialConnectivityErrors.contains(e));
+        }
+    }
+
+    private static List<String> findConnectivityErrors(LibertyServer server) throws Exception {
+        return server.findStringsInLogs("GrpcExporter - Failed to export spans");
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/connectivity/package-info.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/connectivity/package-info.java
@@ -1,0 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+@org.osgi.annotation.versioning.Version("0.1")
+package io.openliberty.microprofile.telemetry.internal_fat.shared.connectivity;


### PR DESCRIPTION
On some test systems we're seeing intermittent network issues. Ignore test failures that are caused by these (unless there's a lot of them).

For RTC 300349

- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

