### PR TITLE
if server xml is deleted, do not remove configuration

### DIFF
--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010, 2020 IBM Corporation and others.
+# Copyright (c) 2010, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -494,7 +494,7 @@ schemagen.info.schema.file.created=CWWKG0109I: The schema was created in the [{0
 schemagen.info.schema.file.created.explanation=The command completed successfully.
 schemagen.info.schema.file.created.useraction=No action is required.
 
-warning.config.root.deleted=CWWKG0110W: The configuration root was deleted. No configuration updates were made.
+warning.config.root.deleted=CWWKG0110W: A configuration update was detected but the configuration root, {0}, does not exist. No configuration updates were made.
 warning.config.root.deleted.explanation=The server.xml was deleted. To cause no disruptions to running apps, no configuration changes will be made.
 warning.config.root.deleted.useraction=Add the server.xml back to the server.
 

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -494,7 +494,7 @@ schemagen.info.schema.file.created=CWWKG0109I: The schema was created in the [{0
 schemagen.info.schema.file.created.explanation=The command completed successfully.
 schemagen.info.schema.file.created.useraction=No action is required.
 
-warning.config.root.deleted=CWWKG0110W: A configuration update was detected but the configuration root, {0}, does not exist. No configuration updates were made.
+warning.config.root.deleted=CWWKG0110W: A configuration update was detected, but the configuration root {0} does not exist. No configuration updates were made.
 warning.config.root.deleted.explanation=The server.xml was deleted. To cause no disruptions to running apps, no configuration changes will be made.
 warning.config.root.deleted.useraction=Add the server.xml back to the server.
 

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -495,8 +495,8 @@ schemagen.info.schema.file.created.explanation=The command completed successfull
 schemagen.info.schema.file.created.useraction=No action is required.
 
 warning.config.root.deleted=CWWKG0110W: A configuration update was detected, but the configuration root {0} does not exist. No configuration updates were made.
-warning.config.root.deleted.explanation=The server.xml was deleted. To cause no disruptions to running apps, no configuration changes will be made.
-warning.config.root.deleted.useraction=Add the server.xml back to the server.
+warning.config.root.deleted.explanation=The server.xml file was deleted. To cause no disruptions to running apps, no configuration changes are made.
+warning.config.root.deleted.useraction=Add the server.xml file back to the server.
 
 # Non-TR message
 error.invalidOCDRef=ERROR: Metatype PID [{0}] specifies non-existent object class definition ID [{1}]

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -494,9 +494,9 @@ schemagen.info.schema.file.created=CWWKG0109I: The schema was created in the [{0
 schemagen.info.schema.file.created.explanation=The command completed successfully.
 schemagen.info.schema.file.created.useraction=No action is required.
 
-warning.config.root.deleted=CWWKG0110W: A configuration update was detected, but the configuration root {0} does not exist. No configuration updates were made.
-warning.config.root.deleted.explanation=The server.xml file was deleted. To cause no disruptions to running apps, no configuration changes are made.
-warning.config.root.deleted.useraction=Add the server.xml file back to the server.
+error.config.root.deleted=CWWKG0110E: A configuration update was detected, but the configuration root {0} does not exist. No configuration updates were made.
+error.config.root.deleted.explanation=The server.xml file was deleted. To cause no disruptions to running apps, no configuration changes are made.
+error.config.root.deleted.useraction=Add the server.xml file back to the server.
 
 # Non-TR message
 error.invalidOCDRef=ERROR: Metatype PID [{0}] specifies non-existent object class definition ID [{1}]

--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -494,5 +494,9 @@ schemagen.info.schema.file.created=CWWKG0109I: The schema was created in the [{0
 schemagen.info.schema.file.created.explanation=The command completed successfully.
 schemagen.info.schema.file.created.useraction=No action is required.
 
+warning.config.root.deleted=CWWKG0110W: The configuration root was deleted. No configuration updates were made.
+warning.config.root.deleted.explanation=The server.xml was deleted. To cause no disruptions to running apps, no configuration changes will be made.
+warning.config.root.deleted.useraction=Add the server.xml back to the server.
+
 # Non-TR message
 error.invalidOCDRef=ERROR: Metatype PID [{0}] specifies non-existent object class definition ID [{1}]

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigFileMonitor.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigFileMonitor.java
@@ -143,11 +143,11 @@ class ConfigFileMonitor implements com.ibm.ws.kernel.filemonitor.FileMonitor {
 
     @Override
     public void onChange(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles) {
-        configRefresher.refreshConfigurationIfServerXMLNotDeleted(createdFiles, modifiedFiles, deletedFiles);
+        configRefresher.refreshConfigurationIfServerXMLExists();
     }
 
     @Override
     public void onChange(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles, String filter) {
-        configRefresher.refreshConfigurationIfServerXMLNotDeleted(createdFiles, modifiedFiles, deletedFiles);
+        configRefresher.refreshConfigurationIfServerXMLExists();
     }
 }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigFileMonitor.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigFileMonitor.java
@@ -143,11 +143,11 @@ class ConfigFileMonitor implements com.ibm.ws.kernel.filemonitor.FileMonitor {
 
     @Override
     public void onChange(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles) {
-        configRefresher.refreshConfiguration();
+        configRefresher.refreshConfigurationIfServerXMLNotDeleted(createdFiles, modifiedFiles, deletedFiles);
     }
 
     @Override
     public void onChange(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles, String filter) {
-        configRefresher.refreshConfiguration();
+        configRefresher.refreshConfigurationIfServerXMLNotDeleted(createdFiles, modifiedFiles, deletedFiles);
     }
 }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigRefresher.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigRefresher.java
@@ -102,7 +102,7 @@ public class ConfigRefresher {
      */
     public void refreshConfigurationIfServerXMLExists(){
         if(!serverXMLConfig.configRootFile().exists()){
-            Tr.warning(tc, "warning.config.root.deleted", serverXMLConfig.configRootFile().getName());
+            Tr.error(tc, "error.config.root.deleted", serverXMLConfig.configRootFile().getName());
         }
         else{
             refreshConfiguration();

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigRefresher.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigRefresher.java
@@ -97,26 +97,16 @@ public class ConfigRefresher {
 
     /*
      * Called after configuration change is detected.
-     * If the only deleted file is the server.xml, no config updates will be made.
+     * If the server.xml does not exist, no config updates will be made.
      * Otherwise, make config updates as normal.
      */
-    public void refreshConfigurationIfServerXMLNotDeleted(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles){
-        if(isOnlyServerXMLDeleted(createdFiles, modifiedFiles, deletedFiles)){
-            Tr.warning(tc, "warning.config.root.deleted");
+    public void refreshConfigurationIfServerXMLExists(){
+        if(!serverXMLConfig.configRootFile().exists()){
+            Tr.warning(tc, "warning.config.root.deleted", serverXMLConfig.configRootFile().getName());
         }
         else{
             refreshConfiguration();
         }
-    }
-
-    private boolean isOnlyServerXMLDeleted(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles){
-        if(createdFiles.isEmpty() && modifiedFiles.isEmpty() && deletedFiles.size() == 1){
-            if(deletedFiles.contains(serverXMLConfig.configRootFile())){
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public void refreshConfiguration() {

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigRefresher.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigRefresher.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.config.xml.internal;
 
+import java.io.File;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -92,6 +93,30 @@ public class ConfigRefresher {
     void stop() {
         configurationMonitor.stopConfigurationMonitoring();
         runtimeUpdateManagerTracker.close();
+    }
+
+    /*
+     * Called after configuration change is detected.
+     * If the only deleted file is the server.xml, no config updates will be made.
+     * Otherwise, make config updates as normal.
+     */
+    public void refreshConfigurationIfServerXMLNotDeleted(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles){
+        if(isOnlyServerXMLDeleted(createdFiles, modifiedFiles, deletedFiles)){
+            Tr.warning(tc, "warning.config.root.deleted");
+        }
+        else{
+            refreshConfiguration();
+        }
+    }
+
+    private boolean isOnlyServerXMLDeleted(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles){
+        if(createdFiles.isEmpty() && modifiedFiles.isEmpty() && deletedFiles.size() == 1){
+            if(deletedFiles.contains(serverXMLConfig.configRootFile())){
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public void refreshConfiguration() {

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerXMLConfiguration.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerXMLConfiguration.java
@@ -87,6 +87,10 @@ class ServerXMLConfiguration {
         return configRoot != null;
     }
 
+    File configRootFile() {
+        return configRoot.asFile();
+    }
+
     private static long getInitialConfigReadTime(BundleContext bundleContext) {
         if (bundleContext == null) {
             return 0;

--- a/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ServerConfigTest.java
+++ b/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ServerConfigTest.java
@@ -390,13 +390,13 @@ public class ServerConfigTest {
         try {
             assertNotNull("The server configuration was not updated when setting it to polled", server.waitForStringInLog("CWWKF0011I")); //server has started
             server.getServerConfigurationFile().delete();
-            assertNotNull("The server configuration was updated after server.xml was deleted", server.waitForStringInLog("CWWKG0110W"));
+            assertNotNull("The server configuration was updated after server.xml was deleted", server.waitForStringInLog("CWWKG0110E"));
 
             //server can't be stopped without a server.xml. Refresh the serverxml so the server can be stopped.
             server.refreshServerXMLFromPublish();
             assertNotNull("The server configuration was updated after server.xml was added back", server.waitForStringInLog("CWWKG0018I"));
         } finally {
-            server.stopServer("CWWKG0110W");
+            server.stopServer("CWWKG0110E");
         }
     }
 

--- a/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ServerConfigTest.java
+++ b/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ServerConfigTest.java
@@ -39,6 +39,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.config.ConfigMonitorElement;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
+import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.exception.TopologyException;
 import componenttest.topology.impl.LibertyFileManager;
@@ -374,6 +375,28 @@ public class ServerConfigTest {
             assertNull("The server configuration was updated even though monitoring is disabled", server.waitForStringInLog("CWWKG0017I", updateDuration));
         } finally {
             server.stopServer();
+        }
+    }
+
+    /**
+     * This test makes sure that if the server.xml is deleted while the server is running, that no configuration changes are made
+     * @throws Exception
+     */
+    @Test
+    public void testServerConfigDeleteUpdate() throws Exception {
+        LibertyServer server = LibertyServerFactory.getStartedLibertyServer("com.ibm.ws.config.update");
+        ShrinkHelper.exportAppToServer(server, restartApp, DeployOptions.DISABLE_VALIDATION);
+
+        try {
+            assertNotNull("The server configuration was not updated when setting it to polled", server.waitForStringInLog("CWWKF0011I")); //server has started
+            server.getServerConfigurationFile().delete();
+            assertNotNull("The server configuration was updated after server.xml was deleted", server.waitForStringInLog("CWWKG0110W"));
+
+            //server can't be stopped without a server.xml. Refresh the serverxml so the server can be stopped.
+            server.refreshServerXMLFromPublish();
+            assertNotNull("The server configuration was updated after server.xml was added back", server.waitForStringInLog("CWWKG0018I"));
+        } finally {
+            server.stopServer("CWWKG0110W");
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

When a configuration update is detected, check if the server.xml is deleted. if it is, make no config updates and warn the user that the server.xml was deleted. Otherwise, make config updates as normal.