### PR TITLE
Removing flag to do a java dump on checkpoint tests

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/publish/servers/CRIULogLevelTest/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/CRIULogLevelTest/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/Telemetry10Jax/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/Telemetry10Jax/bootstrap.properties
@@ -1,4 +1,3 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/TestSPIConfig/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/TestSPIConfig/bootstrap.properties
@@ -15,4 +15,4 @@ websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
 io.openliberty.checkpoint.allowed.features=usr:test.checkpoint.config-1.0
 io.openliberty.checkpoint.debug=true
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/ValidFeatures/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/ValidFeatures/bootstrap.properties
@@ -14,4 +14,4 @@ bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
 io.openliberty.checkpoint.allowed.features=usr:test.checkpoint.config-1.0
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointAppSecurity/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointAppSecurity/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointAudit/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointAudit/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointBells/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointBells/bootstrap.properties
@@ -13,4 +13,3 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:com.ibm.ws.classloading.bells.internal.Bell=debug
-io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointConcurrency/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointConcurrency/bootstrap.properties
@@ -12,5 +12,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointEJB/bootstrap.properties
@@ -14,4 +14,4 @@ bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all
 # TODO the ejb application needs to be updated to work with ejbLite only
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFATServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFATServer/bootstrap.properties
@@ -13,4 +13,3 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-backendServices/bootstrap.properties
@@ -17,4 +17,4 @@ websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:JPA=all:JPAORM=all
 #com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:JPA=all,JPAORM=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled
 #ds.loglevel=DEBUG
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-beanServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-beanServer/bootstrap.properties
@@ -12,5 +12,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
-io.openliberty.checkpoint.dump.threads=true
+
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-frontendUI/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFaces-frontendUI/bootstrap.properties
@@ -13,4 +13,3 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFailServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointFailServer/bootstrap.properties
@@ -15,4 +15,4 @@ websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
 io.openliberty.checkpoint.allowed.features=usr:test.checkpoint.config-1.0
 io.openliberty.checkpoint.debug=true
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointJsonb/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointJsonb/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointJsonp/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointJsonp/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointLauncherArgs/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointLauncherArgs/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointLocalConnector/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointLocalConnector/bootstrap.properties
@@ -1,6 +1,6 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
-io.openliberty.checkpoint.dump.threads=true
+
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 checkpoint=all:\
 logservice=all=enabled:\

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPHealth/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPHealth/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 com.ibm.ws.logging.trace.specification=com.ibm.ws.security.*=all:com.ibm.ws.webcontainer.security.*=all

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPJWT/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPJWT/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 com.ibm.ws.logging.trace.specification=com.ibm.ws.security.*=all:com.ibm.ws.webcontainer.security.*=all

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPMetrics/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPMetrics/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 com.ibm.ws.logging.trace.specification=com.ibm.ws.security.*=all:com.ibm.ws.webcontainer.security.*=all

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPOpenTracing-jaegerServerInventory/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPOpenTracing-jaegerServerInventory/bootstrap.properties
@@ -1,4 +1,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPOpenTracing-jaegerServerSystem/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPOpenTracing-jaegerServerSystem/bootstrap.properties
@@ -1,4 +1,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPTelemetry/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPTelemetry/bootstrap.properties
@@ -12,6 +12,6 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 com.ibm.ws.logging.trace.specification=com.ibm.ws.security.*=all:com.ibm.ws.webcontainer.security.*=all
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointManagedBeans/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointManagedBeans/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:EJBContainer=all:Injection=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMapCache/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMapCache/bootstrap.properties
@@ -12,5 +12,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointPasswordUtilities/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointPasswordUtilities/bootstrap.properties
@@ -13,6 +13,6 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:AuthData=all:config=all
-io.openliberty.checkpoint.dump.threads=true
+
 # TODO JCA seems to be necessary to get access to javax.resource.spi.security
 io.openliberty.checkpoint.allowed.features=jca-1.7,connectors-2.0,connectors-2.1

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointRestConnector/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointRestConnector/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointSSL/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointSSL/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointWithSecurityManager/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointWithSecurityManager/bootstrap.properties
@@ -13,4 +13,3 @@
 bootstrap.include=../testports.properties
 websphere.java.security=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.log.change.tracespec/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.log.change.tracespec/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:fileMonitor=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.log.verification.test/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.log.verification.test/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.osgi.console.test/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointfat.osgi.console.test/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.federation/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.federation/bootstrap.properties
@@ -11,7 +11,7 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 websphere.java.security.exempt=true
-io.openliberty.checkpoint.dump.threads=true
+
 com.ibm.ws.logging.trace.specification=*=info=enabled:checkpoint=all:com.ibm.ws.security.*=all=enabled
 com.ibm.ws.logging.max.file.size=0
 bootstrap.include=../testports.properties

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/jaxWSVirtualHost/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/jaxWSVirtualHost/bootstrap.properties
@@ -1,7 +1,7 @@
 websphere.java.security.exempt=true
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
-io.openliberty.checkpoint.dump.threads=true
+
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
 # TODO these feature will be enabled as supported for InstantOn later
 io.openliberty.checkpoint.allowed.features=localConnector-1.0,jaxb-2.2

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/jndiServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/jndiServer/bootstrap.properties
@@ -12,5 +12,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
-io.openliberty.checkpoint.dump.threads=true
+
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/openAPIserver/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/openAPIserver/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/restClientServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/restClientServer/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/slowStartAppServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/slowStartAppServer/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/timeoutServer/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/webCacheServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/webCacheServer/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/webProfileEARserver/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/webProfileEARserver/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/webProfileJSP/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/webProfileJSP/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/webProfileJSPWithEL/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/webProfileJSPWithEL/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/webSocketServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/webSocketServer/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/xmlBindingServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/xmlBindingServer/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat_beanvalidation/publish/servers/checkpointBeanValidation/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_beanvalidation/publish/servers/checkpointBeanValidation/bootstrap.properties
@@ -12,5 +12,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info=enabled:BeanValidation=all=enabled:org.hibernate.validator.*=all=enabled:EJBContainer=all
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_beanvalidation/publish/servers/checkpointBeanValidationUTC/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_beanvalidation/publish/servers/checkpointBeanValidationUTC/bootstrap.properties
@@ -12,5 +12,5 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info=enabled:BeanValidation=all=enabled:org.hibernate.validator.*=all=enabled:EJBContainer=all
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_crac/publish/servers/cracFATServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_crac/publish/servers/cracFATServer/bootstrap.properties
@@ -11,4 +11,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat_mail/publish/servers/imapTestServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_mail/publish/servers/imapTestServer/bootstrap.properties
@@ -3,4 +3,3 @@ com.ibm.ws.logging.trace.specification=com.ibm.ws.javamail.*=all=enabled:checkpo
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
 websphere.java.security.exempt=true
-io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat_mail/publish/servers/mailSessionInjectionServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_mail/publish/servers/mailSessionInjectionServer/bootstrap.properties
@@ -5,4 +5,3 @@ osgi.console=5678
 bootstrap.include=../testports.properties
 
 websphere.java.security.exempt=true
-io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat_mpconfig/publish/servers/checkpointMPConfig/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_mpconfig/publish/servers/checkpointMPConfig/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat_persistence/publish/servers/checkpointfat.jpa/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_persistence/publish/servers/checkpointfat.jpa/bootstrap.properties
@@ -4,4 +4,4 @@ osgi.console=5678
 ds.loglevel=debug
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat_persistence/publish/servers/io.openliberty.checkpoint.jdbc.fat.db2/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_persistence/publish/servers/io.openliberty.checkpoint.jdbc.fat.db2/bootstrap.properties
@@ -4,6 +4,6 @@ osgi.console=5678
 ds.loglevel=debug
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
-io.openliberty.checkpoint.dump.threads=true
+
 #websphere.java.security=true
 #websphere.java.security.norethrow=true

--- a/dev/io.openliberty.checkpoint_fat_persistence/publish/servers/jakartaDataServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_persistence/publish/servers/jakartaDataServer/bootstrap.properties
@@ -15,4 +15,4 @@ websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:RESTfulWS=all:data=all:persistenceService=all:\
 org.postgresql.jdbc=all:\
 org.postgresql.xa=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat_persistence/publish/servers/sessionDatabaseServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_persistence/publish/servers/sessionDatabaseServer/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:com.ibm.ws.session.*=all:RRA=all:com.ibm.ws.webcontainer.session.impl.*=fine:com.ibm.ws.session.WASSessionCore=fine
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat_security_oidc_social/publish/servers/com.ibm.ws.security.jaspic11.fat/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_security_oidc_social/publish/servers/com.ibm.ws.security.jaspic11.fat/bootstrap.properties
@@ -30,4 +30,4 @@ ds.lock.timeout.milliseconds=30000
 
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat_security_oidc_social/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.op/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_security_oidc_social/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.op/bootstrap.properties
@@ -31,4 +31,3 @@ ds.loglevel=debug
 
 websphere.java.security.exempt=true
 io.openliberty.checkpoint.debug=true
-io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat_security_oidc_social/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rp/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_security_oidc_social/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rp/bootstrap.properties
@@ -31,4 +31,3 @@ ds.loglevel=debug
 
 websphere.java.security.exempt=true
 io.openliberty.checkpoint.debug=true
-io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat_security_oidc_social/publish/servers/com.ibm.ws.security.social_fat.LibertyOP.op/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_security_oidc_social/publish/servers/com.ibm.ws.security.social_fat.LibertyOP.op/bootstrap.properties
@@ -30,5 +30,5 @@ ds.loglevel=debug
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
 io.openliberty.checkpoint.debug=true
-io.openliberty.checkpoint.dump.threads=true
+
 

--- a/dev/io.openliberty.checkpoint_fat_security_oidc_social/publish/servers/com.ibm.ws.security.social_fat.LibertyOP.social/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_security_oidc_social/publish/servers/com.ibm.ws.security.social_fat.LibertyOP.social/bootstrap.properties
@@ -30,4 +30,4 @@ ds.loglevel=debug
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
 io.openliberty.checkpoint.debug=true
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat_springboot/publish/servers/checkpointSpringBoot/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_springboot/publish/servers/checkpointSpringBoot/bootstrap.properties
@@ -13,4 +13,4 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+

--- a/dev/io.openliberty.checkpoint_fat_springboot_data/publish/servers/checkpointSpringBootData/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_springboot_data/publish/servers/checkpointSpringBootData/bootstrap.properties
@@ -13,7 +13,7 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 # The following three spring properties are necessary on the
 # checkpoint side to avoid access the data source before checkpoint
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionCloud001/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionCloud001/bootstrap.properties
@@ -15,5 +15,5 @@ osgi.console=5471
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled
 ds.loglevel=DEBUG
 com.ibm.tx.auditRecovery=true
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionCloud002/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionCloud002/bootstrap.properties
@@ -15,5 +15,5 @@ osgi.console=5471
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled
 ds.loglevel=DEBUG
 com.ibm.tx.auditRecovery=true
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionDbLog/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionDbLog/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionLongLeaseServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionLongLeaseServer/bootstrap.properties
@@ -15,5 +15,5 @@ osgi.console=5471
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.tx.jta.util.TxTMHelper=all=enabled
 ds.loglevel=DEBUG
 com.ibm.tx.auditRecovery=true
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionManager/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionManager/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionMockServlet/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionMockServlet/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionRecovery/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionRecovery/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionScopedBean/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionScopedBean/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionServlet/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionServlet/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:com.ibm.ws.webcontainer*=all
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionServletStartup/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionServletStartup/bootstrap.properties
@@ -14,5 +14,5 @@ bootstrap.include=../testports.properties
 osgi.console=7773
 #com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all:ClassLoadingService=all:logservice=all=enabled
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionServletStartupDbLog/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionServletStartupDbLog/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionStartupBean/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionStartupBean/bootstrap.properties
@@ -13,5 +13,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all:logservice=all=enabled
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionalBean/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_transaction/publish/servers/checkpointTransactionalBean/bootstrap.properties
@@ -14,5 +14,5 @@ bootstrap.include=../testports.properties
 osgi.console=7773
 #com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all:logService=all=enabled
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:Transaction=all:JCDI=all:com.ibm.ws.webbeans*=all:org.apache.webbeans*=all:org.jboss.weld*=all:com.ibm.ws.cdi*=all:logService=all=enabled
-io.openliberty.checkpoint.dump.threads=true
+
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.checkpoint_fat_xmlws/publish/servers/EJBWSBasicServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_xmlws/publish/servers/EJBWSBasicServer/bootstrap.properties
@@ -11,4 +11,3 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true

--- a/dev/io.openliberty.checkpoint_fat_xmlws/publish/servers/LibertyCXFPositivePropertiesTestServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_xmlws/publish/servers/LibertyCXFPositivePropertiesTestServer/bootstrap.properties
@@ -11,7 +11,7 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true
+
 io.openliberty.checkpoint.allowed.features=wsSecurity-1.1
 # Please do not remove the trace below! This is required to check PropertySettingsTest test
 com.ibm.ws.logging.trace.specification=*=info=enabled:LogService=all:org.apache.cxf.ws.policy=fine:org.apache.cxf.jaxws.*=fine

--- a/dev/io.openliberty.checkpoint_fat_xmlws/publish/servers/WebServiceRefTestServer/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat_xmlws/publish/servers/WebServiceRefTestServer/bootstrap.properties
@@ -11,4 +11,3 @@
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
 com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-io.openliberty.checkpoint.dump.threads=true


### PR DESCRIPTION
The dump seems to be causing some issues with getting a good checkpoint.  Trying to disable the flag for now.


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

