### PR TITLE
Update body field with exception type when FFDC event message is null

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULDuplicateTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULDuplicateTest.java
@@ -29,12 +29,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 20)
 public class JULDuplicateTest {
 
     private static Class<?> c = JULDuplicateTest.class;

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULLogServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULLogServletTest.java
@@ -29,12 +29,14 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 20)
 public class JULLogServletTest {
 
     private static Class<?> c = JULLogServletTest.class;

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
@@ -189,7 +189,14 @@ public class MpTelemetryLogMappingUtils {
         builder.setSeverity(Severity.WARN);
 
         // Set the body to the exception message
-        builder.setBody(ffdcData.getMessage());
+        String ffdcMsg = ffdcData.getMessage();
+        if (ffdcMsg != null) {
+            builder.setBody(ffdcData.getMessage());
+
+        } else {
+            // If the message field is null, map the exception name to the body.
+            builder.setBody(ffdcMsg);
+        }
 
         // Get Attributes builder to add additional Log fields
         AttributesBuilder attributes = Attributes.builder();

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
@@ -191,11 +191,10 @@ public class MpTelemetryLogMappingUtils {
         // Set the body to the exception message
         String ffdcMsg = ffdcData.getMessage();
         if (ffdcMsg != null) {
-            builder.setBody(ffdcData.getMessage());
-
+            builder.setBody(ffdcMsg);
         } else {
             // If the message field is null, map the exception name to the body.
-            builder.setBody(ffdcMsg);
+            builder.setBody(ffdcData.getExceptionName());
         }
 
         // Get Attributes builder to add additional Log fields

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryDropinsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryDropinsTest.java
@@ -9,7 +9,6 @@
  *******************************************************************************/
 package io.openliberty.microprofile.telemetry.logging.internal_fat;
 
-import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -75,7 +75,8 @@ public class TelemetryDropinsTest extends FATServletClient {
     public void testTelemetryDropinAppSDK() throws Exception {
         server.startServer();
 
-        String serverStartLine = server.waitForStringInLog("CWWKF0011I", 15000, server.getConsoleLogFile());
+        // Wait for server startup message.
+        server.waitForStringInLog("CWWKF0011I", 15000, server.getConsoleLogFile());
 
         WebArchive app = ShrinkWrap
                         .create(WebArchive.class, "MpTelemetryLogApp.war")
@@ -84,9 +85,10 @@ public class TelemetryDropinsTest extends FATServletClient {
                         .addAsManifestResource(new File("publish/resources/META-INF/microprofile-config.properties"),
                                                "microprofile-config.properties");
 
-        ShrinkHelper.exportDropinAppToServer(server, app, SERVER_ONLY);
+        ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY, DeployOptions.OVERWRITE);
 
-        String appStartLine = server.waitForStringInLog("CWWKZ0001I", 15000, server.getConsoleLogFile());
+        // Wait for application start up message.
+        server.waitForStringInLog("CWWKZ0001I", 15000, server.getConsoleLogFile());
 
         String runtimeLine = server.waitForStringInLog("Runtime OTEL instance is being configured", 10000, server.getConsoleLogFile());
         TestUtils.runApp(server, "logServlet");
@@ -122,12 +124,14 @@ public class TelemetryDropinsTest extends FATServletClient {
         server.addEnvVar("OTEL_SDK_DISABLED", "false");
         server.startServer();
 
-        String serverStartLine = server.waitForStringInLog("CWWKF0011I", 15000, server.getConsoleLogFile());
+        // Wait for server startup message.
+        server.waitForStringInLog("CWWKF0011I", 15000, server.getConsoleLogFile());
 
         WebArchive app = ShrinkHelper.buildDefaultApp(APP_NAME, "io.openliberty.microprofile.telemetry.logging.internal.fat.MpTelemetryLogApp");
-        ShrinkHelper.exportDropinAppToServer(server, app, SERVER_ONLY);
+        ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY, DeployOptions.OVERWRITE);
 
-        String appStartLine = server.waitForStringInLog("CWWKZ0001I", 15000, server.getConsoleLogFile());
+        // Wait for application start up message.
+        server.waitForStringInLog("CWWKZ0001I", 15000, server.getConsoleLogFile());
 
         String runtimeLine = server.waitForStringInLog("Returning io.openliberty.microprofile.telemetry.runtime OTEL instance.", 5000, server.getConsoleLogFile());
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryFFDCTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryFFDCTest.java
@@ -80,7 +80,7 @@ public class TelemetryFFDCTest extends FATServletClient {
     @ExpectedFFDC("java.lang.ArithmeticException")
     // RuntimeException comes out of an early start servlet init;
     // This is async and may or may not happen before the test method enters
-    @AllowedFFDC("java.lang.RuntimeException")
+    @AllowedFFDC({ "java.lang.RuntimeException", "java.lang.IllegalArgumentException" })
     public void testTelemetryFFDCMessages() throws Exception {
         testTelemetryFFDCMessages(server, (linesConsoleLog) -> {
             // We expect to see the early ffdc message

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesTest.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,7 +42,6 @@ public class TelemetryMessagesTest extends FATServletClient {
     public static final String APP_NAME = "MpTelemetryLogApp";
     public static final String SERVER_NAME = "TelemetryMessage";
 
-
     @ClassRule
     public static RepeatTests rt = FATSuite.testRepeatMPTel20();
 
@@ -49,6 +49,11 @@ public class TelemetryMessagesTest extends FATServletClient {
     public static LibertyServer server;
 
     public static final String SERVER_XML_ALL_SOURCES = "allSources.xml";
+
+    @BeforeClass
+    public static void initialSetup() throws Exception {
+        server.saveServerConfiguration();
+    }
 
     @Before
     public void testSetup() throws Exception {
@@ -64,6 +69,9 @@ public class TelemetryMessagesTest extends FATServletClient {
     @After
     public void testTearDown() throws Exception {
         server.stopServer();
+
+        // Restore the server configuration, after each test case.
+        server.restoreServerConfiguration();
     }
 
     /**


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
 
Fixes #29439 
- Includes test failure fixes as well for RTC 301329, 301350
- The OpenTelemetry Java Agent is not supported with Java 21+.
