### PR TITLE
Disable SASL Tests for Java versions >22

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/checkpoint/CheckpointKafkaSaslPlainTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/checkpoint/CheckpointKafkaSaslPlainTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import componenttest.annotation.MaximumJavaLevel;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -60,6 +61,7 @@ import io.openliberty.checkpoint.spi.CheckpointPhase;
  * Basic test using a kafka broker with TLS enabled
  */
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 21)
 @CheckpointTest
 public class CheckpointKafkaSaslPlainTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/checkpoint/CheckpointKafkaSaslPlainTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/checkpoint/CheckpointKafkaSaslPlainTest.java
@@ -61,7 +61,7 @@ import io.openliberty.checkpoint.spi.CheckpointPhase;
  * Basic test using a kafka broker with TLS enabled
  */
 @RunWith(FATRunner.class)
-@MaximumJavaLevel(javaLevel = 21)
+@MaximumJavaLevel(javaLevel = 22)
 @CheckpointTest
 public class CheckpointKafkaSaslPlainTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/LibertyLoginModuleTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/LibertyLoginModuleTest.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
  * Test the login module with an aes encoded password and configured encryption key
  */
 @RunWith(FATRunner.class)
-@MaximumJavaLevel(javaLevel = 21)
+@MaximumJavaLevel(javaLevel = 22)
 public class LibertyLoginModuleTest {
 
     private static final String APP_NAME = "kafkaLoginModuleTest";

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/LibertyLoginModuleTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/LibertyLoginModuleTest.java
@@ -19,6 +19,7 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaU
 import java.util.Collections;
 import java.util.Map;
 
+import componenttest.annotation.MaximumJavaLevel;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -48,6 +49,7 @@ import componenttest.topology.impl.LibertyServer;
  * Test the login module with an aes encoded password and configured encryption key
  */
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 21)
 public class LibertyLoginModuleTest {
 
     private static final String APP_NAME = "kafkaLoginModuleTest";

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/none/LibertyLoginModuleNoEncTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/none/LibertyLoginModuleNoEncTest.java
@@ -18,6 +18,7 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaU
 
 import java.util.Map;
 
+import componenttest.annotation.MaximumJavaLevel;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -44,6 +45,7 @@ import componenttest.topology.impl.LibertyServer;
 /**
  * Test the login module with an unencoded password - should still work
  */
+@MaximumJavaLevel(javaLevel = 21)
 @RunWith(FATRunner.class)
 public class LibertyLoginModuleNoEncTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/none/LibertyLoginModuleNoEncTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/none/LibertyLoginModuleNoEncTest.java
@@ -45,7 +45,7 @@ import componenttest.topology.impl.LibertyServer;
 /**
  * Test the login module with an unencoded password - should still work
  */
-@MaximumJavaLevel(javaLevel = 21)
+@MaximumJavaLevel(javaLevel = 22)
 @RunWith(FATRunner.class)
 public class LibertyLoginModuleNoEncTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
@@ -18,6 +18,7 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaU
 
 import java.util.Map;
 
+import componenttest.annotation.MaximumJavaLevel;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -44,6 +45,7 @@ import componenttest.topology.impl.LibertyServer;
 /**
  * Test the login module with an unencoded password - should still work
  */
+@MaximumJavaLevel(javaLevel = 21)
 @RunWith(FATRunner.class)
 public class LibertyLoginModuleSpecialCharsTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
@@ -45,7 +45,7 @@ import componenttest.topology.impl.LibertyServer;
 /**
  * Test the login module with an unencoded password - should still work
  */
-@MaximumJavaLevel(javaLevel = 21)
+@MaximumJavaLevel(javaLevel = 22)
 @RunWith(FATRunner.class)
 public class LibertyLoginModuleSpecialCharsTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/xor/LibertyLoginModuleXorTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/xor/LibertyLoginModuleXorTest.java
@@ -49,7 +49,7 @@ import componenttest.topology.impl.LibertyServer;
  * Test the login module with xor encoded password
  */
 @RunWith(FATRunner.class)
-@MaximumJavaLevel(javaLevel = 21)
+@MaximumJavaLevel(javaLevel = 22)
 @Mode(TestMode.FULL)
 public class LibertyLoginModuleXorTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/xor/LibertyLoginModuleXorTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/liberty_login/xor/LibertyLoginModuleXorTest.java
@@ -18,6 +18,7 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaU
 
 import java.util.Map;
 
+import componenttest.annotation.MaximumJavaLevel;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -48,6 +49,7 @@ import componenttest.topology.impl.LibertyServer;
  * Test the login module with xor encoded password
  */
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 21)
 @Mode(TestMode.FULL)
 public class LibertyLoginModuleXorTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sasl_plain/KafkaSaslPlainTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sasl_plain/KafkaSaslPlainTest.java
@@ -16,6 +16,7 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaU
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaPermissions;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaStopServer;
 
+import componenttest.annotation.MaximumJavaLevel;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -45,6 +46,7 @@ import componenttest.topology.impl.LibertyServer;
  * Basic test using a kafka broker with TLS enabled
  */
 @RunWith(FATRunner.class)
+@MaximumJavaLevel(javaLevel = 21)
 public class KafkaSaslPlainTest {
 
     private static final String APP_NAME = "kafkaSaslTest";

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sasl_plain/KafkaSaslPlainTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/sasl_plain/KafkaSaslPlainTest.java
@@ -46,7 +46,7 @@ import componenttest.topology.impl.LibertyServer;
  * Basic test using a kafka broker with TLS enabled
  */
 @RunWith(FATRunner.class)
-@MaximumJavaLevel(javaLevel = 21)
+@MaximumJavaLevel(javaLevel = 22)
 public class KafkaSaslPlainTest {
 
     private static final String APP_NAME = "kafkaSaslTest";


### PR DESCRIPTION
The Kafka Client's SASL code uses the Java security, which as of Java 23 now throws exceptions if used. there is currently no Kafka Client version that does not use Security Manager. To allow for the rest of the RM suite of tests to continue passing without the failing Java 23 build, set the maximum java level to 21.

This limitation should be removed once a suitable client is available and included.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".