### PR TITLE
remove workaround for 28912 and 29117

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2035,12 +2035,6 @@ public class QueryInfo {
                         if (!insertEntityVar)
                             for (int i = startAt; !insertEntityVar && i < length; i++)
                                 switch (ql.charAt(i)) {
-                                    case '+':
-                                    case '-':
-                                    case '*':
-                                    case '/': // TODO remove this workaround for #28912 once fixed
-                                        insertEntityVar = true;
-                                        break;
                                     case '(': // TODO remove this workaround for #28908 once fixed
                                         insertEntityVar = ql.regionMatches(true, i - 2, "ID", 0, 2);
                                         break;

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3875,10 +3875,11 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals("Simon", participants.getFirstName(3).orElseThrow());
 
-        assertEquals(List.of("Samantha", "Sarah", "Simon", "Steve"),
-                     participants.withSurname("TestRecordAsEmbeddable")
-                                     .map(p -> p.name.first())
-                                     .collect(Collectors.toList()));
+        // TODO enable once #29460 is fixed
+        //assertEquals(List.of("Samantha", "Sarah", "Simon", "Steve"),
+        //             participants.withSurname("TestRecordAsEmbeddable")
+        //                             .map(p -> p.name.first())
+        //                             .collect(Collectors.toList()));
 
         assertEquals(4L, participants.remove("TestRecordAsEmbeddable"));
     }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participant.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participant.java
@@ -22,27 +22,7 @@ public class Participant {
 
     public Name name;
 
-    //public static record Name(String first, String last) {
-    //}
-    // TODO switch to the above and remove the following once 29117 is fixed
-    public static class Name {
-        public String first, last;
-
-        public Name() {
-        }
-
-        public Name(String first, String last) {
-            this.first = first;
-            this.last = last;
-        }
-
-        public String first() {
-            return first;
-        }
-
-        public String last() {
-            return last;
-        }
+    public static record Name(String first, String last) {
     }
 
     public static Participant of(String firstName, String lastName, int id) {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Rating.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Rating.java
@@ -22,26 +22,11 @@ public record Rating(
                 Reviewer reviewer,
                 Set<String> comments) {
 
-    public static class Reviewer {
-        public String firstName;
-        public String lastName;
-        public String email;
-
-        public Reviewer() {
-        }
-
-        public Reviewer(String firstName, String lastName, String email) {
-            this.firstName = firstName;
-            this.lastName = lastName;
-            this.email = email;
-        }
+    public static record Reviewer(
+                    String firstName, // TODO nested record embeddable for Name(first, last) ?
+                    String lastName,
+                    String email) {
     }
-    // TODO switch the above class to the following record after 29117 is fixed
-    //public static record Reviewer(
-    //                String firstName, // TODO nested record embeddable for Name(first, last) ?
-    //                String lastName,
-    //                String email) {
-    //}
 
     public static class Item {
         public String name;

--- a/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/Part.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/Part.java
@@ -28,7 +28,7 @@ public record Part(Identifier id, String name, float price, int version) {
 
     /**
      * Composite id for the Part entity.
-     * TODO switch to a record once #29117 is fixed
+     * TODO switch to a record once #29460 is fixed
      */
     public static class Identifier {
         public String partNum;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1168,8 +1168,8 @@ public class DataJPATestServlet extends FATServlet {
     /**
      * Use an entity with embeddable attributes that are Java records.
      */
-    // TODO enable when #29117 is fixed
-    //@Test
+    // TODO enable once #29459 is fixed
+    // @Test
     public void testEmbeddableRecord() {
         Segment s1 = new Segment();
         s1.pointA = new Point(0, 0);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
@@ -94,7 +94,7 @@ public interface Demographics {
     @Query("SELECT this.publicDebt / this.numFullTimeWorkers" +
            "  FROM DemographicInfo" +
            " WHERE EXTRACT (YEAR FROM this.collectedOn) = ?1")
-    // TODO once #28912 is fixed:
+    // TODO once #29457 is fixed:
     //@Query("SELECT publicDebt / numFullTimeWorkers" +
     //       "  FROM DemographicInfo" +
     //       " WHERE EXTRACT (YEAR FROM collectedOn) = ?1")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Point.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Point.java
@@ -13,12 +13,8 @@ package test.jakarta.data.jpa.web;
 import jakarta.persistence.Embeddable;
 
 /**
- * Java record that is used as an Embeddable by the DirectedLineSegment entity.
+ * Java record that is used as an Embeddable by the Segment entity.
  */
 @Embeddable
 public record Point(int x, int y) {
-    // TODO remove once #29117 is fixed
-    public Point() {
-        this(0, 0);
-    }
 }


### PR DESCRIPTION
Remove workarounds for #28912 and #29117
Add new TODOs for 3 additional EclipseLink issues that were found after the above workarounds are removed.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
