### PR TITLE
Add the ConsoleLogRecordExporterProvider to mpTelemetry-2.0

### DIFF
--- a/dev/io.openliberty.io.opentelemetry.2.0/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider
+++ b/dev/io.openliberty.io.opentelemetry.2.0/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider
@@ -1,2 +1,3 @@
 io.opentelemetry.exporter.otlp.internal.OtlpLogRecordExporterProvider
 io.opentelemetry.exporter.logging.internal.LoggingLogRecordExporterProvider
+io.opentelemetry.exporter.logging.internal.ConsoleLogRecordExporterProvider

--- a/dev/io.openliberty.io.opentelemetry.2.0/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider
+++ b/dev/io.openliberty.io.opentelemetry.2.0/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider
@@ -1,2 +1,3 @@
 io.opentelemetry.exporter.otlp.internal.OtlpMetricExporterProvider
 io.opentelemetry.exporter.logging.internal.LoggingMetricExporterProvider
+io.opentelemetry.exporter.logging.internal.ConsoleMetricExporterProvider

--- a/dev/io.openliberty.io.opentelemetry.2.0/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
+++ b/dev/io.openliberty.io.opentelemetry.2.0/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
@@ -1,3 +1,4 @@
 io.opentelemetry.exporter.otlp.internal.OtlpSpanExporterProvider
 io.opentelemetry.exporter.logging.internal.LoggingSpanExporterProvider
 io.opentelemetry.exporter.zipkin.internal.ZipkinSpanExporterProvider
+io.opentelemetry.exporter.logging.internal.ConsoleSpanExporterProvider

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/servers/Telemetry20LogsConfigTCKServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/servers/Telemetry20LogsConfigTCKServer/bootstrap.properties
@@ -18,5 +18,5 @@ otel.trace.http.disabled=true
 otel.sdk.disabled=false
 otel.metrics.exporter=none
 otel.traces.exporter=none
-otel.logs.exporter=logging
+otel.logs.exporter=console
 log.file.path=${server.output.dir}/logs/messages.log

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/servers/Telemetry20MetricsConfigTCKServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/servers/Telemetry20MetricsConfigTCKServer/bootstrap.properties
@@ -16,7 +16,7 @@ com.ibm.ws.logging.max.files=1
 com.ibm.ws.logging.trace.specification=*=info:TELEMETRY=all
 otel.trace.http.disabled=true
 otel.sdk.disabled=false
-otel.metrics.exporter=logging
+otel.metrics.exporter=console
 otel.traces.exporter=none
 otel.logs.exporter=none
 otel.metric.export.interval=3000


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Adds the support to use `console` as the OTel exporter, for logs, metrics, and traces.