### PR TITLE
Updating Validation TCK from the sonotype staging area to maven central.

### DIFF
--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -50,7 +50,7 @@
 		<!-- For artifacts not yet in Maven Central -->
 		<!-- Enable the following during development of a vNext release to use a
 		staged TCK rather than a local -SNAPSHOT -->
-		<repository>
+     <!-- <repository>
 			<id>sonatype-nexus-staging</id>
 			<name>Sonatype Nexus Staging</name>
 			<url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
@@ -60,7 +60,7 @@
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
-		</repository>
+		</repository>  -->
 	</repositories>
 
 	<dependencyManagement>


### PR DESCRIPTION
Validation 3.1.1 TCK updated to Maven Central: https://github.com/jakartaee/validation-tck/issues/199
Creating this PR to update from the sonotype staging area to maven central now in pom..xml.

#build