### PR TITLE
sixth batch of error messages for jakarta data

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -459,3 +459,39 @@ CWWKD1045.unknown.entity.anno.explanation=The built-in Jakarta Data provider doe
 CWWKD1045.unknown.entity.anno.useraction=Remove the unrecognized entity annotation \
  or use the provider attribute of the Repository annotation to select a Jakarta \
  Data provider that recognizes the entity annotation.
+
+CWWKD1046.result.convert.err=CWWKD1046E: The {0} result of the {1} method of the \
+ {2} repository interface cannot be converted to the {3} type that is required by \
+ the {4} return type of the repository method.
+CWWKD1046.result.convert.err.explanation=The result value is not compatible with \
+ the repository method return type.
+CWWKD1046.result.convert.err.useraction=Ensure the return type of the repository \
+ method is consistent with the type of result that is returned by the query.
+
+CWWKD1047.result.out.of.range=CWWKD1047E: The {0} result of the {1} method of the \
+ {2} repository interface cannot be converted to the {3} type that is required by \
+ the {4} return type of the repository method because the result is not within the \
+ range of {5} to {6}.
+CWWKD1047.result.out.of.range.explanation=The result value is not compatible with \
+ the repository method return type because it is outside of the range of values \
+ that can be converted.
+CWWKD1047.result.out.of.range.useraction=Adjust the return type of the repository \
+ method to allow for the value to be returned.
+
+CWWKD1048.result.exceeds.max=CWWKD1048E: The {0} result of the {1} method of the \
+ {2} repository interface cannot be converted to the {3} type that is required by \
+ the {4} return type of the repository method because the result value exceeds the \
+ maximum value of {5}.
+CWWKD1048.result.exceeds.max.explanation=The result value is not compatible with \
+ the repository method return type because it exceeds the maximum value that can \
+ be converted to that type.
+CWWKD1048.result.exceeds.max.useraction=Adjust the return type of the repository \
+ method to allow for the value to be returned.
+
+CWWKD1049.count.convert.err=CWWKD1049E: The {0} count value from the {1} method of \
+ the {2} repository interface cannot be converted to the {3} type that is required \
+ by the {4} return type of the repository method.
+CWWKD1049.count.convert.err.explanation=The count value is not compatible with \
+ the repository method return type.
+CWWKD1049.count.convert.err.useraction=Adjust the return type of the repository \
+ method to allow for the value to be returned.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -464,7 +464,7 @@ CWWKD1046.result.convert.err=CWWKD1046E: The {0} result of the {1} method of the
  {2} repository interface cannot be converted to the {3} return type of the \
  repository method.
 CWWKD1046.result.convert.err.explanation=The result value is not compatible with \
- the repository method return type.
+ the return type of the repository method.
 CWWKD1046.result.convert.err.useraction=Ensure the return type of the repository \
  method is consistent with the type of result that is returned by the query.
 
@@ -472,7 +472,7 @@ CWWKD1047.result.out.of.range=CWWKD1047E: The {0} result of the {1} method of th
  {2} repository interface cannot be converted to the {3} return type of the \
  repository method because the result is not within the range of {4} to {5}.
 CWWKD1047.result.out.of.range.explanation=The result value is not compatible with \
- the repository method return type because it is outside of the range of values \
+ the return type for the repository method because it is outside of the range of values \
  that can be converted.
 CWWKD1047.result.out.of.range.useraction=Adjust the return type of the repository \
  method to allow for the value to be returned.
@@ -481,7 +481,7 @@ CWWKD1048.result.exceeds.max=CWWKD1048E: The {0} result of the {1} method of the
  {2} repository interface cannot be converted to the {3} return type of the \
  repository method because the result value exceeds the maximum value of {4}.
 CWWKD1048.result.exceeds.max.explanation=The result value is not compatible with \
- the repository method return type because it exceeds the maximum value that can \
+ the return type for the repository method because it exceeds the maximum value that can \
  be converted to that type.
 CWWKD1048.result.exceeds.max.useraction=Adjust the return type of the repository \
  method to allow for the value to be returned.
@@ -490,13 +490,13 @@ CWWKD1049.count.convert.err=CWWKD1049E: The count value, {0}, from the {1} metho
  of the {2} repository interface cannot be converted to the {3} return type of \
  the repository method.
 CWWKD1049.count.convert.err.explanation=The count value is not compatible with \
- the repository method return type.
+ the return type of the repository method.
 CWWKD1049.count.convert.err.useraction=Adjust the return type of the repository \
  method to allow for the value to be returned.
 
 CWWKD1050.opt.lock.exc=CWWKD1050E: The {0} method of the {1} repository \
  interface did not find a {2} entity that matches the entity properties: {3}. \
- If this is unexpected, ensure that the entity instance that is supplied to the \
+ Verify that the entity instance that is supplied to the \
  {0} method is based on the most recent version of the entity. The most recent \
  version of the entity can be obtained from a find method or from the result \
  value of one of the following lifecycle methods: {4}.
@@ -507,7 +507,7 @@ CWWKD1050.opt.lock.exc.useraction=If it is expected that the entity might \
 
 CWWKD1051.single.opt.lock.exc=CWWKD1051E: The {0} method of the {1} repository \
  interface did not find a matching {2} entity in the database. \
- If this is unexpected, ensure that the entity instance that is supplied to the \
+ Verify that the entity instance that is supplied to the \
  {0} method is based on the most recent version of the entity. The most recent \
  version of the entity can be obtained from a find method or from the result \
  value of one of the following lifecycle methods: {3}.
@@ -518,7 +518,7 @@ CWWKD1051.single.opt.lock.exc.useraction=If it is expected that the entity might
 
 CWWKD1052.multi.opt.lock.exc=CWWKD1052E: The {0} method of the {1} repository \
  interface did not find {2} of the {3} {4} entities in the database. \
- If this is unexpected, ensure that the entity instances that are supplied to the \
+ Verify that the entity instances that are supplied to the \
  {0} method are based on the most recent version of each entity. The most recent \
  version of an entity can be obtained from a find method or from the result \
  value of one of the following lifecycle methods: {5}.
@@ -533,7 +533,7 @@ CWWKD1053.empty.result=CWWKD1053E: The {0} return type of the {1} method of the 
  empty result is expected, the repository method must return an array or one of \
  the following return types: {3}.
 CWWKD1053.empty.result.explanation=The return type of the repository method does \
- not permit it to return an empty result.
+ not allow it to return an empty result.
 CWWKD1053.empty.result.useraction=Update the repository method to use one of the \
  return types that can represent an empty result.
 
@@ -541,7 +541,7 @@ CWWKD1054.non.unique.result=CWWKD1054E: The {0} method of the {1} repository \
  interface has the {2} return type, which is not capable of returning {3} results. \
  To limit to a single result, use one of the following Jakarta Data patterns: {4}.
 CWWKD1054.non.unique.result.explanation=The return type of the repository method \
- does not permit returning multiple results.
-CWWKD1054.non.unique.result.useraction=Update the repository method to use a \
- return type that supports multiple results, or update the repository method \
- to return at most one result.
+ does not allow returning multiple results.
+CWWKD1054.non.unique.result.useraction=Update the repository method to either use a \
+ return type that supports multiple results or update the repository method \
+ to return no more than a single result.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -461,17 +461,16 @@ CWWKD1045.unknown.entity.anno.useraction=Remove the unrecognized entity annotati
  Data provider that recognizes the entity annotation.
 
 CWWKD1046.result.convert.err=CWWKD1046E: The {0} result of the {1} method of the \
- {2} repository interface cannot be converted to the {3} type that is required by \
- the {4} return type of the repository method.
+ {2} repository interface cannot be converted to the {3} return type of the \
+ repository method.
 CWWKD1046.result.convert.err.explanation=The result value is not compatible with \
  the repository method return type.
 CWWKD1046.result.convert.err.useraction=Ensure the return type of the repository \
  method is consistent with the type of result that is returned by the query.
 
 CWWKD1047.result.out.of.range=CWWKD1047E: The {0} result of the {1} method of the \
- {2} repository interface cannot be converted to the {3} type that is required by \
- the {4} return type of the repository method because the result is not within the \
- range of {5} to {6}.
+ {2} repository interface cannot be converted to the {3} return type of the \
+ repository method because the result is not within the range of {4} to {5}.
 CWWKD1047.result.out.of.range.explanation=The result value is not compatible with \
  the repository method return type because it is outside of the range of values \
  that can be converted.
@@ -479,19 +478,52 @@ CWWKD1047.result.out.of.range.useraction=Adjust the return type of the repositor
  method to allow for the value to be returned.
 
 CWWKD1048.result.exceeds.max=CWWKD1048E: The {0} result of the {1} method of the \
- {2} repository interface cannot be converted to the {3} type that is required by \
- the {4} return type of the repository method because the result value exceeds the \
- maximum value of {5}.
+ {2} repository interface cannot be converted to the {3} return type of the \
+ repository method because the result value exceeds the maximum value of {4}.
 CWWKD1048.result.exceeds.max.explanation=The result value is not compatible with \
  the repository method return type because it exceeds the maximum value that can \
  be converted to that type.
 CWWKD1048.result.exceeds.max.useraction=Adjust the return type of the repository \
  method to allow for the value to be returned.
 
-CWWKD1049.count.convert.err=CWWKD1049E: The {0} count value from the {1} method of \
- the {2} repository interface cannot be converted to the {3} type that is required \
- by the {4} return type of the repository method.
+CWWKD1049.count.convert.err=CWWKD1049E: The count value, {0}, from the {1} method \
+ of the {2} repository interface cannot be converted to the {3} return type of \
+ the repository method.
 CWWKD1049.count.convert.err.explanation=The count value is not compatible with \
  the repository method return type.
 CWWKD1049.count.convert.err.useraction=Adjust the return type of the repository \
  method to allow for the value to be returned.
+
+CWWKD1050.opt.lock.exc=CWWKD1050E: The {0} method of the {1} repository \
+ interface did not find a {2} entity that matches the entity properties: {3}. \
+ If this is unexpected, ensure that the entity instance that is supplied to the \
+ {0} method is based on the most recent version of the entity. The most recent \
+ version of the entity can be obtained from a find method or from the result \
+ value of one of the following lifecycle methods: {4}.
+CWWKD1050.opt.lock.exc.explanation=A matching entity was not found.
+CWWKD1050.opt.lock.exc.useraction=If it is expected that the entity might \
+ not be found in the database, no action is needed. Otherwise, ensure that the \
+ most recent version of the entity is used.
+
+CWWKD1051.single.opt.lock.exc=CWWKD1051E: The {0} method of the {1} repository \
+ interface did not find a matching {2} entity in the database. \
+ If this is unexpected, ensure that the entity instance that is supplied to the \
+ {0} method is based on the most recent version of the entity. The most recent \
+ version of the entity can be obtained from a find method or from the result \
+ value of one of the following lifecycle methods: {3}.
+CWWKD1051.single.opt.lock.exc.explanation=A matching entity was not found.
+CWWKD1051.single.opt.lock.exc.useraction=If it is expected that the entity might \
+ not be found in the database, no action is needed. Otherwise, ensure that the \
+ most recent version of the entity is used.
+
+CWWKD1052.multi.opt.lock.exc=CWWKD1052E: The {0} method of the {1} repository \
+ interface did not find {2} of the {3} {4} entities in the database. \
+ If this is unexpected, ensure that the entity instances that are supplied to the \
+ {0} method are based on the most recent version of each entity. The most recent \
+ version of an entity can be obtained from a find method or from the result \
+ value of one of the following lifecycle methods: {5}.
+CWWKD1052.multi.opt.lock.exc.explanation=One or more of the entities were not \
+ found in the database.
+CWWKD1052.multi.opt.lock.exc.useraction=If it is expected that an entity might \
+ not be found in the database, no action is needed. Otherwise, ensure that the \
+ most recent version of each entity is used.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -444,10 +444,10 @@ CWWKD1043.offset.exceeds.max.useraction=Add restrictions to the query to reduce 
 CWWKD1044.invalid.resource.type=CWWKD1044E: The {0} resource accessor method \
  of the {1} repository cannot return a {2} resource. The supported return types \
  for resource accessor methods are: {3}.
-CWWKD1044.invalid.resource.type.explanation=The return type of the resource accessor \
- method is not one of the supported types for Jakarta Data.
-CWWKD1044.invalid.resource.type.useraction=Remove the method or update it to return \
- one of the supported types.
+CWWKD1044.invalid.resource.type.explanation=The return type of the resource \
+ accessor method is not one of the supported types for Jakarta Data.
+CWWKD1044.invalid.resource.type.useraction=Remove the method or update it to \
+ return one of the supported types.
 
 CWWKD1045.unknown.entity.anno=CWWKD1045E: The built-in Jakarta Data provider \
  cannot provide an implementation of the {0} repository interface because the \
@@ -472,8 +472,8 @@ CWWKD1047.result.out.of.range=CWWKD1047E: The {0} result of the {1} method of th
  {2} repository interface cannot be converted to the {3} return type of the \
  repository method because the result is not within the range of {4} to {5}.
 CWWKD1047.result.out.of.range.explanation=The result value is not compatible with \
- the return type for the repository method because it is outside of the range of values \
- that can be converted.
+ the return type for the repository method because it is outside of the range of \
+ values that can be converted.
 CWWKD1047.result.out.of.range.useraction=Adjust the return type of the repository \
  method to allow for the value to be returned.
 
@@ -481,8 +481,8 @@ CWWKD1048.result.exceeds.max=CWWKD1048E: The {0} result of the {1} method of the
  {2} repository interface cannot be converted to the {3} return type of the \
  repository method because the result value exceeds the maximum value of {4}.
 CWWKD1048.result.exceeds.max.explanation=The result value is not compatible with \
- the return type for the repository method because it exceeds the maximum value that can \
- be converted to that type.
+ the return type for the repository method because it exceeds the maximum value \
+ that can be converted to that type.
 CWWKD1048.result.exceeds.max.useraction=Adjust the return type of the repository \
  method to allow for the value to be returned.
 
@@ -542,6 +542,6 @@ CWWKD1054.non.unique.result=CWWKD1054E: The {0} method of the {1} repository \
  To limit to a single result, use one of the following Jakarta Data patterns: {4}.
 CWWKD1054.non.unique.result.explanation=The return type of the repository method \
  does not allow returning multiple results.
-CWWKD1054.non.unique.result.useraction=Update the repository method to either use a \
- return type that supports multiple results or update the repository method \
+CWWKD1054.non.unique.result.useraction=Update the repository method to either use \
+ a return type that supports multiple results or update the repository method \
  to return no more than a single result.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -527,3 +527,21 @@ CWWKD1052.multi.opt.lock.exc.explanation=One or more of the entities were not \
 CWWKD1052.multi.opt.lock.exc.useraction=If it is expected that an entity might \
  not be found in the database, no action is needed. Otherwise, ensure that the \
  most recent version of each entity is used.
+
+CWWKD1053.empty.result=CWWKD1053E: The {0} return type of the {1} method of the \
+ {2} repository interface is not capable of returning an empty result. If an \
+ empty result is expected, the repository method must return an array or one of \
+ the following return types: {3}.
+CWWKD1053.empty.result.explanation=The return type of the repository method does \
+ not permit it to return an empty result.
+CWWKD1053.empty.result.useraction=Update the repository method to use one of the \
+ return types that can represent an empty result.
+
+CWWKD1054.non.unique.result=CWWKD1054E: The {0} method of the {1} repository \
+ interface has the {2} return type, which is not capable of returning {3} results. \
+ To limit to a single result, use one of the following Jakarta Data patterns: {4}.
+CWWKD1054.non.unique.result.explanation=The return type of the repository method \
+ does not permit returning multiple results.
+CWWKD1054.non.unique.result.useraction=Update the repository method to use a \
+ return type that supports multiple results, or update the repository method \
+ to return at most one result.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
@@ -522,6 +522,35 @@ public class DataProvider implements //
     }
 
     /**
+     * Appends a suffix if the repository class/package/method is considered
+     * loggable. Otherwise returns only the prefix.
+     *
+     * @param repoClass      repository class.
+     * @param method         repository method.
+     * @param prefix         first part of value to always include.
+     * @param possibleSuffix suffix to only include if logValues allows.
+     * @return loggable value.
+     */
+    @Trivial
+    String loggableAppend(Class<?> repoClass,
+                          Method method,
+                          String prefix,
+                          Object... possibleSuffix) {
+        StringBuilder b = new StringBuilder(prefix);
+        String className;
+        if (possibleSuffix != null &&
+            !logValues.isEmpty() &&
+            (logValues.contains("*") ||
+             logValues.contains(repoClass.getPackageName()) ||
+             logValues.contains(className = repoClass.getName()) ||
+             logValues.contains(className + '.' + method.getName())))
+            for (Object s : possibleSuffix)
+                b.append(s);
+
+        return b.toString();
+    }
+
+    /**
      * Invoked when configuration is modified.
      *
      * @param props config properties.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -15,18 +15,23 @@ package io.openliberty.data.internal.persistence;
 import static jakarta.data.repository.By.ID;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.RecordComponent;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -542,6 +547,245 @@ public class QueryInfo {
                       method.getName(),
                       repositoryInterface.getName(),
                       "Integer.MAX_VALUE (" + Integer.MAX_VALUE + ")");
+    }
+
+    /**
+     * Converts a value to the type that is required by the repository method
+     * return type.
+     *
+     * @param value              value to convert.
+     * @param type               type to convert to.
+     * @param failIfNotConverted whether or not to fail if unable to convert.
+     * @return converted value.
+     */
+    @FFDCIgnore(ArithmeticException.class) // reported to user as chained exception
+    @Trivial
+    Object convert(Object value, Class<?> toType, boolean failIfNotConverted) {
+        if (value == null) {
+            if (toType.isPrimitive())
+                throw exc(MappingException.class,
+                          "CWWKD1046.result.convert.err",
+                          null,
+                          method.getName(),
+                          repositoryInterface.getName(),
+                          method.getGenericReturnType().getTypeName());
+            else
+                return null;
+        }
+
+        Class<?> fromType = value.getClass();
+        Exception cause = null;
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "convert " + loggableAppend(fromType.getSimpleName(),
+                                                           " (", value, ")")
+                               + " to " + toType.getSimpleName());
+
+        if (value instanceof Number &&
+            (PRIMITIVE_NUMERIC_TYPES.contains(toType) ||
+             Number.class.isAssignableFrom(toType))) {
+            try {
+                if (BigDecimal.class.equals(fromType)) {
+                    BigDecimal v = (BigDecimal) value;
+                    if (long.class.equals(toType) ||
+                        Long.class.equals(toType)) {
+                        return v.longValueExact();
+                    } else if (int.class.equals(toType) ||
+                               Integer.class.equals(toType)) {
+                        return v.intValueExact();
+                    } else if (short.class.equals(toType) ||
+                               Short.class.equals(toType)) {
+                        return v.shortValueExact();
+                    } else if (byte.class.equals(toType) ||
+                               Byte.class.equals(toType)) {
+                        return v.byteValueExact();
+                    } else if (BigInteger.class.equals(toType)) {
+                        return v.toBigIntegerExact();
+                    }
+                } else if (BigInteger.class.equals(fromType)) {
+                    BigInteger v = (BigInteger) value;
+                    if (long.class.equals(toType) ||
+                        Long.class.equals(toType)) {
+                        return v.longValueExact();
+                    } else if (int.class.equals(toType) ||
+                               Integer.class.equals(toType)) {
+                        return v.intValueExact();
+                    } else if (short.class.equals(toType) ||
+                               Short.class.equals(toType)) {
+                        return v.shortValueExact();
+                    } else if (byte.class.equals(toType) ||
+                               Byte.class.equals(toType)) {
+                        return v.byteValueExact();
+                    } else if (BigDecimal.class.equals(toType)) {
+                        return new BigDecimal(v);
+                    }
+                } else if (double.class.equals(fromType) ||
+                           Double.class.equals(fromType)) {
+                    Double v = (Double) value;
+                    if (double.class.equals(toType))
+                        return v;
+                    else if (BigDecimal.class.equals(toType))
+                        return BigDecimal.valueOf(v);
+                } else if (float.class.equals(fromType) ||
+                           Float.class.equals(fromType)) {
+                    Float v = (Float) value;
+                    if (float.class.equals(toType))
+                        return v;
+                    else if (double.class.equals(toType))
+                        return v.doubleValue();
+                    else if (BigDecimal.class.equals(toType))
+                        return BigDecimal.valueOf(v);
+                } else {
+                    Number n = (Number) value;
+                    long v = n.longValue();
+                    if (long.class.equals(toType) ||
+                        Long.class.equals(toType)) {
+                        return v;
+                    } else if (int.class.equals(toType) ||
+                               Integer.class.equals(toType)) {
+                        if (v >= Integer.MIN_VALUE && v <= Integer.MAX_VALUE)
+                            return n.intValue();
+                        else
+                            convertFail(n, Integer.MIN_VALUE, Integer.MAX_VALUE);
+                    } else if (short.class.equals(toType) ||
+                               Short.class.equals(toType)) {
+                        if (v >= Short.MIN_VALUE && v <= Short.MAX_VALUE)
+                            return n.shortValue();
+                        else
+                            convertFail(n, Short.MIN_VALUE, Short.MAX_VALUE);
+                    } else if (byte.class.equals(toType) ||
+                               Byte.class.equals(toType)) {
+                        if (v >= Byte.MIN_VALUE && v <= Byte.MAX_VALUE)
+                            return n.byteValue();
+                        else
+                            convertFail(n, Byte.MIN_VALUE, Byte.MAX_VALUE);
+                    } else if (BigInteger.class.equals(toType)) {
+                        return BigInteger.valueOf(v);
+                    } else if (BigDecimal.class.equals(toType)) {
+                        return BigDecimal.valueOf(v);
+                    } else if (double.class.equals(toType) ||
+                               Double.class.equals(toType)) {
+                        if (Integer.class.equals(fromType) ||
+                            Short.class.equals(fromType) ||
+                            Byte.class.equals(fromType) ||
+                            v >= Integer.MIN_VALUE && v <= Integer.MAX_VALUE)
+                            return n.doubleValue();
+                    } else if (float.class.equals(toType) ||
+                               Float.class.equals(toType)) {
+                        if (Short.class.equals(fromType) ||
+                            Byte.class.equals(fromType) ||
+                            v >= Short.MIN_VALUE && v <= Short.MAX_VALUE)
+                            return n.floatValue();
+                    }
+                }
+            } catch (ArithmeticException x) {
+                cause = x;
+            }
+        } else if (String.class.equals(toType) ||
+                   CharSequence.class.equals(toType)) {
+            return value.toString();
+        } else if (char.class.equals(toType) ||
+                   Character.class.equals(toType)) {
+            if (value instanceof CharSequence) {
+                CharSequence chars = (CharSequence) value;
+                if (chars.length() == 1)
+                    return chars.charAt(0);
+                else if (chars.isEmpty() && Character.class.equals(toType))
+                    return null;
+            }
+        }
+
+        if (failIfNotConverted) {
+            MappingException x;
+            x = exc(MappingException.class,
+                    "CWWKD1046.result.convert.err",
+                    loggableAppend(fromType.getName(), " (", value, ")"),
+                    method.getName(),
+                    repositoryInterface.getName(),
+                    method.getGenericReturnType().getTypeName());
+            if (cause != null)
+                x = (MappingException) x.initCause(cause);
+            throw x;
+        } else {
+            return value;
+        }
+    }
+
+    /**
+     * Raises an error for a type conversion failure due to a value being outside of
+     * the specified range.
+     *
+     * @param queryInfo query information for the repository method.
+     * @param value     the value that fails to convert.
+     * @param min       minimum value for range.
+     * @param max       maximum value for range.
+     * @throws MappingException for the type conversion failure.
+     */
+    @Trivial
+    private void convertFail(Number value, long min, long max) {
+        throw exc(MappingException.class,
+                  "CWWKD1047.result.out.of.range",
+                  loggableAppend(value.getClass().getName(), " (", value, ")"),
+                  method.getName(),
+                  repositoryInterface.getName(),
+                  method.getGenericReturnType().getTypeName(),
+                  min,
+                  max);
+    }
+
+    /**
+     * Convert the results list into an Iterable of the specified type.
+     *
+     * @param results      results of a find or save operation.
+     * @param elementType  the type of each element if a find operation.
+     *                         Can be NULL if a save operation.
+     * @param iterableType the desired type of Iterable.
+     * @return results converted to an Iterable of the specified type.
+     */
+    @Trivial
+    final Iterable<?> convertToIterable(List<?> results,
+                                        Class<?> elementType,
+                                        Class<?> iterableType) {
+        Collection<Object> list;
+        if (iterableType.isInterface()) {
+            if (iterableType.isAssignableFrom(ArrayList.class))
+                // covers Iterable, Collection, List
+                list = new ArrayList<>(results.size());
+            else if (iterableType.isAssignableFrom(ArrayDeque.class))
+                // covers Queue, Deque
+                list = new ArrayDeque<>(results.size());
+            else if (iterableType.isAssignableFrom(LinkedHashSet.class))
+                // covers Set
+                list = new LinkedHashSet<>(results.size());
+            else
+                throw new UnsupportedOperationException(iterableType + " is an unsupported return type."); // TODO NLS
+        } else {
+            try {
+                @SuppressWarnings("unchecked")
+                Constructor<? extends Collection<Object>> c = //
+                                (Constructor<? extends Collection<Object>>) //
+                                iterableType.getConstructor();
+                list = c.newInstance();
+            } catch (NoSuchMethodException x) {
+                throw new MappingException("The " + iterableType.getName() + " result type lacks a public zero parameter constructor.", x); // TODO NLS
+            } catch (IllegalAccessException | InstantiationException x) {
+                throw new MappingException("Unable to access the zero parameter constructor of the " + iterableType.getName() + " result type.", x); // TODO NLS
+            } catch (InvocationTargetException x) {
+                throw new MappingException("The constructor for the " + iterableType.getName() + " result type raised an error: " + x.getCause().getMessage(), x.getCause()); // TODO NLS
+            }
+        }
+        if (results.size() == 1 && results.get(0) instanceof Object[]) {
+            Object[] a = (Object[]) results.get(0);
+            for (int i = 0; i < a.length; i++) {
+                Object element = a[i];
+                if (!elementType.isInstance(element))
+                    element = convert(element, elementType, true);
+                list.add(element);
+            }
+        } else {
+            list.addAll(results);
+        }
+        return list;
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2756,6 +2756,22 @@ public class QueryInfo {
     }
 
     /**
+     * Appends a suffix if the repository class/package/method is considered
+     * loggable. Otherwise returns only the prefix.
+     *
+     * @param prefix         first part of value to always include.
+     * @param possibleSuffix suffix to only include if logValues allows.
+     * @return loggable value.
+     */
+    @Trivial
+    final String loggableAppend(String prefix, Object... possibleSuffix) {
+        return entityInfo.builder.provider.loggableAppend(repositoryInterface,
+                                                          method,
+                                                          prefix,
+                                                          possibleSuffix);
+    }
+
+    /**
      * Raise an error because the PageRequest is missing.
      *
      * @throws IllegalArgumentException      if the user supplied a null PageRequest

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -758,7 +758,12 @@ public class QueryInfo {
                 // covers Set
                 list = new LinkedHashSet<>(results.size());
             else
-                throw new UnsupportedOperationException(iterableType + " is an unsupported return type."); // TODO NLS
+                throw exc(UnsupportedOperationException.class,
+                          "CWWKD1046.result.convert.err",
+                          List.class.getName(),
+                          method.getName(),
+                          repositoryInterface.getName(),
+                          method.getGenericReturnType().getTypeName());
         } else {
             try {
                 @SuppressWarnings("unchecked")

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1117,7 +1117,12 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 else if (DoubleStream.class.equals(multiType))
                                     returnValue = stream.mapToDouble(RepositoryImpl::toDouble);
                                 else
-                                    throw new UnsupportedOperationException("Stream type " + multiType.getName()); // TODO NLS
+                                    throw exc(UnsupportedOperationException.class,
+                                              "CWWKD1046.result.convert.err",
+                                              List.class.getName(),
+                                              method.getName(),
+                                              repositoryInterface.getName(),
+                                              method.getGenericReturnType().getTypeName());
                             } else {
                                 Class<?> singleType = queryInfo.singleType;
 
@@ -1136,7 +1141,12 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 if (queryInfo.type == QueryInfo.Type.FIND_AND_DELETE)
                                     for (Object result : results)
                                         if (result == null) {
-                                            throw new DataException("Unable to delete from the database when the query result includes a null value."); // TODO NLS
+                                            throw exc(DataException.class,
+                                                      "CWWKD1046.result.convert.err",
+                                                      null,
+                                                      method.getName(),
+                                                      repositoryInterface.getName(),
+                                                      method.getGenericReturnType().getTypeName());
                                         } else if (entityInfo.entityClass.isInstance(result)) {
                                             em.remove(result);
                                         } else if (entityInfo.idClassAttributeAccessors != null) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -437,6 +437,7 @@ public class DataExtension implements Extension {
         if (!exceptionType.equals(EmptyResultException.class) &&
             !exceptionType.equals(EntityExistsException.class) &&
             !exceptionType.equals(IllegalArgumentException.class) &&
+            !exceptionType.equals(IllegalStateException.class) &&
             !exceptionType.equals(NoSuchElementException.class) &&
             !exceptionType.equals(NullPointerException.class) &&
             !exceptionType.equals(OptimisticLockingFailureException.class))

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -54,6 +54,7 @@ public class DataTest extends FATServletClient {
                                    "CWWKD1008E.*delete5",
                                    "CWWKD1028E.*findFirst2147483648",
                                    "CWWKD1041E.*findByNumberIdBetween",
+                                   "CWWKD1046E.*minMaxSumCountAverageFloat",
                                    "CWWKD1047E.*numberAsByte",
                                    "CWWKD1049E.*countAsBooleanByNumberIdLessThan"
                     };

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -53,7 +53,9 @@ public class DataTest extends FATServletClient {
                                    "CWWKD1006E.*delete4",
                                    "CWWKD1008E.*delete5",
                                    "CWWKD1028E.*findFirst2147483648",
-                                   "CWWKD1041E.*findByNumberIdBetween"
+                                   "CWWKD1041E.*findByNumberIdBetween",
+                                   "CWWKD1047E.*numberAsByte",
+                                   "CWWKD1049E.*countAsBooleanByNumberIdLessThan"
                     };
 
     @ClassRule

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -542,23 +542,14 @@ public class DataTestServlet extends FATServlet {
             // expected - out of range
         }
 
-        try {
-            double result = primes.numberAsDouble(4003);
-            fail("Should not convert long value to double value " + result);
-        } catch (MappingException x) {
-            // expected - not convertible
-        }
+        assertEquals(4003.0, primes.numberAsDouble(4003), 0.01);
 
-        try {
-            Optional<Float> result = primes.numberAsFloatWrapper(4001)
-                            .get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
-            fail("Should not convert long value to float value " + result);
-        } catch (ExecutionException x) {
-            if (x.getCause() instanceof MappingException)
-                ; // expected - not convertible
-            else
-                throw x;
-        }
+        assertEquals(4001f,
+                     primes.numberAsFloatWrapper(4001)
+                                     .get(TIMEOUT_MINUTES, TimeUnit.MINUTES)
+                                     .orElseThrow()
+                                     .floatValue(),
+                     0.01f);
 
         assertEquals(31,
                      primes.numberAsInt(31));

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3349,12 +3349,17 @@ public class DataTestServlet extends FATServlet {
         assertEquals(12, ints[3]); // count
         assertEquals(16, ints[4]); // average
 
-        float[] floats = primes.minMaxSumCountAverageFloat(35);
-        assertEquals(2.0f, floats[0], 0.01f); // minimum
-        assertEquals(31.0f, floats[1], 0.01f); // maximum
-        assertEquals(160.0f, floats[2], 0.01f); // sum
-        assertEquals(11.0f, floats[3], 0.01f); // count
-        assertEquals(14.0f, Math.floor(floats[4]), 0.01f); // average
+        try {
+            float[] floats = primes.minMaxSumCountAverageFloat(35);
+            fail("Allowed unsafe conversion from double to float: " +
+                 Arrays.toString(floats));
+        } catch (MappingException x) {
+            if (x.getMessage().startsWith("CWWKD1046E") &&
+                x.getMessage().contains("float[]"))
+                ; // unsafe to convert double to float
+            else
+                throw x;
+        }
 
         List<Long> list = primes.minMaxSumCountAverageList(30);
         assertEquals(Long.valueOf(2L), list.get(0)); // minimum

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -279,22 +279,34 @@ public interface Primes {
            " ORDER BY name DESC")
     List<String> matchRightSideOfName(String searchFor);
 
-    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), COUNT(o.numberId), AVG(o.numberId) FROM Prime o WHERE o.numberId < ?1")
+    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), " +
+           "       COUNT(o.numberId), AVG(o.numberId) " +
+           "  FROM Prime o WHERE o.numberId < ?1")
     Deque<Double> minMaxSumCountAverageDeque(long numBelow);
 
-    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), COUNT(o.numberId), AVG(o.numberId) FROM Prime o WHERE o.numberId < ?1")
+    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId)," +
+           "       COUNT(o.numberId), CAST(AVG(o.numberId) AS FLOAT)" +
+           "  FROM Prime o WHERE o.numberId < ?1")
     float[] minMaxSumCountAverageFloat(long numBelow);
 
-    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), COUNT(o.numberId), AVG(o.numberId) FROM Prime o WHERE o.numberId < ?1")
+    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId)," +
+           "       COUNT(o.numberId), CAST(AVG(o.numberId) AS INTEGER)" +
+           "  FROM Prime o WHERE o.numberId < ?1")
     int[] minMaxSumCountAverageInt(long numBelow);
 
-    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), COUNT(o.numberId), AVG(o.numberId) FROM Prime o WHERE o.numberId < ?1")
+    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId)," +
+           "       COUNT(o.numberId), CAST(AVG(o.numberId) AS INTEGER)" +
+           "  FROM Prime o WHERE o.numberId < ?1")
     Iterable<Integer> minMaxSumCountAverageIterable(long numBelow);
 
-    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), COUNT(o.numberId), AVG(o.numberId) FROM Prime o WHERE o.numberId < ?1")
+    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId)," +
+           "       COUNT(o.numberId), CAST(AVG(o.numberId) AS INTEGER)" +
+           "  FROM Prime o WHERE o.numberId < ?1")
     List<Long> minMaxSumCountAverageList(long numBelow);
 
-    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), COUNT(o.numberId), AVG(o.numberId) FROM Prime o WHERE o.numberId < ?1")
+    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId)," +
+           "       COUNT(o.numberId), CAST(AVG(o.numberId) AS INTEGER)" +
+           "  FROM Prime o WHERE o.numberId < ?1")
     Long[] minMaxSumCountAverageLong(long numBelow);
 
     @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId), COUNT(o.numberId), AVG(o.numberId) FROM Prime o WHERE o.numberId < ?1")

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
@@ -42,7 +42,17 @@ public class DataJPATest extends FATServletClient {
      */
     static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
-                                   "CWWKD1026E.*allSorted"
+                                   "CWWKD1010E.*countBySurgePriceGreaterThanEqual",
+                                   "CWWKD1026E.*allSorted",
+                                   "CWWKD1046E.*publicDebtAsByte",
+                                   "CWWKD1046E.*publicDebtAsDouble",
+                                   "CWWKD1046E.*publicDebtAsFloat",
+                                   "CWWKD1046E.*publicDebtAsInt",
+                                   "CWWKD1046E.*publicDebtAsShort",
+                                   "CWWKD1046E.*numFullTimeWorkersAsByte",
+                                   "CWWKD1046E.*numFullTimeWorkersAsDouble",
+                                   "CWWKD1046E.*numFullTimeWorkersAsFloat",
+                                   "CWWKD1046E.*numFullTimeWorkersAsShort",
                     };
 
     @ClassRule


### PR DESCRIPTION
Result conversions, inconsistent result checking, and optimistic locking.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
