### PR TITLE
Pipeline configuration for required copyright header checking

### DIFF
--- a/.ci-orchestrator/checks.yml
+++ b/.ci-orchestrator/checks.yml
@@ -1,0 +1,43 @@
+type: pipeline_definition
+product: Liberty
+name: Open Liberty Delivery Requirements Verification
+description: "Examines Open Liberty code changes for delivery standards compliance"
+triggers:
+- type: github
+  description: "Runs CI Orchestrator-managed Jenkins jobs to examine pull request changes and create the required copyright header check"
+  triggerName: "libby"
+  triggerRank: 50
+  groups: ["LibertyDev"]
+  keyword: "!libby"
+  aliasKeywords:
+    - "#run-libby-bot"
+    - "#run-libby"
+    - "#libby"
+  propertyDefinitions:
+    - name: githubPRNumber
+      defaultValue: ${github_pr_number}
+    - name: githubPRApi
+      defaultValue: ${github_pr_api}
+      steps:
+      - stepName: Copyright Header Check
+
+- type: manual
+  triggerName: "libby-manual"
+  description: "Runs CI Orchestrator-managed Jenkins jobs to examine pull request changes and create the required copyright header check"
+  triggerRank: 50
+  groups: ["LibertyDev"]
+  propertyDefinitions:
+    - name: githubPRNumber
+      isRequired: true
+      defaultValue: "Number of Open Liberty pull request to verify"
+      description: "Number of Open Liberty pull request to verify"
+    - name: githubPRApi
+      defaultValue: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/${github_pr_number}"
+      steps:
+      - stepName: Copyright Header Check
+
+steps:
+- stepName: Copyright Header Check
+  workType: Jenkins
+  projectName: copyrightHeaderCheck
+  timeoutInMinutes: 30

--- a/.ci-orchestrator/checks.yml
+++ b/.ci-orchestrator/checks.yml
@@ -4,7 +4,7 @@ name: Open Liberty Delivery Requirements Verification
 description: "Examines Open Liberty code changes for delivery standards compliance"
 triggers:
 - type: github
-  description: "Runs CI Orchestrator-managed Jenkins jobs to examine pull request changes and create the required copyright header check"
+  description: "Runs CI Orchestrator-managed Jenkins jobs to examine pull request changes and create required status checks"
   triggerName: "libby"
   triggerRank: 50
   groups: ["LibertyDev"]
@@ -23,7 +23,7 @@ triggers:
 
 - type: manual
   triggerName: "libby-manual"
-  description: "Runs CI Orchestrator-managed Jenkins jobs to examine pull request changes and create the required copyright header check"
+  description: "Runs CI Orchestrator-managed Jenkins jobs to examine pull request changes and create required status checks"
   triggerRank: 50
   groups: ["LibertyDev"]
   propertyDefinitions:


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This pull request introduces configuration that allows user to trigger a CI Orchestrator-managed Jenkins job, using a LibbyBot directive comment, that will create the required copyright header status check.

Subsequent pull requests will enable prohibited terms, DHE server, and CLA status validations. Those are not required for PR delivery; hence why I am rolling this functionality in stages.