### PR TITLE
Allow non-EE threads access to java:comp/env names

### DIFF
--- a/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/naming/InjectionJavaColonHelper.java
+++ b/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/naming/InjectionJavaColonHelper.java
@@ -157,7 +157,7 @@ public class InjectionJavaColonHelper implements JavaColonNamingHelper, RemoteJa
         // There is no comp namespace if there is no active component.
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
 
-        if (cmd == null) {
+        if (cmd == null && !Boolean.getBoolean("com.ibm.ws.container.service.naming.disableStrictEEJndiProtection")) {
             NamingException nex = new NamingException(Tr.formatMessage(tc, "JNDI_NON_JEE_THREAD_CWNEN1000E"));
             if (isTraceOn && tc.isDebugEnabled())
                 Tr.debug(tc, "getInjectionScopeData : (no CMD) : " + nex.toString(true));


### PR DESCRIPTION
- [ x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This pull request adds a new boolean com.ibm.ws.container.service.naming.disableStrictEEJndiProtection to allow old apps to use java:comp/env names without getting CWNEN1000E errors

If com.ibm.ws.container.service.naming.disableStrictEEJndiProtection isn't set then then it's disabled, so there are no behavioral changes

This allows an old Java 5 app to run on OpenLiberty with Java 11 without modification
