### PR TITLE
Ensure behavior or element-collection fetch

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Rating.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Rating.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import java.util.Set;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat
+ */
+@Entity
+public class Rating {
+
+    @Id
+    public int id;
+
+    @Embedded
+    public Item item;
+
+    public int numStars;
+
+    @Embedded
+    public Reviewer reviewer;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    public Set<String> comments;
+
+    // Basic constructor for builder method
+    public Rating() {
+    }
+
+    // Test constructor to show that SELECT NEW works without comments field
+    public Rating(int id, Item item, int stars, Reviewer reviewer) {
+        this.id = id;
+        this.item = item;
+        this.numStars = stars;
+        this.reviewer = reviewer;
+        this.comments = null;
+    }
+
+    // The constructor SELECT NEW should be able to use
+    public Rating(int id, Item item, int stars, Reviewer reviewer, Set<String> comments) {
+        this.id = id;
+        this.item = item;
+        this.numStars = stars;
+        this.reviewer = reviewer;
+        this.comments = comments;
+    }
+
+    public static Rating of(int id, Item item, int stars, Reviewer reviewer, String... comments) {
+        Rating inst = new Rating();
+        inst.id = id;
+        inst.item = item;
+        inst.numStars = stars;
+        inst.reviewer = reviewer;
+        inst.comments = Set.of(comments);
+        return inst;
+    }
+
+    @Embeddable
+    public static class Reviewer {
+        public String firstName;
+        public String lastName;
+        public String email;
+
+        public static Reviewer of(String firstName, String lastName, String email) {
+            Reviewer inst = new Reviewer();
+            inst.firstName = firstName;
+            inst.lastName = lastName;
+            inst.email = email;
+            return inst;
+        }
+    }
+
+    @Embeddable
+    public static class Item {
+        public String name;
+        public float price;
+
+        public static Item of(String name, float price) {
+            Item inst = new Item();
+            inst.name = name;
+            inst.price = price;
+            return inst;
+        }
+
+        @Override
+        public String toString() {
+            return "Item: " + name + " $" + price;
+        }
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -1357,6 +1357,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
         assertEquals(3, result.comments.size());
 
     }
+	
     /**
      * Utility method to drop all entities from table.
      *

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -61,6 +61,7 @@ import io.openliberty.jpa.data.tests.models.Person;
 import io.openliberty.jpa.data.tests.models.Prime;
 import io.openliberty.jpa.data.tests.models.Product;
 import io.openliberty.jpa.data.tests.models.PurchaseOrder;
+import io.openliberty.jpa.data.tests.models.Rating;
 import io.openliberty.jpa.data.tests.models.Rebate;
 import io.openliberty.jpa.data.tests.models.Rebate.Status;
 import io.openliberty.jpa.data.tests.models.Reciept;
@@ -1305,6 +1306,57 @@ public class JakartaDataRecreateServlet extends FATServlet {
         }
     }
 
+    @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/29475")
+    public void testOLGH29475() throws Exception {
+        Rating.Reviewer jimmy = Rating.Reviewer.of("Jimothy", "Scramble", "J.Scramble@example.com");
+        Rating.Item blueBerry = Rating.Item.of("BlueBerry 10", 299.99f);
+        Rating rating = Rating.of(1001, blueBerry, 4, jimmy,
+                                  "The buttons are nice for quick typing",
+                                  "The power button could have been in a better place",
+                                  "Poor screen lighting");
+
+        Rating result;
+
+        tx.begin();
+        em.persist(rating);
+        tx.commit();
+
+        tx.begin();
+        List<String> comments = em.createQuery("SELECT o.comments FROM Rating o WHERE o.id = :id", String.class)
+                        .setParameter("id", 1001)
+                        .getResultList();
+        tx.commit();
+
+        assertEquals(3, comments.size());
+
+        tx.begin();
+        try {
+            result = em.createQuery("SELECT NEW io.openliberty.jpa.data.tests.models.Rating( "
+                                    + " o.id, o.item, o.numStars, o.reviewer, o.comments ) "
+                                    + "FROM Rating o WHERE o.id = :id", Rating.class)
+                            .setParameter("id", 1001)
+                            .getSingleResult();
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+
+            /**
+             * Recreate
+             * Exception [EclipseLink-0] (Eclipse Persistence Services - 5.0.0.v202408071314-43356e84b79e71022b1656a5462b0a72d70787a4):
+             * org.eclipse.persistence.exceptions.JPQLException
+             * Exception Description: Problem compiling
+             * [SELECT NEW io.openliberty.jpa.data.tests.models.Rating( o.id, o.item, o.numStars, o.reviewer, o.comments ) FROM Rating o WHERE o.id = :id].
+             * [93, 103] The state field path 'o.comments' cannot be resolved to a collection type.
+             * (SELECT NEW io.openliberty.jpa.data.tests.models.Rating(o.id, o.item, o.numStars, o.reviewer, [ o.comments ] ...
+             */
+            throw e;
+        }
+
+        assertNotNull(result.comments);
+        assertEquals(3, result.comments.size());
+
+    }
     /**
      * Utility method to drop all entities from table.
      *

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -842,7 +842,7 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
             String columnType;
             if (isPrimitive || attributeType.isInterface() || Serializable.class.isAssignableFrom(attributeType)) {
                 columnType = isId ? "id" : //
-                                isCollection ? "element-collection" : // TODO add fetch-type eager
+                                isCollection ? "element-collection" : //
                                                 attributeName.equals(versionAttributeName) ? "version" : //
                                                                 "basic";
             } else {
@@ -851,8 +851,12 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
             }
 
             xml.append("   <").append(columnType).append(" name=\"").append(attributeName).append('"');
+
+            // All other queries when using un-annotated entities or record entities are eager,
+            // element-collections should be as well.
             if (isCollection)
                 xml.append(" fetch=\"EAGER\"");
+
             xml.append('>').append(EOLN);
 
             if (isEmbeddable) {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3082,7 +3082,7 @@ public class DataTestServlet extends FATServlet {
         Rating user1Rating = ratings.get(1000).orElseThrow();
 
         assertFalse("Expected comments to be populated when using fetch type eager", user1Rating.comments().isEmpty());
-        assertTrue("Expected comments to be populated when using fetch type eager", user1Rating.comments().containsAll(comments));
+        assertEquals("Expected comments to be populated when using fetch type eager", comments, user1Rating.comments());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -19,6 +19,7 @@ import static componenttest.annotation.SkipIfSysProp.DB_SQLServer;
 import static jakarta.data.repository.By.ID;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -3064,6 +3065,22 @@ public class DataTestServlet extends FATServlet {
         } catch (NoSuchElementException x) {
             // expected
         }
+    }
+
+    @Test
+    public void testFetchTypeDefault() {
+        ratings.clear();
+
+        Rating.Reviewer user1 = new Rating.Reviewer("Rex", "TestRecordWithEmbeddables", "rex@openliberty.io");
+        Rating.Item toaster = new Rating.Item("toaster", 28.98f);
+        Set<String> comments = Set.of("Burns everything.", "Often gets stuck.", "Bagels don't fit.");
+
+        ratings.add(new Rating(1000, toaster, 2, user1, comments));
+
+        Rating user1Rating = ratings.get(1000).orElseThrow();
+
+        assertFalse("Expected comments to be populated when using default fetch type lazy", user1Rating.comments().isEmpty());
+        assertTrue("Expected comments to be populated when using default fetch type lazy", user1Rating.comments().containsAll(comments));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3073,7 +3073,7 @@ public class DataTestServlet extends FATServlet {
     public void testFetchTypeDefault() {
         ratings.clear();
 
-        Rating.Reviewer user1 = new Rating.Reviewer("Rex", "TestRecordWithEmbeddables", "rex@openliberty.io");
+        Rating.Reviewer user1 = new Rating.Reviewer("Rex", "TestFetchTypeDefault", "rex@openliberty.io");
         Rating.Item toaster = new Rating.Item("toaster", 28.98f);
         Set<String> comments = Set.of("Burns everything.", "Often gets stuck.", "Bagels don't fit.");
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -89,6 +89,7 @@ import jakarta.transaction.TransactionRequiredException;
 import jakarta.transaction.TransactionalException;
 import jakarta.transaction.UserTransaction;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import componenttest.annotation.AllowedFFDC;
@@ -3067,7 +3068,8 @@ public class DataTestServlet extends FATServlet {
         }
     }
 
-    @Test
+    @Test //TODO
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/29475")
     public void testFetchTypeDefault() {
         ratings.clear();
 
@@ -3079,8 +3081,8 @@ public class DataTestServlet extends FATServlet {
 
         Rating user1Rating = ratings.get(1000).orElseThrow();
 
-        assertFalse("Expected comments to be populated when using default fetch type lazy", user1Rating.comments().isEmpty());
-        assertTrue("Expected comments to be populated when using default fetch type lazy", user1Rating.comments().containsAll(comments));
+        assertFalse("Expected comments to be populated when using fetch type eager", user1Rating.comments().isEmpty());
+        assertTrue("Expected comments to be populated when using fetch type eager", user1Rating.comments().containsAll(comments));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Ratings.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Ratings.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -35,6 +36,9 @@ public interface Ratings {
 
     @Delete
     long clear();
+
+    @Find
+    Optional<Rating> get(int id);
 
     Stream<Rating> findByCommentsContainsOrderByIdDesc(String comment);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1710,11 +1710,11 @@ public class DataJPATestServlet extends FATServlet {
         // Outside of transaction, returned entity should be detached
         Mobile johnsMobile = mobilePhones.findById(id).orElseThrow();
 
-        // Fetch type Lazy should be populated when accessing apps field
+        // Fetch type lazy should be populated when accessing apps field
         assertFalse("Expected apps to be populated when using fetch type lazy", johnsMobile.apps.isEmpty());
         assertTrue("Entity apps did not match expected apps", johnsMobile.apps.containsAll(apps));
 
-        // Fetch type eager should be pre-populated
+        // Fetch type eager emails field should be pre-populated
         assertFalse("Expected emails to be populated when using fetch type eager", johnsMobile.emails.isEmpty());
         assertTrue("Entity emails did not match expected apps", johnsMobile.emails.containsAll(emails));
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1712,11 +1712,11 @@ public class DataJPATestServlet extends FATServlet {
 
         // Fetch type lazy should be populated when accessing apps field
         assertFalse("Expected apps to be populated when using fetch type lazy", johnsMobile.apps.isEmpty());
-        assertTrue("Entity apps did not match expected apps", johnsMobile.apps.containsAll(apps));
+        assertEquals("Entity apps did not match expected apps", apps, johnsMobile.apps);
 
         // Fetch type eager emails field should be pre-populated
         assertFalse("Expected emails to be populated when using fetch type eager", johnsMobile.emails.isEmpty());
-        assertTrue("Entity emails did not match expected apps", johnsMobile.emails.containsAll(emails));
+        assertEquals("Entity emails did not match expected apps", emails, johnsMobile.emails);
 
     }
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -18,7 +18,9 @@ import static componenttest.annotation.SkipIfSysProp.DB_Postgres;
 import static componenttest.annotation.SkipIfSysProp.DB_SQLServer;
 import static jakarta.data.repository.By.ID;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static test.jakarta.data.jpa.web.Assertions.assertArrayEquals;
 import static test.jakarta.data.jpa.web.Assertions.assertIterableEquals;
@@ -90,6 +92,7 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 import test.jakarta.data.jpa.web.CreditCard.CardId;
 import test.jakarta.data.jpa.web.CreditCard.Issuer;
+import test.jakarta.data.jpa.web.Mobile.OS;
 
 @DataSourceDefinition(name = "java:module/jdbc/RepositoryDataStore",
                       className = "${repository.datasource.class.name}",
@@ -135,6 +138,9 @@ public class DataJPATestServlet extends FATServlet {
 
     @Inject
     MixedRepository mixed;
+
+    @Inject
+    MobilePhones mobilePhones;
 
     @Inject
     Models models;
@@ -1684,6 +1690,34 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(1, results.size());
         assertEquals(4000921042220002L, results.get(0).number);
+    }
+
+    /**
+     * Verify that fetch type eager and lazy both work when using a detached entity returned by Jakarta Data
+     */
+    @Test
+    public void testFetchType() {
+        mobilePhones.removeAll();
+
+        List<String> apps = Arrays.asList("Settings", "Camera", "Phone", "Email", "Messages",
+                                          "UnoLingo", "BankApp", "SoloGame", "LocalNews");
+
+        List<String> emails = Arrays.asList("john.smith@example.com", "JohnDSmith@example.work.com");
+
+        // Populate database
+        UUID id = mobilePhones.insert(Mobile.of(OS.ANDROID, apps, emails)).deviceId;
+
+        // Outside of transaction, returned entity should be detached
+        Mobile johnsMobile = mobilePhones.findById(id).orElseThrow();
+
+        // Fetch type Lazy should be populated when accessing apps field
+        assertFalse("Expected apps to be populated when using fetch type lazy", johnsMobile.apps.isEmpty());
+        assertTrue("Entity apps did not match expected apps", johnsMobile.apps.containsAll(apps));
+
+        // Fetch type eager should be pre-populated
+        assertFalse("Expected emails to be populated when using fetch type eager", johnsMobile.emails.isEmpty());
+        assertTrue("Entity emails did not match expected apps", johnsMobile.emails.containsAll(emails));
+
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Mobile.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Mobile.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+
+/**
+ * This entity has ElementCollections that fetch lazily and eagerly
+ */
+@Entity
+public class Mobile {
+    public enum OS {
+        ANDROID, IOS, WINDOWS, FIRE
+    }
+
+    @Id
+    public UUID deviceId;
+
+    public OS operatingSystem;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    public List<String> apps;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    public List<String> emails;
+
+    public static Mobile of(OS os, List<String> apps, List<String> emails) {
+        Mobile inst = new Mobile();
+
+        inst.deviceId = UUID.randomUUID();
+        inst.operatingSystem = os;
+        inst.apps = apps;
+        inst.emails = emails;
+
+        return inst;
+    }
+
+    @Override
+    public String toString() {
+        return "Mobile [deviceId=" + deviceId + ", operatingSystem=" + operatingSystem + ", apps=" + apps + ", emails=" + emails + "]";
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MobilePhones.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MobilePhones.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.UUID;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for the Mobile Entity
+ */
+@Repository
+public interface MobilePhones extends CrudRepository<Mobile, UUID> {
+
+    @Delete
+    public long removeAll();
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Verify element-collection fetch behavior for detached entities returned by Jakarta Data
- Always use fetch = eager for unannoated and record entities to match behavior of all other queries
- Write tests that verify behavior and recreate bug in EclipseLink
