### PR TITLE
Data NLS messages for query language errors and more parameter-related errors

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -313,3 +313,50 @@ CWWKD1029.first.neg.or.zero.explanation=The maximum number of query results \
  must be a positive number.
 CWWKD1029.first.neg.or.zero.useraction=Update the repository method to specify \
  a positive maximum number of results.
+
+CWWKD1030.ql.lacks.entity=CWWKD1030E: The entity name is missing from the {0} \
+ query that is specified for the {1} method of the {2} repository. In Jakarta \
+ Data Query Language, {3} queries should be formed like: {4}.
+CWWKD1030.ql.lacks.entity.explanation=The query contains a clause that requires \
+ the entity name.
+CWWKD1030.ql.lacks.entity.useraction=Update the query for repository method to \
+ include the entity name.
+
+CWWKD1031.ql.similar.entity=CWWKD1031E: The {0} method of the {1} repository \
+ interface specifies a query that requires a {2} entity name that is not found \
+ but is a close match for the {3} entity name. The query is: {4}.
+CWWKD1031.ql.similar.entity.explanation=The query might have a typo in its \
+ reference to the entity name.
+CWWKD1031.ql.similar.entity.useraction=Review the query to ensure the correct \
+ entity name is used.
+
+CWWKD1032.ql.unknown.entity=CWWKD1032E: The {0} method of the {1} repository \
+ interface specifies a query that requires a {2} entity name that is not found. \
+ Check if {2} is the name of a valid entity. To enable the entity to be found, \
+ give the repository a lifecycle method that is annotated with one of the {3} \
+ annotations and supply the entity as its parameter. Alternatively, have the \
+ repository extend DataRepository or another built-in repository interface, \
+ with the entity class as the first type variable. The query is: {4}.
+CWWKD1032.ql.unknown.entity.explanation=The query might have a typo in its \
+ reference to the entity name, or the repository does not specify its primary \
+ entity class.
+CWWKD1032.ql.unknown.entity.useraction=Review the query to ensure the correct \
+ entity name is used. Review the repository definition to ensure the correct \
+ primary entity class is specified.
+
+CWWKD1033.ql.orderby.disallowed=CWWKD1033E: The {0} method of the {1} repository \
+ interface cannot specify a query that includes an ORDER BY clause because \
+ the method returns {2}. Remove the ORDER BY clause and instead use the {3} \
+ annotation to specify static sort criteria. The query is: {4}.
+CWWKD1033.ql.orderby.disallowed.explanation=The ORDER BY clause is incompatible \
+ with cursor-based pagination.
+CWWKD1033.ql.orderby.disallowed.useraction=Replace the ORDER BY clause with \
+ annotations that specify the sort criteria.
+
+CWWKD1034.ql.where.required=CWWKD1034E: The query that is specified by the \
+ {0} method of the {1} repository interface must end in a WHERE clause because \
+ the method returns {2}. There WHERE clause ends at position {3}, but the \
+ length of the query is {4}. The query is: {5}.
+CWWKD1034.ql.where.required.explanation=A WHERE clause is required when \
+ using cursor-based pagination.
+CWWKD1034.ql.where.required.useraction=Add a WHERE clause to the query.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -270,16 +270,16 @@ CWWKD1024.missing.entity.prop.useraction=Inspect the declaration and usage of \
  each query condition and sort criterion.
 
 CWWKD1025.missing.id.prop=CWWKD1025E: The {0} entity class that is used by the \
- {1} method of the {2} repository interface does not have an Id property or \
+ {1} method of the {2} repository interface does not have an ID property or \
  accessor method.
 CWWKD1025.missing.id.prop.explanation=Repository methods that delete and return \
- an entity must have an Id property.
+ an entity must have an ID property.
 CWWKD1025.missing.id.prop.useraction=If the entity does not have a single \
- property that is the Id, define separate repository methods to query for the \
+ property for the ID, define separate repository methods that query for the \
  entity and delete the entity.
 
-CWWKD1026.ignore.case.not.text=CWWKD1026E: The {0} property of the {1} entity \
- is not a character or character sequence, so the {2} sort criteria must not \
+CWWKD1026.ignore.case.not.text=CWWKD1026E: The {0} property of the {1} entity is \
+ not a character or character sequence; therefore, the {2} sort criteria must not \
  specify to ignore case. The type of the property is {3}, and it was supplied to \
  the {4} method of the {5} repository interface.
 CWWKD1026.ignore.case.not.text.explanation=Sorting with case ignored is only \
@@ -291,7 +291,7 @@ CWWKD1026.ignore.case.not.text.useraction=Ensure the sort criteria is applied \
 CWWKD1027.anno.missing.prop.name=CWWKD1027E: Parameter {0} of the {1} method of \
  the {2} repository interface is annotated with an {3} annotation that does not \
  specify an entity property name as its value. The annotation must either specify \
- the entity property name as its value or the -parameters compile option must be \
+ the entity property name as its value, or the -parameters compile option must be \
  enabled and the parameter must have the same name as the entity property.
 CWWKD1027.anno.missing.prop.name.explanation=Parameters of repository update \
  methods must correspond to entity properties.
@@ -308,7 +308,7 @@ CWWKD1028.first.exceeds.max.useraction=Reduce the requested maximum number of \
 
 CWWKD1029.first.neg.or.zero=CWWKD1029E: The {0} method of the {1} repository \
  interface requests the first {2} results. The requested maximum number of \
- results to return must be positive.
+ results to return must be a positive number.
 CWWKD1029.first.neg.or.zero.explanation=The maximum number of query results \
  must be a positive number.
 CWWKD1029.first.neg.or.zero.useraction=Update the repository method to specify \
@@ -325,21 +325,21 @@ CWWKD1030.ql.lacks.entity.useraction=Update the query for repository method to \
 CWWKD1031.ql.similar.entity=CWWKD1031E: The {0} method of the {1} repository \
  interface specifies a query that requires a {2} entity name that is not found \
  but is a close match for the {3} entity name. The query is: {4}.
-CWWKD1031.ql.similar.entity.explanation=The query might have a typo in its \
- reference to the entity name.
+CWWKD1031.ql.similar.entity.explanation=The query might have a typographical \
+ error in its reference to the entity name.
 CWWKD1031.ql.similar.entity.useraction=Review the query to ensure the correct \
  entity name is used.
 
 CWWKD1032.ql.unknown.entity=CWWKD1032E: The {0} method of the {1} repository \
  interface specifies a query that requires a {2} entity name that is not found. \
- Check if {2} is the name of a valid entity. To enable the entity to be found, \
+ Ensure that {2} is the name of a valid entity. To enable the entity to be found, \
  give the repository a lifecycle method that is annotated with one of the {3} \
  annotations and supply the entity as its parameter. Alternatively, have the \
- repository extend DataRepository or another built-in repository interface, \
- with the entity class as the first type variable. The query is: {4}.
-CWWKD1032.ql.unknown.entity.explanation=The query might have a typo in its \
- reference to the entity name, or the repository does not specify its primary \
- entity class.
+ repository extend the DataRepository interface or another built-in repository \
+ interface, with the entity class as the first type variable. The query is: {4}.
+CWWKD1032.ql.unknown.entity.explanation=The query might have a typographical error \
+ in its reference to the entity name, or the repository does not specify its \
+ primary entity class.
 CWWKD1032.ql.unknown.entity.useraction=Review the query to ensure the correct \
  entity name is used. Review the repository definition to ensure the correct \
  primary entity class is specified.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -258,3 +258,58 @@ CWWKD1023.extra.param.explanation=Query conditions that define \
  parameters to supply the values. Extra parameters are not permitted.
 CWWKD1023.extra.param.useraction=Update the repository method signature \
  to remove extra parameters that do not correspond to declared conditions.
+
+CWWKD1024.missing.entity.prop=CWWKD1024E: The {0} method of the {1} repository \
+ interface is missing an entity property name or was supplied with a parameter \
+ that lacks an entity property name. Valid property names for the {2} entity \
+ class are: {3}.
+CWWKD1024.missing.entity.prop.explanation=The query conditions and sort criteria \
+ for a repository method must include an entity property name.
+CWWKD1024.missing.entity.prop.useraction=Inspect the declaration and usage of \
+ the repository method to ensure that an entity property name is supplied for \
+ each query condition and sort criterion.
+
+CWWKD1025.missing.id.prop=CWWKD1025E: The {0} entity class that is used by the \
+ {1} method of the {2} repository interface does not have an Id property or \
+ accessor method.
+CWWKD1025.missing.id.prop.explanation=Repository methods that delete and return \
+ an entity must have an Id property.
+CWWKD1025.missing.id.prop.useraction=If the entity does not have a single \
+ property that is the Id, define separate repository methods to query for the \
+ entity and delete the entity.
+
+CWWKD1026.ignore.case.not.text=CWWKD1026E: The {0} property of the {1} entity \
+ is not a character or character sequence, so the {2} sort criteria must not \
+ specify to ignore case. The type of the property is {3}, and it was supplied to \
+ the {4} method of the {5} repository interface.
+CWWKD1026.ignore.case.not.text.explanation=Sorting with case ignored is only \
+ possible with entity properties that represent text.
+CWWKD1026.ignore.case.not.text.useraction=Ensure the sort criteria is applied \
+ to the correct entity property and remove the instruction to ignore case if the \
+ entity property does not represent text.
+
+CWWKD1027.anno.missing.prop.name=CWWKD1027E: Parameter {0} of the {1} method of \
+ the {2} repository interface is annotated with an {3} annotation that does not \
+ specify an entity property name as its value. The annotation must either specify \
+ the entity property name as its value or the -parameters compile option must be \
+ enabled and the parameter must have the same name as the entity property.
+CWWKD1027.anno.missing.prop.name.explanation=Parameters of repository update \
+ methods must correspond to entity properties.
+CWWKD1027.anno.missing.prop.name.useraction=Update the repository method to \
+ indicate the entity property to which the parameter pertains.
+
+CWWKD1028.first.exceeds.max=CWWKD1028E: The {0} method of the {1} repository \
+ interface requests the first {2} results, which exceeds the maximum allowed \
+ number of results: {3}.
+CWWKD1028.first.exceeds.max.explanation=The maximum number of query results is \
+ limited by system constraints and the value specified.
+CWWKD1028.first.exceeds.max.useraction=Reduce the requested maximum number of \
+ query results to a smaller value.
+
+CWWKD1029.first.neg.or.zero=CWWKD1029E: The {0} method of the {1} repository \
+ interface requests the first {2} results. The requested maximum number of \
+ results to return must be positive.
+CWWKD1029.first.neg.or.zero.explanation=The maximum number of query results \
+ must be a positive number.
+CWWKD1029.first.neg.or.zero.useraction=Update the repository method to specify \
+ a positive maximum number of results.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -156,7 +156,7 @@ public class PageImpl<T> implements Page<T> {
             throw new NullPointerException("PageRequest: null");
         else
             throw new UnsupportedOperationException("The " + queryInfo.method.getName() + " method of the " +
-                                                    queryInfo.method.getDeclaringClass().getName() +
+                                                    queryInfo.repositoryInterface.getName() +
                                                     " repository has a " + queryInfo.method.getReturnType().getName() +
                                                     " return type but does not have a " + PageRequest.class.getName() +
                                                     " parameter."); // TODO NLS

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1133,11 +1133,12 @@ public class QueryInfo {
                                 if (Boolean.TRUE.equals(isNamePresent))
                                     attribute = params[p].getName();
                                 else
-                                    throw new MappingException("You must specify an entity attribute name as the value of the" +
-                                                               " annotation on parameter " + (p + 1) +
-                                                               " of the " + method.getName() + " method of the " +
-                                                               method.getDeclaringClass().getName() + " repository or compile the application" +
-                                                               " with the -parameters compiler option that preserves the parameter names."); // TODO NLS
+                                    throw exc(MappingException.class,
+                                              "CWWKD1027.anno.missing.prop.name",
+                                              p + 1,
+                                              method.getName(),
+                                              method.getDeclaringClass().getName(),
+                                              "Assign");
                             }
 
                             String name = getAttributeName(attribute, true);
@@ -1682,9 +1683,14 @@ public class QueryInfo {
             String lowerName = name.toLowerCase();
             attributeName = entityInfo.attributeNames.get(lowerName);
             if (attributeName == null)
-                if (name.length() == 0)
-                    throw new MappingException("Error parsing method name or entity property name is missing."); // TODO NLS
-                else {
+                if (name.length() == 0) {
+                    throw exc(MappingException.class,
+                              "CWWKD1024.missing.entity.prop",
+                              method.getName(),
+                              method.getDeclaringClass().getName(),
+                              entityInfo.getType().getName(),
+                              entityInfo.attributeTypes.keySet());
+                } else {
                     // tolerate possible mixture of . and _ separators:
                     lowerName = lowerName.replace('.', '_');
                     attributeName = entityInfo.attributeNames.get(lowerName);
@@ -2715,7 +2721,12 @@ public class QueryInfo {
                     if (num <= (Integer.MAX_VALUE - (ch - '0')) / 10)
                         num = num * 10 + (ch - '0');
                     else
-                        throw new UnsupportedOperationException(methodName.substring(0, endBefore) + " exceeds Integer.MAX_VALUE (2147483647)."); // TODO
+                        throw exc(UnsupportedOperationException.class,
+                                  "CWWKD1028.first.exceeds.max",
+                                  methodName,
+                                  method.getDeclaringClass().getName(),
+                                  methodName.substring(0, endBefore),
+                                  "Integer.MAX_VALUE (" + Integer.MAX_VALUE + ")");
                     start++;
                 } else {
                     if (num == 0)
@@ -2724,7 +2735,11 @@ public class QueryInfo {
                 }
             }
         if (num == 0)
-            throw new UnsupportedOperationException("The number of results to retrieve must not be 0 on the " + methodName + " method."); // TODO NLS
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1029.first.neg.or.zero",
+                      methodName,
+                      method.getDeclaringClass().getName(),
+                      0);
         else
             maxResults = num;
 
@@ -3197,9 +3212,14 @@ public class QueryInfo {
                 && !CharSequence.class.isAssignableFrom(propertyClass)
                 && !char.class.equals(propertyClass)
                 && !Character.class.equals(propertyClass))
-                throw new UnsupportedOperationException("The ignoreCase parameter in a Sort can only be true if the Entity" +
-                                                        " property being sorted is a character sequence. The property [" + propName +
-                                                        "] is of type [" + propertyClass.getName() + "]"); //TODO NLS
+                throw exc(UnsupportedOperationException.class,
+                          "CWWKD1026.ignore.case.not.text",
+                          propName,
+                          entityInfo.getType().getName(),
+                          sort,
+                          propertyClass.getName(),
+                          method.getName(),
+                          method.getDeclaringClass().getName());
         }
     }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1282,7 +1282,11 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                                 entityInfo.recordClass != null && entityInfo.recordClass.isInstance(result)) {
                                                 List<Member> accessors = entityInfo.attributeAccessors.get(entityInfo.attributeNames.get(ID));
                                                 if (accessors == null || accessors.isEmpty())
-                                                    throw new MappingException("Unable to find the id attribute on the " + entityInfo.name + " entity."); // TODO NLS
+                                                    throw exc(MappingException.class,
+                                                              "CWWKD1025.missing.id.prop",
+                                                              entityInfo.getType().getName(),
+                                                              method.getName(),
+                                                              repositoryInterface);
                                                 for (Member accessor : accessors)
                                                     value = accessor instanceof Method ? ((Method) accessor).invoke(value) : ((Field) accessor).get(value);
                                             } else if (!entityInfo.idType.isInstance(value)) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -374,7 +374,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
         }
 
         throw new MappingException("The " + queryInfo.method.getName() + " method of the " +
-                                   queryInfo.method.getDeclaringClass().getName() +
+                                   repositoryInterface.getName() +
                                    " repository is unable to convert a " +
                                    fromType.getName() + " value into a " + toType.getName() +
                                    " value that is required by the return type of the method.", // TODO NLS
@@ -394,7 +394,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
     private void convertFail(Method method, Class<?> fromType, long min, long max) {
         Class<?> toType = method.getReturnType();
         throw new MappingException("The " + method.getName() + " method of the " +
-                                   method.getDeclaringClass().getName() +
+                                   repositoryInterface.getName() +
                                    " repository is unable to convert a " +
                                    fromType.getName() + " value into a " + toType.getName() +
                                    " value because the value is not within the range of " +
@@ -656,7 +656,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     returnValue = null;
                 else
                     throw new NonUniqueResultException("The " + queryInfo.method.getName() +
-                                                       " method of the " + queryInfo.method.getDeclaringClass().getName() +
+                                                       " method of the " + repositoryInterface.getName() +
                                                        " repository interface has the " +
                                                        queryInfo.method.getGenericReturnType().getTypeName() +
                                                        " return type, which is not capable of returning " +
@@ -746,7 +746,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
             throw new UnsupportedOperationException(); // TODO
         } else if (id != null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                Tr.debug(tc, "set ?" + (p + 1) + ' ' + id.getClass().getSimpleName());
+                Tr.debug(tc, "set ?" + (p + 1) + ' ' + queryInfo.loggable(id));
             query.setParameter(++p, id);
         }
 
@@ -754,7 +754,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
         if (entityInfo.versionAttributeName != null && version != null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                Tr.debug(tc, "set ?" + (p + 1) + ' ' + version.getClass().getSimpleName());
+                Tr.debug(tc, "set ?" + (p + 1) + ' ' + queryInfo.loggable(version));
             query.setParameter(++p, version);
         }
 
@@ -936,7 +936,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                         returnValue = null;
                     else
                         throw new NonUniqueResultException("The " + queryInfo.method.getName() +
-                                                           " method of the " + queryInfo.method.getDeclaringClass().getName() +
+                                                           " method of the " + repositoryInterface.getName() +
                                                            " repository interface has the " +
                                                            queryInfo.method.getGenericReturnType().getTypeName() +
                                                            " return type, which is not capable of returning " +
@@ -1102,7 +1102,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                     throw exc(UnsupportedOperationException.class,
                                               "CWWKD1017.dup.special.param",
                                               method.getName(),
-                                              method.getDeclaringClass().getName(),
+                                              repositoryInterface.getName(),
                                               "Limit");
                             } else if (param instanceof Order) {
                                 @SuppressWarnings("unchecked")
@@ -1115,7 +1115,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                     throw exc(UnsupportedOperationException.class,
                                               "CWWKD1017.dup.special.param",
                                               method.getName(),
-                                              method.getDeclaringClass().getName(),
+                                              repositoryInterface.getName(),
                                               "PageRequest");
                             } else if (param instanceof Sort) {
                                 @SuppressWarnings("unchecked")
@@ -1131,7 +1131,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 throw exc(DataException.class,
                                           "CWWKD1023.extra.param",
                                           method.getName(),
-                                          method.getDeclaringClass().getName(),
+                                          repositoryInterface.getName(),
                                           queryInfo.paramCount,
                                           method.getParameterTypes()[i].getName(),
                                           queryInfo.jpql);
@@ -1142,7 +1142,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             throw exc(UnsupportedOperationException.class,
                                       "CWWKD1018.confl.special.param",
                                       method.getName(),
-                                      method.getDeclaringClass().getName(),
+                                      repositoryInterface.getName(),
                                       "Limit",
                                       "PageRequest");
 
@@ -1158,7 +1158,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 // TODO raise a helpful error to prevent some cases of attempted unordered pagination?
                                 //else if (!queryInfo.hasOrderBy)
                                 //    throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
-                                //                                            queryInfo.method.getDeclaringClass().getName() +
+                                //                                            repositoryInterface.getName() +
                                 //                                            " repository has a PageRequest parameter without a way to " +
                                 //                                            " specify a deterministic ordering of results, which is required " +
                                 //                                            " when requesting pages. Use the OrderBy annotation or add a " +
@@ -1197,7 +1197,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                         } else if (pagination != null && !PageRequest.Mode.OFFSET.equals(pagination.mode())) {
                             throw new IllegalArgumentException("A PageRequest that specifies the " + pagination.mode() +
                                                                " mode must not be supplied to the " + method.getName() +
-                                                               " method of the " + method.getDeclaringClass().getName() +
+                                                               " method of the " + repositoryInterface.getName() +
                                                                " repository because the method returns " +
                                                                queryInfo.method.getGenericReturnType().getTypeName() +
                                                                " rather than " + CursoredPage.class.getName() + "."); // TODO NLS
@@ -1272,7 +1272,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                                 Object value = accessor instanceof Method ? ((Method) accessor).invoke(result) : ((Field) accessor).get(result);
                                                 if (trace && tc.isDebugEnabled())
                                                     Tr.debug(this, tc, queryInfo.jpqlDelete,
-                                                             "set ?" + (numParams + 1) + ' ' + (value == null ? null : value.getClass().getSimpleName()));
+                                                             "set ?" + (numParams + 1) + ' ' + queryInfo.loggable(value));
                                                 delete.setParameter(++numParams, value);
                                             }
                                             delete.executeUpdate();
@@ -1301,7 +1301,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                             jakarta.persistence.Query delete = em.createQuery(queryInfo.jpqlDelete);
                                             if (trace && tc.isDebugEnabled())
                                                 Tr.debug(this, tc, queryInfo.jpqlDelete,
-                                                         "set ?1 " + (value == null ? null : value.getClass().getSimpleName()));
+                                                         "set ?1 " + queryInfo.loggable(value));
                                             delete.setParameter(1, value);
                                             delete.executeUpdate();
                                         }
@@ -1376,7 +1376,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                         throw new MappingException("The " + queryInfo.returnArrayType.getName() +
                                                                    " array type that is declared to be returned by the " +
                                                                    queryInfo.method.getName() + " method of the " +
-                                                                   queryInfo.method.getDeclaringClass().getName() +
+                                                                   repositoryInterface.getName() +
                                                                    " repository is incompatible with the " +
                                                                    firstNonNullResult.getClass().getName() +
                                                                    " type of the observed query results."); // TODO NLS
@@ -1617,14 +1617,14 @@ public class RepositoryImpl<R> implements InvocationHandler {
         if (e == null)
             throw exc(NullPointerException.class,
                       "CWWKD1015.null.entity.param",
-                      queryInfo.method,
-                      queryInfo.method.getDeclaringClass());
+                      queryInfo.method.getName(),
+                      repositoryInterface.getName());
 
         if (!entityClass.isInstance(e))
             throw exc(IllegalArgumentException.class,
                       "CWWKD1016.incompat.entity.param",
-                      queryInfo.method,
-                      queryInfo.method.getDeclaringClass(),
+                      queryInfo.method.getName(),
+                      repositoryInterface.getName(),
                       entityClass.getName(),
                       e.getClass().getName());
 
@@ -1658,12 +1658,12 @@ public class RepositoryImpl<R> implements InvocationHandler {
             int p = 1;
             if (id != null) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                    Tr.debug(tc, "set ?" + p + ' ' + id.getClass().getSimpleName());
+                    Tr.debug(tc, "set ?" + p + ' ' + queryInfo.loggable(id));
                 delete.setParameter(p++, id);
             }
             if (version != null) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                    Tr.debug(tc, "set ?" + p + ' ' + version.getClass().getSimpleName());
+                    Tr.debug(tc, "set ?" + p + ' ' + queryInfo.loggable(version));
                 delete.setParameter(p, version);
             }
         } else {
@@ -1939,7 +1939,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                         returnValue = null;
                     else
                         throw new NonUniqueResultException("The " + queryInfo.method.getName() +
-                                                           " method of the " + queryInfo.method.getDeclaringClass().getName() +
+                                                           " method of the " + repositoryInterface.getName() +
                                                            " repository interface has the " +
                                                            queryInfo.method.getGenericReturnType().getTypeName() +
                                                            " return type, which is not capable of returning " +
@@ -1997,14 +1997,14 @@ public class RepositoryImpl<R> implements InvocationHandler {
         if (e == null)
             throw exc(NullPointerException.class,
                       "CWWKD1015.null.entity.param",
-                      queryInfo.method,
-                      queryInfo.method.getDeclaringClass());
+                      queryInfo.method.getName(),
+                      repositoryInterface.getName());
 
         if (!entityClass.isInstance(e))
             throw exc(IllegalArgumentException.class,
                       "CWWKD1016.incompat.entity.param",
-                      queryInfo.method,
-                      queryInfo.method.getDeclaringClass(),
+                      queryInfo.method.getName(),
+                      repositoryInterface.getName(),
                       entityClass.getName(),
                       e.getClass().getName());
 
@@ -2036,8 +2036,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
         int p = 0;
         for (String attrName : attrsToUpdate)
-            QueryInfo.setParameter(++p, update, e,
-                                   entityInfo.attributeAccessors.get(attrName));
+            queryInfo.setParameter(++p, update, e, attrName);
 
         // id parameter(s)
 
@@ -2045,7 +2044,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
             throw new UnsupportedOperationException(); // TODO
         } else if (id != null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                Tr.debug(tc, "set ?" + (p + 1) + ' ' + id.getClass().getSimpleName());
+                Tr.debug(tc, "set ?" + (p + 1) + ' ' + queryInfo.loggable(id));
             update.setParameter(++p, id);
         }
 
@@ -2053,7 +2052,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
         if (entityInfo.versionAttributeName != null && version != null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                Tr.debug(tc, "set ?" + (p + 1) + ' ' + version.getClass().getSimpleName());
+                Tr.debug(tc, "set ?" + (p + 1) + ' ' + queryInfo.loggable(version));
             update.setParameter(++p, version);
         }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -190,7 +190,10 @@ public class DataExtension implements Extension {
                 (EntityManager.class.equals(returnType)
                  || DataSource.class.equals(returnType)
                  || Connection.class.equals(returnType))) {
-                QueryInfo queryInfo = new QueryInfo(method, QueryInfo.Type.RESOURCE_ACCESS);
+                QueryInfo queryInfo = new QueryInfo( //
+                                repositoryInterface, //
+                                method, //
+                                QueryInfo.Type.RESOURCE_ACCESS);
 
                 List<QueryInfo> queries = queriesPerEntity.get(Void.class);
                 if (queries == null)
@@ -333,7 +336,12 @@ public class DataExtension implements Extension {
                 }
             }
 
-            queries.add(new QueryInfo(method, entityParamType, returnArrayComponentType, returnTypeAtDepth));
+            queries.add(new QueryInfo( //
+                            repositoryInterface, //
+                            method, //
+                            entityParamType, //
+                            returnArrayComponentType, //
+                            returnTypeAtDepth));
         }
 
         // Confirm which classes are actually entity classes and that all entity classes are supported

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -49,10 +49,10 @@ public class DataTest extends FATServletClient {
      */
     static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
-                                   "CWWKD1006E.*delete3", // TODO more specific message ID once translated
-                                   "CWWKD1006E.*delete4", // TODO more specific message ID once translated
-                                   "CWWKD1008E.*delete5", // TODO more specific message ID once translated
-                                   "CWWKD1000E.*findFirst2147483648" // TODO more specific message ID once translated
+                                   "CWWKD1006E.*delete3",
+                                   "CWWKD1006E.*delete4",
+                                   "CWWKD1008E.*delete5",
+                                   "CWWKD1028E.*findFirst2147483648"
                     };
 
     @ClassRule

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
@@ -35,6 +35,16 @@ import test.jakarta.data.jpa.web.DataJPATestServlet;
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
 public class DataJPATest extends FATServletClient {
+    /**
+     * Error messages, typically for invalid repository methods, that are
+     * intentionally caused by tests to cover error paths.
+     * These are ignored when checking the messages.log file for errors.
+     */
+    static final String[] EXPECTED_ERROR_MESSAGES = //
+                    new String[] {
+                                   "CWWKD1026E.*allSorted"
+                    };
+
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 
@@ -58,6 +68,6 @@ public class DataJPATest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer(EXPECTED_ERROR_MESSAGES);
     }
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATestCheckpoint.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATestCheckpoint.java
@@ -72,6 +72,6 @@ public class DataJPATestCheckpoint extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer(DataJPATest.EXPECTED_ERROR_MESSAGES);
     }
 }


### PR DESCRIPTION
Includes NLS messages for query language errors and additional parameter-related errors.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
