### PR TITLE
Don't wait infinitely for client run or server stop to complete

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/Machine.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/Machine.java
@@ -460,7 +460,7 @@ public class Machine {
         if (OperatingSystem.ISERIES.compareTo(getOperatingSystem()) == 0) {
             cmd = "qsh -c " + cmd;
         }
-        return LocalProvider.executeCommand(this, cmd, parameters, workDir, envVars);
+        return LocalProvider.executeCommand(this, cmd, parameters, workDir, envVars, timeout);
     }
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/common/apiservices/cmdline/LocalProvider.java
+++ b/dev/fattest.simplicity/src/componenttest/common/apiservices/cmdline/LocalProvider.java
@@ -267,6 +267,7 @@ public class LocalProvider {
         }
 
         // wait till completion
+        // A timeout value of zero or less means to wait indefinitely for the process to complete
         int exitValue;
         if (timeout <= 0) {
             exitValue = proc.waitFor();

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -764,7 +764,7 @@ public class LibertyClient {
             Log.info(c, method, "Started client process in debug mode");
             output = null;
         } else {
-            output = machine.execute(cmd, parameters, envVars);
+            output = machine.execute(cmd, parameters, machine.getWorkDir(), envVars, 300);
 
             int rc = output.getReturnCode();
             Log.info(c, method, "Response from script is: " + output.getStdout());

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3214,7 +3214,7 @@ public class LibertyServer implements LogMonitorClient {
             ProgramOutput output = null;
 
             if (!runAsAWindowService) {
-                output = machine.execute(cmd, parameters, useEnvVars);
+                output = machine.execute(cmd, parameters, machine.getWorkDir(), useEnvVars, 300);
             } else {
                 ArrayList<String> parametersList = new ArrayList<String>();
                 for (int i = 0; i < parameters.length; i++) {
@@ -3225,8 +3225,11 @@ public class LibertyServer implements LogMonitorClient {
                 String[] stopServiceParameters = stopServiceParmList.toArray(new String[] {});
                 String[] removeServiceParameters = removeServiceParmList.toArray(new String[] {});
 
-                output = machine.execute(cmd, stopServiceParameters, useEnvVars);
-                output = machine.execute(cmd, removeServiceParameters, useEnvVars);
+                try {
+                    output = machine.execute(cmd, stopServiceParameters, machine.getWorkDir(), useEnvVars, 300);
+                } finally {
+                    output = machine.execute(cmd, removeServiceParameters, machine.getWorkDir(), useEnvVars, 300);
+                }
             }
 
             String stdout = output.getStdout();


### PR DESCRIPTION
- Update LocalProvider to handle a timeout value
- Update LibertyClient to pass in a timeout of 300 seconds for a client to finish so it doesn't hang
- Update LibertyServer to pass in a timeout of 300 seconds for a server stop call to finish so it doesn't hang


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

#build