### PR TITLE
Skip testFetchType on PostgreSQL

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1695,6 +1695,7 @@ public class DataJPATestServlet extends FATServlet {
     /**
      * Verify that fetch type eager and lazy both work when using a detached entity returned by Jakarta Data
      */
+    @SkipIfSysProp(DB_Postgres) //TODO Failing due to Eclipselink Issue on PostgreSQL: https://github.com/OpenLiberty/open-liberty/issues/28368
     @Test
     public void testFetchType() {
         mobilePhones.removeAll();


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Skip new test that is failing due to exiting known issue using PostgreSQL with UUID fields on Eclipselink
https://github.com/OpenLiberty/open-liberty/issues/28368
