### PR TITLE
Added null check if event does not have a message in MpTelemetry 2.0 …

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingServletTest.java
@@ -146,7 +146,7 @@ public class LoggingServletTest {
      * Ensures that an FFDC message from a Liberty application are bridged over to the otlp container.
      */
     @Test
-    @ExpectedFFDC({ "java.lang.NullPointerException" })
+    @ExpectedFFDC({ "java.lang.ArithmeticException" })
     public void testFFDCLogs() throws Exception {
 
         assertTrue("The server was not started successfully.", server.isStarted());
@@ -163,10 +163,10 @@ public class LoggingServletTest {
 
         Log.info(c, "testFFDCLogs", logs);
 
-        assertTrue("FFDC message log could not be found.", logs.contains("Body: Str(Cannot invoke"));
-        assertTrue("Exception message could not be found.", logs.contains("exception.message: Str(Cannot invoke"));
-        assertTrue("Exception Stacktrace  could not be found.", logs.contains("exception.stacktrace: Str(java.lang.NullPointerException"));
-        assertTrue("Exception type could not be found.", logs.contains("exception.type: Str(java.lang.NullPointerException)"));
+        assertTrue("FFDC message log could not be found.", logs.contains("Body: Str(FFDC_TEST_DOGET"));
+        assertTrue("Exception message could not be found.", logs.contains("exception.message: Str(FFDC_TEST_DOGET"));
+        assertTrue("Exception Stacktrace  could not be found.", logs.contains("exception.stacktrace: Str(java.lang.ArithmeticException"));
+        assertTrue("Exception type could not be found.", logs.contains("exception.type: Str(java.lang.ArithmeticException)"));
         assertTrue("Probe ID could not be found.", logs.contains("io.openliberty.probe_id"));
         assertTrue("SeverityText message could not be found.", logs.contains("SeverityText:"));
         assertTrue("SeverityNumber message could not be found.", logs.contains("SeverityNumber: Warn(13)"));

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/test-applications/MpTelemetryLogApp/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/MpTelemetryLogApp/FFDCServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/test-applications/MpTelemetryLogApp/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/MpTelemetryLogApp/FFDCServlet.java
@@ -49,8 +49,7 @@ public class FFDCServlet extends HttpServlet {
         PrintWriter out;
 
         if ((isFFDC != null) && isFFDC.equalsIgnoreCase("true")) {
-            String myString = null;
-            myString.toString();
+            throw new ArithmeticException("FFDC_TEST_DOGET");
         }
         String secondFFDC = req.getParameter("secondFFDC");
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/OpenTelemetryLogHandler.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/OpenTelemetryLogHandler.java
@@ -37,8 +37,8 @@ import com.ibm.wsspi.collector.manager.CollectorManager;
 import com.ibm.wsspi.collector.manager.Handler;
 import com.ibm.wsspi.collector.manager.SynchronousHandler;
 
-import io.openliberty.microprofile.telemetry.internal.common.AgentDetection;
 import io.openliberty.checkpoint.spi.CheckpointPhase;
+import io.openliberty.microprofile.telemetry.internal.common.AgentDetection;
 import io.openliberty.microprofile.telemetry.internal.common.constants.OpenTelemetryConstants;
 import io.openliberty.microprofile.telemetry.internal.common.info.OpenTelemetryInfo;
 import io.openliberty.microprofile.telemetry.internal.interfaces.OpenTelemetryAccessor;
@@ -226,7 +226,9 @@ public class OpenTelemetryLogHandler implements SynchronousHandler {
         } else if (event instanceof FFDCData) {
             eventMsg = ((FFDCData) event).getMessage();
         }
-        isOTelMappedEvent = eventMsg.contains(MpTelemetryLogFieldConstants.OTEL_SCOPE_INFO);
+        if (eventMsg != null) {
+            isOTelMappedEvent = eventMsg.contains(MpTelemetryLogFieldConstants.OTEL_SCOPE_INFO);
+        }
         return isOTelMappedEvent;
     }
 


### PR DESCRIPTION
…logging
 
- Sometimes, FFDC event dont have a message field, need to account for that.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #29420