### PR TITLE
second batch of error message for Jakarta Data

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -87,7 +87,7 @@ CWWKD1006.delete.rtrn.err=CWWKD1006E: The {0} return type of the {1} method \
  type of long or int for a deletion count. Use a return type of boolean for \
  an indicator of whether any entities were deleted. Use a return type of array, \
  List, or Optional, parameterized with either the {3} entity class or the \
- {4} Id class, to return the deleted entities or entity Ids.
+ {4} unique identifier class, to return the deleted entities or entity Ids.
 CWWKD1006.delete.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for a delete operation.
 CWWKD1006.delete.rtrn.err.useraction=Update the repository method to use one \
@@ -107,7 +107,8 @@ CWWKD1008.ambig.rtrn.err=CWWKD1008E: The {0} return type of the {1} method \
  of the {2} repository interface is ambiguous as a return type because it \
  corresponds to multiple entity properties: {3}. To use this result type, \
  the repository method must switch to the Query annotation and use a JDQL \
- query with a SELECT clause that specifies which entity property to return.
+ or JPQL query with a SELECT clause that specifies which entity property to \
+ return.
 CWWKD1008.ambig.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for a delete method.
 CWWKD1008.ambig.rtrn.err.useraction=Update the repository method to use the \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -83,11 +83,12 @@ CWWKD1005.find.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
 
 CWWKD1006.delete.rtrn.err=CWWKD1006E: The {0} return type of the {1} method \
  of the {2} repository interface is not a valid return type for a delete \
- operation. Use a return type of void to return no value. Use a return \
- type of long or int for a deletion count. Use a return type of boolean for \
- an indicator of whether any entities were deleted. Use a return type of array, \
- List, or Optional, that is parameterized with either the {3} entity class or \
- the {4} unique identifier class to return the deleted entities or entity IDs.
+ operation. The return type must be either void, long, int, boolean, array, \
+ List, or Optional. A return type of void returns no value. A return type of \
+ long or int returns a deletion count. A return type of boolean returns \
+ an indicator of whether any entities were deleted. A return type of array, \
+ List, or Optional, that is parameterized with either a {3} entity class or \
+ a {4} unique identifier class returns the deleted entities or entity IDs.
 CWWKD1006.delete.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for a delete operation.
 CWWKD1006.delete.rtrn.err.useraction=Update the repository method to use one \
@@ -95,9 +96,10 @@ CWWKD1006.delete.rtrn.err.useraction=Update the repository method to use one \
 
 CWWKD1007.updel.rtrn.err=CWWKD1007E: The {0} return type of the {1} method \
  of the {2} repository interface is not a valid return type for a repository \
- {3} operation. Use a return type of void to return no value. Use a return \
- type of long or int for a count of matching entities. Use a return type of \
- boolean for an indicator of whether any entities match.
+ {3} operation. The return type must be either void, long, int, or boolean. \
+ A return type of void returns no value. A return type of long or int returns \
+ a count of matching entities. A return type of boolean returns an indicator \
+ of whether any entities match.
 CWWKD1007.updel.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for an update or delete operation.
 CWWKD1007.updel.rtrn.err.useraction=Update the repository method to use one \
@@ -105,10 +107,9 @@ CWWKD1007.updel.rtrn.err.useraction=Update the repository method to use one \
 
 CWWKD1008.ambig.rtrn.err=CWWKD1008E: The {0} return type of the {1} method \
  of the {2} repository interface is ambiguous as a return type because it \
- corresponds to multiple entity properties: {3}. To use this result type, \
- the repository method must switch to the Query annotation and use a JDQL \
- or JPQL query with a SELECT clause that specifies which entity property to \
- return.
+ corresponds to multiple entity properties: {3}. The repository method \
+ must switch to the Query annotation and use a JDQL or JPQL query with a \
+ SELECT clause that specifies which entity property to return.
 CWWKD1008.ambig.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for a delete method.
 CWWKD1008.ambig.rtrn.err.useraction=Update the repository method to use the \
@@ -122,7 +123,7 @@ CWWKD1009.lifecycle.param.err=CWWKD1009E: The {0} method of the {1} repository \
 CWWKD1009.lifecycle.param.err.explanation=Lifecycle methods must have a single \
  entity parameter.
 CWWKD1009.lifecycle.param.err.useraction=Update the repository method to have a \
- single parameter that is the entity or an array or List of the entity.
+ single parameter that is an entity or an array of List of the entity.
 
 CWWKD1010.unknown.entity.prop=CWWKD1010E: The {0} method of the {1} repository \
  interface expects an entity property named {2} that is not found on the \
@@ -133,16 +134,16 @@ CWWKD1010.unknown.entity.prop.useraction=Update the repository method to match \
  a valid property that is defined by the entity.
 
 CWWKD1011.unknown.method.pattern=CWWKD1011E: The {0} method of the {1} repository \
- interface does not match any of the patterns defined by Jakarta Data. \
- A repository method must either use annotations such as {2} to define operations, \
- be a resource accessor method with no parameters and returning one of {3}, \
- or the method must be named according to the Query by Method Name pattern. \
- Method names for Query by Method Name must begin with one of the {4} keywords, \
- followed by 0 or more additional characters, optionally followed by the \
- 'By' keyword and one or more conditions delimited by 'And' or 'Or' keywords. \
- Some examples of valid repository method names are: {5}.
+ interface does not match any of the Jakarta Data defined patterns. \
+ A repository method must either use annotations, be a resource accessor method, \
+ or be named according to the Query by Method Name pattern. Annotations such as \
+ {2} are used to define operations. A resource accessor method must contain \
+ no parameters and any of the {3} return types. The Query by Method Name pattern \
+ must begin with one of the {4} keywords, followed by 0 or more characters. \
+ Method names can also include the By keyword and one or more delimited \
+ conditions. Examples of valid repository method names are: {5}.
 CWWKD1011.unknown.method.pattern.explanation=Repository methods must follow the \
- patterns that are defined by Jakarta Data.
+ Jakarta Data defined patterns.
 CWWKD1011.unknown.method.pattern.useraction=Update the repository method to \
  adhere to one of the patterns from Jakarta Data.
 
@@ -150,8 +151,8 @@ CWWKD1012.fd.missing.param.anno=CWWKD1012E: Parameter {0} of the {1} method of \
  the {2} repository interface does not match an entity property. Parameters that \
  do not match an entity property must be annotated with the By annotation or have \
  one of the special parameter types: {3}. To define a condition for the \
- restriction of query results, annotate the parameter with \
- the By annotation and assign the value of the By annotation to be the entity \
+ restriction of query results, the parameter must be annotated with the By \
+ annotation and the value of the By annotation must be assigned to be the entity \
  property name. Alternatively, enable the -parameters compile option and give \
  the parameter the same name as the entity property.
 CWWKD1012.fd.missing.param.anno.explanation=Parameters of repository find and \
@@ -162,9 +163,9 @@ CWWKD1012.fd.missing.param.anno.useraction=Update the repository method such \
  Data special parameter types.
 
 CWWKD1013.cde.missing.param.anno=CWWKD1013E: Parameter {0} of the {1} method of \
- the {2} repository interface does not match an entity property. Annotate \
- parameters that do not match an entity property with the By annotation and \
- assign the value of the By annotation to be the entity property name. \
+ the {2} repository interface does not match an entity property. Parameters \
+ that do not match an entity property must be annotated with the By annotation and \
+ the By annotation value must be assigned to be the entity property name. \
  Alternatively, enable the -parameters compile option and give the parameter \
  the same name as the entity property.
 CWWKD1013.cde.missing.param.anno.explanation=Parameters of repository count, \
@@ -175,9 +176,9 @@ CWWKD1013.cde.missing.param.anno.useraction=Update the repository method such \
 CWWKD1014.upd.missing.param.anno=CWWKD1014E: Parameter {0} of the {1} method of \
  the {2} repository interface does not match an entity property. Parameters that \
  do not match an entity property must have one of the parameter annotations: {3}. \
- To define a condition for the restriction of query \
- results, annotate the parameter with the By annotation and assign the value of \
- the By annotation to be the entity property name. Alternatively, enable the \
+ To define a condition for the restriction of query results, the parameter must \
+ be annotated with the By annotation and the By annotation value must be \
+ assigned to be the entity property name. Alternatively, enable the \
  -parameters compile option and give the parameter the same name as the entity \
  property.
 CWWKD1014.upd.missing.param.anno.explanation=Parameters of repository update \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -36,7 +36,7 @@ CWWKD1000.repo.general.err.useraction=Locate the repository interface and method
 
 CWWKD1001.no.primary.entity=CWWKD1001E: The {0} repository method requires \
  an entity class but the {1} repository interface does not specify a primary \
- entity class. To correct this error, the {1} repository interface must extend \
+ entity class. To correct this error, the {1} repository interface can extend \
  one of the built-in repository supertypes, such as {2}, and supply the entity \
  class as the first type parameter.
 CWWKD1001.no.primary.entity.explanation=Repository methods without an entity \
@@ -57,7 +57,7 @@ CWWKD1003.lifecycle.rtrn.err=CWWKD1003E: The {0} return type of the {1} method \
 CWWKD1003.lifecycle.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for Insert, Update, and Save methods.
 CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
- information for the Insert, Update, and Save methods for valid return types.
+ information for the Insert, Update, and Save annotations for valid return types.
 
 CWWKD1004.general.rtrn.err=CWWKD1004E: The {0} return type of the {1} method \
  of the {2} repository interface is not a valid return type for a repository \
@@ -81,6 +81,47 @@ CWWKD1005.find.rtrn.err.explanation=The return type of the method is not \
 CWWKD1005.find.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
  information for a list of valid return types for repository find methods.
 
+CWWKD1006.delete.rtrn.err=CWWKD1006E: The {0} return type of the {1} method \
+ of the {2} repository interface is not a valid return type for a repository \
+ Delete operation. Use a return type of void to return no value. Use a return \
+ type of long or int for a deletion count. Use a return type of boolean for \
+ an indicator of whether any entities were deleted. Use a return type of array, \
+ List, or Optional, parameterized with either the {3} entity class or the \
+ {4} Id class, to return the deleted entities or entity Ids.
+CWWKD1006.delete.rtrn.err.explanation=The return type of the method is not \
+ one of the supported return types for a delete operation.
+CWWKD1006.delete.rtrn.err.useraction=Update the repository method to use one \
+ of the supported return types.
+
+CWWKD1007.updel.rtrn.err=CWWKD1007E: The {0} return type of the {1} method \
+ of the {2} repository interface is not a valid return type for a repository \
+ {3} operation. Use a return type of void to return no value. Use a return \
+ type of long or int for a count of matching entities. Use a return type of \
+ boolean for an indicator of whether any entities match.
+CWWKD1007.updel.rtrn.err.explanation=The return type of the method is not \
+ one of the supported return types for an update or delete operation.
+CWWKD1007.updel.rtrn.err.useraction=Update the repository method to use one \
+ of the supported return types.
+
+CWWKD1008.ambig.rtrn.err=CWWKD1008E: The {0} return type of the {1} method \
+ of the {2} repository interface is ambiguous as a return type because it \
+ corresponds to multiple entity properties: {3}. To use this result type, \
+ the repository method must switch to the Query annotation and use a JDQL \
+ query with a SELECT clause that specifies which entity property to return.
+CWWKD1008.ambig.rtrn.err.explanation=The return type of the method is not \
+ one of the supported return types for a delete method.
+CWWKD1008.ambig.rtrn.err.useraction=Update the repository method to use the \
+ Query annotation to select the entity property.
+
+CWWKD1009.lifecycle.param.err=CWWKD1009E: The {0} method of the {1} repository \
+ interface cannot have {2} parameters because the method is annotated with the \
+ {3} life cycle annotation. Repository methods that are annotated with a life \
+ cycle annotation must have exactly 1 parameter, which must be the entity or an \
+ array or List of the entity.
+CWWKD1009.lifecycle.param.err.explanation=Life cycle methods must have a single \
+ entity parameter.
+CWWKD1009.lifecycle.param.err.useraction=Update the repository method to have a \
+ single parameter that is entity or an array of List of the entity.
 
 CWWKD1010.unknown.entity.prop=CWWKD1010E: The {0} method of the {1} repository \
  interface expects an entity property named {2} that is not found on the \
@@ -89,3 +130,56 @@ CWWKD1010.unknown.entity.prop.explanation=The repository method is attempting \
  to use an entity property that does not exist.
 CWWKD1010.unknown.entity.prop.useraction=Update the repository method to match \
  a valid property that is defined by the entity.
+
+CWWKD1011.unknown.method.pattern=CWWKD1011E: The {0} method of the {1} repository \
+ interface does not match any of the patterns defined by Jakarta Data. \
+ A repository method must either use annotations such as {2} to define operations, \
+ be a resource accessor method with no parameters and returning one of {3}, \
+ or the method must be named according to the Query by Method Name pattern. \
+ Method names for Query by Method Name must begin with one of the {4} keywords, \
+ followed by 0 or more additional characters, optionally followed by the \
+ 'By' keyword and one or more conditions delimited by 'And' or 'Or' keywords. \
+ Some examples of valid repository method names are: {5}.
+CWWKD1011.unknown.method.pattern.explanation=Repository methods must follow the \
+ patterns that are defined by Jakarta Data.
+CWWKD1011.unknown.method.pattern.useraction=Update the repository method to \
+ adhere to one of the patterns from Jakarta Data.
+
+CWWKD1012.fd.missing.param.anno=CWWKD1012E: Parameter {0} of the {1} method of \
+ the {2} repository interface does not match an entity property. Parameters that \
+ do not match an entity property must be annotated with the By annotation or have \
+ one of the special parameter types: {3}. If the parameter is intended to define \
+ a condition for the restriction of query results, annotate the parameter with \
+ the By annotation and assign the value of the By annotation to be the entity \
+ property name. Alternatively, enable the -parameters compile option and give \
+ the parameter the same name as the entity property.
+CWWKD1012.fd.missing.param.anno.explanation=Parameters of repository find and \
+ delete methods must correspond to entity properties or be special parameter \
+ types that are defined by Jakarta Data.
+CWWKD1012.fd.missing.param.anno.useraction=Update the repository method such \
+ that all parameters correspond to entity properties or have one of the Jakarta \
+ Data special parameter types.
+
+CWWKD1013.cde.missing.param.anno=CWWKD1013E: Parameter {0} of the {1} method of \
+ the {2} repository interface does not match an entity property. Parameters that \
+ do not match an entity property must be annotated with the By annotation and \
+ assign the value of the By annotation to be the entity property name. \
+ Alternatively, enable the -parameters compile option and give the parameter \
+ the same name as the entity property.
+CWWKD1013.cde.missing.param.anno.explanation=Parameters of repository count, \
+ delete, and exists methods must correspond to entity properties.
+CWWKD1013.cde.missing.param.anno.useraction=Update the repository method such \
+ that all parameters correspond to entity properties.
+
+CWWKD1014.upd.missing.param.anno=CWWKD1014E: Parameter {0} of the {1} method of \
+ the {2} repository interface does not match an entity property. Parameters that \
+ do not match an entity property must have one of the parameter annotations: {3}. \
+ If the parameter is intended to define a condition for the restriction of query \
+ results, annotate the parameter with the By annotation and assign the value of \
+ the By annotation to be the entity property name. Alternatively, enable the \
+ -parameters compile option and give the parameter the same name as the entity \
+ property.
+CWWKD1014.upd.missing.param.anno.explanation=Parameters of repository update \
+ methods must correspond to entity properties.
+CWWKD1014.upd.missing.param.anno.useraction=Update the repository method such that \
+ all parameters correspond to entity properties.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -82,12 +82,12 @@ CWWKD1005.find.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
  information for a list of valid return types for repository find methods.
 
 CWWKD1006.delete.rtrn.err=CWWKD1006E: The {0} return type of the {1} method \
- of the {2} repository interface is not a valid return type for a repository \
- Delete operation. Use a return type of void to return no value. Use a return \
+ of the {2} repository interface is not a valid return type for a delete \
+ operation. Use a return type of void to return no value. Use a return \
  type of long or int for a deletion count. Use a return type of boolean for \
  an indicator of whether any entities were deleted. Use a return type of array, \
- List, or Optional, parameterized with either the {3} entity class or the \
- {4} unique identifier class, to return the deleted entities or entity Ids.
+ List, or Optional, that is parameterized with either the {3} entity class or \
+ the {4} unique identifier class to return the deleted entities or entity IDs.
 CWWKD1006.delete.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for a delete operation.
 CWWKD1006.delete.rtrn.err.useraction=Update the repository method to use one \
@@ -116,13 +116,13 @@ CWWKD1008.ambig.rtrn.err.useraction=Update the repository method to use the \
 
 CWWKD1009.lifecycle.param.err=CWWKD1009E: The {0} method of the {1} repository \
  interface cannot have {2} parameters because the method is annotated with the \
- {3} life cycle annotation. Repository methods that are annotated with a life \
- cycle annotation must have exactly 1 parameter, which must be the entity or an \
+ {3} lifecycle annotation. Repository methods that are annotated with a lifecycle \
+ annotation must have exactly 1 parameter, which must be the entity or an \
  array or List of the entity.
-CWWKD1009.lifecycle.param.err.explanation=Life cycle methods must have a single \
+CWWKD1009.lifecycle.param.err.explanation=Lifecycle methods must have a single \
  entity parameter.
 CWWKD1009.lifecycle.param.err.useraction=Update the repository method to have a \
- single parameter that is entity or an array of List of the entity.
+ single parameter that is the entity or an array or List of the entity.
 
 CWWKD1010.unknown.entity.prop=CWWKD1010E: The {0} method of the {1} repository \
  interface expects an entity property named {2} that is not found on the \
@@ -149,21 +149,21 @@ CWWKD1011.unknown.method.pattern.useraction=Update the repository method to \
 CWWKD1012.fd.missing.param.anno=CWWKD1012E: Parameter {0} of the {1} method of \
  the {2} repository interface does not match an entity property. Parameters that \
  do not match an entity property must be annotated with the By annotation or have \
- one of the special parameter types: {3}. If the parameter is intended to define \
- a condition for the restriction of query results, annotate the parameter with \
+ one of the special parameter types: {3}. To define a condition for the \
+ restriction of query results, annotate the parameter with \
  the By annotation and assign the value of the By annotation to be the entity \
  property name. Alternatively, enable the -parameters compile option and give \
  the parameter the same name as the entity property.
 CWWKD1012.fd.missing.param.anno.explanation=Parameters of repository find and \
- delete methods must correspond to entity properties or be special parameter \
- types that are defined by Jakarta Data.
+ delete methods must correspond to entity properties or be special Jakarta Data \
+ defined parameter types.
 CWWKD1012.fd.missing.param.anno.useraction=Update the repository method such \
  that all parameters correspond to entity properties or have one of the Jakarta \
  Data special parameter types.
 
 CWWKD1013.cde.missing.param.anno=CWWKD1013E: Parameter {0} of the {1} method of \
- the {2} repository interface does not match an entity property. Parameters that \
- do not match an entity property must be annotated with the By annotation and \
+ the {2} repository interface does not match an entity property. Annotate \
+ parameters that do not match an entity property with the By annotation and \
  assign the value of the By annotation to be the entity property name. \
  Alternatively, enable the -parameters compile option and give the parameter \
  the same name as the entity property.
@@ -175,7 +175,7 @@ CWWKD1013.cde.missing.param.anno.useraction=Update the repository method such \
 CWWKD1014.upd.missing.param.anno=CWWKD1014E: Parameter {0} of the {1} method of \
  the {2} repository interface does not match an entity property. Parameters that \
  do not match an entity property must have one of the parameter annotations: {3}. \
- If the parameter is intended to define a condition for the restriction of query \
+ To define a condition for the restriction of query \
  results, annotate the parameter with the By annotation and assign the value of \
  the By annotation to be the entity property name. Alternatively, enable the \
  -parameters compile option and give the parameter the same name as the entity \

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -49,9 +49,9 @@ public class DataTest extends FATServletClient {
      */
     static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
-                                   "CWWKD1000E.*delete3", // TODO more specific message ID once translated
-                                   "CWWKD1000E.*delete4", // TODO more specific message ID once translated
-                                   "CWWKD1000E.*delete5", // TODO more specific message ID once translated
+                                   "CWWKD1006E.*delete3", // TODO more specific message ID once translated
+                                   "CWWKD1006E.*delete4", // TODO more specific message ID once translated
+                                   "CWWKD1008E.*delete5", // TODO more specific message ID once translated
                                    "CWWKD1000E.*findFirst2147483648" // TODO more specific message ID once translated
                     };
 


### PR DESCRIPTION
Add a second batch of translatable error messages for Jakarta Data.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
