### PR TITLE
Data NLS messages for parameter related errors

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -185,3 +185,76 @@ CWWKD1014.upd.missing.param.anno.explanation=Parameters of repository update \
  methods must correspond to entity properties.
 CWWKD1014.upd.missing.param.anno.useraction=Update the repository method such that \
  all parameters correspond to entity properties.
+
+CWWKD1015.null.entity.param=CWWKD1015E: The {0} method of the {1} repository \
+ interface cannot accept a null entity.
+CWWKD1015.null.entity.param.explanation=Lifecycle methods require a non-null \
+ entity instance.
+CWWKD1015.null.entity.param.useraction=Update application code to avoid supplying \
+ a null entity value to the repository method.
+
+CWWKD1016.incompat.entity.param=CWWKD1016E: The {0} method of the {1} repository \
+ interface requires a {0} entity, but a {1} value was supplied.
+CWWKD1016.incompat.entity.param.explanation=The lifecycle method only accepts \
+ entity values of the declared type.
+CWWKD1016.incompat.entity.param.useraction=Update application code to supply an \
+ entity value of the same entity type that is declared by the repository method.
+
+CWWKD1017.dup.special.param=CWWKD1017E: The {0} method of the {1} repository \
+ cannot have multiple {2} parameters.
+CWWKD1017.dup.special.param.explanation=Some of the Jakarta Data special \
+ parameter, including Limit and PageRequest, cannot appear multiple times within \
+ a repository method signature.
+CWWKD1017.dup.special.param.useraction=Update the repository method signature \
+ to have at most one occurrence of the Jakarta Data special parameter type.
+
+CWWKD1018.confl.special.param=CWWKD1018E: The {0} method of the {1} repository \
+ cannot have a {2} parameter and a {3} parameter.
+CWWKD1018.confl.special.param.explanation=Some of the Jakarta Data special \
+ parameters, such as Limit and PageRequest, cannot be combined on a single \
+ repository method signature.
+CWWKD1018.confl.special.param.useraction=Update the repository to avoid using \
+ both of the Jakarta Data special parameter types in the same method signature.
+
+CWWKD1019.mixed.positional.named=CWWKD1019E: The {0} method of the {1} repository \
+ interface cannot have a query with a mixture of positional parameters and named \
+ parameters.
+CWWKD1019.mixed.positional.named.explanation=Queries with parameters must use all \
+ named parameters or all positional parameters, not a combination.
+CWWKD1019.mixed.positional.named.useraction=Update the repository method to only \
+ use named parameters or only use positional parameters.
+
+CWWKD1020.invalid.param.type=CWWKD1020E: Parameters of the {0} method of the \
+ {1} repository interface must not be of the {2} type because the repository \
+ method is a {3} operation.
+CWWKD1020.invalid.param.type.explanation=The parameter type is not permitted \
+ on this type of method.
+CWWKD1020.invalid.param.type.useraction=Update the repository method to define \
+ a method parameter for each value that is required by a comparison.
+
+CWWKD1021.insufficient.params=CWWKD1021E: The {0} method of the {1} repository \
+ interface has {2} parameters, but the query conditions that are defined by the \
+ method require {3} parameters. The JPQL query for the method is: {4}.
+CWWKD1021.insufficient.params.explanation=Query conditions that define \
+ comparisons of values require a corresponding number of repository method \
+ parameters to supply the values.
+CWWKD1021.insufficient.params.useraction=Update the repository method to define \
+ a method parameter for each value that is required by a comparison.
+
+CWWKD1022.too.many.params=CWWKD1022E: The query conditions of the {0} method \
+ of the {1} repository interface require {2} parameters, but the repository \
+ method signature has {3} parameters. The JPQL query for the method is: {4}.
+CWWKD1022.too.many.params.explanation=Query conditions that define \
+ comparisons of values require a corresponding number of repository method \
+ parameters to supply the values. Extra parameters are not permitted.
+CWWKD1022.too.many.params.useraction=Update the repository method signature \
+ to remove extra parameters that do not correspond to declared conditions.
+
+CWWKD1023.extra.param=CWWKD1023E: The query conditions of the {0} method \
+ of the {1} repository interface require {2} parameters, but the repository \
+ method has an additional {3} parameter. The JPQL query for the method is: {4}.
+CWWKD1023.extra.param.explanation=Query conditions that define \
+ comparisons of values require a corresponding number of repository method \
+ parameters to supply the values. Extra parameters are not permitted.
+CWWKD1023.extra.param.useraction=Update the repository method signature \
+ to remove extra parameters that do not correspond to declared conditions.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -195,15 +195,15 @@ CWWKD1015.null.entity.param.useraction=Update application code to avoid supplyin
 
 CWWKD1016.incompat.entity.param=CWWKD1016E: The {0} method of the {1} repository \
  interface requires a {0} entity, but a {1} value was supplied.
-CWWKD1016.incompat.entity.param.explanation=The lifecycle method only accepts \
+CWWKD1016.incompat.entity.param.explanation=The lifecycle method accepts only \
  entity values of the declared type.
 CWWKD1016.incompat.entity.param.useraction=Update application code to supply an \
- entity value of the same entity type that is declared by the repository method.
+ entity value of the same entity type that the repository method declares.
 
 CWWKD1017.dup.special.param=CWWKD1017E: The {0} method of the {1} repository \
  cannot have multiple {2} parameters.
 CWWKD1017.dup.special.param.explanation=Some of the Jakarta Data special \
- parameter, including Limit and PageRequest, cannot appear multiple times within \
+ parameters, including Limit and PageRequest, cannot appear multiple times within \
  a repository method signature.
 CWWKD1017.dup.special.param.useraction=Update the repository method signature \
  to have at most one occurrence of the Jakarta Data special parameter type.
@@ -213,7 +213,7 @@ CWWKD1018.confl.special.param=CWWKD1018E: The {0} method of the {1} repository \
 CWWKD1018.confl.special.param.explanation=Some of the Jakarta Data special \
  parameters, such as Limit and PageRequest, cannot be combined on a single \
  repository method signature.
-CWWKD1018.confl.special.param.useraction=Update the repository to avoid using \
+CWWKD1018.confl.special.param.useraction=Update the repository to not use \
  both of the Jakarta Data special parameter types in the same method signature.
 
 CWWKD1019.mixed.positional.named=CWWKD1019E: The {0} method of the {1} repository \
@@ -221,8 +221,8 @@ CWWKD1019.mixed.positional.named=CWWKD1019E: The {0} method of the {1} repositor
  parameters.
 CWWKD1019.mixed.positional.named.explanation=Queries with parameters must use all \
  named parameters or all positional parameters, not a combination.
-CWWKD1019.mixed.positional.named.useraction=Update the repository method to only \
- use named parameters or only use positional parameters.
+CWWKD1019.mixed.positional.named.useraction=Update the repository method to use \
+ only named parameters or only positional parameters.
 
 CWWKD1020.invalid.param.type=CWWKD1020E: Parameters of the {0} method of the \
  {1} repository interface must not be of the {2} type because the repository \

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1099,7 +1099,11 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 if (limit == null)
                                     limit = (Limit) param;
                                 else
-                                    throw new UnsupportedOperationException("Repository method " + method + " cannot have multiple Limit parameters."); // TODO NLS
+                                    throw exc(UnsupportedOperationException.class,
+                                              "CWWKD1017.dup.special.param",
+                                              method.getName(),
+                                              method.getDeclaringClass().getName(),
+                                              "Limit");
                             } else if (param instanceof Order) {
                                 @SuppressWarnings("unchecked")
                                 Iterable<Sort<Object>> order = (Iterable<Sort<Object>>) param;
@@ -1108,9 +1112,11 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 if (pagination == null)
                                     pagination = (PageRequest) param;
                                 else
-                                    throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
-                                                                            method.getDeclaringClass().getName() +
-                                                                            " repository cannot have multiple PageRequest parameters."); // TODO NLS
+                                    throw exc(UnsupportedOperationException.class,
+                                              "CWWKD1017.dup.special.param",
+                                              method.getName(),
+                                              method.getDeclaringClass().getName(),
+                                              "PageRequest");
                             } else if (param instanceof Sort) {
                                 @SuppressWarnings("unchecked")
                                 List<Sort<Object>> newList = queryInfo.supplySorts(sortList, (Sort<Object>) param);
@@ -1119,13 +1125,26 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 @SuppressWarnings("unchecked")
                                 List<Sort<Object>> newList = queryInfo.supplySorts(sortList, (Sort<Object>[]) param);
                                 sortList = newList;
+                            } else if (param == null) {
+                                // ignore null for empty Sort...
+                            } else {
+                                throw exc(DataException.class,
+                                          "CWWKD1023.extra.param",
+                                          method.getName(),
+                                          method.getDeclaringClass().getName(),
+                                          queryInfo.paramCount,
+                                          method.getParameterTypes()[i].getName(),
+                                          queryInfo.jpql);
                             }
                         }
 
                         if (pagination != null && limit != null)
-                            throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
-                                                                    method.getDeclaringClass().getName() +
-                                                                    " repository cannot have both Limit and PageRequest as parameters."); // TODO NLS
+                            throw exc(UnsupportedOperationException.class,
+                                      "CWWKD1018.confl.special.param",
+                                      method.getName(),
+                                      method.getDeclaringClass().getName(),
+                                      "Limit",
+                                      "PageRequest");
 
                         if (sortList == null && queryInfo.hasDynamicSortCriteria())
                             sortList = queryInfo.sorts;
@@ -1592,12 +1611,18 @@ public class RepositoryImpl<R> implements InvocationHandler {
         Class<?> entityClass = queryInfo.entityInfo.recordClass == null ? queryInfo.entityInfo.entityClass : queryInfo.entityInfo.recordClass;
 
         if (e == null)
-            throw new NullPointerException("The entity parameter cannot have a null value."); // TODO NLS // required by spec
+            throw exc(NullPointerException.class,
+                      "CWWKD1015.null.entity.param",
+                      queryInfo.method,
+                      queryInfo.method.getDeclaringClass());
 
         if (!entityClass.isInstance(e))
-            throw new IllegalArgumentException("The " + (e == null ? null : e.getClass().getName()) +
-                                               " parameter does not match the " + entityClass.getName() +
-                                               " entity type that is expected for this repository."); // TODO NLS
+            throw exc(IllegalArgumentException.class,
+                      "CWWKD1016.incompat.entity.param",
+                      queryInfo.method,
+                      queryInfo.method.getDeclaringClass(),
+                      entityClass.getName(),
+                      e.getClass().getName());
 
         EntityInfo entityInfo = queryInfo.entityInfo;
         String jpql = queryInfo.jpql;
@@ -1966,12 +1991,18 @@ public class RepositoryImpl<R> implements InvocationHandler {
         Class<?> entityClass = queryInfo.entityInfo.recordClass == null ? queryInfo.entityInfo.entityClass : queryInfo.entityInfo.recordClass;
 
         if (e == null)
-            throw new NullPointerException("The entity parameter cannot have a null value."); // TODO NLS // required by spec
+            throw exc(NullPointerException.class,
+                      "CWWKD1015.null.entity.param",
+                      queryInfo.method,
+                      queryInfo.method.getDeclaringClass());
 
         if (!entityClass.isInstance(e))
-            throw new IllegalArgumentException("The " + (e == null ? null : e.getClass().getName()) +
-                                               " parameter does not match the " + entityClass.getName() +
-                                               " entity type that is expected for this repository."); // TODO NLS
+            throw exc(IllegalArgumentException.class,
+                      "CWWKD1016.incompat.entity.param",
+                      queryInfo.method,
+                      queryInfo.method.getDeclaringClass(),
+                      entityClass.getName(),
+                      e.getClass().getName());
 
         String jpql = queryInfo.jpql;
         EntityInfo entityInfo = queryInfo.entityInfo;


### PR DESCRIPTION
Add NLS messages for a some Jakarta Data error paths that are related to repository method parameters.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
