### PR TITLE
EE 11 test updates

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019,2022 IBM Corporation and others.
+# Copyright (c) 2019,2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -21,9 +21,11 @@ fat.project: true
 tested.features=\
   concurrent-2.0,\
   concurrent-3.0,\
+  concurrent-3.1,\
   cdi-3.0,\
   cdi-4.0,\
+  cdi-4.1,\
   jsonp-2.1,\
   restfulws-3.1,\
-  restfulwsclient-3.1,\
+  restfulws-4.0,\
   mpconfig-3.1

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/fat/src/com/ibm/ws/concurrent/mp/v1_3/fat/tck/MPContextPropagationTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2022 IBM Corporation and others.
+ * Copyright (c) 2018,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,8 @@ public class MPContextPropagationTCKLauncher {
     private static final String SERVER_NAME = "tckServerForMPContextPropagation13";
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP61, MicroProfileActions.MP60, MicroProfileActions.MP50);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE11, MicroProfileActions.MP61, MicroProfileActions.MP60,
+                                                             MicroProfileActions.MP50);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/io.openliberty.jee.internal_fat/publish/features/io.extension.jeeTestFeature.internal-11.0.mf
+++ b/dev/io.openliberty.jee.internal_fat/publish/features/io.extension.jeeTestFeature.internal-11.0.mf
@@ -31,7 +31,8 @@ Subsystem-Content: com.ibm.websphere.appserver.servlet-6.1; type="osgi.subsystem
  io.openliberty.appClientSupport-2.0; type="osgi.subsystem.feature",
  io.openliberty.messagingSecurity-3.0; type="osgi.subsystem.feature",
  io.openliberty.messagingServer-3.0; type="osgi.subsystem.feature",
- io.openliberty.messagingClient-3.0; type="osgi.subsystem.feature"
+ io.openliberty.messagingClient-3.0; type="osgi.subsystem.feature",
+ io.openliberty.data-1.0; type="osgi.subsystem.feature"
 Subsystem-SymbolicName: io.extension.jeeTestFeature.internal-11.0;visibility:=private; singleton:=true
 Subsystem-ManifestVersion: 1.0
 

--- a/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2022 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -19,7 +19,7 @@ src: \
 
 fat.project: true
 
-tested.features=concurrent-3.0, jsonb-3.0, jsonp-2.1, cdi-4.0
+tested.features=concurrent-3.0, jsonb-3.0, jsonp-2.1, cdi-4.0, concurrent-3.1, cdi-4.1, mpconfig-3.1
 
 
 # To define a global minimum java level for the FAT, use the following property.

--- a/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -36,7 +36,7 @@ public class GraphQLTckPackageTest {
     private static final String SERVER_NAME = "FATServer";
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP61, MicroProfileActions.MP50);
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE11, MicroProfileActions.MP61, MicroProfileActions.MP50);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2023 IBM Corporation and others.
+# Copyright (c) 2018, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -26,7 +26,6 @@ Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
 
 tested.features: \
     cdi-4.1,\
-    concurrent-3.0,\
     mpconfig-3.1,\
     mpmetrics-4.0,\
     mpmetrics-5.1,\


### PR DESCRIPTION
- Update MP Context Propagation 1.3 and Graph QL 2.0 TCK FAT projects to do a repeat with MP 7.0 with EE 11 features
- Add data-1.0 into the jee.internal_fat project now that it doesn't include tolerates in its feature definition.
- Remove concurrent-3.0 from tested.features list from reactive messaging 3.0 tck project


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
