### PR TITLE
BadConnectorID test wait for exception instead of immediately on server start

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BadConnectorIDTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/BadConnectorIDTest.java
@@ -15,6 +15,7 @@ package com.ibm.ws.microprofile.reactive.messaging.fat.suite;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleIncomingChannel;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleOutgoingChannel;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -85,9 +86,8 @@ public class BadConnectorIDTest {
     @Test
     public void testBadConnectorID() throws Exception {
         // Message in Reactive Messaging 3.0 added msg identifier and quotes around the channel name. So regex needs to support message id and quotes, but allow for them to be missing.
-        List<String> errors = server
-                        .findStringsInLogs("java.lang.IllegalArgumentException:( SRMSG00072:)? Unknown connector for (`)?" + BasicMessagingBean.CHANNEL_OUT + "(`)?");
-        assertTrue(errors.size() > 0);
+        assertNotNull("Did not find broken connector in logs",server
+                .waitForStringInLog("java.lang.IllegalArgumentException:( SRMSG00072:)? Unknown connector for (`)?" + BasicMessagingBean.CHANNEL_OUT + "(`)?"));
     }
 
     @AfterClass


### PR DESCRIPTION
In the BadConnector test, we expect App start to fail given this is an explicit invalid context test. As such we only wait for Server start, not app start. In this case it is possible that the server is declared ready, the logs checked for the error immediately upon the server being declared up. but the application and the RM initialization has not gotten to a sufficient stage to emit the exception.

By allowing time for the exception to occur after app start as latest run had just over 20 seconds between Server start and exception being thrown, we should prevent this test from being declared a failure when it would of passed if we had been more patient.

Resolves [298026](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=298026)


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
