### PR TITLE
set minimum java level

### DIFF
--- a/dev/io.openliberty.microprofile7.internal_fat/fat/src/io/openliberty/microprofile7/internal/test/suite/MP7EE11CompatibleTest.java
+++ b/dev/io.openliberty.microprofile7.internal_fat/fat/src/io/openliberty/microprofile7/internal/test/suite/MP7EE11CompatibleTest.java
@@ -14,6 +14,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -22,6 +23,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
+@MinimumJavaLevel(javaLevel = 17)
 public class MP7EE11CompatibleTest {
 
     private static final String SERVER_NAME = "MP70andEE11";


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Resolves https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=301623

The server logs where filled with errors complaining that features can't run below Java 17 and that's a correct behavior so I'm updating the test to not run on earlier javas.