### PR TITLE
Update mavenCoordinates to match the actual version consumed

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.cdi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.cdi-2.0.feature
@@ -5,7 +5,7 @@ singleton=true
 -features=com.ibm.websphere.appserver.eeCompatible-8.0; ibm.tolerates:="6.0,7.0", \
   com.ibm.websphere.appserver.javax.el-3.0; apiJar=false, \
   com.ibm.websphere.appserver.javax.interceptor-1.2
--bundles=com.ibm.websphere.javaee.cdi.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise:cdi-api:2.0"
+-bundles=com.ibm.websphere.javaee.cdi.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise:cdi-api:2.0.SP1"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javax.jaxrs-2.0.feature
@@ -13,7 +13,7 @@ Subsystem-Name: Java RESTful Services API 2.0
   com.ibm.websphere.appserver.api.jaxrs20; location:="dev/api/ibm/,lib/", \
   com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false,\
   com.ibm.websphere.javaee.jaxb.2.2; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
-  com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0.1"
+  com.ibm.websphere.javaee.jaxrs.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.ws.rs:javax.ws.rs-api:2.0"
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.jaxrs20_1.1-javadoc.zip
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.1.0.feature
@@ -7,6 +7,6 @@ singleton=true
 visibility=private
 -features=com.ibm.websphere.appserver.bells-1.0, \
   com.ibm.websphere.appserver.eeCompatible-8.0
--bundles=com.ibm.websphere.javaee.jsonp.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.1.3"
+-bundles=com.ibm.websphere.javaee.jsonp.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.1.4"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.1.1.feature
@@ -5,7 +5,7 @@ WLP-DisableAllFeatures-OnConflict: false
 singleton=true
 visibility=private
 -features=com.ibm.websphere.appserver.eeCompatible-8.0
--bundles=com.ibm.websphere.javaee.jsonp.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.1.3", \
+-bundles=com.ibm.websphere.javaee.jsonp.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.1.4", \
  com.ibm.ws.org.glassfish.json.1.1
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.faulttolerance-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.faulttolerance-2.0.feature
@@ -4,7 +4,7 @@ WLP-DisableAllFeatures-OnConflict: false
 singleton=true
 -features=io.openliberty.mpCompatible-0.0, \
   com.ibm.websphere.appserver.javax.cdi-2.0
--bundles=com.ibm.websphere.org.eclipse.microprofile.faulttolerance.2.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.0"
+-bundles=com.ibm.websphere.org.eclipse.microprofile.faulttolerance.2.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.0.1"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.opentracing-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.opentracing-1.0.feature
@@ -4,7 +4,7 @@ WLP-DisableAllFeatures-OnConflict: false
 visibility=private
 singleton=true
 -features=io.openliberty.mpCompatible-0.0
--bundles=com.ibm.websphere.org.eclipse.microprofile.opentracing.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.0"
+-bundles=com.ibm.websphere.org.eclipse.microprofile.opentracing.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.0.1"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.reactive.streams.operators-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.reactive.streams.operators-1.0.feature
@@ -7,7 +7,7 @@ singleton=true
   com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.org.reactivestreams.reactive-streams-1.0
 -bundles=\
-  com.ibm.websphere.org.eclipse.microprofile.reactive.streams.operators.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-api:1.0"
+  com.ibm.websphere.org.eclipse.microprofile.reactive.streams.operators.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.reactive-streams-operators:microprofile-reactive-streams-operators-api:1.0.1"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.health-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.health-4.0.feature
@@ -4,7 +4,7 @@ singleton=true
 # io.openliberty.mpCompatible-5.0; ibm.tolerates:="6.0,6.1,7.0" comes from io.openliberty.microprofile.cdi.api features
 -features=\
   io.openliberty.microprofile.cdi.api-3.0; ibm.tolerates:="4.0,4.1"
--bundles=io.openliberty.org.eclipse.microprofile.health.4.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.health:microprofile-health-api:4.0"
+-bundles=io.openliberty.org.eclipse.microprofile.health.4.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.health:microprofile-health-api:4.0.1"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.lra-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.lra-1.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.org.eclipse.microprofile.lra-1.0
 singleton=true
--bundles=io.openliberty.org.eclipse.microprofile.lra.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.lra:microprofile-lra-api:1.0-M1"
+-bundles=io.openliberty.org.eclipse.microprofile.lra.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.lra:microprofile-lra-api:1.0-M2"
 -features=io.openliberty.mpCompatible-4.0; ibm.tolerates:="0.0", \
   com.ibm.websphere.appserver.javax.jaxrs-2.1
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.0/io.openliberty.cdi-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.0/io.openliberty.cdi-4.0.feature
@@ -64,7 +64,7 @@ Subsystem-Name: Jakarta Contexts and Dependency Injection 4.0
  com.ibm.ws.cdi.interfaces.jakarta, \
  io.openliberty.cdi.4.0.internal.interfaces, \
  io.openliberty.cdi.spi; location:="dev/spi/ibm/,lib/"
--jars=io.openliberty.cdi.4.0.thirdparty; location:="dev/api/third-party/,lib/"; mavenCoordinates="org.jboss.weld:weld-osgi-bundle:5.1.0.Final"
+-jars=io.openliberty.cdi.4.0.thirdparty; location:="dev/api/third-party/,lib/"; mavenCoordinates="org.jboss.weld:weld-osgi-bundle:5.1.1.SP2"
 -files=dev/api/ibm/schema/ibm-managed-bean-bnd_1_0.xsd, \
  dev/api/ibm/schema/ibm-managed-bean-bnd_1_1.xsd, \
  dev/spi/ibm/javadoc/io.openliberty.cdi.spi_1.1-javadoc.zip

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mail-2.0/io.openliberty.mail-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mail-2.0/io.openliberty.mail-2.0.feature
@@ -49,7 +49,7 @@ IBM-SPI-Package: \
 -bundles=\
   io.openliberty.mail.2.0.internal, \
   com.ibm.ws.javamail.config
--jars=io.openliberty.mail.2.0.thirdparty; location:=dev/api/third-party/; mavenCoordinates="com.sun.mail:jakarta.mail:2.0.0"
+-jars=io.openliberty.mail.2.0.thirdparty; location:=dev/api/third-party/; mavenCoordinates="com.sun.mail:jakarta.mail:2.0.1"
 kind=ga
 edition=core
 WLP-InstantOn-Enabled: true


### PR DESCRIPTION
- Update feature file mavenCoordinates property to match the version of the artifact that is consumed by the Liberty spec bundle.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
