### PR TITLE
check status of components with new server command

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/LaunchArguments.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/LaunchArguments.java
@@ -174,6 +174,9 @@ public class LaunchArguments {
                     } else if (argToLower.equals("--resume")) {
                         returnValue = checkPreviousAction(returnValue, ReturnCode.RESUME_ACTION, arg);
                         action = setActionIfOk(returnValue, action, arg);
+                    } else if (argToLower.equals("--compstatus")) {
+                        returnValue = checkPreviousAction(returnValue, ReturnCode.COMP_STATUS_ACTION, arg);
+                        action = setActionIfOk(returnValue, action, arg);
                     } else if (argToLower.startsWith(MESSAGE_ACTION)) {
                         returnValue = checkPreviousAction(returnValue, ReturnCode.MESSAGE_ACTION, arg);
                         action = setActionIfOk(returnValue, action, arg);

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/Launcher.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/Launcher.java
@@ -289,6 +289,9 @@ public class Launcher {
             case RESUME_ACTION:
                 rc = new com.ibm.ws.kernel.boot.internal.commands.ProcessControlHelper(bootProps, launchArgs).resume();
                 break;
+            case COMP_STATUS_ACTION:
+                rc = new com.ibm.ws.kernel.boot.internal.commands.ProcessControlHelper(bootProps, launchArgs).compStatus();
+                break;
             case LIST_ACTION:
                 rc = new ListServerHelper(bootProps, launchArgs).listServers();
                 break;

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/ReturnCode.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/ReturnCode.java
@@ -58,6 +58,7 @@ public enum ReturnCode implements ExitCode {
     CLIENT_RUNNER_EXCEPTION(35),
     ERROR_SERVER_PAUSE(36),
     ERROR_SERVER_RESUME(37),
+    ERROR_SERVER_COMP_STATUS(38),
 
     // All "actions" should be < 0, these are not returned externally
     MESSAGE_ACTION(-1),
@@ -76,7 +77,8 @@ public enum ReturnCode implements ExitCode {
     INVALID(13),
     PACKAGE_WLP_ACTION(-15, "package.log"),
     PAUSE_ACTION(-16),
-    RESUME_ACTION(-17);
+    RESUME_ACTION(-17),
+    COMP_STATUS_ACTION(-18);
 
     final int val;
     final String logName;

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/ServerCommand.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/ServerCommand.java
@@ -34,6 +34,7 @@ public abstract class ServerCommand {
     protected static final String INTROSPECT_JAVADUMP_COMMAND = "introspectJavadump";
     protected static final String JAVADUMP_COMMAND = "javadump";
     protected static final String PAUSE_COMMAND = "pause";
+    protected static final String COMP_STATUS_COMMAND = "compStatus";
     protected static final String RESUME_COMMAND = "resume";
 
     private final CharsetDecoder decoder = StandardCharsets.ISO_8859_1.newDecoder();

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
@@ -701,7 +701,7 @@ public class ProcessControlHelper {
         return resumeRc;
     }
 
-        /**
+    /**
      * Resume inbound work to the server.
      *
      * @return
@@ -735,7 +735,16 @@ public class ProcessControlHelper {
                     }
 
                     output = scc.compStatus(targetParm);
-                    compStatusRc = ReturnCode.OK;
+                    if(output.indexOf("#") != -1){
+                        //set the return code and remove it from output string
+                        int returnCode = Integer.parseInt(output.substring(output.indexOf("#") + 1).trim());
+                        compStatusRc = ReturnCode.getEnum(returnCode);
+                        output = output.substring(0, output.indexOf("#"));
+                    }
+                    else{
+                        // Something went wrong when communicating with server...
+                        compStatusRc = ReturnCode.SERVER_UNKNOWN_STATUS;
+                    }
                 } else {
                     // We can't communicate to the server...
                     compStatusRc = ReturnCode.SERVER_UNKNOWN_STATUS;
@@ -749,17 +758,13 @@ public class ProcessControlHelper {
             compStatusRc = ReturnCode.SERVER_UNKNOWN_STATUS;
         }
 
-        if (compStatusRc == ReturnCode.OK) {
-            if (targetParm != null) {
-                System.out.println(output);
-            } else {
-                System.out.println(output);
-            }
-        } else if (compStatusRc == ReturnCode.SERVER_UNKNOWN_STATUS) {
+        System.out.println(output);
+        
+        if (compStatusRc == ReturnCode.SERVER_UNKNOWN_STATUS) {
             System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("info.serverNotRunning"), serverName));
         } else if (compStatusRc == ReturnCode.SERVER_COMMAND_PORT_DISABLED_STATUS) {
             System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("error.server.resume.command.port.disabled"), serverName));
-        } else {
+        } else if (compStatusRc != ReturnCode.OK){
             if (targetParm != null) {
                 System.out.println("Component status failed in " + serverName);
             } else {

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
@@ -700,4 +700,73 @@ public class ProcessControlHelper {
 
         return resumeRc;
     }
+
+        /**
+     * Resume inbound work to the server.
+     *
+     * @return
+     */
+    public ReturnCode compStatus() {
+        // Use initialized bootstrap configuration to find the server lock file.
+        ServerLock serverLock = ServerLock.createTestLock(bootProps);
+
+        // we can not pre-test the server: on some platforms, the server lock file
+        // can be deleted, which means waiting to see if it is there leads to
+        // an abandoned server.
+        ReturnCode compStatusRc = ReturnCode.COMP_STATUS_ACTION;
+        String output = "";
+
+        // The lock file may have been (erroneously) deleted: this can happen on linux
+        boolean lockExists = serverLock.lockFileExists();
+
+        String targetParm = launchArgs.getOption("target");
+        if (lockExists) {
+            // If the lock exists, check quickly to see if the process is holding it.
+            if (serverLock.testServerRunning()) {
+                // We need to tell the server to resume...
+                ServerCommandClient scc = new ServerCommandClient(bootProps);
+
+                if (scc.isValid()) {
+                    if (targetParm != null) {
+                        System.out.println("Checking status of components in " + serverName);
+                        targetParm = "target=" + targetParm;
+                    } else {
+                        System.out.println("Checking status of components in " + serverName);
+                    }
+
+                    output = scc.compStatus(targetParm);
+                    compStatusRc = ReturnCode.OK;
+                } else {
+                    // We can't communicate to the server...
+                    compStatusRc = ReturnCode.SERVER_UNKNOWN_STATUS;
+                }
+            } else {
+                // nope: lock not held, server not up
+                compStatusRc = ReturnCode.SERVER_UNKNOWN_STATUS;
+            }
+        } else {
+            // no lock file: we assume the server is not running, we have nothing to do.
+            compStatusRc = ReturnCode.SERVER_UNKNOWN_STATUS;
+        }
+
+        if (compStatusRc == ReturnCode.OK) {
+            if (targetParm != null) {
+                System.out.println(output);
+            } else {
+                System.out.println(output);
+            }
+        } else if (compStatusRc == ReturnCode.SERVER_UNKNOWN_STATUS) {
+            System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("info.serverNotRunning"), serverName));
+        } else if (compStatusRc == ReturnCode.SERVER_COMMAND_PORT_DISABLED_STATUS) {
+            System.out.println(MessageFormat.format(BootstrapConstants.messages.getString("error.server.resume.command.port.disabled"), serverName));
+        } else {
+            if (targetParm != null) {
+                System.out.println("Component status failed in " + serverName);
+            } else {
+                System.out.println("Component status failed in " + serverName);
+            }
+        }
+
+        return compStatusRc;
+    }
 }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ServerCommandClient.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ServerCommandClient.java
@@ -431,4 +431,8 @@ public class ServerCommandClient extends ServerCommand {
             Utils.tryToClose(channel);
         }
     }
+
+    public char getDelim(){
+        return DELIM;
+    }
 }

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -1499,4 +1499,28 @@ public class FrameworkManager {
 
         return ReturnCode.OK;
     }
+
+    public String compStatusListeners(String args) {
+
+        // A registered service for delivering pause/resume requests to interested Components.
+        PauseableComponentController pauseableComponentController;
+
+        ServiceReference<PauseableComponentController> reference = systemBundleCtx.getServiceReference(PauseableComponentController.class);
+        pauseableComponentController = reference == null ? null : systemBundleCtx.getService(reference);
+        if (pauseableComponentController == null) {
+            System.out.println("Error comp status request failed");
+            return ReturnCode.ERROR_SERVER_COMP_STATUS.toString();
+        }
+        String response = "";
+        if (args == null) {
+            response = pauseableComponentController.componentStatus("");
+
+        } else {
+            String targetList = args.substring(args.indexOf("=") + 1);
+            response = pauseableComponentController.componentStatus(targetList);
+        }
+
+
+        return response;
+    }
 }

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -1501,6 +1501,7 @@ public class FrameworkManager {
     }
 
     public String compStatusListeners(String args) {
+        String response = "";
 
         // A registered service for delivering pause/resume requests to interested Components.
         PauseableComponentController pauseableComponentController;
@@ -1509,9 +1510,10 @@ public class FrameworkManager {
         pauseableComponentController = reference == null ? null : systemBundleCtx.getService(reference);
         if (pauseableComponentController == null) {
             System.out.println("Error comp status request failed");
-            return ReturnCode.ERROR_SERVER_COMP_STATUS.toString();
+            response = "#" + ReturnCode.ERROR_SERVER_COMP_STATUS.getValue();
+            return response;
         }
-        String response = "";
+
         if (args == null) {
             response = pauseableComponentController.componentStatus("");
 
@@ -1519,6 +1521,15 @@ public class FrameworkManager {
             String targetList = args.substring(args.indexOf("=") + 1);
             response = pauseableComponentController.componentStatus(targetList);
         }
+
+        if(response.contains("CWWKE")){
+            response += "#" + ReturnCode.ERROR_SERVER_COMP_STATUS.getValue();
+        }
+        else{
+            response += "#" + ReturnCode.OK.getValue();
+        }
+
+        System.out.println(response);
 
 
         return response;

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/PauseableComponentControllerImpl.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/PauseableComponentControllerImpl.java
@@ -69,6 +69,8 @@ public class PauseableComponentControllerImpl implements PauseableComponentContr
 
         Tr.info(tc, "info.server.pause.all.request.received");
 
+        getPauseableComponents();
+
         Set<String> failed = new HashSet<String>();
 
         if (tracker.getTracked().isEmpty()) {
@@ -126,6 +128,8 @@ public class PauseableComponentControllerImpl implements PauseableComponentContr
     public void pause(String targets) throws PauseableComponentControllerRequestFailedException {
 
         Tr.info(tc, "info.server.pause.request.received", targets);
+
+        getPauseableComponents();
 
         Set<String> foundTargets = new HashSet<String>();
 
@@ -206,6 +210,8 @@ public class PauseableComponentControllerImpl implements PauseableComponentContr
 
         Tr.info(tc, "info.server.resume.all.request.received");
 
+        getPauseableComponents();
+
         Set<String> failed = new HashSet<String>();
 
         if (tracker.getTracked().isEmpty()) {
@@ -262,6 +268,8 @@ public class PauseableComponentControllerImpl implements PauseableComponentContr
     public void resume(String targets) throws PauseableComponentControllerRequestFailedException {
 
         Tr.info(tc, "info.server.resume.request.received", targets);
+
+        getPauseableComponents();
 
         Set<String> foundTargets = new HashSet<String>();
 
@@ -462,8 +470,50 @@ public class PauseableComponentControllerImpl implements PauseableComponentContr
     @Override
     public Collection<PauseableComponent> getPauseableComponents() {
 
+        for(PauseableComponent pc : tracker.getTracked().values()){
+            System.out.println(pc.getName());
+        }
         return tracker.getTracked().values();
 
+    }
+
+    @Override
+    public String componentStatus(String targets){
+        Set<String> foundTargets = new HashSet<String>();
+
+        Set<String> targetList = createTargetList(targets);
+
+        boolean allTargets = targetList.isEmpty();
+
+        String output = "";
+
+        //Add each pauseable component to this list. If the tracked values get modified
+        //while we are iterating and we start over, skip anyone already in this list
+        Set<PauseableComponent> processedList = new HashSet<PauseableComponent>();
+
+        // Sync with other methods changing/querying states for PauseableComponents
+        synchronized (this) {
+            while (true) {
+                try {
+                    for (PauseableComponent pauseableComponent : tracker.getTracked().values()) {
+
+                        if (processedList.add(pauseableComponent)) {
+
+                            if (targetList.contains(pauseableComponent.getName()) || allTargets) {
+                                foundTargets.add(pauseableComponent.getName());
+
+                                output += "Target " + pauseableComponent.getName() + " paused: " + pauseableComponent.isPaused() + "\n";
+                            }
+                        }
+                    }
+
+                    break;
+                } catch (Throwable t) {
+                    // Someone modified our list of services. Retry.
+                }
+            }
+        }
+        return output;
     }
 
     /**

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/PauseableComponentControllerImpl.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/PauseableComponentControllerImpl.java
@@ -479,13 +479,16 @@ public class PauseableComponentControllerImpl implements PauseableComponentContr
 
     @Override
     public String componentStatus(String targets){
+        StringBuilder output = new StringBuilder();
+
+        if (tracker.getTracked().isEmpty()) {
+            output.append(Tr.formatMessage(tc, "warning.server.resume.no.targets") + "\n");
+            return output.toString();
+        }
+
         Set<String> foundTargets = new HashSet<String>();
-
         Set<String> targetList = createTargetList(targets);
-
         boolean allTargets = targetList.isEmpty();
-
-        String output = "";
 
         //Add each pauseable component to this list. If the tracked values get modified
         //while we are iterating and we start over, skip anyone already in this list
@@ -502,7 +505,7 @@ public class PauseableComponentControllerImpl implements PauseableComponentContr
                             if (targetList.contains(pauseableComponent.getName()) || allTargets) {
                                 foundTargets.add(pauseableComponent.getName());
 
-                                output += "Target " + pauseableComponent.getName() + " paused: " + pauseableComponent.isPaused() + "\n";
+                                output.append("Target " + pauseableComponent.getName() + " paused: " + pauseableComponent.isPaused() + "\n");
                             }
                         }
                     }
@@ -513,7 +516,16 @@ public class PauseableComponentControllerImpl implements PauseableComponentContr
                 }
             }
         }
-        return output;
+
+        //Check which (if any) targets were not found
+        boolean targetsNotFound = false;
+        targetList.removeAll(foundTargets);
+        if (!targetList.isEmpty()) {
+            targetsNotFound = true;
+            output.append(Tr.formatMessage(tc, "warning.server.resume.missing.targets", Arrays.toString(targetList.toArray())) + "\n");
+        }
+
+        return output.toString();
     }
 
     /**

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/ServerCommandListener.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/ServerCommandListener.java
@@ -493,6 +493,16 @@ public class ServerCommandListener extends ServerCommand implements CheckpointHo
             ReturnCode rc = frameworkManager.resumeListeners(args);
 
             writeResponse(sc, rc.getValue());
+        } else if (command.startsWith(COMP_STATUS_COMMAND)) {
+            String args = null;
+            int index = command.indexOf("#");
+            if (index > 0 && (command.length() > (index + 1))) {
+                args = command.substring(index + 1);
+            }
+
+            String responseText = frameworkManager.compStatusListeners(args);
+
+            writeResponse(sc, responseText);
         } else {
             if (tc.isWarningEnabled()) {
                 Tr.warning(tc, "warning.unrecognized.command", command);
@@ -537,6 +547,15 @@ public class ServerCommandListener extends ServerCommand implements CheckpointHo
     private void writeResponse(SocketChannel sc, int rc) throws IOException {
         synchronized (responseLock) {
             write(sc, serverUUID + DELIM + rc);
+        }
+    }
+
+    /**
+     * Write a response on a socket channel with response code.
+     */
+    private void writeResponse(SocketChannel sc, String text) throws IOException {
+        synchronized (responseLock) {
+            write(sc, serverUUID + DELIM + text);
         }
     }
 

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/service/PauseableComponentController.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/service/PauseableComponentController.java
@@ -68,4 +68,8 @@ public interface PauseableComponentController {
      */
     boolean isActive(String targets);
 
+    /**
+     * Status of components
+     */
+    String componentStatus(String targets);
 }

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1981,6 +1981,19 @@ case "$ACTION" in
     fi    
   ;;
 
+  # get status of components of the server
+  compstatus)
+    serverEnv
+    # Check to see if the server exists
+    if checkServer true
+    then
+      javaCmd '' "${SERVER_NAME}" --compStatus "$@" 
+      exit $?
+    else
+      exit 2
+    fi    
+  ;;
+
   # resume the server
   resume)
     serverEnv

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/FATSuite.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.kernel.boot.commandline.ComponentStatusCommandTest;
 import com.ibm.ws.kernel.boot.commandline.CreateCommandTest;
 import com.ibm.ws.kernel.boot.commandline.DumpCommandTest;
 import com.ibm.ws.kernel.boot.commandline.PauseResumeCommandTest;
@@ -45,35 +46,37 @@ import com.ibm.wsspi.kernel.embeddable.EmbeddedServerTest;
  * in a combined total of 5 minutes or less.
  */
 @SuiteClasses({
-                EmbeddedServerTest.class,
-                EmbeddedServerAddProductExtensionTest.class,
-                EmbeddedServerAddProductExtensionMultipleTest.class,
-                ProvisioningTest.class,
-                KernelChangeTest.class,
-                ServerEnvTest.class,
-                ServerStartTest.class,
-                ServerStopTest.class,
-                ServerStartAsServiceTest.class,
-                ShutdownTest.class,
-                ServerCommandPortTest.class,
-                DumpCommandTest.class,
-                PackageCommandTest.class,
-                PackageLooseRunnableTest.class,
-                PackageLooseContentsTest.class,
-                PackageVersionlessFeatures.class,
-                // PackageLooseFilterTest.class, // Recreates issue 15724; disabled until that is fixed.
-                LogLevelPropertyTest.class,
-                CreateCommandTest.class,
-                StartCommandTest.class,
-                ServerClasspathTest.class,
-                ServerStartJVMOptionsTest.class,
-                ServerStartJavaEnvironmentVariablesTest.class,
-                PauseResumeCommandTest.class,
-                EmbeddedServerMergeProductExtensionTest.class,
-                ServerEndpointControlMBeanTest.class,
-                OSGiEmbedManagerTest.class,
-                ServerCleanTest.class,
-                VerboseLogTest.class
+                // EmbeddedServerTest.class,
+                // EmbeddedServerAddProductExtensionTest.class,
+                // EmbeddedServerAddProductExtensionMultipleTest.class,
+                // ProvisioningTest.class,
+                // KernelChangeTest.class,
+                // ServerEnvTest.class,
+                // ServerStartTest.class,
+                // ServerStopTest.class,
+                // ServerStartAsServiceTest.class,
+                // ShutdownTest.class,
+                // ServerCommandPortTest.class,
+                // DumpCommandTest.class,
+                // PackageCommandTest.class,
+                // PackageLooseRunnableTest.class,
+                // PackageLooseContentsTest.class,
+                // PackageVersionlessFeatures.class,
+                // // PackageLooseFilterTest.class, // Recreates issue 15724; disabled until that is fixed.
+                // LogLevelPropertyTest.class,
+                // CreateCommandTest.class,
+                // StartCommandTest.class,
+                // ServerClasspathTest.class,
+                // ServerStartJVMOptionsTest.class,
+                // ServerStartJavaEnvironmentVariablesTest.class,
+                // PauseResumeCommandTest.class,
+                // EmbeddedServerMergeProductExtensionTest.class,
+                // ServerEndpointControlMBeanTest.class,
+                // OSGiEmbedManagerTest.class,
+                // ServerCleanTest.class,
+                // VerboseLogTest.class
+
+                ComponentStatusCommandTest.class
 })
 public class FATSuite {
     // Empty

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/ComponentStatusCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/ComponentStatusCommandTest.java
@@ -1,0 +1,202 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.boot.commandline;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+/**
+ *
+ */
+@RunWith(FATRunner.class)
+public class ComponentStatusCommandTest {
+
+    private static final Class<?> c = PauseResumeCommandTest.class;
+
+    private static final String COMPONENT_STATUS_SERVER_NAME = "com.ibm.ws.kernel.boot.component.status.fat";
+    private static final String PAUSE_RESUME_SERVER_NAME = "com.ibm.ws.kernel.boot.pause.resume.fat";
+
+    private static final LibertyServer componentStatusServer = LibertyServerFactory.getLibertyServer(COMPONENT_STATUS_SERVER_NAME);
+    private static final LibertyServer pauseResumeServer = LibertyServerFactory.getLibertyServer(PAUSE_RESUME_SERVER_NAME);
+
+    public void setup(LibertyServer server) throws Exception {
+        server.startServer();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        componentStatusServer.stopServer("CWWKE093*");
+        pauseResumeServer.stopServer("CWWKE093*");
+    }
+
+    /**
+     * Tests the case where the "server pause" command is issued then get the status of components
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPauseStatusComponents() throws Exception {
+        final String METHOD_NAME = "testPauseStatusComponents";
+        Log.entering(c, METHOD_NAME);
+
+        setup(componentStatusServer);
+
+        String pauseOutput = componentStatusServer.executeServerScript("pause", null).getStdout();
+        System.out.println(pauseOutput);
+
+        String statusOutput = componentStatusServer.executeServerScript("compstatus", null).getStdout();
+        System.out.println(statusOutput);
+
+        assertTrue(statusOutput.contains("failed"));
+        assertNotNull(componentStatusServer.waitForStringInLog("CWWKE0933W", 10000));
+
+        Log.exiting(c, METHOD_NAME);
+    }
+
+    /**
+     * Tests the case where the "server resume" command is issued and no
+     * pauseable components exist
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPauseStatusNoPauseableComponents() throws Exception {
+        final String METHOD_NAME = "testPauseStatusNoPauseableComponents";
+        Log.entering(c, METHOD_NAME);
+
+        setup(pauseResumeServer);
+
+        String pauseOutput = pauseResumeServer.executeServerScript("pause", null).getStdout();
+        System.out.println(pauseOutput);
+
+        String statusOutput = pauseResumeServer.executeServerScript("compstatus", null).getStdout();
+        System.out.println(statusOutput);
+
+        assertTrue(statusOutput.contains("failed"));
+        assertNotNull(pauseResumeServer.waitForStringInLog("CWWKE0933W", 10000));
+
+        Log.exiting(c, METHOD_NAME);
+    }
+
+    /**
+     * Tests the case where the "server resume" command is issued and no
+     * pauseable components exist
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testStressTestComponents() throws Exception {
+        final String METHOD_NAME = "testPauseStatusNoPauseableComponents";
+        Log.entering(c, METHOD_NAME);
+
+        componentStatusServer.addDropinDefaultConfiguration("more-endpoints.xml");
+
+        setup(componentStatusServer);
+
+        String pauseOutput = componentStatusServer.executeServerScript("pause", null).getStdout();
+        System.out.println(pauseOutput);
+
+        String statusOutput = componentStatusServer.executeServerScript("compstatus", null).getStdout();
+        System.out.println(statusOutput);
+
+        assertTrue(statusOutput.contains("failed"));
+        assertNotNull(componentStatusServer.waitForStringInLog("CWWKE0933W", 10000));
+
+        Log.exiting(c, METHOD_NAME);
+    }
+
+    // /**
+    //  * Tests the case where the "server pause" command is issued with an empty target list.
+    //  *
+    //  * @throws Exception
+    //  */
+    // @Test
+    // public void testPauseEmptyTargetList() throws Exception {
+    //     final String METHOD_NAME = "testPauseEmptyTargetList";
+    //     Log.entering(c, METHOD_NAME);
+
+    //     String output = componentStatusServer.executeServerScript("pause", new String[] { "--target=" }).getStdout();
+
+    //     assertTrue(output.contains("failed"));
+    //     assertNotNull(componentStatusServer.waitForStringInLog("CWWKE0931W", 10000));
+
+    //     Log.exiting(c, METHOD_NAME);
+    // }
+
+    // /**
+    //  * Tests the case where the "server resume" command is issued with an empty target list.
+    //  *
+    //  * @throws Exception
+    //  */
+    // @Test
+    // public void testResumeEmptyTargetList() throws Exception {
+    //     final String METHOD_NAME = "testResumeEmptyTargetList";
+    //     Log.entering(c, METHOD_NAME);
+
+    //     String output = componentStatusServer.executeServerScript("resume", new String[] { "--target=" }).getStdout();
+
+    //     assertTrue(output.contains("failed"));
+    //     assertNotNull(componentStatusServer.waitForStringInLog("CWWKE0932W", 10000));
+
+    //     Log.exiting(c, METHOD_NAME);
+    // }
+
+    // /**
+    //  * Tests the case where the "server resume" command is issued with an invalid target.
+    //  *
+    //  * @throws Exception
+    //  */
+    // @Test
+    // public void testPauseInvalidTarget() throws Exception {
+    //     final String METHOD_NAME = "testPauseInvalidTarget";
+    //     Log.entering(c, METHOD_NAME);
+
+    //     String output = componentStatusServer.executeServerScript("pause", new String[] { "--target=InvalidTarget" }).getStdout();
+
+    //     assertTrue(output.contains("failed"));
+    //     assertNotNull(componentStatusServer.waitForStringInLog("CWWKE0935W",
+    //                                                        10000));
+
+    //     Log.exiting(c, METHOD_NAME);
+    // }
+
+    // /**
+    //  * Tests the case where the "server resume" command is issued with an empty target list.
+    //  *
+    //  * @throws Exception
+    //  */
+    // @Test
+    // public void testResumeInvalidTarget() throws Exception {
+    //     final String METHOD_NAME = "testResumeInvalidTarget";
+    //     Log.entering(c, METHOD_NAME);
+
+    //     String output = componentStatusServer.executeServerScript("resume", new String[] { "--target=InvalidTarget" }).getStdout();
+
+    //     assertTrue(output.contains("failed"));
+    //     assertNotNull(componentStatusServer.waitForStringInLog("CWWKE0936W",
+    //                                                        10000));
+
+    //     Log.exiting(c, METHOD_NAME);
+    // }
+}

--- a/dev/com.ibm.ws.kernel.boot_fat/publish/files/more-endpoints.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/publish/files/more-endpoints.xml
@@ -1,0 +1,44 @@
+<!--
+    Copyright (c) 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <httpEndpoint id="default" httpPort="9081"/>
+    <httpEndpoint id="default2" httpPort="9082"/>
+    <httpEndpoint id="default3" httpPort="9083"/>
+    <httpEndpoint id="default4" httpPort="9084"/>
+    <httpEndpoint id="default5" httpPort="9085"/>
+    <httpEndpoint id="default6" httpPort="9086"/>
+    <httpEndpoint id="default7" httpPort="9087"/>
+    <httpEndpoint id="default8" httpPort="9088"/>
+    <httpEndpoint id="default9" httpPort="9089"/>
+    <httpEndpoint id="default10" httpPort="9090"/>
+    <httpEndpoint id="default11" httpPort="9091"/>
+    <httpEndpoint id="default12" httpPort="9092"/>
+    <httpEndpoint id="default13" httpPort="9093"/>
+    <httpEndpoint id="default14" httpPort="9094"/>
+    <httpEndpoint id="default15" httpPort="9095"/>
+    <httpEndpoint id="default16" httpPort="9096"/>
+    <httpEndpoint id="default17" httpPort="9097"/>
+    <httpEndpoint id="default18" httpPort="9098"/>
+    <httpEndpoint id="default19" httpPort="9099"/>
+    <httpEndpoint id="default20" httpPort="9100"/>
+    <httpEndpoint id="default21" httpPort="9101"/>
+    <httpEndpoint id="default22" httpPort="9102"/>
+    <httpEndpoint id="default23" httpPort="9103"/>
+    <httpEndpoint id="default24" httpPort="9104"/>
+    <httpEndpoint id="default25" httpPort="9105"/>
+    <httpEndpoint id="default26" httpPort="9106"/>
+    <httpEndpoint id="default27" httpPort="9107"/>
+    <httpEndpoint id="default28" httpPort="9108"/>
+    <httpEndpoint id="default29" httpPort="9109"/>
+    <httpEndpoint id="default30" httpPort="9110"/>
+</server>

--- a/dev/com.ibm.ws.kernel.boot_fat/publish/servers/com.ibm.ws.kernel.boot.component.status.fat/server.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/publish/servers/com.ibm.ws.kernel.boot.component.status.fat/server.xml
@@ -1,0 +1,25 @@
+<!--
+    Copyright (c) 2017 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+	    <feature>servlet-6.0</feature>
+    </featureManager>
+
+    <httpEndpoint id="default" httpPort="9081"/>
+    <httpEndpoint id="default2" httpPort="9082"/>
+    <httpEndpoint id="default3" httpPort="9083"/>
+    <httpEndpoint id="default4" httpPort="9084"/>
+    <httpEndpoint id="default5" httpPort="9085"/>
+
+    <include location="../fatTestCommon.xml"/>
+</server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Changes:
- new server command `server compStatus` (placeholder name, not finalized)
- allows checking for either specific component or all components
- checks if they are paused or active
- prints status back to command line