### PR TITLE
initial set of error messages for jakarta data

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -36,7 +36,7 @@ CWWKD1000.repo.general.err.useraction=Locate the repository interface and method
 
 CWWKD1001.no.primary.entity=CWWKD1001E: An entity class is needed by the {0} \
  repository method, but the {1} repository interface does not specify a primary \
- entity class. To correct this, have the {1} interface extend one of the \
+ entity class. To correct this, have the {1} repository interface extend one of the \
  built-in repository supertypes, such as {2}, supplying the entity class as \
  the first type parameter.
 CWWKD1001.no.primary.entity.explanation=Repository methods without an entity \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -58,7 +58,7 @@ CWWKD1003.lifecycle.rtrn.err=CWWKD1003E: The {0} return type of the {1} method \
  {3} method. Valid return types include: {4}.
 CWWKD1003.lifecycle.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for Insert, Update, and Save methods.
-CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the JavaDoc of the Insert, \
+CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the Jakarta Data JavaDoc of the Insert, \
  Update, and Save methods for valid return types.
 
 CWWKD1004.general.rtrn.err=CWWKD1004E: The {0} return type of the {1} method \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -27,27 +27,25 @@
 # All messages must use the range CWWKD1000 to CWWKD1399
 
 CWWKD1000.repo.general.err=CWWKD1000E: The {0} method of the {1} repository \
- interface encountered an error indicating that the repository method might \
- not be valid. The error is: {2}.
+ interface encountered an error. The error might indicate that the repository \
+ method is not valid. The error is: {2}.
 CWWKD1000.repo.general.err.explanation=An error was found with the specified \
  repository method.
 CWWKD1000.repo.general.err.useraction=Locate the repository interface and method \
  and determine whether corrections are needed.
 
-CWWKD1001.no.primary.entity=CWWKD1001E: An entity class is needed by the {0} \
- repository method, but the {1} repository interface does not specify a primary \
- entity class. To correct this, have the {1} repository interface extend one of \
- the built-in repository supertypes, such as {2}, supplying the entity class as \
- the first type parameter.
+CWWKD1001.no.primary.entity=CWWKD1001E: The {0} repository method requires \
+ an entity class but the {1} repository interface does not specify a primary \
+ entity class. To correct this error, the {1} repository interface must extend \
+ one of the built-in repository supertypes, such as {2}, and supply the entity \
+ class as the first type parameter.
 CWWKD1001.no.primary.entity.explanation=Repository methods without an entity \
- class of their own require a primary entity class to be defined by the \
- repository.
+ class of their own require the repository to define a primary entity class.
 CWWKD1001.no.primary.entity.useraction=Define a primary entity class for the \
  repository.
 
 CWWKD1002.method.annos.err=CWWKD1002E: The {0} method of the {1} repository \
- interface is annotated with a combination of annotations, {2}, that is not \
- valid.
+ interface is annotated with a combination of annotations that is not valid: {2}.
 CWWKD1002.method.annos.err.explanation=This combination of annotations is not \
  valid on a single repository method.
 CWWKD1002.method.annos.err.useraction=Locate the repository interface and method \
@@ -58,29 +56,31 @@ CWWKD1003.lifecycle.rtrn.err=CWWKD1003E: The {0} return type of the {1} method \
  {3} method. Valid return types include: {4}.
 CWWKD1003.lifecycle.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for Insert, Update, and Save methods.
-CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the Jakarta Data Javadoc information for the \
- Insert, Update, and Save methods for valid return types.
+CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
+ information for the Insert, Update, and Save methods for valid return types.
 
 CWWKD1004.general.rtrn.err=CWWKD1004E: The {0} return type of the {1} method \
  of the {2} repository interface is not a valid return type for a repository \
  method.
 CWWKD1004.general.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for the type of repository method.
-CWWKD1004.general.rtrn.err.useraction=Refer to the Jakarta Data Javadoc information for a \
- list of valid return types for the type of repository method.
+CWWKD1004.general.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
+ information for a list of valid return types for the type of repository method.
+
 
 CWWKD1005.find.rtrn.err=CWWKD1005E: The {0} method of the {1} repository \
- interface specifies the {2} return type, which is not convertible from the \
- {3} entity type. The result type of a find operation must be the \
- entity type, the type of an entity property, a Java record composed of \
- entity properties, or be constructed by JPQL that is supplied to the \
+ interface is not valid. The method specifies a {2} return type that is \
+ not convertible from the {3} entity type. The result type of a \
+ find operation must be the entity type, a type of an entity property, \
+ a Java record composed of entity properties, or a type constructed \
+ by the JPQL or JDQL that is supplied to the \
  Query annotation. The return type of the repository find method can be an \
  Optional or single value of the result type or it can be one of {4} or an \
- array of the result type, allowing multiple results to be returned.
+ array of the result type.
 CWWKD1005.find.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for repository find methods.
-CWWKD1005.find.rtrn.err.useraction=Refer to the Jakarta Data Javadoc information for a \
- list of valid return types for repository find methods.
+CWWKD1005.find.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
+ information for a list of valid return types for repository find methods.
 
 
 CWWKD1010.unknown.entity.prop=CWWKD1010E: The {0} method of the {1} repository \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -88,5 +88,5 @@ CWWKD1010.unknown.entity.prop=CWWKD1010E: The {0} method of the {1} repository \
 CWWKD1010.unknown.entity.prop.explanation=The repository method is attempting \
  to use an entity property that does not exist.
 CWWKD1010.unknown.entity.prop.useraction=Update the repository method to match \
- the properties that are defined by the entity.
+ a valid property that is defined by the entity.
 

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -48,17 +48,17 @@ CWWKD1001.no.primary.entity.useraction=Define a primary entity class for the \
 CWWKD1002.method.annos.err=CWWKD1002E: The {0} method of the {1} repository \
  interface is annotated with a combination of annotations, {2}, that is not \
  valid.
-CWWKD1002.method.annos.err.explanation=The combination of annotations is not \
+CWWKD1002.method.annos.err.explanation=This combination of annotations is not \
  valid on a single repository method.
 CWWKD1002.method.annos.err.useraction=Locate the repository interface and method \
- and determine the correct method annotations to use.
+ and determine the correct combination of method annotations.
 
 CWWKD1003.lifecycle.rtrn.err=CWWKD1003E: The {0} return type of the {1} method \
  of the {2} repository interface is not a valid return type for a repository \
  {3} method. Valid return types include: {4}.
 CWWKD1003.lifecycle.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for Insert, Update, and Save methods.
-CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the Jakarta Data JavaDoc of the \
+CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the Jakarta Data Javadoc information for the \
  Insert, Update, and Save methods for valid return types.
 
 CWWKD1004.general.rtrn.err=CWWKD1004E: The {0} return type of the {1} method \
@@ -66,7 +66,7 @@ CWWKD1004.general.rtrn.err=CWWKD1004E: The {0} return type of the {1} method \
  method.
 CWWKD1004.general.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for the type of repository method.
-CWWKD1004.general.rtrn.err.useraction=Refer to the Jakarta Data JavaDoc for a \
+CWWKD1004.general.rtrn.err.useraction=Refer to the Jakarta Data Javadoc information for a \
  list of valid return types for the type of repository method.
 
 CWWKD1005.find.rtrn.err=CWWKD1005E: The {0} method of the {1} repository \
@@ -79,7 +79,7 @@ CWWKD1005.find.rtrn.err=CWWKD1005E: The {0} method of the {1} repository \
  array of the result type, allowing multiple results to be returned.
 CWWKD1005.find.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for repository find methods.
-CWWKD1005.find.rtrn.err.useraction=Refer to the Jakarta Data JavaDoc for a \
+CWWKD1005.find.rtrn.err.useraction=Refer to the Jakarta Data Javadoc information for a \
  list of valid return types for repository find methods.
 
 

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -36,8 +36,8 @@ CWWKD1000.repo.general.err.useraction=Locate the repository interface and method
 
 CWWKD1001.no.primary.entity=CWWKD1001E: An entity class is needed by the {0} \
  repository method, but the {1} repository interface does not specify a primary \
- entity class. To correct this, have the {1} repository interface extend one of the \
- built-in repository supertypes, such as {2}, supplying the entity class as \
+ entity class. To correct this, have the {1} repository interface extend one of \
+ the built-in repository supertypes, such as {2}, supplying the entity class as \
  the first type parameter.
 CWWKD1001.no.primary.entity.explanation=Repository methods without an entity \
  class of their own require a primary entity class to be defined by the \
@@ -58,8 +58,8 @@ CWWKD1003.lifecycle.rtrn.err=CWWKD1003E: The {0} return type of the {1} method \
  {3} method. Valid return types include: {4}.
 CWWKD1003.lifecycle.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for Insert, Update, and Save methods.
-CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the Jakarta Data JavaDoc of the Insert, \
- Update, and Save methods for valid return types.
+CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the Jakarta Data JavaDoc of the \
+ Insert, Update, and Save methods for valid return types.
 
 CWWKD1004.general.rtrn.err=CWWKD1004E: The {0} return type of the {1} method \
  of the {2} repository interface is not a valid return type for a repository \
@@ -70,12 +70,13 @@ CWWKD1004.general.rtrn.err.useraction=Refer to the Jakarta Data JavaDoc for a \
  list of valid return types for the type of repository method.
 
 CWWKD1005.find.rtrn.err=CWWKD1005E: The {0} method of the {1} repository \
- interface specifies the {2} result type, which is not convertible from the \
- {3} entity type. The return type of a repository find method must be an \
- array, Collection, Optional, or single value of a result type that is the \
- entity type, an entity attribute type, or a Java record with component names \
- that are a subset of the entity property names, or the Query annotation must \
- be used to construct the result type with JPQL.
+ interface specifies the {2} return type, which is not convertible from the \
+ {3} entity type. The result type of a find operation must be the \
+ entity type, the type of an entity property, a Java record composed of \
+ entity properties, or be constructed by JPQL that is supplied to the \
+ Query annotation. The return type of the repository find method can be an \
+ Optional or single value of the result type or it can be one of {4} or an \
+ array of the result type, allowing multiple results to be returned.
 CWWKD1005.find.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for repository find methods.
 CWWKD1005.find.rtrn.err.useraction=Refer to the Jakarta Data JavaDoc for a \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -67,16 +67,15 @@ CWWKD1004.general.rtrn.err.explanation=The return type of the method is not \
 CWWKD1004.general.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
  information for a list of valid return types for the type of repository method.
 
-
 CWWKD1005.find.rtrn.err=CWWKD1005E: The {0} method of the {1} repository \
  interface is not valid. The method specifies a {2} return type that is \
  not convertible from the {3} entity type. The result type of a \
  find operation must be the entity type, a type of an entity property, \
  a Java record composed of entity properties, or a type constructed \
  by the JPQL or JDQL that is supplied to the \
- Query annotation. The return type of the repository find method can be an \
- Optional or single value of the result type or it can be one of {4} or an \
- array of the result type.
+ Query annotation. The return type of the repository find method can be \
+ the result type, an array of the result type, or any of the following types \
+ parameterized with the result type: {4}.
 CWWKD1005.find.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for repository find methods.
 CWWKD1005.find.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
@@ -90,4 +89,3 @@ CWWKD1010.unknown.entity.prop.explanation=The repository method is attempting \
  to use an entity property that does not exist.
 CWWKD1010.unknown.entity.prop.useraction=Update the repository method to match \
  a valid property that is defined by the entity.
-

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022,2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -24,5 +24,69 @@
 #   which do NOT contain replacement variables are NOT processed by the MessageFormat class 
 #   (single quote must be coded as one single quote '). 
 
-# All messages must use the range CWWKD1100 to CWWKD1499
+# All messages must use the range CWWKD1000 to CWWKD1399
+
+CWWKD1000.repo.general.err=CWWKD1000E: The {0} method of the {1} repository \
+ interface encountered an error indicating that the repository method might \
+ not be valid. The error is: {2}.
+CWWKD1000.repo.general.err.explanation=An error was found with the specified \
+ repository method.
+CWWKD1000.repo.general.err.useraction=Locate the repository interface and method \
+ and determine whether corrections are needed.
+
+CWWKD1001.no.primary.entity=CWWKD1001E: An entity class is needed by the {0} \
+ repository method, but the {1} repository interface does not specify a primary \
+ entity class. To correct this, have the {1} interface extend one of the \
+ built-in repository supertypes, such as {2}, supplying the entity class as \
+ the first type parameter.
+CWWKD1001.no.primary.entity.explanation=Repository methods without an entity \
+ class of their own require a primary entity class to be defined by the \
+ repository.
+CWWKD1001.no.primary.entity.useraction=Define a primary entity class for the \
+ repository.
+
+CWWKD1002.method.annos.err=CWWKD1002E: The {0} method of the {1} repository \
+ interface is annotated with a combination of annotations, {2}, that is not \
+ valid.
+CWWKD1002.method.annos.err.explanation=The combination of annotations is not \
+ valid on a single repository method.
+CWWKD1002.method.annos.err.useraction=Locate the repository interface and method \
+ and determine the correct method annotations to use.
+
+CWWKD1003.lifecycle.rtrn.err=CWWKD1003E: The {0} return type of the {1} method \
+ of the {2} repository interface is not a valid return type for a repository \
+ {3} method. Valid return types include: {4}.
+CWWKD1003.lifecycle.rtrn.err.explanation=The return type of the method is not \
+ one of the supported return types for Insert, Update, and Save methods.
+CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the JavaDoc of the Insert, \
+ Update, and Save methods for valid return types.
+
+CWWKD1004.general.rtrn.err=CWWKD1004E: The {0} return type of the {1} method \
+ of the {2} repository interface is not a valid return type for a repository \
+ method.
+CWWKD1004.general.rtrn.err.explanation=The return type of the method is not \
+ one of the supported return types for the type of repository method.
+CWWKD1004.general.rtrn.err.useraction=Refer to the Jakarta Data JavaDoc for a \
+ list of valid return types for the type of repository method.
+
+CWWKD1005.find.rtrn.err=CWWKD1005E: The {0} method of the {1} repository \
+ interface specifies the {2} result type, which is not convertible from the \
+ {3} entity type. The return type of a repository find method must be an \
+ array, Collection, Optional, or single value of a result type that is the \
+ entity type, an entity attribute type, or a Java record with component names \
+ that are a subset of the entity property names, or the Query annotation must \
+ be used to construct the result type with JPQL.
+CWWKD1005.find.rtrn.err.explanation=The return type of the method is not \
+ one of the supported return types for repository find methods.
+CWWKD1005.find.rtrn.err.useraction=Refer to the Jakarta Data JavaDoc for a \
+ list of valid return types for repository find methods.
+
+
+CWWKD1010.unknown.entity.prop=CWWKD1010E: The {0} method of the {1} repository \
+ interface expects an entity property named {2} that is not found on the \
+ {3} entity class. Valid property names for the entity are: {4}.
+CWWKD1010.unknown.entity.prop.explanation=The repository method is attempting \
+ to use an entity property that does not exist.
+CWWKD1010.unknown.entity.prop.useraction=Update the repository method to match \
+ the properties that are defined by the entity.
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1319,12 +1319,14 @@ public class QueryInfo {
                                 first = false;
                             }
                         else
+                            // TODO include/exclude Page/CursoredPage based on whether PageRequest is supplied?
                             throw exc(MappingException.class,
                                       "CWWKD1005.find.rtrn.err",
                                       method.getName(),
                                       method.getDeclaringClass().getName(),
                                       method.getGenericReturnType().getTypeName(),
-                                      entityInfo.entityClass.getName());
+                                      entityInfo.entityClass.getName(),
+                                      List.of("List", "Page", "CursoredPage", "Stream"));
                         q.append(')');
                     }
                 } else {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1326,7 +1326,9 @@ public class QueryInfo {
                                       method.getDeclaringClass().getName(),
                                       method.getGenericReturnType().getTypeName(),
                                       entityInfo.entityClass.getName(),
-                                      List.of("List", "Page", "CursoredPage", "Stream"));
+                                      List.of("List", "Optional",
+                                              "Page", "CursoredPage",
+                                              "Stream"));
                         q.append(')');
                     }
                 } else {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -329,19 +329,23 @@ public class QueryInfo {
             if (++d < depth)
                 type = returnTypeAtDepth.get(d);
             else
-                throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
-                                                        method.getDeclaringClass().getName() +
-                                                        " repository specifies the " + method.getGenericReturnType() +
-                                                        " result type, which is not a supported result type for a repository method."); // TODO NLS and add helpful information about supported result types
+                // TODO add helpful information about supported result types
+                throw exc(UnsupportedOperationException.class,
+                          "CWWKD1004.general.rtrn.err",
+                          method.getGenericReturnType().getTypeName(),
+                          method.getName(),
+                          method.getDeclaringClass().getName());
         if (isOptional = Optional.class.equals(type)) {
             multiType = null;
             if (++d < depth)
                 type = returnTypeAtDepth.get(d);
             else
-                throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
-                                                        method.getDeclaringClass().getName() +
-                                                        " repository specifies the " + method.getGenericReturnType() +
-                                                        " result type, which is not a supported result type for a repository method."); // TODO NLS and add helpful information about supported result types
+                // TODO add helpful information about supported result types
+                throw exc(UnsupportedOperationException.class,
+                          "CWWKD1004.general.rtrn.err",
+                          method.getGenericReturnType().getTypeName(),
+                          method.getName(),
+                          method.getDeclaringClass().getName());
         } else {
             if (returnArrayType != null
                 || Iterator.class.equals(type)
@@ -351,10 +355,12 @@ public class QueryInfo {
                 if (++d < depth)
                     type = returnTypeAtDepth.get(d);
                 else
-                    throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
-                                                            method.getDeclaringClass().getName() +
-                                                            " repository specifies the " + method.getGenericReturnType() +
-                                                            " result type, which is not a supported result type for a repository method."); // TODO NLS and add helpful information about supported result types
+                    // TODO add helpful information about supported result types
+                    throw exc(UnsupportedOperationException.class,
+                              "CWWKD1004.general.rtrn.err",
+                              method.getGenericReturnType().getTypeName(),
+                              method.getName(),
+                              method.getDeclaringClass().getName());
             } else {
                 multiType = null;
             }
@@ -518,6 +524,30 @@ public class QueryInfo {
     private static boolean endsWith(String searchFor, String text, int minStart, int endBefore) {
         int searchLen = searchFor.length();
         return endBefore - minStart >= searchLen && text.regionMatches(endBefore - searchLen, searchFor, 0, searchLen);
+    }
+
+    /**
+     * Construct a RuntimeException or subclass and log the error.
+     *
+     * @param exceptionType RuntimeException or subclass, which must have a
+     *                          constructor that accepts the message as a single
+     *                          String argument.
+     * @param messageId     NLS message ID.
+     * @param args          message arguments.
+     * @return RuntimeException or subclass.
+     */
+    @Trivial
+    private final static <T extends RuntimeException> T exc(Class<T> exceptionType,
+                                                            String messageId,
+                                                            Object... args) {
+        Tr.error(tc, messageId, args);
+        String message = Tr.formatMessage(tc, messageId, args);
+        try {
+            return exceptionType.getConstructor(String.class).newInstance(message);
+        } catch (Exception x) {
+            // should never occur
+            throw new DataException(messageId + ' ' + Arrays.toString(args));
+        }
     }
 
     /**
@@ -1289,13 +1319,12 @@ public class QueryInfo {
                                 first = false;
                             }
                         else
-                            throw new MappingException("The " + method.getName() + " method of the " +
-                                                       method.getDeclaringClass().getName() + " repository specifies the " +
-                                                       singleType.getName() + " result type, which is not convertible from the " +
-                                                       entityInfo.entityClass.getName() + " entity type. A repository method " +
-                                                       "result type must be the entity type, an entity attribute type, or a " +
-                                                       "Java record with attribute names that are a subset of the entity attribute names, " +
-                                                       "or the Query annotation must be used to construct the result type with JPQL."); // TODO NLS
+                            throw exc(MappingException.class,
+                                      "CWWKD1005.find.rtrn.err",
+                                      method.getName(),
+                                      method.getDeclaringClass().getName(),
+                                      method.getGenericReturnType().getTypeName(),
+                                      entityInfo.entityClass.getName());
                         q.append(')');
                     }
                 } else {
@@ -1592,10 +1621,13 @@ public class QueryInfo {
                                     .append(')') //
                                     .toString();
             else
-                throw new MappingException("Entity class " + entityInfo.getType().getName() +
-                                           " does not have a property named " + name +
-                                           ". The following are valid property names for the entity: " +
-                                           entityInfo.attributeTypes.keySet()); // TODO NLS
+                throw exc(MappingException.class,
+                          "CWWKD1010.unknown.entity.prop",
+                          method.getName(),
+                          method.getDeclaringClass().getName(),
+                          name,
+                          entityInfo.getType().getName(),
+                          entityInfo.attributeTypes.keySet());
         } else {
             String lowerName = name.toLowerCase();
             attributeName = entityInfo.attributeNames.get(lowerName);
@@ -1610,12 +1642,17 @@ public class QueryInfo {
                         // tolerate possible mixture of . and _ separators with lack of separators:
                         lowerName = lowerName.replace("_", "");
                         attributeName = entityInfo.attributeNames.get(lowerName);
-                        if (attributeName == null && failIfNotFound)
+                        if (attributeName == null && failIfNotFound) {
                             // TODO If attempting to parse Query by Method Name without a By keyword, then the message
                             // should also include the possibility that repository method is missing an annotation.
-                            throw new MappingException("Entity class " + entityInfo.getType().getName() + " does not have a property named " + name +
-                                                       ". The following are valid property names for the entity: " +
-                                                       entityInfo.attributeTypes.keySet()); // TODO NLS
+                            throw exc(MappingException.class,
+                                      "CWWKD1010.unknown.entity.prop",
+                                      method.getName(),
+                                      method.getDeclaringClass().getName(),
+                                      name,
+                                      entityInfo.getType().getName(),
+                                      entityInfo.attributeTypes.keySet());
+                        }
                     }
                 }
         }
@@ -1931,14 +1968,15 @@ public class QueryInfo {
                 Tr.exit(this, tc, "init", new Object[] { this, entityInfo });
             return this;
         } catch (Throwable x) {
+            String message = x.getMessage();
+            if (message == null || !message.startsWith("CWWKD1"))
+                Tr.error(tc, "CWWKD1000.repo.general.err",
+                         method.getName(),
+                         method.getDeclaringClass().getName(),
+                         x);
+            // else the error was already logged
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "init", x);
-            System.err.println("The " + method.getName() + " method of the " +
-                               method.getDeclaringClass().getName() +
-                               " repository interface encountered an error" +
-                               " and might not be a valid repository method." +
-                               " Refer to the cause exception: "); // TODO NLS
-            x.printStackTrace(); // TODO Tr.error instead
             throw x;
         }
 
@@ -3086,9 +3124,11 @@ public class QueryInfo {
             if (orderBy.length > 0)
                 annoClassNames.add(OrderBy.class.getName());
 
-            throw new UnsupportedOperationException("The " + method.getDeclaringClass().getName() + '.' + method.getName() +
-                                                    " repository method cannot be annotated with the following combination of annotations: " +
-                                                    annoClassNames); // TODO NLS
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1002.method.annos.err",
+                      method.getName(),
+                      method.getDeclaringClass().getName(),
+                      annoClassNames);
         }
 
         return ius == 1 //

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -33,6 +33,7 @@ import java.sql.SQLSyntaxErrorException;
 import java.sql.SQLTransientConnectionException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
@@ -476,6 +477,30 @@ public class RepositoryImpl<R> implements InvocationHandler {
     }
 
     /**
+     * Construct a RuntimeException or subclass and log the error.
+     *
+     * @param exceptionType RuntimeException or subclass, which must have a
+     *                          constructor that accepts the message as a single
+     *                          String argument.
+     * @param messageId     NLS message ID.
+     * @param args          message arguments.
+     * @return RuntimeException or subclass.
+     */
+    @Trivial
+    private final static <T extends RuntimeException> T exc(Class<T> exceptionType,
+                                                            String messageId,
+                                                            Object... args) {
+        Tr.error(tc, messageId, args);
+        String message = Tr.formatMessage(tc, messageId, args);
+        try {
+            return exceptionType.getConstructor(String.class).newInstance(message);
+        } catch (Exception x) {
+            // should never occur
+            throw new DataException(messageId + ' ' + Arrays.toString(args));
+        }
+    }
+
+    /**
      * Replaces an exception with a Jakarta Data specification-defined exception,
      * chaining the original exception as the cause.
      * This method replaces all exceptions that are not RuntimeExceptions.
@@ -642,13 +667,15 @@ public class RepositoryImpl<R> implements InvocationHandler {
             else if (Iterator.class.equals(multiType))
                 returnValue = results.iterator();
             else
-                throw new MappingException("The " + queryInfo.method.getGenericReturnType().getTypeName() +
-                                           " return type of the " +
-                                           queryInfo.method.getName() + " method of the " +
-                                           queryInfo.method.getDeclaringClass().getName() +
-                                           " class is not a valid return type for a repository " +
-                                           "@Update" + " method. Valid return types include " +
-                                           getValidReturnTypes(results.get(0).getClass().getSimpleName(), hasSingularEntityParam, false) + "."); // TODO NLS
+                throw exc(MappingException.class,
+                          "CWWKD1003.lifecycle.rtrn.err",
+                          queryInfo.method.getGenericReturnType().getTypeName(),
+                          queryInfo.method.getName(),
+                          repositoryInterface.getName(),
+                          "Update",
+                          getValidReturnTypes(results.get(0).getClass().getSimpleName(),
+                                              hasSingularEntityParam,
+                                              false));
         }
 
         if (Optional.class.equals(returnType)) {
@@ -656,13 +683,15 @@ public class RepositoryImpl<R> implements InvocationHandler {
         } else if (CompletableFuture.class.equals(returnType) || CompletionStage.class.equals(returnType)) {
             returnValue = CompletableFuture.completedFuture(returnValue); // useful for @Asynchronous
         } else if (returnValue != null && !returnType.isInstance(returnValue)) {
-            throw new MappingException("The " + queryInfo.method.getGenericReturnType().getTypeName() +
-                                       " return type of the " +
-                                       queryInfo.method.getName() + " method of the " +
-                                       queryInfo.method.getDeclaringClass().getName() +
-                                       " class is not a valid return type for a repository " +
-                                       "@Update" + " method. Valid return types include " +
-                                       getValidReturnTypes(results.get(0).getClass().getSimpleName(), hasSingularEntityParam, false) + "."); // TODO NLS
+            throw exc(MappingException.class,
+                      "CWWKD1003.lifecycle.rtrn.err",
+                      queryInfo.method.getGenericReturnType().getTypeName(),
+                      queryInfo.method.getName(),
+                      repositoryInterface.getName(),
+                      "Update",
+                      getValidReturnTypes(results.get(0).getClass().getSimpleName(),
+                                          hasSingularEntityParam,
+                                          false));
         }
 
         return returnValue;
@@ -919,26 +948,30 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 else if (Iterator.class.equals(multiType))
                     returnValue = results.iterator();
                 else
-                    throw new MappingException("The " + queryInfo.method.getGenericReturnType().getTypeName() +
-                                               " return type of the " +
-                                               queryInfo.method.getName() + " method of the " +
-                                               queryInfo.method.getDeclaringClass().getName() +
-                                               " class is not a valid return type for a repository " +
-                                               "@Insert" + " method. Valid return types include " +
-                                               getValidReturnTypes(results.get(0).getClass().getSimpleName(), hasSingularEntityParam, false) + "."); // TODO NLS
+                    throw exc(MappingException.class,
+                              "CWWKD1003.lifecycle.rtrn.err",
+                              queryInfo.method.getGenericReturnType().getTypeName(),
+                              queryInfo.method.getName(),
+                              repositoryInterface.getName(),
+                              "Insert",
+                              getValidReturnTypes(results.get(0).getClass().getSimpleName(),
+                                                  hasSingularEntityParam,
+                                                  false));
             }
         }
 
         if (CompletableFuture.class.equals(returnType) || CompletionStage.class.equals(returnType)) {
             returnValue = CompletableFuture.completedFuture(returnValue); // useful for @Asynchronous
         } else if (!resultVoid && !returnType.isInstance(returnValue)) {
-            throw new MappingException("The " + queryInfo.method.getGenericReturnType().getTypeName() +
-                                       " return type of the " +
-                                       queryInfo.method.getName() + " method of the " +
-                                       queryInfo.method.getDeclaringClass().getName() +
-                                       " class is not a valid return type for a repository " +
-                                       "@Insert" + " method. Valid return types include " +
-                                       getValidReturnTypes(results.get(0).getClass().getSimpleName(), hasSingularEntityParam, false) + "."); // TODO NLS
+            throw exc(MappingException.class,
+                      "CWWKD1003.lifecycle.rtrn.err",
+                      queryInfo.method.getGenericReturnType().getTypeName(),
+                      queryInfo.method.getName(),
+                      repositoryInterface.getName(),
+                      "Insert",
+                      getValidReturnTypes(results.get(0).getClass().getSimpleName(),
+                                          hasSingularEntityParam,
+                                          false));
         }
 
         return returnValue;
@@ -1891,26 +1924,30 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 else if (Iterator.class.equals(multiType))
                     returnValue = results.iterator();
                 else
-                    throw new MappingException("The " + queryInfo.method.getGenericReturnType().getTypeName() +
-                                               " return type of the " +
-                                               queryInfo.method.getName() + " method of the " +
-                                               queryInfo.method.getDeclaringClass().getName() +
-                                               " class is not a valid return type for a repository " +
-                                               "@Save" + " method. Valid return types include " +
-                                               getValidReturnTypes(results.get(0).getClass().getSimpleName(), hasSingularEntityParam, false) + "."); // TODO NLS
+                    throw exc(MappingException.class,
+                              "CWWKD1003.lifecycle.rtrn.err",
+                              queryInfo.method.getGenericReturnType().getTypeName(),
+                              queryInfo.method.getName(),
+                              repositoryInterface.getName(),
+                              "Save",
+                              getValidReturnTypes(results.get(0).getClass().getSimpleName(),
+                                                  hasSingularEntityParam,
+                                                  false));
             }
         }
 
         if (CompletableFuture.class.equals(returnType) || CompletionStage.class.equals(returnType)) {
             returnValue = CompletableFuture.completedFuture(returnValue); // useful for @Asynchronous
         } else if (!resultVoid && !returnType.isInstance(returnValue)) {
-            throw new MappingException("The " + queryInfo.method.getGenericReturnType().getTypeName() +
-                                       " return type of the " +
-                                       queryInfo.method.getName() + " method of the " +
-                                       queryInfo.method.getDeclaringClass().getName() +
-                                       " class is not a valid return type for a repository " +
-                                       "@Save" + " method. Valid return types include " +
-                                       getValidReturnTypes(results.get(0).getClass().getSimpleName(), hasSingularEntityParam, false) + "."); // TODO NLS
+            throw exc(MappingException.class,
+                      "CWWKD1003.lifecycle.rtrn.err",
+                      queryInfo.method.getGenericReturnType().getTypeName(),
+                      queryInfo.method.getName(),
+                      repositoryInterface.getName(),
+                      "Save",
+                      getValidReturnTypes(results.get(0).getClass().getSimpleName(),
+                                          hasSingularEntityParam,
+                                          false));
         }
 
         return returnValue;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -855,7 +855,6 @@ public class RepositoryImpl<R> implements InvocationHandler {
             validReturnTypes.add(singularClassName);
         } else {
             validReturnTypes.add(singularClassName + "[]");
-            validReturnTypes.add("Iterable<" + singularClassName + ">");
             validReturnTypes.add("List<" + singularClassName + ">");
         }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -483,7 +483,7 @@ public class DataExtension implements Extension {
                       "CWWKD1001.no.primary.entity",
                       method.getName(),
                       repositoryInterface.getName(),
-                      "DataRepository<EntityClass, KeyClass>");
+                      "DataRepository<EntityClass, EntityIdClass>");
         return primaryEntityClass;
     }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -47,6 +47,7 @@ import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.QueryInfo;
+import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.MappingException;
 import jakarta.data.repository.By;
 import jakarta.data.repository.DataRepository;
@@ -406,6 +407,30 @@ public class DataExtension implements Extension {
     }
 
     /**
+     * Construct a RuntimeException or subclass and log the error.
+     *
+     * @param exceptionType RuntimeException or subclass, which must have a
+     *                          constructor that accepts the message as a single
+     *                          String argument.
+     * @param messageId     NLS message ID.
+     * @param args          message arguments.
+     * @return RuntimeException or subclass.
+     */
+    @Trivial
+    private final static <T extends RuntimeException> T exc(Class<T> exceptionType,
+                                                            String messageId,
+                                                            Object... args) {
+        Tr.error(tc, messageId, args);
+        String message = Tr.formatMessage(tc, messageId, args);
+        try {
+            return exceptionType.getConstructor(String.class).newInstance(message);
+        } catch (Exception x) {
+            // should never occur
+            throw new DataException(messageId + ' ' + Arrays.toString(args));
+        }
+    }
+
+    /**
      * Look for parameterized type variable of the repository interface.
      * For example,
      *
@@ -454,13 +479,11 @@ public class DataExtension implements Extension {
                                                  Class<?> repositoryInterface,
                                                  Method method) {
         if (primaryEntityClass == null)
-            throw new MappingException("An entity class is needed by the " + method.getName() +
-                                       " method, but the " + repositoryInterface.getName() +
-                                       " repository interface does not specify a primary entity class." +
-                                       " To correct this, have the " + repositoryInterface.getSimpleName() +
-                                       " interface extend one of the built-in repository supertypes," +
-                                       " such as DataRepository<EntityClass, KeyClass>, supplying the" +
-                                       " entity class as the first type parameter."); // TODO NLS
+            throw exc(MappingException.class,
+                      "CWWKD1001.no.primary.entity",
+                      method.getName(),
+                      repositoryInterface.getName(),
+                      "DataRepository<EntityClass, KeyClass>");
         return primaryEntityClass;
     }
 

--- a/dev/io.openliberty.data.internal/resources/io/openliberty/data/internal/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal/resources/io/openliberty/data/internal/resources/CWWKDMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022,2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -24,5 +24,5 @@
 #   which do NOT contain replacement variables are NOT processed by the MessageFormat class 
 #   (single quote must be coded as one single quote '). 
 
-# All messages must use the range CWWKD1000 to CWWKD1099
+# All messages must use the range CWWKD1400 to CWWKD1499
 

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -42,6 +42,18 @@ import test.jakarta.data.web.DataTestServlet;
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
 public class DataTest extends FATServletClient {
+    /**
+     * Error messages, typically for invalid repository methods, that are
+     * intentionally caused by tests to cover error paths.
+     * These are ignored when checking the messages.log file for errors.
+     */
+    static final String[] EXPECTED_ERROR_MESSAGES = //
+                    new String[] {
+                                   "CWWKD1000E.*delete3", // TODO more specific message ID once translated
+                                   "CWWKD1000E.*delete4", // TODO more specific message ID once translated
+                                   "CWWKD1000E.*delete5", // TODO more specific message ID once translated
+                                   "CWWKD1000E.*findFirst2147483648" // TODO more specific message ID once translated
+                    };
 
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
@@ -79,10 +91,6 @@ public class DataTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKD1000E.*delete3", // TODO more specific message ID once translated
-                          "CWWKD1000E.*delete4", // TODO more specific message ID once translated
-                          "CWWKD1000E.*delete5", // TODO more specific message ID once translated
-                          "CWWKD1000E.*findFirst2147483648" // TODO more specific message ID once translated
-        );
+        server.stopServer(EXPECTED_ERROR_MESSAGES);
     }
 }

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -79,6 +79,10 @@ public class DataTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKD1000E.*delete3", // TODO more specific message ID once translated
+                          "CWWKD1000E.*delete4", // TODO more specific message ID once translated
+                          "CWWKD1000E.*delete5", // TODO more specific message ID once translated
+                          "CWWKD1000E.*findFirst2147483648" // TODO more specific message ID once translated
+        );
     }
 }

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
@@ -90,6 +90,6 @@ public class DataTestCheckpoint extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer(DataTest.EXPECTED_ERROR_MESSAGES);
     }
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3992,6 +3992,7 @@ public class DataTestServlet extends FATServlet {
     /**
      * Use repository methods that have various return types for a record entity.
      */
+    @Test
     public void testRecordReturnTypes() throws Exception {
         receipts.removeIfTotalUnder(1000000.0f);
 
@@ -4014,9 +4015,13 @@ public class DataTestServlet extends FATServlet {
 
         // various forms of completion stage results
         CompletableFuture<Receipt> futureResult = receipts.findByPurchaseId(3013L);
-        CompletionStage<Optional<Receipt>> futureOptionalPresent = receipts.findByPurchaseIdIfPresent(3014L);
-        CompletionStage<Optional<Receipt>> futureOptionalMissing = receipts.findByPurchaseIdIfPresent(3116L);
-        CompletableFuture<List<Receipt>> futureList = receipts.forCustomer("RRT20618", Order.by(Sort.desc("total")));
+        CompletionStage<Optional<Receipt>> futureOptionalPresent = //
+                        receipts.findIfPresentByPurchaseId(3014L);
+        CompletionStage<Optional<Receipt>> futureOptionalMissing = //
+                        receipts.findIfPresentByPurchaseId(3116L);
+        CompletableFuture<List<Receipt>> futureList = //
+                        receipts.forCustomer("RRT20618",
+                                             Order.by(Sort.desc("total")));
 
         // single record
         Receipt receipt = receipts.withPurchaseNum(3015L);
@@ -4074,7 +4079,7 @@ public class DataTestServlet extends FATServlet {
                                      .toList());
 
         CursoredPage<Receipt> pageBelow3003 = receipts.forCustomer("RRT10155", pageBelow3007.previousPageRequest(), Sort.asc("purchaseId"));
-        assertEquals(List.of(3000L, 3001),
+        assertEquals(List.of(3000L, 3001L),
                      pageBelow3003.stream()
                                      .map(Receipt::purchaseId)
                                      .toList());
@@ -4099,7 +4104,8 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(1L, receipts.removeByPurchaseId(3000L));
 
-        assertEquals(List.of(3002L, 3010L, 3012L), receipts.removeByTotalBetween(10.00f, 20.00f));
+        assertEquals(Set.of(3002L, 3010L, 3012L),
+                     receipts.removeByTotalBetween(10.00f, 20.00f));
 
         // remove data to avoid interference with other tests
         assertEquals(12, receipts.removeIfTotalUnder(1000000.0f));

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
@@ -15,6 +15,7 @@ package test.jakarta.data.web;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
@@ -26,6 +27,7 @@ import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
@@ -62,25 +64,28 @@ public interface Receipts extends CrudRepository<Receipt, Long> {
     @Asynchronous
     CompletableFuture<Receipt> findByPurchaseId(long purchaseId);
 
-    @Asynchronous
-    CompletionStage<Optional<Receipt>> findByPurchaseIdIfPresent(long purchaseId);
-
     Stream<Receipt> findByPurchaseIdIn(Iterable<Long> ids);
 
+    @Asynchronous
+    CompletionStage<Optional<Receipt>> findIfPresentByPurchaseId(long purchaseId);
+
+    @Find
     @OrderBy("purchaseId")
     Receipt[] forCustomer(String customer);
 
     @Asynchronous
+    @Find
     CompletableFuture<List<Receipt>> forCustomer(String customer, Order<Receipt> sorts);
 
+    @Find
     Page<Receipt> forCustomer(String customer, PageRequest req, Order<Receipt> sorts);
 
+    @Find
     CursoredPage<Receipt> forCustomer(String customer, PageRequest req, Sort<?>... sorts);
 
     long removeByPurchaseId(long purchaseId);
 
-    @OrderBy("purchaseId")
-    List<Long> removeByTotalBetween(float min, float max);
+    Set<Long> removeByTotalBetween(float min, float max);
 
     @Query("DELETE FROM Receipt WHERE total < :max")
     int removeIfTotalUnder(float max);
@@ -97,5 +102,6 @@ public interface Receipts extends CrudRepository<Receipt, Long> {
     @Query("SELECT total ORDER BY total DESC")
     Page<Float> totalsDecreasing(PageRequest req);
 
+    @Find
     Receipt withPurchaseNum(long purchaseId);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
@@ -63,7 +63,7 @@ public interface CreditCards extends DataRepository<CreditCard, CardId> {
     Stream<CreditCard> findByIssuedOnWithDayBetween(int minDayOfMonth, int maxDayOfMonth);
 
     @OrderBy("debtor_email")
-    Stream<Customer> findByIssuer(Issuer cardIssuer);
+    Stream<CreditCard> findByIssuer(Issuer cardIssuer);
 
     @OrderBy(ID)
     Stream<CardId> findBySecurityCode(int code);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Customers.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Customers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package test.jakarta.data.jpa.web;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -31,15 +32,15 @@ import test.jakarta.data.jpa.web.CreditCard.Issuer;
 @Repository(dataStore = "java:module/jdbc/RepositoryDataStore")
 public interface Customers extends DataRepository<Customer, Integer> {
 
+    Optional<Customer> findByEmail(String emailAddress);
+
+    @OrderBy("email")
+    Stream<Customer> findByPhoneIn(List<Long> phoneNumbers);
+
     @OrderBy("phone")
     Stream<CreditCard> findCardsByEmailEndsWith(String ending);
 
-    Set<CreditCard> findCardsById(int customerId);
-
-    Set<DeliveryLocation> findLocationsByEmail(String emailAddress);
-
-    @OrderBy("email")
-    Stream<DeliveryLocation> findLocationsByPhoneIn(List<Long> phoneNumbers);
+    Set<CreditCard> findCardsByCustomerId(int customerId);
 
     @OrderBy("email")
     @Query("SELECT c.email FROM Customer c JOIN c.cards cc WHERE (cc.issuer=?1)")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2438,35 +2438,41 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Query that matches multiple entities and returns a combined collection of results across matches for the ManyToMany association.
+     * Query that matches multiple entities and returns a stream of results
+     * where each result has a ManyToMany association.
      */
-    //@Test
-    // This test is currently incorrect because Phone is an attribute of Customer (primary entity type), not DeliveryLocation (result type).
-    // This would require a way to indicate that a projection is desired, meaning the return type indicates
-    // an attribute of the entity rather than the entity class itself.
-    // TODO Could this be achieved with @Select?
+    @Test
     public void testManyToManyReturnsCombinedCollectionFromMany() {
 
-        List<String> addresses = customers.findLocationsByPhoneIn(List.of(5075552444L, 5075550101L))
-                        .map(loc -> loc.houseNum + " " + loc.street.toString())
+        List<String> addresses = customers.findByPhoneIn(List.of(5075552444L,
+                                                                 5075550101L))
+                        .map(cust -> cust.deliveryLocations)
+                        .map(locs -> locs
+                                        .stream()
+                                        .map(loc -> loc.houseNum + " " +
+                                                    loc.street.toString())
+                                        .sorted()
+                                        .collect(Collectors.toList())
+                                        .toString())
                         .collect(Collectors.toList());
 
-        // Customer 1's delivery addresses must come before Customer 4's card numbers due to the ordering on Customer.email.
-        assertEquals(addresses.toString(),
-                     true, List.of("1001 1st Ave SW", "2800 37th St NW", "4004 4th Ave SE").equals(addresses) ||
-                           List.of("1001 1st Ave SW", "4004 4th Ave SE", "2800 37th St NW").equals(addresses));
+        // Customer 1's delivery address must come before
+        // Customer 4's delivery addresses due to ordering
+        // on Customer.email
+        assertEquals(List.of("[1001 1st Ave SW]",
+                             "[2800 37th St NW, 4004 4th Ave SE]"),
+                     addresses);
     }
 
     /**
-     * Query that matches a single entity and returns the corresponding collection from its ManyToMany association.
+     * Query that matches a single entity, from which the corresponding collection
+     * from its ManyToMany association can be accessed.
      */
-    //@Test
-    // This test is currently incorrect because Email is an attribute of Customer (primary entity type), not DeliveryLocation (result type)
-    // This would require a way to indicate that a projection is desired, meaning the return type indicates
-    // an attribute of the entity rather than the entity class itself.
-    // TODO Could this be achieved with @Select?
-    public void testManyToManyReturnsOneSetOfMany() {
-        Set<DeliveryLocation> locations = customers.findLocationsByEmail("Maximilian@tests.openliberty.io");
+    @Test
+    public void testManyToManyReturnsOneWithSetOfMany() {
+        Set<DeliveryLocation> locations = customers //
+                        .findByEmail("Maximilian@tests.openliberty.io")
+                        .orElseThrow().deliveryLocations;
 
         assertEquals(locations.toString(), 2, locations.size());
 
@@ -2528,21 +2534,19 @@ public class DataJPATestServlet extends FATServlet {
 
     /**
      * Many-to-one entity mapping, where a repository query from the many side
-     * filters on an attribute from the many side,
-     * orders by an attribute on the one side,
-     * returning results from the one side.
+     * filters on an attribute from the many side (CreditCard),
+     * orders by an attribute on the one side (Customer email),
+     * returning results (CreditCard) from which the one (Customer)
+     * can be obtained.
      */
-    //@Test
-    // This test is currently incorrect because Issuer is an attribute of CreditCard (primary entity type), not Customer (result type).
-    // This would require a way to indicate that a projection is desired, meaning the return type indicates
-    // an attribute of the entity rather than the entity class itself.
-    // TODO Could this be achieved with @Select?
+    @Test
     public void testManyToOneMM11() {
         assertIterableEquals(List.of("MICHELLE@TESTS.OPENLIBERTY.IO",
                                      "Matthew@tests.openliberty.io",
                                      "Maximilian@tests.openliberty.io",
                                      "Megan@tests.openliberty.io"),
                              creditCards.findByIssuer(Issuer.MonsterCard)
+                                             .map(cc -> cc.debtor)
                                              .map(c -> c.email)
                                              .collect(Collectors.toList()));
 
@@ -2551,6 +2555,7 @@ public class DataJPATestServlet extends FATServlet {
                                      "Megan@tests.openliberty.io",
                                      "Monica@tests.openliberty.io"),
                              creditCards.findByIssuer(Issuer.Feesa)
+                                             .map(cc -> cc.debtor)
                                              .map(c -> c.email)
                                              .collect(Collectors.toList()));
     }
@@ -2787,14 +2792,9 @@ public class DataJPATestServlet extends FATServlet {
     /**
      * Query that matches a single entity and so returns one collection for a OneToMany association.
      */
-    //@Test
-    // Test is currently incorrect because the text expects to query on the Id of Customer (primary entity type),
-    // not the Id of CreditCard (result type).
-    // This would require a way to indicate that a projection is desired, meaning the return type indicates
-    // an attribute of the entity rather than the entity class itself.
-    // TODO Could this be achieved with @Select?
+    @Test
     public void testOneToManyReturnsOneSetOfMany() {
-        Set<CreditCard> cards = customers.findCardsById(9210005);
+        Set<CreditCard> cards = customers.findCardsByCustomerId(9210005);
 
         assertEquals(cards.toString(), 2, cards.size());
 


### PR DESCRIPTION
Add the first set of translatable messages to the nlprops file for Jakarta Data. After doing this, the tests identified error messages that were being written to the logs for invalid repository methods. It turns out the tests for those were disabled with TODOs on them. So I corrected the repository methods and resolved the TODOs, and reenabled the tests.  In some cases, there are error messages being logged for repository methods that tests intentionally defined to be invalid.  This PR adds excludes for those.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

