### PR TITLE
cursor pagination without WHERE clause

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1202,10 +1202,17 @@ public class QueryInfo {
         if (type == Type.FIND_AND_DELETE && !(singleType.isAssignableFrom(wrapperClassIfPrimitive(entityInfo.idType)) ||
                                               singleType.isAssignableFrom(entityInfo.entityClass) ||
                                               (entityInfo.recordClass != null && singleType.isAssignableFrom(entityInfo.recordClass)))) {
-            throw new MappingException("Results for find-and-delete repository queries must be the entity class (" +
+            throw new MappingException("The " + method.getGenericReturnType().getTypeName() +
+                                       " type cannot be used as a return type for the " +
+                                       method.getName() + " method of the " +
+                                       method.getDeclaringClass().getName() +
+                                       " repository inteface. The return type can be" +
+                                       " void to return no value, long or int for a deletion count," +
+                                       " boolean to indicate whether any entities were deleted," +
+                                       " or an array, Collection, or Optional of either the " +
                                        (entityInfo.recordClass == null ? entityInfo.entityClass : entityInfo.recordClass).getName() +
-                                       ") or the id class (" + entityInfo.idType +
-                                       "), not the " + singleType.getName() + " class."); // TODO NLS
+                                       " entity class or the " + entityInfo.idType.getName() +
+                                       " Id class to return the deleted entities or entity Ids."); // TODO NLS
         }
 
         if (cols == null || cols.length == 0) {
@@ -1724,7 +1731,7 @@ public class QueryInfo {
      * @param repository  repository implementation.
      * @return information about the query.
      */
-    @FFDCIgnore(Throwable.class) // TODO look into these failures and decide if FFDC should be enabled
+    @FFDCIgnore(Throwable.class) // report invalid repository methods as errors instead
     @Trivial
     QueryInfo init(Map<String, CompletableFuture<EntityInfo>> entityInfos, RepositoryImpl<?> repository) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -1909,6 +1916,12 @@ public class QueryInfo {
         } catch (Throwable x) {
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "init", x);
+            System.err.println("The " + method.getName() + " method of the " +
+                               method.getDeclaringClass().getName() +
+                               " repository interface encountered an error" +
+                               " and might not be a valid repository method." +
+                               " Refer to the cause exception: "); // TODO NLS
+            x.printStackTrace(); // TODO Tr.error instead
             throw x;
         }
 
@@ -2568,10 +2581,17 @@ public class QueryInfo {
                 && !type.equals(entityInfo.recordClass)
                 && !type.equals(Object.class)
                 && !wrapperClassIfPrimitive(singleType).equals(wrapperClassIfPrimitive(entityInfo.idType)))
-                throw new MappingException("Results for find-and-delete repository queries must be the entity class (" +
+                throw new MappingException("The " + method.getGenericReturnType().getTypeName() +
+                                           " type cannot be used as a return type for the " +
+                                           method.getName() + " method of the " +
+                                           method.getDeclaringClass().getName() +
+                                           " repository inteface. The return type can be" +
+                                           " void to return no value, long or int for a deletion count," +
+                                           " boolean to indicate whether any entities were deleted," +
+                                           " or an array, Collection, or Optional of either the " +
                                            (entityInfo.recordClass == null ? entityInfo.entityClass : entityInfo.recordClass).getName() +
-                                           ") or the id class (" + entityInfo.idType +
-                                           "), not the " + method.getGenericReturnType() + " class."); // TODO NLS
+                                           " entity class or the " + entityInfo.idType.getName() +
+                                           " Id class to return the deleted entities or entity Ids."); // TODO NLS
         }
 
         return isFindAndDelete;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2273,23 +2273,25 @@ public class QueryInfo {
                                                             " clause and instead use the " + "OrderBy" +
                                                             " annotation to specify static sort criteria."); // TODO NLS
 
-                if (where0 + whereLen != length)
-                    throw new UnsupportedOperationException("The " + ql + " query that is supplied to the " + method.getName() +
-                                                            " method of the " + method.getDeclaringClass().getName() +
-                                                            " repository must end in a WHERE clause because" +
-                                                            " the method returns a " + "CursoredPage" + ". There WHERE clause" +
-                                                            " ends at position " + (where0 + whereLen) + " but the length of the" +
-                                                            " query is " + length + "."); // TODO NLS
+                if (whereLen > 0) {
+                    if (where0 + whereLen != length)
+                        throw new UnsupportedOperationException("The " + ql + " query that is supplied to the " + method.getName() +
+                                                                " method of the " + method.getDeclaringClass().getName() +
+                                                                " repository must end in a WHERE clause because" +
+                                                                " the method returns a " + "CursoredPage" + ". There WHERE clause" +
+                                                                " ends at position " + (where0 + whereLen) + " but the length of the" +
+                                                                " query is " + length + "."); // TODO NLS
 
-                // Enclose the WHERE clause in parenthesis so that conditions can be appended.
-                boolean addSpace = ql.charAt(where0) != ' ';
-                ql = new StringBuilder(ql.length() + 2) //
-                                .append(ql.substring(0, where0)) //
-                                .append(" (") //
-                                .append(ql.substring(where0 + (addSpace ? 0 : 1), where0 + whereLen)) //
-                                .append(")") //
-                                .toString();
-                whereLen += 2 + (addSpace ? 1 : 0);
+                    // Enclose the WHERE clause in parenthesis so that conditions can be appended.
+                    boolean addSpace = ql.charAt(where0) != ' ';
+                    ql = new StringBuilder(ql.length() + 2) //
+                                    .append(ql.substring(0, where0)) //
+                                    .append(" (") //
+                                    .append(ql.substring(where0 + (addSpace ? 0 : 1), where0 + whereLen)) //
+                                    .append(")") //
+                                    .toString();
+                    whereLen += 2 + (addSpace ? 1 : 0);
+                }
             }
 
             StringBuilder q;
@@ -2331,6 +2333,8 @@ public class QueryInfo {
             }
 
             if (whereLen > 0)
+                // TODO once fixed, test #28931 by adding: && !"this.".equalsIgnoreCase(entityVar_)
+                // and running DataJPATestServlet.testCountQueryWithFromAndWhereClausesOnly
                 if (insertEntityVar) {
                     q.append("WHERE");
                     appendWithIdentifierName(ql, where0, where0 + whereLen, entityVar_, q);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -51,6 +51,15 @@ import jakarta.enterprise.concurrent.Asynchronous;
  */
 @Repository
 public interface Primes {
+    @Find
+    CursoredPage<Prime> all(Order<Prime> sorts, PageRequest req);
+
+    @Query("")
+    CursoredPage<Prime> all(PageRequest req, Order<Prime> sorts);
+
+    @Query("FROM Prime")
+    CursoredPage<Prime> all(PageRequest req, Sort<?>... sorts);
+
     @Query("SELECT (num.name) FROM Prime As num")
     Page<String> all(Sort<Prime> sort, PageRequest pagination);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
@@ -39,9 +39,8 @@ public interface Receipts extends CrudRepository<Receipt, Long> {
     @Query("UPDATE Receipt SET total = total * (1.0 + :taxRate) WHERE purchaseId = :id")
     boolean addTax(long id, float taxRate);
 
-    // TODO should this be able to return CursoredPage even though it has no WHERE clause?
     @Query(" ")
-    Page<Receipt> all(PageRequest req, Order<PageRequest> sorts);
+    Page<Receipt> all(PageRequest req, Order<Receipt> sorts);
 
     @Query("FROM Receipt")
     Page<Receipt> all(PageRequest req, Sort<?>... sorts);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -45,21 +45,23 @@ public interface Cities {
     @Delete
     void delete(City city); // copied from BasicRepository
 
+    CityId delete1ByStateName(String state, Limit limitOf1);
+
     // "IN" (which is needed for this) is not supported for composite IDs, but EclipseLink generates SQL
     // that leads to an SQLSyntaxErrorException rather than rejecting it outright
     @Delete
     void deleteAll(Iterable<City> list); // copied from BasicRepository
+
+    Optional<CityId> deleteAtMost1ByStateName(String state,
+                                              Limit limitOf1,
+                                              Order<City> sorts);
 
     @Delete
     long deleteById(@By(ID) CityId id);
 
     LinkedList<CityId> deleteByStateName(String state);
 
-    CityId deleteByStateName(String state, Limit limitOf1);
-
-    Optional<CityId> delete1ByStateName(String state, Limit limit, Order<City> sorts);
-
-    Iterable<CityId> delete3ByStateName(String state, Limit limit, Order<City> sorts);
+    Iterable<CityId> deleteByStateName(String state, Limit limit, Order<City> sorts);
 
     @Delete
     List<CityId> deleteSome(@By("stateName") String state,

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -799,7 +799,7 @@ public class DataJPATestServlet extends FATServlet {
         }
 
         Order<City> orderByCityName = supportsOrderByForUpdate ? Order.by(Sort.asc("name")) : Order.by();
-        Iterator<CityId> ids = cities.delete3ByStateName("South Dakota", Limit.of(3), orderByCityName).iterator();
+        Iterator<CityId> ids = cities.deleteByStateName("South Dakota", Limit.of(3), orderByCityName).iterator();
         CityId id;
 
         assertEquals(true, ids.hasNext());
@@ -829,14 +829,14 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(false, ids.hasNext());
 
         Order<City> orderByPopulation = supportsOrderByForUpdate ? Order.by(Sort.asc("population")) : Order.by();
-        id = cities.delete1ByStateName("South Dakota", Limit.of(1), orderByPopulation).orElseThrow();
+        id = cities.deleteAtMost1ByStateName("South Dakota", Limit.of(1), orderByPopulation).orElseThrow();
         assertEquals("South Dakota", id.getStateName());
         if (supportsOrderByForUpdate)
             assertEquals("Spearfish", id.name);
         // else order is unknown, but at least must be one of the city names that we added and haven't removed yet
         assertEquals("Found " + id, true, cityNames.remove(id.name));
 
-        id = cities.deleteByStateName("South Dakota", Limit.of(1));
+        id = cities.delete1ByStateName("South Dakota", Limit.of(1));
         assertEquals("South Dakota", id.getStateName());
         assertEquals("Found " + id, true, cityNames.remove(id.name));
 


### PR DESCRIPTION
Make cursor-based pagination work regardless of whether the user's explicit or implicit query contains a WHERE clause. There already some support for this in the code that generates the conditions for the cursor, but it cannot get that far because earlier code path disallows it.  This PR gets that working and adds some tests.

Also, it addresses various TODOs, improves various error messages, and adds the declared type parameters of repository method return types in both debug trace and error messages. Also, I renamed a few test case repository methods to more accurately reflect what they are doing so that test code can be better understood.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
