### PR TITLE
Validation TCK Failure: Correcting javafx dependancies on linux

### DIFF
--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
@@ -60,9 +60,6 @@ public class ValidationTckLauncher {
          */
         Map<String, String> opts = server.getJvmOptionsAsMap();
         opts.put("-Dvalidation.provider", validationProvider);
-        if (server.getMachine().getOperatingSystem() == OperatingSystem.LINUX){
-            opts.put("-Djavafx.platform", "linux");
-        }
 
         /*
          * Client config:
@@ -70,6 +67,9 @@ public class ValidationTckLauncher {
          * - exclude.tests used for skipping tests if we find a TCK bug that needs a service release
          */
         additionalProps.put("validation.provider", validationProvider);
+        if (server.getMachine().getOperatingSystem() == OperatingSystem.LINUX){
+            additionalProps.put("javafx.platform", "linux");
+        }
         additionalProps.put("exclude.tests", "");
 
         //Configure server and install user feature

--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
@@ -20,6 +20,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.OperatingSystem;
+
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
@@ -27,6 +29,7 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKRunner;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
+
 
 /**
  * This is a test class that runs the entire Jakarta Validation TCK against Full
@@ -57,6 +60,9 @@ public class ValidationTckLauncher {
          */
         Map<String, String> opts = server.getJvmOptionsAsMap();
         opts.put("-Dvalidation.provider", validationProvider);
+        if (server.getMachine().getOperatingSystem() == OperatingSystem.LINUX){
+            opts.put("-Djavafx.platform", "linux");
+        }
 
         /*
          * Client config:


### PR DESCRIPTION
TCK failure due to ${javafx.platform} isn’t resolving in linux platform

Build failure: https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=301597

Fix:
Adding `-Djavafx.platform=linux`,  if its linux platform.
