### PR TITLE
Update projects to build with Java 17 only in Eclipse

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/TaskStatusImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/TaskStatusImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014,2022 IBM Corporation and others.
+ * Copyright (c) 2014,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -182,7 +182,7 @@ public class TaskStatusImpl<T> implements TaskStatus<T>, TimerStatus<T> {
      * Unimplemented because persistent executor futures (TaskStatus) are only usable by persistent EJB timers
      * and not directly by applications.
      */
-    Throwable exceptionNow() {
+    public Throwable exceptionNow() {
         throw new UnsupportedOperationException();
     }
 
@@ -387,7 +387,7 @@ public class TaskStatusImpl<T> implements TaskStatus<T>, TimerStatus<T> {
      * Unimplemented because persistent executor futures (TaskStatus) are only usable by persistent EJB timers
      * and not directly by applications.
      */
-    T resultNow() {
+    public T resultNow() {
         throw new UnsupportedOperationException();
     }
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2/bnd.bnd
@@ -35,6 +35,7 @@ Import-Package: \
   javax.xml.bind.annotation;version=!, \
   javax.xml.bind.annotation.adapters;version=!, \
   javax.xml.bind.attachment;version=!, \
+  javax.xml.ws;version=!, \
   *
 
 Export-Package: \
@@ -62,4 +63,5 @@ instrument.classesIncludes: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
   com.ibm.ws.logging.core, \
   com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
-  com.ibm.websphere.javaee.wsdl4j.1.2
+  com.ibm.websphere.javaee.wsdl4j.1.2, \
+  com.ibm.websphere.javaee.jaxws.2.2

--- a/dev/com.ibm.ws.security.context/src/com/ibm/ws/security/context/internal/SecurityContextImpl.java
+++ b/dev/com.ibm.ws.security.context/src/com/ibm/ws/security/context/internal/SecurityContextImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -335,7 +335,7 @@ public class SecurityContextImpl implements ThreadContext {
      * @param fields
      * @throws IOException if there are I/O errors while reading from the underlying InputStream
      */
-    private void readState(GetField fields) throws IOException {
+    private void readState(GetField fields) throws IOException, ClassNotFoundException {
         //get caller principal
         callerPrincipal = (WSPrincipal) fields.get(CALLER_PRINCIPAL, null);
 

--- a/dev/io.openliberty.checkpoint_fat_xmlws/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_xmlws/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2023 IBM Corporation and others.
+# Copyright (c) 2023, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -31,6 +31,10 @@ tested.features: servlet-5.0, servlet-6.0, xmlws-3.0, xmlbinding-3.0, enterprise
 # fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
+	com.ibm.websphere.javaee.activation.1.1;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.3;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.websphere.javaee.jaxws.2.2;version=latest,\
+	com.ibm.websphere.javaee.jws.1.0;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest
 

--- a/dev/io.openliberty.jaxws.executor_fat/bnd.bnd
+++ b/dev/io.openliberty.jaxws.executor_fat/bnd.bnd
@@ -38,7 +38,7 @@ tested.features: \
   com.ibm.websphere.javaee.jsonb.1.0,\
   com.ibm.websphere.javaee.jsonp.1.1,\
   com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-  com.ibm.websphere.javaee.concurrent.1.0;version=latest  
+  com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
   com.ibm.websphere.javaee.annotation.1.2,\
   com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
   com.ibm.websphere.javaee.jaxws.2.2,\


### PR DESCRIPTION
- Add activation, annotation, jaxb, jaxws, and jws, activation bundles to buildpath so that things can build when not having Java 8 in your eclipse
- Update SecurityContextImpl to add ClassNotFoundException to resetState method throws list
- Update TaskStatusImpl to make two methods public so that they compile cleanly with Java 17

This PR is the latest incantation of the work done last year with PR #25850.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
