### PR TITLE
More logging for repeat action and test method entry and exit

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
@@ -192,13 +192,18 @@ public class FATRunner extends BlockJUnit4ClassRunner {
         Statement statement = new Statement() {
             @Override
             public void evaluate() throws Throwable {
+                String m = "evaluate";
+
                 if (!RepeatTestFilter.shouldRun(method)) {
                     throw new AssumptionViolatedException("Test skipped for current RepeatAction");
                 }
                 Map<String, Long> tmpDirFilesBeforeTest = createDirectorySnapshot("/tmp");
                 try {
-                    Log.info(c, "evaluate", "entering " + getTestClass().getName() + "." + method.getName());
-
+                    Log.info(c, m, "***********************************");
+                    Log.info(c, m, "");
+                    Log.info(c, m, "entering " + getTestClass().getName() + "." + method.getName());
+                    Log.info(c, m, "");
+                    Log.info(c, m, "***********************************");
                     Map<String, FFDCInfo> ffdcBeforeTest = retrieveFFDCCounts();
 
                     superStatement.evaluate();
@@ -306,7 +311,11 @@ public class FATRunner extends BlockJUnit4ClassRunner {
                 } finally {
                     Map<String, Long> tmpDirFilesAfterTest = createDirectorySnapshot("/tmp");
                     compareDirectorySnapshots("/tmp", tmpDirFilesBeforeTest, tmpDirFilesAfterTest);
-                    Log.info(c, "evaluate", "exiting " + getTestClass().getName() + "." + method.getName());
+                    Log.info(c, m, "***********************************");
+                    Log.info(c, m, "");
+                    Log.info(c, m, "exiting " + getTestClass().getName() + "." + method.getName());
+                    Log.info(c, m, "");
+                    Log.info(c, m, "***********************************");
                 }
             }
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatTests.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatTests.java
@@ -109,7 +109,7 @@ public class RepeatTests extends ExternalResource {
 
     @Override
     public Statement apply(Statement statement, Description description) {
-        return new CompositeRepeatTestActionStatement(actions, statement);
+        return new CompositeRepeatTestActionStatement(actions, statement, description);
     }
 
     private static class CompositeRepeatTestActionStatement extends Statement {
@@ -117,16 +117,20 @@ public class RepeatTests extends ExternalResource {
 
         private final Statement statement;
         private final List<RepeatTestAction> actions;
+        private final Description description;
 
-        private CompositeRepeatTestActionStatement(List<RepeatTestAction> actions, Statement statement) {
+        private CompositeRepeatTestActionStatement(List<RepeatTestAction> actions, Statement statement, Description description) {
             this.statement = statement;
             this.actions = actions;
+            this.description = description;
         }
 
         @Override
         public void evaluate() throws Throwable {
             final String m = "evaluate";
             ArrayList<Throwable> errors = new ArrayList<>();
+
+            String descriptionDisplayName = description != null ? description.getDisplayName() : "tests";
 
             Log.info(c, m, "All tests attempt to run " + actions.size() + " times:");
             for (int i = 0; i < actions.size(); i++)
@@ -138,16 +142,21 @@ public class RepeatTests extends ExternalResource {
                     if (shouldRun(action)) {
                         Log.info(c, m, "===================================");
                         Log.info(c, m, "");
-                        Log.info(c, m, "Running tests with action: " + action);
+                        Log.info(c, m, "Running " + descriptionDisplayName + " with action: " + action);
                         Log.info(c, m, "");
                         Log.info(c, m, "===================================");
                         action.setup();
                         statement.evaluate();
                         action.cleanup();
+                        Log.info(c, m, "===================================");
+                        Log.info(c, m, "");
+                        Log.info(c, m, "Exiting " + descriptionDisplayName + " with action: " + action);
+                        Log.info(c, m, "");
+                        Log.info(c, m, "===================================");
                     } else {
                         Log.info(c, m, "===================================");
                         Log.info(c, m, "");
-                        Log.info(c, m, "Skipping tests with action: " + action);
+                        Log.info(c, m, "Skipping " + descriptionDisplayName + " with action: " + action);
                         Log.info(c, m, "");
                         Log.info(c, m, "===================================");
                     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This 
- Prints out the Description when entering a repeat action (usually the test class that will be run at that repeat)
- Makes the message saying which test method we're entering or exiting much more visible