### PR TITLE
Rename `ServiceCaller.call(Function)` to `run` to avoid ambiguity

### DIFF
--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/framework/VisTester.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/vistest/framework/VisTester.java
@@ -190,7 +190,7 @@ public class VisTester {
     }
 
     public static Optional<String> getModuleForClass(Class<?> clazz) {
-        Optional<Optional<J2EEName>> result = cdiServiceCaller.call(cdiService -> {
+        Optional<Optional<J2EEName>> result = cdiServiceCaller.run(cdiService -> {
             return cdiService.getModuleNameForClass(clazz);
         });
         return result.orElseThrow(() -> new RuntimeException("Failed to get CDI Service"))

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/ServiceCaller.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/ServiceCaller.java
@@ -149,15 +149,15 @@ public class ServiceCaller<S> {
      * }
      * </pre>
      *
-     * @param caller      a class from the bundle that will use service
+     * @param caller a class from the bundle that will use service
      * @param serviceType the OSGi service type to look up
-     * @param consumer    the consumer of the OSGi service
-     * @param <S>         the OSGi service type to look up
+     * @param consumer the consumer of the OSGi service
+     * @param <S> the OSGi service type to look up
      * @return true if the OSGi service was located and called successfully, false
      *         otherwise
-     * @throws NullPointerException  if any of the parameters are {@code null}
+     * @throws NullPointerException if any of the parameters are {@code null}
      * @throws IllegalStateException if the bundle associated with the caller class
-     *                                   cannot be determined
+     *             cannot be determined
      */
     public static <S> boolean callOnce(Class<?> caller, Class<S> serviceType, Consumer<S> consumer) {
         return callOnce(caller, serviceType, null, consumer);
@@ -166,16 +166,16 @@ public class ServiceCaller<S> {
     /**
      * As {@link #callOnce(Class, Class, Consumer)} with an additional OSGi filter.
      *
-     * @param caller      a class from the bundle that will use service
+     * @param caller a class from the bundle that will use service
      * @param serviceType the OSGi service type to look up
-     * @param consumer    the consumer of the OSGi service
-     * @param filter      an OSGi filter to restrict the services found
-     * @param <S>         the OSGi service type to look up
+     * @param consumer the consumer of the OSGi service
+     * @param filter an OSGi filter to restrict the services found
+     * @param <S> the OSGi service type to look up
      * @return true if the OSGi service was located and called successfully, false
      *         otherwise
-     * @throws NullPointerException  if any of the parameters except filter are {@code null}
+     * @throws NullPointerException if any of the parameters except filter are {@code null}
      * @throws IllegalStateException if the bundle associated with the caller class
-     *                                   cannot be determined
+     *             cannot be determined
      */
     public static <S> boolean callOnce(Class<?> caller, Class<S> serviceType, String filter, Consumer<S> consumer) {
         return new ServiceCaller<>(caller, serviceType, filter).getCurrent().map(r -> {
@@ -191,43 +191,43 @@ public class ServiceCaller<S> {
     /**
      * As {@link #callOnce(Class, Class, Consumer)} but replaces the Consumer with a Function that returns a value.
      *
-     * @param caller      a class from the bundle that will use service
+     * @param caller a class from the bundle that will use service
      * @param serviceType the OSGi service type to look up
-     * @param function    a function that consumes the OSGi service and retrns a value
-     * @param <S>         the OSGi service type to look up
-     * @param <R>         the type returned by calling the method on the service
+     * @param function a function that consumes the OSGi service and retrns a value
+     * @param <S> the OSGi service type to look up
+     * @param <R> the type returned by calling the method on the service
      * @return an Optional containing the object returned by function, or null if it failed to return a value
-     * @throws NullPointerException  if any of the parameters are {@code null}
+     * @throws NullPointerException if any of the parameters are {@code null}
      * @throws IllegalStateException if the bundle associated with the caller class
-     *                                   cannot be determined
+     *             cannot be determined
      */
-    public static <S, R> Optional<R> callOnce(Class<?> caller, Class<S> serviceType, Function<S, R> function) {
+    public static <S, R> Optional<R> runOnce(Class<?> caller, Class<S> serviceType, Function<S, R> function) {
         ServiceCaller<S> sc = new ServiceCaller<>(caller, serviceType);
         try {
-            return sc.call(function);
+            return sc.run(function);
         } finally {
             sc.unget();
         }
     }
 
     /**
-     * As {@link #callOnce(Class, Class, Consumer)} but with an additional OSGi filter.
+     * As {@link #runOnce(Class, Class, Function)} but with an additional OSGi filter.
      *
-     * @param caller      a class from the bundle that will use service
+     * @param caller a class from the bundle that will use service
      * @param serviceType the OSGi service type to look up
-     * @param function    a function that consumes the OSGi service and retrns a value
-     * @param filter      an OSGi filter to restrict the services found
-     * @param <S>         the OSGi service type to look up
-     * @param <R>         the type returned by calling the method on the service
+     * @param function a function that consumes the OSGi service and retrns a value
+     * @param filter an OSGi filter to restrict the services found
+     * @param <S> the OSGi service type to look up
+     * @param <R> the type returned by calling the method on the service
      * @return an Optional containing the object returned by function, or null if it failed to return a value
-     * @throws NullPointerException  if any of the parameters except filter are {@code null}
+     * @throws NullPointerException if any of the parameters except filter are {@code null}
      * @throws IllegalStateException if the bundle associated with the caller class
-     *                                   cannot be determined
+     *             cannot be determined
      */
-    public static <S, R> Optional<R> callOnce(Class<?> caller, Class<S> serviceType, String filter, Function<S, R> function) {
+    public static <S, R> Optional<R> runOnce(Class<?> caller, Class<S> serviceType, String filter, Function<S, R> function) {
         ServiceCaller<S> sc = new ServiceCaller<>(caller, serviceType, filter);
         try {
-            return sc.call(function);
+            return sc.run(function);
         } finally {
             sc.unget();
         }
@@ -367,7 +367,7 @@ public class ServiceCaller<S> {
      * Creates a {@code ServiceCaller} instance for invoking an OSGi service many
      * times with a consumer function.
      *
-     * @param caller      a class from the bundle that will consume the service
+     * @param caller a class from the bundle that will consume the service
      * @param serviceType the OSGi service type to look up
      * @throws NullPointerException if any of the parameters are {@code null}
      */
@@ -379,10 +379,10 @@ public class ServiceCaller<S> {
      * Creates a {@code ServiceCaller} instance for invoking an OSGi service many
      * times with a consumer function.
      *
-     * @param caller      a class from the bundle that will consume the service
+     * @param caller a class from the bundle that will consume the service
      * @param serviceType the OSGi service type to look up
-     * @param filter      the service filter used to look up the service. May be
-     *                        {@code null}.
+     * @param filter the service filter used to look up the service. May be
+     *            {@code null}.
      * @throws NullPointerException if any of the parameters are {@code null}
      */
     public ServiceCaller(Class<?> caller, Class<S> serviceType, String filter) {
@@ -434,7 +434,7 @@ public class ServiceCaller<S> {
      * @return true if the OSGi service was located and called successfully, false
      *         otherwise
      * @throws IllegalStateException if the bundle associated with the caller class
-     *                                   cannot be determined
+     *             cannot be determined
      */
     public boolean call(Consumer<S> consumer) {
         return trackCurrent().map(r -> {
@@ -444,15 +444,15 @@ public class ServiceCaller<S> {
     }
 
     /**
-     * As {@link #call(call)} but replaces the Consumer with a Function that returns a value.
+     * As {@link #call(Consumer)} but replaces the Consumer with a Function that returns a value.
      *
-     * @param <R>      the type returned by calling the method on the service
+     * @param <R> the type returned by calling the method on the service
      * @param function A function that calls a method on the OSGi service and returns its output
      * @return an Optional containing the object returned by function, or null if it failed to return a value
      * @throws IllegalStateException if the bundle associated with the caller class
-     *                                   cannot be determined
+     *             cannot be determined
      */
-    public <R> Optional<R> call(Function<S, R> function) {
+    public <R> Optional<R> run(Function<S, R> function) {
         return Optional.ofNullable(trackCurrent().map(r -> {
             return function.apply(r.instance);
         }).orElse(null));
@@ -464,7 +464,7 @@ public class ServiceCaller<S> {
      * @return the currently available service or empty if the service cannot be
      *         found.
      * @throws IllegalStateException if the bundle associated with the caller class
-     *                                   cannot be determined
+     *             cannot be determined
      */
     public Optional<S> current() {
         return trackCurrent().map(r -> r.instance);

--- a/dev/io.openliberty.cdi.4.0.internal.services.fragment/src/io/openliberty/cdi40/internal/services/OSGIBuildServices.java
+++ b/dev/io.openliberty.cdi.4.0.internal.services.fragment/src/io/openliberty/cdi40/internal/services/OSGIBuildServices.java
@@ -32,7 +32,7 @@ public class OSGIBuildServices implements BuildServices {
     public AnnotationBuilderFactory annotationBuilderFactory() {
         //Use OSGi to lookup an instance of BuildServices
         //OSGIBuildServices itself will not be found because it is only Service Loaded and is not an OSGi Service
-        Optional<AnnotationBuilderFactory> factoryOpt = ServiceCaller.callOnce(OSGIBuildServices.class, BuildServices.class,
+        Optional<AnnotationBuilderFactory> factoryOpt = ServiceCaller.runOnce(OSGIBuildServices.class, BuildServices.class,
                                                                                (bs) -> {
                                                                                    return bs.annotationBuilderFactory();
                                                                                });

--- a/dev/io.openliberty.cdi.4.1.internal.services.fragment/src/io/openliberty/cdi41/internal/services/OSGIBuildServices.java
+++ b/dev/io.openliberty.cdi.4.1.internal.services.fragment/src/io/openliberty/cdi41/internal/services/OSGIBuildServices.java
@@ -32,7 +32,7 @@ public class OSGIBuildServices implements BuildServices {
     public AnnotationBuilderFactory annotationBuilderFactory() {
         //Use OSGi to lookup an instance of BuildServices
         //OSGIBuildServices itself will not be found because it is only Service Loaded and is not an OSGi Service
-        Optional<AnnotationBuilderFactory> factoryOpt = ServiceCaller.callOnce(OSGIBuildServices.class, BuildServices.class,
+        Optional<AnnotationBuilderFactory> factoryOpt = ServiceCaller.runOnce(OSGIBuildServices.class, BuildServices.class,
                                                                                (bs) -> {
                                                                                    return bs.annotationBuilderFactory();
                                                                                });

--- a/dev/io.openliberty.io.smallrye.reactive.messaging-provider4/src/io/openliberty/microprofile/reactive/messaging30/internal/OLReactiveMessaging30Extension.java
+++ b/dev/io.openliberty.io.smallrye.reactive.messaging-provider4/src/io/openliberty/microprofile/reactive/messaging30/internal/OLReactiveMessaging30Extension.java
@@ -144,7 +144,7 @@ public class OLReactiveMessaging30Extension extends ReactiveMessagingExtension i
 
     private ContextBeginnerEnder createContextBeginnerEnderIfCheckpointEnabled() {
         if (CheckpointPhase.getPhase() != CheckpointPhase.INACTIVE) {
-            return ServiceCaller.callOnce(OLReactiveMessaging30Extension.class, CDIService.class, 
+            return ServiceCaller.runOnce(OLReactiveMessaging30Extension.class, CDIService.class, 
                 (cdiService) -> { return ((CDIRuntime) cdiService).cloneActiveContextBeginnerEnder(); }).get(); //Call get because if we can't get context from CDIservice inside a CDI extension throwing an exception is better than covering this up.
         }
         return null;

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/OpenAPIUtils.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/OpenAPIUtils.java
@@ -112,7 +112,7 @@ public class OpenAPIUtils {
      */
     @Trivial
     public static void validateDocument(OpenAPI document) {
-        OASValidationResult result = validatorService.call(v -> {
+        OASValidationResult result = validatorService.run(v -> {
             return v.validate(document);
         }).orElseThrow(() -> new NoSuchElementException("validatorService"));
         final StringBuilder sbError = new StringBuilder();

--- a/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/internal/common/cdi/OpenTelemetryProducer.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/internal/common/cdi/OpenTelemetryProducer.java
@@ -52,7 +52,7 @@ public class OpenTelemetryProducer {
      *         is disabled or the application has shut down.
      */
     private OpenTelemetryInfoInternal getOpenTelemetryInfo() {
-        Optional<OpenTelemetryInfoInternal> openTelemetryInfo = openTelemetryInfoFactoryService.call((lifecycleManager) -> {
+        Optional<OpenTelemetryInfoInternal> openTelemetryInfo = openTelemetryInfoFactoryService.run((lifecycleManager) -> {
             return lifecycleManager.getOpenTelemetryInfo(metaData);
         });
         return openTelemetryInfo.orElseGet(ErrorOpenTelemetryInfo::new);

--- a/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/internal/interfaces/OpenTelemetryAccessor.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/internal/interfaces/OpenTelemetryAccessor.java
@@ -43,7 +43,7 @@ public class OpenTelemetryAccessor {
      */
     public static OpenTelemetryInfoInternal getOpenTelemetryInfo() {
         //TOOD when the SPI is out of beta, make this a redirect to the SPI accessor to avoid code duplication
-        Optional<OpenTelemetryInfoInternal> openTelemetryInfo = openTelemetryLifecycleManagerService.call((lifecycle) -> {
+        Optional<OpenTelemetryInfoInternal> openTelemetryInfo = openTelemetryLifecycleManagerService.run((lifecycle) -> {
             return lifecycle.getOpenTelemetryInfo();
         });
         return openTelemetryInfo.orElseGet(ErrorOpenTelemetryInfo::new);
@@ -85,7 +85,7 @@ public class OpenTelemetryAccessor {
      * @throws IllegalArgumentException if InvocationContext is not an instance of org.jboss.weld.interceptor.proxy.AbstractInvocationContext;
      */
     public static Set<Annotation> getInterceptorBindingsFromInvocationContext(final InvocationContext context) {
-        Optional<Set<Annotation>> bindings = cdiService.call((service) -> {
+        Optional<Set<Annotation>> bindings = cdiService.run((service) -> {
             return service.getInterceptorBindingsFromInvocationContext(context);
         });
         return bindings.orElseThrow(() -> new IllegalStateException("Unable to get CDIService"));
@@ -97,7 +97,7 @@ public class OpenTelemetryAccessor {
      * Note that in a checkpoint environment this will always return false before a checkpoint restore.
      */
     public static boolean isRuntimeEnabled() {
-        Optional<Object> isRuntimeEnabled = openTelemetryLifecycleManagerService.call((lifecycle) -> {
+        Optional<Object> isRuntimeEnabled = openTelemetryLifecycleManagerService.run((lifecycle) -> {
             return lifecycle.isRuntimeEnabled();
         });
         return (boolean) isRuntimeEnabled.orElse(false);

--- a/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/spi/OpenTelemetryAccessor.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/spi/OpenTelemetryAccessor.java
@@ -39,7 +39,7 @@ public class OpenTelemetryAccessor {
     public static OpenTelemetryInfo getOpenTelemetryInfo() {
 
         if (ProductInfo.getBetaEdition()) {
-            Optional<OpenTelemetryInfo> openTelemetryInfo = openTelemetryLifecycleManagerService.call((factory) -> {
+            Optional<OpenTelemetryInfo> openTelemetryInfo = openTelemetryLifecycleManagerService.run((factory) -> {
                 return factory.getOpenTelemetryInfo();
             });
 


### PR DESCRIPTION
`call(Consumer)` and `call(Function)` are ambiguous when called with a lambda which doesn't return a value.

~~I picked "run" to match Runnable/Callable, even though we're actually using Consumer and Function.~~ See discussion below, we're now using `call` and `run`, but with the _opposite_ meaning of Runnable and Callable...

The upstream version does not have this issue because it does not have the `call(Function)` variant.

I could not find any existing code using the `call(Consumer)` variant.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
