### PR TITLE
Rtc301434 split tel fat buckets to avoid timeouts

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/suite/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/suite/FATSuite.java
@@ -18,8 +18,6 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
-import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.microprofile.telemetry.internal.tests.Agent129Test;
 import io.openliberty.microprofile.telemetry.internal.tests.Agent210Test;
 import io.openliberty.microprofile.telemetry.internal.tests.AgentConfigMultiAppTest;
@@ -37,7 +35,6 @@ import io.openliberty.microprofile.telemetry.internal.tests.ZipkinOtelCollectorT
 import io.openliberty.microprofile.telemetry.internal.tests.ZipkinTest;
 import io.openliberty.microprofile.telemetry.internal.tests.JvmMetricsOtelCollectorTest;
 import io.openliberty.microprofile.telemetry.internal.tests.MetricsApiOtelCollectorTest;
-import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -66,36 +63,5 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
  * Purpose: This suite collects and runs all known good test suites.
  */
 public class FATSuite extends TestContainerSuite {
-
-    public static RepeatTests allMPRepeats(String serverName) {
-        return TelemetryActions.repeat(serverName,
-                                       MicroProfileActions.MP70_EE11,
-                                       MicroProfileActions.MP60,
-                                       TelemetryActions.MP14_MPTEL11,
-                                       TelemetryActions.MP41_MPTEL11,
-                                       TelemetryActions.MP50_MPTEL11,
-                                       MicroProfileActions.MP61, TelemetryActions.MP14_MPTEL20, TelemetryActions.MP41_MPTEL20, TelemetryActions.MP50_MPTEL20,
-                                       TelemetryActions.MP50_MPTEL20_JAVA8,
-                                       MicroProfileActions.MP70_EE10);
-    }
-
-    public static RepeatTests mp60Repeat(String serverName) {
-        return TelemetryActions.repeat(serverName, MicroProfileActions.MP60);
-    }
-
-    public static RepeatTests telemetry11Repeats(String serverName) {
-        return TelemetryActions.repeat(serverName, TelemetryActions.MP14_MPTEL11, TelemetryActions.MP41_MPTEL11, TelemetryActions.MP50_MPTEL11, MicroProfileActions.MP61);
-    }
-
-    public static RepeatTests telemetry10and11Repeats(String serverName) {
-        return TelemetryActions.repeat(serverName, MicroProfileActions.MP60, TelemetryActions.MP14_MPTEL11, TelemetryActions.MP41_MPTEL11, TelemetryActions.MP50_MPTEL11,
-                                       MicroProfileActions.MP61);
-    }
-
-    public static RepeatTests telemetry20Repeats(String serverName) {
-        return TelemetryActions.repeat(serverName, MicroProfileActions.MP70_EE11, TelemetryActions.MP14_MPTEL20, TelemetryActions.MP41_MPTEL20, TelemetryActions.MP50_MPTEL20,
-                                       TelemetryActions.MP50_MPTEL20_JAVA8,
-                                       MicroProfileActions.MP70_EE10);
-    }
 
 }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent129Test.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent129Test.java
@@ -58,7 +58,6 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.jaegertracing.api_v2.Model.Span;
 import io.openliberty.microprofile.telemetry.internal.apps.agent.AgentTestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
@@ -81,7 +80,7 @@ public class Agent129Test {
     public static LibertyServer server;
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    public static RepeatTests repeat = FATSuite.telemetry11Repeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.telemetry11Repeats(SERVER_NAME);
 
     // In contrast to most tests, this test needs a new jaeger instance for each repeat
     // so that it can check for any trace IDs not accounted for

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent210Test.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent210Test.java
@@ -58,7 +58,6 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.jaegertracing.api_v2.Model.Span;
 import io.openliberty.microprofile.telemetry.internal.apps.agent.AgentTestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
@@ -81,7 +80,7 @@ public class Agent210Test {
     public static LibertyServer server;
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    public static RepeatTests repeat = FATSuite.telemetry20Repeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.telemetry20Repeats(SERVER_NAME);
 
     // In contrast to most tests, this test needs a new jaeger instance for each repeat
     // so that it can check for any trace IDs not accounted for

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigMultiAppTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigMultiAppTest.java
@@ -78,7 +78,7 @@ public class AgentConfigMultiAppTest {
     public static LibertyServer server;
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);
@@ -120,7 +120,8 @@ public class AgentConfigMultiAppTest {
 
     @Test
     // Skipping for MP 5.0 and 6.1 as JavaAgent 1.29 is sometimes successful and sometimes fails (possible classLoader issue in JavaAgent (BUG))
-    @SkipForRepeat({ TelemetryActions.MP50_MPTEL11_ID, MicroProfileActions.MP61_ID, TelemetryActions.MP50_MPTEL20_ID, MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID })
+    @SkipForRepeat({ TelemetryActions.MP50_MPTEL11_ID, MicroProfileActions.MP61_ID, TelemetryActions.MP50_MPTEL20_ID, MicroProfileActions.MP70_EE10_ID,
+                     MicroProfileActions.MP70_EE11_ID })
     public void testAgentMultiApp() throws Exception {
         PropertiesAsset app1Config = new PropertiesAsset().addProperty("otel.service.name", "multi-app-1");
         WebArchive app1 = ShrinkWrap.create(WebArchive.class, "multiApp1.war")
@@ -158,7 +159,8 @@ public class AgentConfigMultiAppTest {
         if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {
             // MP6.0 uses JavaAgent 1.19 therefore the internal span is not created
             assertThat(serverSpan, hasName("/multiApp1/"));
-        } else if (RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP14_MPTEL11_ID) || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP41_MPTEL11_ID) || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP41_MPTEL20_ID) || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP14_MPTEL20_ID)) {
+        } else if (RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP14_MPTEL11_ID) || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP41_MPTEL11_ID)
+                   || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP41_MPTEL20_ID) || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP14_MPTEL20_ID)) {
             assertThat(serverSpan, hasName("GET /multiApp1"));
             assertThat(serverSpan, JaegerSpanMatcher.isSpan().withTraceId(traceId)
                                                     .withAttribute(SemanticAttributes.HTTP_ROUTE, "/multiApp1")
@@ -197,7 +199,9 @@ public class AgentConfigMultiAppTest {
                                                      .withAttribute(SemanticAttributes.HTTP_ROUTE, "/multiApp2/")
                                                      .withAttribute(SemanticAttributes.HTTP_TARGET, "/multiApp2")
                                                      .withAttribute(SemanticAttributes.HTTP_METHOD, "GET"));
-        } else if (RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP14_MPTEL11_ID) || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP41_MPTEL11_ID) || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP41_MPTEL20_ID) || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP14_MPTEL20_ID)) {            assertThat(serverSpan2, hasName("GET /multiApp2"));
+        } else if (RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP14_MPTEL11_ID) || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP41_MPTEL11_ID)
+                   || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP41_MPTEL20_ID) || RepeatTestFilter.isRepeatActionActive(TelemetryActions.MP14_MPTEL20_ID)) {
+            assertThat(serverSpan2, hasName("GET /multiApp2"));
             assertThat(serverSpan2, JaegerSpanMatcher.isSpan().withTraceId(traceId2)
                                                      .withAttribute(SemanticAttributes.HTTP_ROUTE, "/multiApp2")
                                                      .withAttribute(SemanticAttributes.HTTP_TARGET, "/multiApp2")

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigMultiAppTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigMultiAppTest.java
@@ -55,7 +55,6 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.jaegertracing.api_v2.Model.Span;
 import io.openliberty.microprofile.telemetry.internal.apps.agentconfig.AgentConfigTestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
@@ -79,7 +78,7 @@ public class AgentConfigMultiAppTest {
     public static LibertyServer server;
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    public static RepeatTests repeat = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
@@ -236,7 +236,7 @@ public class AgentConfigTest {
      * Skipping for 1.4 and 4.1 as JavaAgent 1.29 currently will not return a span for methods annotated with @withSpan
      * (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/10159)
      */
-    @SkipForRepeat({ TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID, TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID})
+    @SkipForRepeat({ TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID, TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID })
     public void testEnableSpecificInstrumentation() throws Exception {
         // Enable only @WithSpan instrumentation
         server.addEnvVar("OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED", "false");

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
@@ -59,7 +59,6 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.jaegertracing.api_v2.Model.Span;
 import io.openliberty.microprofile.telemetry.internal.apps.agentconfig.AgentConfigTestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.TestUtils;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
@@ -82,7 +81,7 @@ public class AgentConfigTest {
     public static LibertyServer server;
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    public static RepeatTests repeat = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureJaegerTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureJaegerTest.java
@@ -45,7 +45,6 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.jaegertracing.api_v2.Model.Span;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
@@ -67,7 +66,7 @@ public class CrossFeatureJaegerTest {
     private static final AttributeKey<String> JAEGER_VERSION = AttributeKey.stringKey("jaeger.version");
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    public static RepeatTests repeat = FATSuite.allMPRepeats(CROSS_FEATURE_TELEMETRY_SERVER);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(CROSS_FEATURE_TELEMETRY_SERVER);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureZipkinTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureZipkinTest.java
@@ -47,7 +47,6 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinQueryClient;
@@ -66,7 +65,7 @@ public class CrossFeatureZipkinTest {
     private static final Class<?> c = CrossFeatureZipkinTest.class;
 
     public static ZipkinContainer zipkinContainer = new ZipkinContainer().withLogConsumer(new SimpleLogConsumer(ZipkinTest.class, "zipkin"));
-    public static RepeatTests repeat = FATSuite.allMPRepeats(CROSS_FEATURE_TELEMETRY_SERVER);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(CROSS_FEATURE_TELEMETRY_SERVER);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(zipkinContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerLegacyTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerLegacyTest.java
@@ -30,10 +30,10 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Test exporting traces to a Jaeger server with the legacy Jaeger protocol
@@ -44,7 +44,7 @@ public class JaegerLegacyTest extends JaegerBaseTest {
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
     //The native Jaeger exporter has been discontinued and is not supported in MpTelemetry-2.0. OTLP is used for Jaeger instead
-    public static RepeatTests repeat = FATSuite.telemetry10and11Repeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.telemetry10and11Repeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtelCollectorTest.java
@@ -60,7 +60,7 @@ public class JaegerOtelCollectorTest extends JaegerBaseTest {
                                                                                                                                                                    .withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class,
                                                                                                                                                                                                           "otelCol"))
                                                                                                                                                                    .withNetworkAliases("otel-collector-jaeger");
-    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtelCollectorTest.java
@@ -33,11 +33,11 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
 import io.openliberty.microprofile.telemetry.internal.utils.otelCollector.OtelCollectorContainer;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Test exporting traces to a Jaeger server with OpenTelemetry Collector
@@ -60,7 +60,7 @@ public class JaegerOtelCollectorTest extends JaegerBaseTest {
                                                                                                                                                                    .withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class,
                                                                                                                                                                                                           "otelCol"))
                                                                                                                                                                    .withNetworkAliases("otel-collector-jaeger");
-    public static RepeatTests repeat = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtlpTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtlpTest.java
@@ -40,7 +40,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
 public class JaegerOtlpTest extends JaegerBaseTest {
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtlpTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtlpTest.java
@@ -28,10 +28,10 @@ import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Test exporting traces to a Jaeger server with OTLP
@@ -40,7 +40,7 @@ import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryCl
 public class JaegerOtlpTest extends JaegerBaseTest {
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    public static RepeatTests repeat = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtelCollectorTest.java
@@ -71,7 +71,7 @@ public class JaegerSecureOtelCollectorTest extends JaegerBaseTest {
                                                                                                                                                                "otelCol"))
                                                                                                                         .withNetworkAliases("otel-collector-jaeger");
 
-    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtelCollectorTest.java
@@ -39,11 +39,11 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.security.utils.SSLUtils;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
 import io.openliberty.microprofile.telemetry.internal.utils.otelCollector.OtelCollectorContainer;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Test exporting traces to a Jaeger server with OpenTelemetry Collector
@@ -71,7 +71,7 @@ public class JaegerSecureOtelCollectorTest extends JaegerBaseTest {
                                                                                                                                                                "otelCol"))
                                                                                                                         .withNetworkAliases("otel-collector-jaeger");
 
-    public static RepeatTests repeat = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtlpTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtlpTest.java
@@ -48,7 +48,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
 public class JaegerSecureOtlpTest extends JaegerBaseTest {
 
     public static JaegerContainer jaegerContainer = new JaegerContainer(getCertificate(), getKey()).withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtlpTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtlpTest.java
@@ -36,10 +36,10 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.security.utils.SSLUtils;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Test exporting traces to a Jaeger server with OTLP
@@ -48,7 +48,7 @@ import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryCl
 public class JaegerSecureOtlpTest extends JaegerBaseTest {
 
     public static JaegerContainer jaegerContainer = new JaegerContainer(getCertificate(), getKey()).withLogConsumer(new SimpleLogConsumer(JaegerBaseTest.class, "jaeger"));
-    public static RepeatTests repeat = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JvmMetricsOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JvmMetricsOtelCollectorTest.java
@@ -36,10 +36,10 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.otelCollector.OtelCollectorContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.otelCollector.OtelCollectorQueryClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Test exporting metrics to a OpenTelemetry Collector
@@ -55,7 +55,7 @@ public class JvmMetricsOtelCollectorTest {
                                                                                                                                                                    .withNetworkAliases("otel-collector-metrics")
                                                                                                                                                                    .withLogConsumer(new SimpleLogConsumer(JvmMetricsOtelCollectorTest.class,
                                                                                                                                                                                                           "otelCol"));
-    public static RepeatTests repeat = FATSuite.telemetry20Repeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.telemetry20Repeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(network)

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MetricsApiOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MetricsApiOtelCollectorTest.java
@@ -40,10 +40,10 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.openliberty.microprofile.telemetry.internal.apps.metricTest.TestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.otelCollector.OtelCollectorContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.otelCollector.OtelCollectorQueryClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Test exporting metrics to a OpenTelemetry Collector
@@ -61,7 +61,7 @@ public class MetricsApiOtelCollectorTest {
                                                                                                                                                                           .withNetworkAliases("otel-collector-metrics")
                                                                                                                                                                           .withLogConsumer(new SimpleLogConsumer(MetricsApiOtelCollectorTest.class,
                                                                                                                                                                                                                  "otelCol"));
-    public static RepeatTests repeat = FATSuite.telemetry20Repeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.telemetry20Repeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(network)

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
@@ -63,7 +63,7 @@ public class TracingNotEnabledTest {
     private static final Class<TracingNotEnabledTest> c = TracingNotEnabledTest.class;
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(TracingNotEnabledTest.class, "jaeger"));
-    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
@@ -43,10 +43,10 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.jaegertracing.api_v2.Model.Span;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Test logging to Jaeger without tracing enabled
@@ -63,7 +63,7 @@ public class TracingNotEnabledTest {
     private static final Class<TracingNotEnabledTest> c = TracingNotEnabledTest.class;
 
     public static JaegerContainer jaegerContainer = new JaegerContainer().withLogConsumer(new SimpleLogConsumer(TracingNotEnabledTest.class, "jaeger"));
-    public static RepeatTests repeat = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinOtelCollectorTest.java
@@ -17,6 +17,9 @@ import static io.openliberty.microprofile.telemetry.internal.utils.zipkin.Zipkin
 import static io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpanMatcher.hasNoParent;
 import static io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpanMatcher.hasParentSpanId;
 import static io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpanMatcher.span;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_REQUEST_METHOD;
+// In MpTelemetry-2.0 SemanticAttributes was moved to a new package, so we use import static to allow both versions to coexist
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_ROUTE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.hasProperty;
@@ -40,15 +43,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.MicroProfileActions;
-import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
@@ -58,10 +60,8 @@ import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinContain
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinQueryClient;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpan;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpanMatcher;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-// In MpTelemetry-2.0 SemanticAttributes was moved to a new package, so we use import static to allow both versions to coexist
-import static io.opentelemetry.semconv.SemanticAttributes.HTTP_ROUTE;
-import static io.opentelemetry.semconv.SemanticAttributes.HTTP_REQUEST_METHOD;
 
 /**
  * Test exporting traces to a Zipkin server with the OpenTelemetry Collector
@@ -83,7 +83,7 @@ public class ZipkinOtelCollectorTest {
                                                                                                                                                                    .withNetworkAliases("otel-collector-zipkin")
                                                                                                                                                                    .withLogConsumer(new SimpleLogConsumer(ZipkinOtelCollectorTest.class,
                                                                                                                                                                                                           "otelCol"));
-    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(network)
@@ -118,7 +118,8 @@ public class ZipkinOtelCollectorTest {
     }
 
     @Test
-    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID, MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID})
+    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID,
+                     MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID })
     public void testBasicTelemetry1() throws Exception {
         HttpRequest request = new HttpRequest(server, "/spanTest");
 
@@ -136,7 +137,8 @@ public class ZipkinOtelCollectorTest {
     }
 
     @Test
-    @SkipForRepeat({MicroProfileActions.MP60_ID, TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID, TelemetryActions.MP50_MPTEL11_ID, MicroProfileActions.MP61_ID})
+    @SkipForRepeat({ MicroProfileActions.MP60_ID, TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID, TelemetryActions.MP50_MPTEL11_ID,
+                     MicroProfileActions.MP61_ID })
     public void testBasicTelemetry2() throws Exception {
         HttpRequest request = new HttpRequest(server, "/spanTest");
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinOtelCollectorTest.java
@@ -52,7 +52,6 @@ import componenttest.annotation.SkipForRepeat;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.otelCollector.OtelCollectorContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinContainer;
@@ -84,7 +83,7 @@ public class ZipkinOtelCollectorTest {
                                                                                                                                                                    .withNetworkAliases("otel-collector-zipkin")
                                                                                                                                                                    .withLogConsumer(new SimpleLogConsumer(ZipkinOtelCollectorTest.class,
                                                                                                                                                                                                           "otelCol"));
-    public static RepeatTests repeat = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(network)

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinTest.java
@@ -47,7 +47,6 @@ import componenttest.annotation.SkipForRepeat;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
-import io.openliberty.microprofile.telemetry.internal.suite.FATSuite;
 import io.openliberty.microprofile.telemetry.internal.utils.TestConstants;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinContainer;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinQueryClient;
@@ -69,7 +68,7 @@ public class ZipkinTest {
     private static final Class<?> c = ZipkinTest.class;
 
     public static ZipkinContainer zipkinContainer = new ZipkinContainer().withLogConsumer(new SimpleLogConsumer(ZipkinTest.class, "zipkin"));
-    public static RepeatTests repeat = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(zipkinContainer).around(repeat);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinTest.java
@@ -16,6 +16,9 @@ import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONL
 import static io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpanMatcher.hasNoParent;
 import static io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpanMatcher.hasParentSpanId;
 import static io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpanMatcher.span;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_REQUEST_METHOD;
+// In MpTelemetry-2.0 SemanticAttributes was moved to a new package, so we use import static to allow both versions to coexist
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_ROUTE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.hasProperty;
@@ -37,13 +40,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.RepeatTestFilter;
-import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpRequest;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
@@ -52,10 +54,8 @@ import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinContain
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinQueryClient;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpan;
 import io.openliberty.microprofile.telemetry.internal.utils.zipkin.ZipkinSpanMatcher;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-// In MpTelemetry-2.0 SemanticAttributes was moved to a new package, so we use import static to allow both versions to coexist
-import static io.opentelemetry.semconv.SemanticAttributes.HTTP_ROUTE;
-import static io.opentelemetry.semconv.SemanticAttributes.HTTP_REQUEST_METHOD;
 
 /**
  * Test exporting traces to a Zipkin server
@@ -68,7 +68,7 @@ public class ZipkinTest {
     private static final Class<?> c = ZipkinTest.class;
 
     public static ZipkinContainer zipkinContainer = new ZipkinContainer().withLogConsumer(new SimpleLogConsumer(ZipkinTest.class, "zipkin"));
-    public static RepeatTests repeat = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests repeat = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(zipkinContainer).around(repeat);
@@ -101,7 +101,8 @@ public class ZipkinTest {
     }
 
     @Test
-    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID, MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID})
+    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID,
+                     MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID })
     public void testBasicTelemetry1() throws Exception {
         HttpRequest request = new HttpRequest(server, "/spanTest");
         String traceId = request.run(String.class);
@@ -112,12 +113,13 @@ public class ZipkinTest {
 
         ZipkinSpan span = spans.get(0);
         assertThat(span, span().withTraceId(traceId)
-                                .withTag(SemanticAttributes.HTTP_ROUTE.getKey(), "/spanTest/")
-                                .withTag(SemanticAttributes.HTTP_METHOD.getKey(), "GET"));
+                               .withTag(SemanticAttributes.HTTP_ROUTE.getKey(), "/spanTest/")
+                               .withTag(SemanticAttributes.HTTP_METHOD.getKey(), "GET"));
     }
 
     @Test
-    @SkipForRepeat({MicroProfileActions.MP60_ID, TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID, TelemetryActions.MP50_MPTEL11_ID, MicroProfileActions.MP61_ID})
+    @SkipForRepeat({ MicroProfileActions.MP60_ID, TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID, TelemetryActions.MP50_MPTEL11_ID,
+                     MicroProfileActions.MP61_ID })
     public void testBasicTelemetry2() throws Exception {
         HttpRequest request = new HttpRequest(server, "/spanTest");
         String traceId = request.run(String.class);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/ClientWithNoCdi.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/ClientWithNoCdi.java
@@ -50,7 +50,7 @@ public class ClientWithNoCdi {
     public static final String NO_CDI_APP_NAME = "clientNoCDI";
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @TestServlets({
                     @TestServlet(contextRoot = NO_CDI_APP_NAME, servlet = ClientTriggeringServlet.class),

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/FATSuite.java
@@ -16,7 +16,6 @@ import org.junit.runners.Suite.SuiteClasses;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(Suite.class)
@@ -53,25 +52,6 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
 
 })
 public class FATSuite {
-
-    public static RepeatTests allMPRepeats(String serverName) {
-        return TelemetryActions
-                        .repeat(serverName, MicroProfileActions.MP70_EE11, MicroProfileActions.MP70_EE10, MicroProfileActions.MP61, TelemetryActions.MP14_MPTEL11,
-                                TelemetryActions.MP41_MPTEL11, TelemetryActions.MP50_MPTEL11,
-                                TelemetryActions.MP50_MPTEL20, TelemetryActions.MP41_MPTEL20, TelemetryActions.MP14_MPTEL20);
-    }
-
-    public static RepeatTests allMPRepeatsWithoutMPTel20(String serverName) {
-        return TelemetryActions
-                        .repeat(serverName, MicroProfileActions.MP61, TelemetryActions.MP14_MPTEL11, TelemetryActions.MP41_MPTEL11, TelemetryActions.MP50_MPTEL11,
-                                MicroProfileActions.MP60);
-    }
-
-    public static RepeatTests allMPRepeatsWithMPTel20OrLater(String serverName) {
-        return TelemetryActions
-                        .repeat(serverName, MicroProfileActions.MP70_EE11, MicroProfileActions.MP70_EE10,
-                                TelemetryActions.MP50_MPTEL20, TelemetryActions.MP41_MPTEL20, TelemetryActions.MP14_MPTEL20);
-    }
 
     public static String getTelemetryVersionUnderTest() {
         if (RepeatTestFilter.isRepeatActionActive(MicroProfileActions.MP60_ID)) {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegration.java
@@ -96,7 +96,7 @@ public class JaxRsIntegration extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegrationWithConcurrency.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/JaxRsIntegrationWithConcurrency.java
@@ -61,6 +61,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrspropagation.
 import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.spans.AbstractSpanMatcher;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 
@@ -93,7 +94,7 @@ public class JaxRsIntegrationWithConcurrency extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeatsWithoutMPTel20(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.telemetry10and11Repeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/MultiThreadedContextTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/MultiThreadedContextTest.java
@@ -31,6 +31,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.context.MultiThreadedContextServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Check that the Context API can be used to transfer context between threads when submitting tasks to a ManagedExecutor,
@@ -64,7 +65,7 @@ public class MultiThreadedContextTest extends FATServletClient {
     }
     
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
     
     @AfterClass
     public static void teardown() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
@@ -62,7 +62,7 @@ public class Telemetry10 extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/Telemetry10.java
@@ -62,7 +62,7 @@ public class Telemetry10 extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAPITest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAPITest.java
@@ -33,6 +33,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.api.BaggageAPISer
 import io.openliberty.microprofile.telemetry.internal_fat.apps.api.CommonSDKServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.api.ContextAPIServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.api.TraceAPIServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Test use of the Open Telemetry APIs:
@@ -61,7 +62,7 @@ public class TelemetryAPITest extends FATServletClient {
     public static LibertyServer server;
     
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAttributesTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryAttributesTest.java
@@ -30,6 +30,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.ResourceServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -46,7 +47,7 @@ public class TelemetryAttributesTest extends FATServletClient {
 
     //This test tests resources that were added to Liberty in MPTel 2.0
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeatsWithMPTel20OrLater(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.telemetry20Repeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryBeanTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryBeanTest.java
@@ -28,8 +28,6 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -49,8 +47,8 @@ public class TelemetryBeanTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
-    
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
+
     @BeforeClass
     public static void setUp() throws Exception {
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryBeanTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryBeanTest.java
@@ -34,6 +34,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.bean.TelemetryBeanTestServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(FATRunner.class)
 public class TelemetryBeanTest extends FATServletClient {
@@ -48,7 +49,7 @@ public class TelemetryBeanTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
     
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvOnlyTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvOnlyTest.java
@@ -46,7 +46,7 @@ public class TelemetryConfigEnvOnlyTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvOnlyTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvOnlyTest.java
@@ -30,6 +30,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.ConfigServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -45,7 +46,7 @@ public class TelemetryConfigEnvOnlyTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvTest.java
@@ -30,6 +30,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.ConfigServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -45,7 +46,7 @@ public class TelemetryConfigEnvTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigEnvTest.java
@@ -46,7 +46,7 @@ public class TelemetryConfigEnvTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigNullTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigNullTest.java
@@ -46,7 +46,7 @@ public class TelemetryConfigNullTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigNullTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigNullTest.java
@@ -30,6 +30,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.ConfigServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -45,7 +46,7 @@ public class TelemetryConfigNullTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigRuntimeModeIgnoresMPConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigRuntimeModeIgnoresMPConfigTest.java
@@ -32,6 +32,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.LoggingServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * This test verifies that a property set in META-INF/microprofile-config.properties
@@ -52,7 +53,7 @@ public class TelemetryConfigRuntimeModeIgnoresMPConfigTest extends FATServletCli
 
     //This test will break in app mode, which is the only mode before OTel 2.0
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeatsWithMPTel20OrLater(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.telemetry20Repeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigRuntimeModeIgnoresMPConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigRuntimeModeIgnoresMPConfigTest.java
@@ -51,7 +51,7 @@ public class TelemetryConfigRuntimeModeIgnoresMPConfigTest extends FATServletCli
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
-    //This test will break in app mode, which is the only mode before OTel 2.0
+    //This test is for the runtime mode, introduced in OTel 2.0
     @ClassRule
     public static RepeatTests r = TelemetryActions.telemetry20Repeats(SERVER_NAME);
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigServerVarTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigServerVarTest.java
@@ -50,7 +50,7 @@ public class TelemetryConfigServerVarTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigServerVarTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigServerVarTest.java
@@ -50,7 +50,7 @@ public class TelemetryConfigServerVarTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -67,7 +67,8 @@ public class TelemetryConfigServerVarTest extends FATServletClient {
 
     @Test
     //We don't throw warning related to runtime mode in versions older than the runtime mode.
-    @SkipForRepeat({ TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID, TelemetryActions.MP50_MPTEL11_ID, MicroProfileActions.MP61_ID })
+    @SkipForRepeat({ TelemetryActions.MP14_MPTEL11_ID, TelemetryActions.MP41_MPTEL11_ID, TelemetryActions.MP50_MPTEL11_ID, MicroProfileActions.MP61_ID,
+                     MicroProfileActions.MP60_ID })
     public void testWarningForConflictingValues() throws Exception {
         //Don't set the mark, as the warning comes from app startup.
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigSystemPropTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigSystemPropTest.java
@@ -46,7 +46,7 @@ public class TelemetryConfigSystemPropTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigSystemPropTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryConfigSystemPropTest.java
@@ -30,6 +30,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.ConfigServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -45,7 +46,7 @@ public class TelemetryConfigSystemPropTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryDisabledTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryDisabledTest.java
@@ -52,7 +52,7 @@ public class TelemetryDisabledTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryDisabledTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryDisabledTest.java
@@ -52,7 +52,7 @@ public class TelemetryDisabledTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryGlobalOpenTelemetryTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryGlobalOpenTelemetryTest.java
@@ -33,6 +33,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.globalopentelemetry.TelemetryGlobalOpenTelemetryServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(FATRunner.class)
 public class TelemetryGlobalOpenTelemetryTest extends FATServletClient {
@@ -44,7 +45,7 @@ public class TelemetryGlobalOpenTelemetryTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryGlobalOpenTelemetryTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryGlobalOpenTelemetryTest.java
@@ -45,7 +45,7 @@ public class TelemetryGlobalOpenTelemetryTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLoggingExporterTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLoggingExporterTest.java
@@ -32,6 +32,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.LoggingServlet;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(FATRunner.class)
 public class TelemetryLoggingExporterTest extends FATServletClient {
@@ -43,7 +44,7 @@ public class TelemetryLoggingExporterTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLongRunningTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLongRunningTest.java
@@ -31,8 +31,6 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -54,7 +52,7 @@ public class TelemetryLongRunningTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLongRunningTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryLongRunningTest.java
@@ -39,6 +39,7 @@ import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.longrunning.LongRunningTask;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 
 @Mode(TestMode.FULL)
@@ -53,7 +54,7 @@ public class TelemetryLongRunningTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMisconfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMisconfigTest.java
@@ -35,8 +35,8 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpRequest;
-import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.jaxrsmisconfig.JaxRsMisConfigEndpoints;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 //Tests behaviour when placing an invalid value into the OpenTelemetry configuration options
 @Mode(TestMode.FULL)
@@ -63,7 +63,7 @@ public class TelemetryMisconfigTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     private static WebArchive invalidExporterApp = null;
     private static WebArchive invalidJaegerEndpointApp = null;
@@ -138,7 +138,8 @@ public class TelemetryMisconfigTest extends FATServletClient {
     @ExpectedFFDC(repeatAction = { MicroProfileActions.MP61_ID, MicroProfileActions.MP50_ID, MicroProfileActions.MP41_ID, MicroProfileActions.MP14_ID },
                   value = { "io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException" })
     //The native Jaeger exporter has been discontinued and is not supported in MpTelemetry-2.0. OTLP is used for Jaeger instead
-    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID,TelemetryActions.MP50_MPTEL20_JAVA8_ID, MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID})
+    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID,
+                     MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID })
     public void testInvalidJaegerExporterEndpoint() throws Exception {
         deployAndWaitForApp(invalidJaegerEndpointApp, INVALID_JAEGER_ENDPOINT_APP_NAME);
         new HttpRequest(server, "/" + INVALID_JAEGER_ENDPOINT_APP_NAME + "/misconfig/jaxrsclient")
@@ -153,8 +154,10 @@ public class TelemetryMisconfigTest extends FATServletClient {
 
     @Test
     @ExpectedFFDC(repeatAction = MicroProfileActions.MP60_ID, value = { "java.lang.IllegalArgumentException" })
-    @ExpectedFFDC(repeatAction = { MicroProfileActions.MP61_ID, MicroProfileActions.MP50_ID, MicroProfileActions.MP41_ID, MicroProfileActions.MP14_ID, TelemetryActions.MP14_MPTEL20_ID, 
-                                    TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID, MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID},
+    @ExpectedFFDC(repeatAction = { MicroProfileActions.MP61_ID, MicroProfileActions.MP50_ID, MicroProfileActions.MP41_ID, MicroProfileActions.MP14_ID,
+                                   TelemetryActions.MP14_MPTEL20_ID,
+                                   TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID, MicroProfileActions.MP70_EE10_ID,
+                                   MicroProfileActions.MP70_EE11_ID },
                   value = { "io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException" })
     public void testInvalidZipkinExporterEndpoint() throws Exception {
         deployAndWaitForApp(invalidZipkinEndpointApp, INVALID_ZIPKIN_ENDPOINT_APP_NAME);
@@ -181,7 +184,8 @@ public class TelemetryMisconfigTest extends FATServletClient {
     }
 
     @Test
-    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID, MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID})
+    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID,
+                     MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID })
     //The native Jaeger exporter has been discontinued and is not supported in MpTelemetry-2.0. OTLP is used for Jaeger instead
     public void testNotKnownEndpoint() throws Exception {
         deployAndWaitForApp(notKnownEndpointApp, NOT_KNOWN_ENDPOINT_APP_NAME);
@@ -199,7 +203,8 @@ public class TelemetryMisconfigTest extends FATServletClient {
     }
 
     @Test
-    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID,  MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID})
+    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID,
+                     MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID })
     //The native Jaeger exporter has been discontinued and is not supported in MpTelemetry-2.0. OTLP is used for Jaeger instead
     public void testDoesNotExistEndpoint() throws Exception {
         deployAndWaitForApp(doesNotExistEndpointApp, DOES_NOT_EXIST_ENDPOINT_APP_NAME);
@@ -216,7 +221,8 @@ public class TelemetryMisconfigTest extends FATServletClient {
 
     @Test
     @ExpectedFFDC({ "io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException" })
-    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID,TelemetryActions.MP50_MPTEL20_JAVA8_ID, MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID})
+    @SkipForRepeat({ TelemetryActions.MP14_MPTEL20_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_JAVA8_ID,
+                     MicroProfileActions.MP70_EE10_ID, MicroProfileActions.MP70_EE11_ID })
     //The native Jaeger exporter has been discontinued and is not supported in MpTelemetry-2.0. OTLP is used for Jaeger instead
     public void testInvalidJaegerTimeout() throws Exception {
         deployAndWaitForApp(invalidJaegerTimeoutApp, INVALID_JAEGER_TIMEOUT_APP_NAME);

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMisconfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMisconfigTest.java
@@ -63,7 +63,7 @@ public class TelemetryMisconfigTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     private static WebArchive invalidExporterApp = null;
     private static WebArchive invalidJaegerEndpointApp = null;

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryMultiAppTest.java
@@ -38,6 +38,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.multiapp2.MultiAp
 import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.spans.AbstractSpanMatcher;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 
@@ -59,7 +60,7 @@ public class TelemetryMultiAppTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeatsWithoutMPTel20(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.telemetry10and11Repeats(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryRuntimeInstanceTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryRuntimeInstanceTest.java
@@ -35,6 +35,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.Runtime
 import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.spans.AbstractSpanMatcher;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 
@@ -51,7 +52,7 @@ public class TelemetryRuntimeInstanceTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeatsWithMPTel20OrLater(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.telemetry20Repeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
@@ -53,7 +53,7 @@ public class TelemetryServiceNameTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServiceNameTest.java
@@ -35,6 +35,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.Service
 import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.spans.AbstractSpanMatcher;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 
@@ -52,7 +53,7 @@ public class TelemetryServiceNameTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryServletTest.java
@@ -38,6 +38,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.servlet.SimpleSer
 import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.spans.AbstractSpanMatcher;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 
@@ -60,7 +61,7 @@ public class TelemetryServletTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeatsWithoutMPTel20(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.telemetry10and11Repeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryShimTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryShimTest.java
@@ -36,6 +36,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.shim.OpenTracingShimServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.shim.TracedBean;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * Test use of the Open Telemetry Autoconfigure Trace SPIs: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/latest/index.html
@@ -53,7 +54,7 @@ public class TelemetryShimTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryShimTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryShimTest.java
@@ -54,7 +54,7 @@ public class TelemetryShimTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
@@ -45,6 +45,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.spi.sampler.TestS
 import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.spans.AbstractSpanMatcher;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider;
@@ -76,7 +77,7 @@ public class TelemetrySpiTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.allMPRepeats(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryWithSpanErrorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryWithSpanErrorTest.java
@@ -35,6 +35,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.apps.telemetry.WithSpa
 import io.openliberty.microprofile.telemetry.internal_fat.common.TestSpans;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporter;
 import io.openliberty.microprofile.telemetry.internal_fat.common.spanexporter.InMemorySpanExporterProvider;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.spans.AbstractSpanMatcher;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 
@@ -52,7 +53,7 @@ public class TelemetryWithSpanErrorTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.allMPRepeatsWithoutMPTel20(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.telemetry10and11Repeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/FATSuite.java
@@ -22,12 +22,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
-import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -43,12 +39,6 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
 })
 
 public class FATSuite {
-
-    public static RepeatTests testRepeatMPTel20() {
-        return TelemetryActions
-                        .repeat(FeatureReplacementAction.ALL_SERVERS, MicroProfileActions.MP70_EE11, MicroProfileActions.MP70_EE10,
-                                TelemetryActions.MP50_MPTEL20_JAVA8, TelemetryActions.MP41_MPTEL20, TelemetryActions.MP14_MPTEL20);
-    }
 
     private static final int CONN_TIMEOUT = 10;
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryApplicationConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryApplicationConfigTest.java
@@ -31,6 +31,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(FATRunner.class)
 public class TelemetryApplicationConfigTest extends FATServletClient {
@@ -44,7 +45,7 @@ public class TelemetryApplicationConfigTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = FATSuite.testRepeatMPTel20();
+    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 
     @Before
     public void testSetup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryDropinsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryDropinsTest.java
@@ -35,6 +35,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(FATRunner.class)
 public class TelemetryDropinsTest extends FATServletClient {
@@ -46,7 +47,7 @@ public class TelemetryDropinsTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = FATSuite.testRepeatMPTel20();
+    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 
     @BeforeClass
     public static void initialSetup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryFFDCCheckpointTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryFFDCCheckpointTest.java
@@ -44,7 +44,7 @@ public class TelemetryFFDCCheckpointTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = FATSuite.testRepeatMPTel20();
+    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 
     @BeforeClass
     public static void initialSetup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryFFDCTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryFFDCTest.java
@@ -33,6 +33,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(FATRunner.class)
 public class TelemetryFFDCTest extends FATServletClient {
@@ -44,7 +45,7 @@ public class TelemetryFFDCTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = FATSuite.testRepeatMPTel20();
+    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 
     private static final String USER_FEATURE_PATH = "usr/extension/lib/features/";
     private static final String USER_BUNDLE_PATH = "usr/extension/lib/";

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesCheckpointTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesCheckpointTest.java
@@ -43,7 +43,7 @@ public class TelemetryMessagesCheckpointTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = FATSuite.testRepeatMPTel20();
+    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 
     @BeforeClass
     public static void testSetup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesTest.java
@@ -35,6 +35,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(FATRunner.class)
 public class TelemetryMessagesTest extends FATServletClient {
@@ -43,7 +44,7 @@ public class TelemetryMessagesTest extends FATServletClient {
     public static final String SERVER_NAME = "TelemetryMessage";
 
     @ClassRule
-    public static RepeatTests rt = FATSuite.testRepeatMPTel20();
+    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetrySourcesTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetrySourcesTest.java
@@ -34,6 +34,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 @RunWith(FATRunner.class)
 public class TelemetrySourcesTest extends FATServletClient {
@@ -47,7 +48,7 @@ public class TelemetrySourcesTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = FATSuite.testRepeatMPTel20();
+    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 
     public static final String SERVER_XML_ALL_SOURCES = "allSources.xml";
     public static final String SERVER_XML_EMPTY_SOURCE = "emptySource.xml";

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryTraceCheckpointTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryTraceCheckpointTest.java
@@ -42,7 +42,7 @@ public class TelemetryTraceCheckpointTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = FATSuite.testRepeatMPTel20();
+    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 
     @BeforeClass
     public static void initialSetup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryTraceTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryTraceTest.java
@@ -32,6 +32,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
 
 /**
  * HTTP request tracing tests
@@ -46,7 +47,7 @@ public class TelemetryTraceTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = FATSuite.testRepeatMPTel20();
+    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 
     @BeforeClass
     public static void testSetup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/TelemetryActions.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/TelemetryActions.java
@@ -123,4 +123,38 @@ public class TelemetryActions {
         return RepeatActions.repeat(server, otherFeatureSetsTestMode, ALL_MPTEL_SETS_LIST, firstFeatureSet, Arrays.asList(otherFeatureSets));
     }
 
+    public static RepeatTests telemetry10and11Repeats(String serverName) {
+        return repeat(serverName, MicroProfileActions.MP61, MP14_MPTEL11, MP41_MPTEL11, MP50_MPTEL11,
+                      MicroProfileActions.MP60);
+    }
+
+    public static RepeatTests telemetry20Repeats(String serverName) {
+        return repeat(serverName, MicroProfileActions.MP70_EE11, MP14_MPTEL20, MP41_MPTEL20, MP50_MPTEL20,
+                      MP50_MPTEL20_JAVA8, MicroProfileActions.MP70_EE10);
+    }
+
+    public static RepeatTests telemetry20Repeats() {
+        return telemetry20Repeats(FeatureReplacementAction.ALL_SERVERS);
+    }
+
+    public static RepeatTests telemetry11Repeats(String serverName) {
+        return repeat(serverName, MP14_MPTEL11, MP41_MPTEL11, MP50_MPTEL11, MicroProfileActions.MP61);
+    }
+
+    public static RepeatTests mp60Repeat(String serverName) {
+        return repeat(serverName, MicroProfileActions.MP60);
+    }
+
+    public static RepeatTests allMPRepeats(String serverName) {
+        return repeat(serverName,
+                      MicroProfileActions.MP70_EE11,
+                      MicroProfileActions.MP60,
+                      MP14_MPTEL11,
+                      MP41_MPTEL11,
+                      MP50_MPTEL11,
+                      MicroProfileActions.MP61, MP14_MPTEL20, MP41_MPTEL20, MP50_MPTEL20,
+                      MP50_MPTEL20_JAVA8,
+                      MicroProfileActions.MP70_EE10);
+    }
+
 }

--- a/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/TelemetryActions.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/TelemetryActions.java
@@ -137,6 +137,18 @@ public class TelemetryActions {
         return telemetry20Repeats(FeatureReplacementAction.ALL_SERVERS);
     }
 
+    /*
+     * This returns one repeat for every released version of MPTelemetry; the latest 1.0, 1.1, etc.
+     * It also returns a repeat to cover ongoing development if that is not covered by one of the above.
+     */
+    public static RepeatTests latestTelemetryRepeats(String serverName) {
+        return repeat(serverName,
+                      MicroProfileActions.MP70_EE11,
+                      MicroProfileActions.MP70_EE10,
+                      MicroProfileActions.MP61,
+                      MicroProfileActions.MP60);
+    }
+
     public static RepeatTests telemetry11Repeats(String serverName) {
         return repeat(serverName, MP14_MPTEL11, MP41_MPTEL11, MP50_MPTEL11, MicroProfileActions.MP61);
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Resolves https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=301434

- Merge duplicate code for acquiring repeat actions into the common test project
- Move many tests to running on just a few repeats.