### PR TITLE
Add translations for OIDC client token endpoint auth methods

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -186,6 +186,8 @@ validationEndpointUrl.desc=The endpoint URL for validating the token inbound pro
 tokenEndpointAuthMethod=Authentication method of token endpoint
 tokenEndpointAuthMethod.desc=The method to use for sending credentials to the token endpoint of the OpenID Connect provider in order to authenticate the client.
 
+tokenEndpointAuthMethod.basic=Use the HTTP Basic authentication scheme to authenticate the client with the token endpoint of the OpenID Connect provider.
+tokenEndpointAuthMethod.post=Include the client credentials in the request body to authenticate the client with the token endpoint of the OpenID Connect provider.
 tokenEndpointAuthMethod.privateKeyJwt=Private key JWT client authentication.
 
 tokenEndpointAuthSigningAlgorithm=Token endpoint authentication signing algorithm

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -89,8 +89,8 @@
          <AD id="uniqueUserIdentifier" name="%userUniqueIdentifier" description="%userUniqueIdentifier.desc" required="false" type="String" default="uniqueSecurityName" />
          <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="post" >
-                <Option label="basic" value="basic" />
-                <Option label="post"  value="post" />
+                <Option label="%tokenEndpointAuthMethod.basic" value="basic" />
+                <Option label="%tokenEndpointAuthMethod.post"  value="post" />
                 <Option label="%tokenEndpointAuthMethod.privateKeyJwt" value="private_key_jwt" />
          </AD>
          <AD id="tokenEndpointAuthSigningAlgorithm" name="%tokenEndpointAuthSigningAlgorithm" description="%tokenEndpointAuthSigningAlgorithm.desc" required="false"

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/l10n/metatype.properties
@@ -94,6 +94,8 @@ responseType.desc=Specifies the OAuth response type.
 tokenEndpointAuthMethod=Authentication method
 tokenEndpointAuthMethod.desc=Specifies required authentication method.
 
+tokenEndpointAuthMethod.clientSecretBasic=Use the HTTP Basic authentication scheme to authenticate the client with the token endpoint of the OpenID Connect provider.
+tokenEndpointAuthMethod.clientSecretPost=Include the client credentials in the request body to authenticate the client with the token endpoint of the OpenID Connect provider.
 tokenEndpointAuthMethod.privateKeyJwt=Private key JWT client authentication.
 
 tokenEndpointAuthSigningAlgorithm=Token endpoint authentication signing algorithm

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -47,8 +47,8 @@
         <AD id="website" name="%website" description="%website.desc" required="false" type="String" ibm:type="token" default="https://accounts.google.com" />
         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
-               <Option label="client_secret_basic" value="client_secret_basic" />
-               <Option label="client_secret_post"  value="client_secret_post" />
+               <Option label="%tokenEndpointAuthMethod.clientSecretBasic" value="client_secret_basic" />
+               <Option label="%tokenEndpointAuthMethod.clientSecretPost"  value="client_secret_post" />
         </AD>
         <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
 
@@ -160,8 +160,8 @@
         <AD id="website" name="%website" description="%website.desc" required="false" type="String" ibm:type="token" default="https://www.facebook.com" />
         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
-                <Option label="client_secret_basic" value="client_secret_basic" />
-                <Option label="client_secret_post"  value="client_secret_post" />
+                <Option label="%tokenEndpointAuthMethod.clientSecretBasic" value="client_secret_basic" />
+                <Option label="%tokenEndpointAuthMethod.clientSecretPost"  value="client_secret_post" />
         </AD>
         <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
         <AD id="useSystemPropertiesForHttpClientConnections" name="%useSystemPropertiesForHttpClientConnections" description="%useSystemPropertiesForHttpClientConnections.desc" required="false" type="Boolean" default="false"/>
@@ -212,8 +212,8 @@
              type="Boolean" default="true" />
 	<AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
-               <Option label="client_secret_basic" value="client_secret_basic" />
-               <Option label="client_secret_post"  value="client_secret_post" />
+               <Option label="%tokenEndpointAuthMethod.clientSecretBasic" value="client_secret_basic" />
+               <Option label="%tokenEndpointAuthMethod.clientSecretPost"  value="client_secret_post" />
         </AD>
         <AD id="redirectToRPHostAndPort" name="%redirectToRPHostAndPort" description="%redirectToRPHostAndPort.desc" required="false" type="String" />
         <AD id="useSystemPropertiesForHttpClientConnections" name="%useSystemPropertiesForHttpClientConnections" description="%useSystemPropertiesForHttpClientConnections.desc" required="false" type="Boolean" default="false"/>
@@ -262,8 +262,8 @@
         <AD id="website" name="%website" description="%website.desc" required="false" type="String" ibm:type="token" default="https://www.linkednin.com" />
         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
-                <Option label="client_secret_basic" value="client_secret_basic" />
-                <Option label="client_secret_post"  value="client_secret_post" />
+                <Option label="%tokenEndpointAuthMethod.clientSecretBasic" value="client_secret_basic" />
+                <Option label="%tokenEndpointAuthMethod.clientSecretPost"  value="client_secret_post" />
         </AD>
         <AD id="userApiNeedsSpecialHeader" name="internal" description="internal use only" required="false"
              type="Boolean" default="true" />
@@ -302,8 +302,8 @@
 
         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
-                <Option label="client_secret_basic" value="client_secret_basic" />
-                <Option label="client_secret_post"  value="client_secret_post" />
+                <Option label="%tokenEndpointAuthMethod.clientSecretBasic" value="client_secret_basic" />
+                <Option label="%tokenEndpointAuthMethod.clientSecretPost"  value="client_secret_post" />
         </AD>
         <AD id="introspectionTokenTypeHint" name="internal" description="internal use only" type="String" required="false" default="access_token">
     		<Option label="access_token" value="access_token" />
@@ -416,8 +416,8 @@
         <!-- todo: might need a name for this next one in metatype.properties after 2q -->
         <AD id="tokenEndpointAuthMethod" name="%tokenEndpointAuthMethod" description="%tokenEndpointAuthMethod.desc" required="false"
              type="String" default="client_secret_post" >
-               <Option label="client_secret_basic" value="client_secret_basic" />
-               <Option label="client_secret_post"  value="client_secret_post" />
+               <Option label="%tokenEndpointAuthMethod.clientSecretBasic" value="client_secret_basic" />
+               <Option label="%tokenEndpointAuthMethod.clientSecretPost"  value="client_secret_post" />
                <Option label="%tokenEndpointAuthMethod.privateKeyJwt" value="private_key_jwt" />
          </AD>
         <AD id="tokenEndpointAuthSigningAlgorithm" name="%tokenEndpointAuthSigningAlgorithm" description="%tokenEndpointAuthSigningAlgorithm.desc" required="false"


### PR DESCRIPTION
The metatype for token endpoint authentication methods in our OIDC clients were missing translations for the `client_secret_basic` and `client_secret_post` values in both the `com.ibm.ws.security.openidconnect.client` and `com.ibm.ws.security.social` projects. This adds labels to be translated for those metatype attributes.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
