### PR TITLE
Delay local connector until the checkpoint running condition is registered

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.local/bnd.bnd
+++ b/dev/com.ibm.ws.jmx.connector.local/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -27,6 +27,8 @@ Private-Package: com.ibm.ws.jmx.connector.local
 	com.ibm.websphere.appserver.spi.kernel.service,\
 	com.ibm.websphere.appserver.spi.logging,\
 	com.ibm.websphere.org.osgi.service.component,\
+	com.ibm.websphere.org.osgi.core,\
+	com.ibm.ws.kernel.boot.common,\
 	com.ibm.ws.kernel.service,\
 	com.ibm.wsspi.org.osgi.service.component.annotations,\
 	com.ibm.ws.kernel.feature.core

--- a/dev/com.ibm.ws.jmx.connector.local/src/com/ibm/ws/jmx/connector/local/LocalConnectorActivator.java
+++ b/dev/com.ibm.ws.jmx.connector.local/src/com/ibm/ws/jmx/connector/local/LocalConnectorActivator.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -26,6 +26,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.SatisfyingConditionTarget;
+import org.osgi.service.condition.Condition;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -36,7 +38,10 @@ import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
 import com.ibm.wsspi.kernel.service.location.WsLocationConstants;
 import com.ibm.wsspi.kernel.service.location.WsResource;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
 @Component(service = {}, configurationPolicy = ConfigurationPolicy.IGNORE)
+@SatisfyingConditionTarget("(" + Condition.CONDITION_ID + "=" + CheckpointPhase.CONDITION_PROCESS_RUNNING_ID + ")")
 public final class LocalConnectorActivator {
 
     /**  */


### PR DESCRIPTION
Waiting only for ServerStarted is not good enough for checkpoint failure scenarios because it allows the component to activate on the checkpoint side before the server is stopped in error on checkpoint.  This causes unnecessary FFDCs to occur.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

