### PR TITLE
ClassCastException occurred during session invalidation

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -306,7 +306,14 @@ public class CacheHashMap extends BackedHashMap {
                     // ignore - some JCache providers might raise this instead of returning null when modified during iterator
                     entry = null;
                 }
-                String id = entry == null ? null : entry.getKey();
+                String id;
+                try {
+                    id = entry == null ? null : entry.getKey();
+                } catch (ClassCastException e) {
+                    id = null;
+                    if (trace && tc.isDebugEnabled())
+                        tcInvoke(tcSessionMetaCache, "Ignore unexpected entry key = ", entry.getKey());
+                }
                 ArrayList<?> value = id == null ? null : entry.getValue();
 
                 if (trace && tc.isDebugEnabled())
@@ -1183,7 +1190,14 @@ public class CacheHashMap extends BackedHashMap {
                 // ignore - some JCache providers might raise this instead of returning null when modified during iterator
                 entry = null;
             }
-            String id = entry == null ? null : entry.getKey();
+            String id;
+            try {
+                id = entry == null ? null : entry.getKey();
+            } catch (ClassCastException e) {
+                id = null;
+                if (trace && tc.isDebugEnabled())
+                    tcInvoke(tcSessionMetaCache, "Ignore unexpected entry key = ", entry.getKey());
+            }
             ArrayList<?> value = id == null ? null : entry.getValue();
 
             if (trace && tc.isDebugEnabled())


### PR DESCRIPTION
For JCache session persistence, customers session tables may contains unexpected records from other source. For example, from migration tools. Although it would not cause any application issue but it will give ClassCastException during session invalidation. 

This changes will catch those unexpected records/entries.