### PR TITLE
Making changes for Upgrading Jackson 1.6.2 for Collectives Part

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler.internal-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler.internal-1.0.feature
@@ -11,7 +11,7 @@ IBM-App-ForceRestart: uninstall, \
   io.openliberty.restHandler1.0.internal.ee-6.0; ibm.tolerates:="9.0, 10.0", \
   com.ibm.websphere.appserver.httptransport-1.0
 -bundles=com.ibm.ws.org.joda.time.1.6.2, \
- com.ibm.websphere.jsonsupport, \
+ io.openliberty.jsonsupport.internal, \
  com.ibm.websphere.rest.handler
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/adminCenter-1.0/com.ibm.websphere.appserver.adminCenter-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/adminCenter-1.0/com.ibm.websphere.appserver.adminCenter-1.0.feature
@@ -12,7 +12,7 @@ Subsystem-Icon: OSGI-INF/admincenter_200x200.png,OSGI-INF/admincenter_200x200.pn
   io.openliberty.adminCenter1.0.internal.ee-6.0; ibm.tolerates:="9.0,10.0,11.0"
 -bundles=\
     com.ibm.ws.ui,\
-    com.ibm.websphere.jsonsupport,\
+    io.openliberty.jsonsupport.internal,\
     com.ibm.ws.org.joda.time.1.6.2, \
     io.openliberty.com.google.gson
 kind=ga

--- a/dev/com.ibm.ws.jmx.connector.server.rest/bnd.bnd
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/bnd.bnd
@@ -31,7 +31,7 @@ Private-Package: \
   com.ibm.ws.jmx.connector.server.internal.resources.*
 
 Import-Package: \
-  com.ibm.websphere.jsonsupport;version='[2.0,3.0)', \
+  
   *
 
 Export-Package: \
@@ -95,7 +95,7 @@ instrument.classesExcludes: com/ibm/ws/jmx/connector/server/internal/resources/*
 	com.ibm.ws.jmx.request;version=latest,\
 	com.ibm.websphere.rest.handler;version=latest,\
 	com.ibm.ws.rest.handler;version=latest,\
-	io.openliberty.jsonsupport.internal;version=latest,\
+
 	com.ibm.ws.webcontainer;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 

--- a/dev/com.ibm.ws.jmx.connector.server.rest/bnd.bnd
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/bnd.bnd
@@ -31,7 +31,7 @@ Private-Package: \
   com.ibm.ws.jmx.connector.server.internal.resources.*
 
 Import-Package: \
-  com.ibm.websphere.jsonsupport;version='[1.0,2.0)', \
+  com.ibm.websphere.jsonsupport;version='[2.0,3.0)', \
   *
 
 Export-Package: \

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/repository.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/repository.xml
@@ -233,11 +233,11 @@
             <version-range>[1.0.0,1.1.0)</version-range>
         </constituent>
         <constituent>
-            <symbolic-name>com.ibm.websphere.jsonsupport</symbolic-name>
+            <symbolic-name>io.openliberty.jsonsupport.internal</symbolic-name>
             <start-level>12</start-level>
             <activation-type>SEQUENTIAL</activation-type>
             <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.1.0)</version-range>
+            <version-range>[2.0.0,3.0.0)</version-range>
         </constituent>
         <constituent>
             <symbolic-name>com.ibm.ws.org.joda.time.1.6.2</symbolic-name>
@@ -50985,11 +50985,11 @@
             <version-range>[1.0.0,1.1.0)</version-range>
         </constituent>
         <constituent>
-            <symbolic-name>com.ibm.websphere.jsonsupport</symbolic-name>
+            <symbolic-name>io.openliberty.jsonsupport.internal</symbolic-name>
             <start-level>12</start-level>
             <activation-type>SEQUENTIAL</activation-type>
             <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.1.0)</version-range>
+            <version-range>[2.0.0,3.0.0)</version-range>
         </constituent>
         <constituent>
             <symbolic-name>com.ibm.websphere.rest.handler</symbolic-name>

--- a/dev/com.ibm.ws.ui/bnd.bnd
+++ b/dev/com.ibm.ws.ui/bnd.bnd
@@ -23,7 +23,7 @@ instrument.disabled: true
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
-	com.ibm.websphere.jsonsupport;version=latest,\
+	io.openliberty.jsonsupport.internal;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.websphere.rest.handler;version=latest,\

--- a/dev/com.ibm.ws.ui/main.bnd
+++ b/dev/com.ibm.ws.ui/main.bnd
@@ -28,10 +28,10 @@ Private-Package: \
 
 # Need a special import to properly construct import for commons.io
 Import-Package: \
-  com.ibm.websphere.jsonsupport.*;version='[1.0,2.0)', \
-  com.ibm.ws.ui.servlet.filter, \
-  !*.internal.*, \
-  *
+	com.ibm.websphere.jsonsupport.*;version='[2.0,3.0)',\
+	com.ibm.ws.ui.servlet.filter,\
+	!*.internal.*,\
+	*
 
 DynamicImport-Package: \
  com.ibm.ws.security.openidconnect.server.plugins

--- a/dev/com.ibm.ws.ui_rest_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ui_rest_fat/bnd.bnd
@@ -47,5 +47,5 @@ tested.features:\
     com.ibm.ws.org.slf4j.jdk14;version=latest,\
     com.ibm.websphere.org.osgi.core;version-=latest,\
     com.ibm.ws.ui;version=latest,\
-    com.ibm.websphere.jsonsupport;version=latest,\
+    io.openliberty.jsonsupport.internal;version=latest,\
 	io.openliberty.org.apache.commons.logging;version=latest


### PR DESCRIPTION
The com.ibm.websphere.jsonsupport package uses jackson 1.6.2 . The upgradation done in this change includes io.openliberty.jsonsuppport.internal which will be replacing com.ibm.websphere.jsonsupport and includes IBM supported jackson 1.9.13.