### PR TITLE
Remove Java 8 settings from bnd files since it is the configured default

### DIFF
--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/opentracing.mock11.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/opentracing.mock11.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: com.ibm.ws.opentracing.mock-1.1
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.1
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
 Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:='com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation'
-                
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"
 

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/opentracing.mock12.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/opentracing.mock12.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: com.ibm.ws.opentracing.mock-1.2
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.2
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
 Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:='com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation'
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"
 

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/opentracing.mock13.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/opentracing.mock13.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: com.ibm.ws.opentracing.mock-1.3
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.3
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
 Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:='com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation'
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"
 

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/opentracing.mock.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: com.ibm.ws.opentracing.mock
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock
 Bundle-Description:Opentracing mock Tracer, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description:Opentracing mock Tracer, version ${bVersion}
 Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:="com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation"
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"
 

--- a/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock11.bnd
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock11.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: com.ibm.ws.opentracing.mock-1.1
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.1
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
@@ -26,8 +23,6 @@ Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:='com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation'
                 
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"
 
 -includeresource: \

--- a/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock12.bnd
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock12.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: com.ibm.ws.opentracing.mock-1.2
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.2
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
 Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:='com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation'
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"
 

--- a/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock13.bnd
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock13.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: com.ibm.ws.opentracing.mock-1.3
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.3
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
 Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:='com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation'
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"
 

--- a/dev/com.ibm.ws.opentracing_fat/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.opentracing_fat/opentracing.mock.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: com.ibm.ws.opentracing.mock
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock
 Bundle-Description:Opentracing mock Tracer, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description:Opentracing mock Tracer, version ${bVersion}
 Import-Package: *
 
 Export-Package: com.ibm.ws.opentracing.mock;uses:="com.ibm.ws.opentracing.tracer,io.opentracing,io.opentracing.propagation"
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="com.ibm.ws.opentracing.tracer.OpentracingTracerFactory"
 

--- a/dev/io.openliberty.http.monitor/bnd.bnd
+++ b/dev/io.openliberty.http.monitor/bnd.bnd
@@ -13,12 +13,8 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 -sub: *.bnd
 
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 Bundle-Name: io.openliberty.http.monitor
 Bundle-SymbolicName: io.openliberty.http.monitor
 Bundle-Description: io.openliberty.http.monitor; version=${bVersion}

--- a/dev/io.openliberty.http.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.http.monitor_fat/bnd.bnd
@@ -16,12 +16,10 @@ src: \
 	test-applications/RestApp/src,\
 	test-applications/ServletApp/src,\
 	test-applications/WildCardServletApp/src,\
-	test-applications/jspApp/src,\
+	test-applications/JspApp/src,\
 	test-applications/MBeanGetter/src
 
 fat.project: true
-
-fat.minimum.java.level: 1.8
 
 tested.features:\
   restfulwsclient-3.0,\
@@ -53,9 +51,6 @@ tested.features:\
   jsp-2.3,\
   jsp-2.2,\
   el-3.0
-
-javac.source: 1.8
-javac.target: 1.8
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/io.openliberty.io.opentelemetry.2.0/bnd.bnd
+++ b/dev/io.openliberty.io.opentelemetry.2.0/bnd.bnd
@@ -20,9 +20,6 @@ openTelemetryInstrumentationVersion=2.5.0
 alphaOpenTelemetryInstrumentationVersion=2.5.0.alpha
 alphaSemconvOpenTelemetryVersion=1.25.0.alpha
 
-javac.source: 1.8
-javac.target: 1.8
-
 src: src, resources
 
 Import-Package: \
@@ -87,8 +84,6 @@ Service-Component: \
         provide:=com.ibm.wsspi.classloading.ResourceProvider; \
         configuration-policy:=optional; \
         properties:="resources=${app-resources}"
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 -buildpath: \
 	io.openliberty.com.squareup.okhttp;version=latest,\

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/opentracing.mock.2.0.bnd
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/opentracing.mock.2.0.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: io.openliberty.opentracing.mock-2.0
 Bundle-SymbolicName: io.openliberty.opentracing.mock-2.0
 Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
 Import-Package: *
 
 Export-Package: io.openliberty.opentracing.internal.mock;uses:='io.openliberty.opentracing.spi.tracer,io.opentracing,io.opentracing.propagation'
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="io.openliberty.opentracing.spi.tracer.OpentracingTracerFactory"
 

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/opentracing.mock.3.0.bnd
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/opentracing.mock.3.0.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: io.openliberty.opentracing.mock-3.0
 Bundle-SymbolicName: io.openliberty.opentracing.mock-3.0
 Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
 Import-Package: *
 
 Export-Package: io.openliberty.opentracing.internal.mock;uses:='io.openliberty.opentracing.spi.tracer,io.opentracing,io.opentracing.propagation'
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="io.openliberty.opentracing.spi.tracer.OpentracingTracerFactory"
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/bnd.bnd
@@ -10,11 +10,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
-fat.minimum.java.level: 1.8
-
 src: \
     fat/src
 	

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
@@ -10,11 +10,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
-fat.minimum.java.level: 1.8
-
 src: \
 	fat/src
 	

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal/bnd.bnd
@@ -17,11 +17,6 @@ Bundle-SymbolicName: io.openliberty.microprofile.telemetry.2.0.internal
 Bundle-Activator: io.openliberty.microprofile.telemetry20.internal.helper.InstrumenterActivator
 Bundle-Description: MicroProfile.telemetry, version 2.0
 
-javac.source: 1.8
-javac.target: 1.8
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
 src: src, resources
 
 -dsannotations-inherit: true

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/bnd.bnd
@@ -18,11 +18,6 @@ src: \
 
 fat.project: true
 
-javac.source: 1.8
-javac.target: 1.8
-
-fat.minimum.java.level: 1.8
-
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/bnd.bnd
@@ -17,11 +17,6 @@ Bundle-SymbolicName: io.openliberty.microprofile.telemetry.2.0.logging.internal
 Bundle-Description: MicroProfile.telemetry.logging, version 2.0
 WS-TraceGroup: TELEMETRY
 
-javac.source: 1.8
-javac.target: 1.8
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
 -dsannotations-inherit: true
 
 Export-Package: io.openliberty.microprofile.telemetry20.logging.internal;provide:=true

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/bnd.bnd
@@ -13,11 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
-fat.minimum.java.level: 1.8
-
 src: \
         fat/src,\
         test-applications/ffdc-servlet/src,\

--- a/dev/io.openliberty.microprofile.telemetry.internal.common/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.internal.common/bnd.bnd
@@ -14,12 +14,7 @@ alphaSemconvOpenTelemetryVersion=1.25.0.alpha
 
 -sub: *.bnd
 
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
 src: src, resources
-
-javac.source: 1.8
-javac.target: 1.8
 
 #-cdiannotations:
 

--- a/dev/io.openliberty.microprofile.telemetry.internal_fat.common/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.internal_fat.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2023 IBM Corporation and others.
+# Copyright (c) 2022, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,9 +16,6 @@ bVersion=1.0
 
 test.project: true
 publish.wlp.jar.disabled: true
-
-javac.source: 1.8
-javac.target: 1.8
 
 Export-Package: \
 	io.openliberty.microprofile.telemetry.internal_fat.shared.*

--- a/dev/io.openliberty.microprofile.telemetry.monitor.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.monitor.internal/bnd.bnd
@@ -15,10 +15,6 @@ Bundle-Description: MicroProfile Telemetry Monitor Bridge, version ${bVersion}
 
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 Import-Package: \
 	jakarta.enterprise.*;version="[4.0,5)",\
 	jakarta.ws.rs.container;resolution:=optional,\

--- a/dev/io.openliberty.opentracing.2.x_fat/opentracing.mock20.bnd
+++ b/dev/io.openliberty.opentracing.2.x_fat/opentracing.mock20.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: io.openliberty.opentracing.mock-2.0
 Bundle-SymbolicName: io.openliberty.opentracing.mock-2.0
 Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
 Import-Package: *
 
 Export-Package: io.openliberty.opentracing.internal.mock;uses:='io.openliberty.opentracing.spi.tracer,io.opentracing,io.opentracing.propagation'
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="io.openliberty.opentracing.spi.tracer.OpentracingTracerFactory"
 

--- a/dev/io.openliberty.opentracing.3.x_fat/opentracing.mock30.bnd
+++ b/dev/io.openliberty.opentracing.3.x_fat/opentracing.mock30.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,9 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: io.openliberty.opentracing.mock-3.0
 Bundle-SymbolicName: io.openliberty.opentracing.mock-3.0
 Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
@@ -25,8 +22,6 @@ Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
 Import-Package: *
 
 Export-Package: io.openliberty.opentracing.internal.mock;uses:='io.openliberty.opentracing.spi.tracer,io.opentracing,io.opentracing.propagation'
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Provide-Capability: osgi.service;objectClass:List<String>="io.openliberty.opentracing.spi.tracer.OpentracingTracerFactory"
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
