### PR TITLE
Update Java 23 specific FAT with GA build

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -72,7 +72,7 @@ io.openliberty:java-apps:19.0.0
 io.openliberty:java-apps:20.0.0
 io.openliberty:java-apps:21.0.0
 io.openliberty:java-apps:22.1.0
-io.openliberty:java-apps:23.0.0
+io.openliberty:java-apps:23.1.0
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0

--- a/dev/io.openliberty.java.internal_fat/build.gradle
+++ b/dev/io.openliberty.java.internal_fat/build.gradle
@@ -28,7 +28,7 @@ configurations {
     app20 'io.openliberty:java-apps:20.0.0'
     app21 'io.openliberty:java-apps:21.0.0'
     app22 'io.openliberty:java-apps:22.1.0'
-    app23 'io.openliberty:java-apps:23.0.0'
+    app23 'io.openliberty:java-apps:23.1.0'
  }
 
 task copyKernelService(type: Copy) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

With Java 23 being released on 17-Sep-2024 and our 24.0.0.10 GM being selected on/by 24-Sep-2024, we have a short runway to get the WAR file used by the Java 23 specific FAT recompiled with the GA version of Java 23 and into that weekend's SOE (starts early on 19-Sep-2024) before the GM is picked.

In `cnf/oss_ibm.maven` and `io.openliberty.java.internal_fat/build.gradle` we currently pull in `io.openliberty:java-apps:23.0.0` which is the EA build of the WAR file and in  we require .  Normally, once Java 23 is GAed, a PR would get opened to move `io.openliberty:java-apps:23.0.0` -> `io.openliberty:java-apps:23.1.0`.  Since we won't have time to get that completed in the window between 17-Sep-2024 to 19-Sep-2024, this PR will be put in early and a placeholder for the GA built version of the WAR (which will be the current EA build of the WAR file) will be put in place to continue to allow the Java 23 specific FAT to be able to run.

Once Java 23 is released, then the Java 23 WAR file will get recompiled at the GA Java 23 level and then pushed out to Artifactory/DHE to replace the EA built one, which we should be able to get in before that weekend's SOE (19-Sep-2024 through 22-Sep-2024).
