### PR TITLE
JDQL processing updates and more test permutations for count queries

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2265,6 +2265,9 @@ public class QueryInfo {
                         c.append("WHERE").append(ql.substring(where0, where0 + whereLen));
 
                 jpqlCount = c.toString();
+
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(tc, ql, "count query: " + jpqlCount);
             }
 
             if (isCursoredPage) {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -232,9 +232,12 @@ public interface Primes {
 
     Boolean existsByNumberIdBetween(Long first, Long last);
 
-    // TODO after JDQL SELECT is added: "Select name Where length(romanNumeral) * 2 >= length(name) Order By name Asc",
-    @Query(value = "Where numberId < 50 and romanNumeral is not null and length(romanNumeral) * 2 >= length(name) Order By name Desc")
-    Page<Prime> lengthBasedQuery(PageRequest pageRequest);
+    @Query(value = "Select name" +
+                   " Where numberId < 50 and" +
+                   "       romanNumeral is not null and" +
+                   "       length(romanNumeral) * 2 >= length(name)" +
+                   " Order By name Desc")
+    Page<String> lengthBasedQuery(PageRequest pageRequest);
 
     @OrderBy(ID)
     @Query("SELECT ID(THIS) FROM Prime o WHERE (o.name = :numberName OR :numeral=o.romanNumeral OR o.hex =:hex OR ID(THIS)=:num)")

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipt.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipt.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,8 +11,7 @@
 package test.jakarta.data.web;
 
 /**
- * Entity that is a Java record
- * TODO add more fields
+ * Entity that is a Java record.
  */
 public record Receipt(long purchaseId, String customer, float total) {
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
@@ -39,6 +39,13 @@ public interface Receipts extends CrudRepository<Receipt, Long> {
     @Query("UPDATE Receipt SET total = total * (1.0 + :taxRate) WHERE purchaseId = :id")
     boolean addTax(long id, float taxRate);
 
+    // TODO should this be able to return CursoredPage even though it has no WHERE clause?
+    @Query(" ")
+    Page<Receipt> all(PageRequest req, Order<PageRequest> sorts);
+
+    @Query("FROM Receipt")
+    Page<Receipt> all(PageRequest req, Sort<?>... sorts);
+
     @Query("SELECT COUNT(this)")
     long count();
 
@@ -79,8 +86,17 @@ public interface Receipts extends CrudRepository<Receipt, Long> {
     @Query("DELETE FROM Receipt WHERE total < :max")
     int removeIfTotalUnder(float max);
 
+    @Query("ORDER BY total ASC")
+    Page<Receipt> sortedByTotalIncreasing(PageRequest req);
+
     @Query("SELECT total FROM Receipt WHERE purchaseId=:id")
     float totalOf(long id);
+
+    @Query("SELECT total")
+    Page<Float> totals(PageRequest req, Sort<?>... sorts);
+
+    @Query("SELECT total ORDER BY total DESC")
+    Page<Float> totalsDecreasing(PageRequest req);
 
     Receipt withPurchaseNum(long purchaseId);
 }


### PR DESCRIPTION
Add more test permutations for inferred count queries where the primary query JDQL/JPQL is lacking various clauses.
Also, remove some workarounds from the processing of JDQL.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
