### PR TITLE
Adding delay to ensure message/console log files are synced

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.junit.After;
@@ -85,6 +86,10 @@ public class TelemetryMessagesTest extends FATServletClient {
 
     static void testTelemetryMessages(LibertyServer s, Consumer<List<String>> consoleConsumer) throws Exception {
         String line = s.waitForStringInLog("CWWKF0011I", s.getConsoleLogFile());
+
+        //Sleep for 5s to ensure messages/console log files are in sync
+        TimeUnit.SECONDS.sleep(5);
+
         List<String> linesMessagesLog = s.findStringsInLogs("^(?!.*scopeInfo).*\\[.*$", s.getDefaultLogFile());
         List<String> linesConsoleLog = s.findStringsInLogs(".*scopeInfo.*", s.getConsoleLogFile());
 


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Fixes RTC 301329

Sleeps for 5s to ensure messages/console log files are in sync