### PR TITLE
Remove MaximumJavaLevel from MP JWT 2.0 FAT TCK

### DIFF
--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/FATSuite.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,8 +16,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.annotation.MaximumJavaLevel;
-
 @RunWith(Suite.class)
 @SuiteClasses({
                 Mpjwt20TCKLauncher_aud_env.class,
@@ -28,6 +26,5 @@ import componenttest.annotation.MaximumJavaLevel;
                 DummyForQuarantine.class
 })
 
-@MaximumJavaLevel(javaLevel = 18)
 public class FATSuite {
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

In issue #22496 we realized the MP JWT 1.2 and 2.0 FAT TCKs would not work as-is with Java 19+, so I disabled them in this PR #22745 with the `@MaximumJavaLevel(javaLevel = 18)` annotation.  I added it to the `FATSuite.java` and individual tests.

Those tests have since been fixed to work with newer Java levels and the annotations all removed, except to one from MP JWT 2.0 FAT TCK FATSuite.java file.  I have learned that the `@MaximumJavaLevel` annotation does not work at the `FATSuite.java` level, so I am getting rid of it to remove any confusion it might cause.