### PR TITLE
29591 telemetry cannot handle user feature wab

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.classpath
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-bundles/telemetry.user.wab/src"/>
 	<classpathentry kind="src" path="test-bundles/telemetry.user.feature/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
@@ -19,7 +19,8 @@ fat.minimum.java.level: 1.8
 
 src: \
 	fat/src,\
-	test-bundles/telemetry.user.feature/src	
+	test-bundles/telemetry.user.feature/src,\
+	test-bundles/telemetry.user.wab/src	
 	
 fat.project: true
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryUserFeatureTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetryUserFeatureTest.java
@@ -19,6 +19,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.LocalFile;
@@ -33,8 +34,10 @@ import componenttest.rules.repeater.JakartaEEAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpRequest;
 import io.openliberty.microprofile.telemetry.internal_fat.apps.userfeature.UserFeatureServlet;
 import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
+import junit.framework.Assert;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
@@ -44,20 +47,27 @@ public class TelemetryUserFeatureTest extends FATServletClient {
     public static final String SERVER_NAME = "Telemetry10UserFeature";
     public static final String FEATURE_NAME = "telemetry.user.feature-1.0";
     public static final String FEATURE_JAKARTA_NAME = "telemetry.user.feature-2.0";
+    public static final String WAB_FEATURE_NAME = "telemetry.user.wab-1.0";
+    public static final String WAB_FEATURE_JAKARTA_NAME = "telemetry.user.wab-2.0";
     public static final String BUNDLE_NAME = "telemetry.user.feature";
     public static final String BUNDLE_JAKARTA_NAME = "telemetry.user.feature-jakarta";
+    public static final String WAB_BUNDLE_NAME = "telemetry.user.wab";
+    public static final String WAB_BUNDLE_JAKARTA_NAME = "telemetry.user.wab-jakarta";
     public static final String BUNDLE_PATH = "publish/bundles/";
 
     private static final String SEVER_XML_SNIPPET = "serverxmlsnippet.xml";
     private static final String JAVAX_SNIPPET = "javax/" + SEVER_XML_SNIPPET;
-    private static final String JAKARTA_SNIPPET = "jakarta/" + SEVER_XML_SNIPPET;;
+    private static final String JAKARTA_SNIPPET = "jakarta/" + SEVER_XML_SNIPPET;
+
+    private static final String USER_WAB_CONTEXT_ROOT = "telemetryuserwab";
 
     @TestServlet(contextRoot = APP_NAME, servlet = UserFeatureServlet.class)
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
+    //Telemetry 20 because we're only testing runtime mode
     @ClassRule
-    public static RepeatTests r = TelemetryActions.latestTelemetryRepeats(SERVER_NAME);
+    public static RepeatTests r = TelemetryActions.telemetry20Repeats(SERVER_NAME);
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -65,33 +75,28 @@ public class TelemetryUserFeatureTest extends FATServletClient {
         System.out.println("Install the user feature bundles...");
 
         if (JakartaEEAction.isEE9OrLaterActive()) {
-            String fullPath = BUNDLE_PATH + BUNDLE_JAKARTA_NAME;
-            LocalFile bundleFile = new LocalFile(fullPath);
-            if (bundleFile.exists()) {
-                bundleFile.delete();
-            }
-            JakartaEEAction.transformApp(Paths.get(BUNDLE_PATH + BUNDLE_NAME + ".jar"), Paths.get(fullPath + ".jar"));
-            server.installUserBundle(BUNDLE_JAKARTA_NAME);
+            installBundle(BUNDLE_JAKARTA_NAME, BUNDLE_NAME);
+            installBundle(WAB_BUNDLE_JAKARTA_NAME, WAB_BUNDLE_NAME);
+
             server.installUserFeature(FEATURE_JAKARTA_NAME);
+            server.installUserFeature(WAB_FEATURE_JAKARTA_NAME);
 
             //Rather than force all the other tests to be aware of our user feature so a feature replacement action
             //can modify it. We'll use an includes in the server.xml and slide in a snippet with the right version
             server.copyFileToLibertyServerRoot(JAKARTA_SNIPPET);
         } else {
-            String fullPath = BUNDLE_PATH + BUNDLE_NAME;
-            LocalFile bundleFile = new LocalFile(fullPath);
-            if (bundleFile.exists()) {
-                bundleFile.delete();
-            }
-            server.installUserBundle(BUNDLE_NAME);
+            installBundle(BUNDLE_NAME, BUNDLE_NAME);
+            installBundle(WAB_BUNDLE_NAME, WAB_BUNDLE_NAME);
+
             server.installUserFeature(FEATURE_NAME);
+            server.installUserFeature(WAB_FEATURE_NAME);
 
             server.copyFileToLibertyServerRoot(JAVAX_SNIPPET);
         }
 
         // Don't enable otel sdk here. Use server.env so we test a runtime instance
         WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
-                        .addClass(UserFeatureServlet.class);
+                        .addPackage(UserFeatureServlet.class.getPackage());
 
         ShrinkHelper.exportAppToServer(server, app, SERVER_ONLY);
 
@@ -99,6 +104,38 @@ public class TelemetryUserFeatureTest extends FATServletClient {
         server.addEnvVar("OTEL_SDK_DISABLED", "false");
 
         server.startServer();
+    }
+
+    private static void installBundle(String bundleName, String bundleNameWithoutJakarta) throws Exception {
+        String fullPath = BUNDLE_PATH + bundleName;
+        LocalFile bundleFile = new LocalFile(fullPath);
+        if (bundleFile.exists()) {
+            bundleFile.delete();
+        }
+
+        if (JakartaEEAction.isEE9OrLaterActive()) {
+            JakartaEEAction.transformApp(Paths.get(BUNDLE_PATH + bundleNameWithoutJakarta + ".jar"), Paths.get(fullPath + ".jar"));
+        }
+
+        server.installUserBundle(bundleName);
+    }
+
+    @Test
+    public void testTelemetryEnabledInWAB() throws Exception {
+        String wabOutput = new HttpRequest(server, "/" + USER_WAB_CONTEXT_ROOT + "/servletInsideWab")
+                        .expectCode(200)
+                        .run(String.class);
+
+        Assert.assertEquals("telemetry enabled: true", wabOutput.trim());
+    }
+
+    @Test
+    public void testTelemetryFilterInApp() throws Exception {
+        String appOutput = new HttpRequest(server, "/" + APP_NAME + "/servletInsideApp")
+                        .expectCode(200)
+                        .run(String.class);
+
+        Assert.assertEquals("telemetry enabled: true", appOutput.trim());
     }
 
     @AfterClass
@@ -109,9 +146,13 @@ public class TelemetryUserFeatureTest extends FATServletClient {
         if (JakartaEEAction.isEE9OrLaterActive()) {
             server.uninstallUserBundle(BUNDLE_JAKARTA_NAME);
             server.uninstallUserFeature(FEATURE_JAKARTA_NAME);
+            server.uninstallUserBundle(WAB_BUNDLE_JAKARTA_NAME);
+            server.uninstallUserFeature(WAB_FEATURE_JAKARTA_NAME);
         } else {
             server.uninstallUserBundle(BUNDLE_NAME);
             server.uninstallUserFeature(FEATURE_NAME);
+            server.uninstallUserBundle(WAB_BUNDLE_NAME);
+            server.uninstallUserFeature(WAB_FEATURE_NAME);
         }
         server.deleteFileFromLibertyServerRoot(SEVER_XML_SNIPPET);
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/userfeature/UserFeatureServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/userfeature/UserFeatureServlet.java
@@ -20,7 +20,7 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import junit.framework.Assert;
 
 @SuppressWarnings("serial")
-@WebServlet("/testSpanCurrent")
+@WebServlet("/userfeature")
 public class UserFeatureServlet extends FATServlet {
 
     //Copied from UserFeatureServletFilter to avoid creating a compile dependency

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/userfeature/UserFeatureWABServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/userfeature/UserFeatureWABServlet.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.telemetry.internal_fat.apps.userfeature;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("servletInsideApp")
+public class UserFeatureWABServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        ServletOutputStream sos = response.getOutputStream();
+
+        System.out.println("Servlet inside app filtered by WAB");
+        sos.println("telemetry enabled: " + request.getAttribute("telemetryEnabled"));
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/features/telemetry.user.feature-1.0.mf
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/features/telemetry.user.feature-1.0.mf
@@ -4,6 +4,5 @@ Subsystem-SymbolicName: telemetry.user.feature-1.0;visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Content: telemetry.user.feature; version="[1.0,1.100)"
 Subsystem-Type: osgi.subsystem.feature
-IBM-API-Package: com.ibm.ws.cdi.extension.spi.test.bundle,
-  io.openliberty.telemetry.user.feature
+IBM-API-Package: io.openliberty.telemetry.user.feature
 IBM-Feature-Version: 2

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/features/telemetry.user.wab-1.0.mf
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/features/telemetry.user.wab-1.0.mf
@@ -1,0 +1,9 @@
+Subsystem-ManifestVersion: 1
+IBM-ShortName: telemetry.user.wab-1.0
+Subsystem-SymbolicName: telemetry.user.wab-1.0;visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Content: telemetry.user.wab; version="[1.0,1.100)", com.ibm.wsspi.appserver.webBundle-1.0; type="osgi.subsystem.feature",
+  com.ibm.websphere.appserver.servlet-3.1; type="osgi.subsystem.feature";  ibm.tolerates:="4.0,5.0,6.0,6.1"
+Subsystem-Type: osgi.subsystem.feature
+IBM-API-Package: io.openliberty.telemetry.user.feature
+IBM-Feature-Version: 2

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/features/telemetry.user.wab-2.0.mf
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/features/telemetry.user.wab-2.0.mf
@@ -1,0 +1,9 @@
+Subsystem-ManifestVersion: 1
+IBM-ShortName: telemetry.user.wab-2.0
+Subsystem-SymbolicName: telemetry.user.wab-2.0;visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Content: telemetry.user.wab.jakarta; version="[1.0,1.100)", com.ibm.wsspi.appserver.webBundle-1.0; type="osgi.subsystem.feature",
+  com.ibm.websphere.appserver.servlet-3.1; type="osgi.subsystem.feature";  ibm.tolerates:="4.0,5.0,6.0,6.1"
+Subsystem-Type: osgi.subsystem.feature
+IBM-API-Package: io.openliberty.telemetry.user.feature
+IBM-Feature-Version: 2

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/files/jakarta/serverxmlsnippet.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/files/jakarta/serverxmlsnippet.xml
@@ -1,5 +1,6 @@
 <server description="Versioned telemetry user feature snippet">
     <featureManager>
       <feature>usr:telemetry.user.feature-2.0</feature>
+      <feature>usr:telemetry.user.wab-2.0</feature>
     </featureManager>
 </server>

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/files/javax/serverxmlsnippet.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/files/javax/serverxmlsnippet.xml
@@ -1,5 +1,6 @@
 <server description="Versioned telemetry user feature snippet">
     <featureManager>
       <feature>usr:telemetry.user.feature-1.0</feature>
+      <feature>usr:telemetry.user.wab-1.0</feature>
     </featureManager>
 </server>

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Spi/jvm.options.orig
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/publish/servers/Telemetry10Spi/jvm.options.orig
@@ -1,1 +1,0 @@
--Dio.opentelemetry.context.enableStrictContext=true

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/test-bundles/telemetry.user.wab/resources/WEB-INF/ibm-web-ext.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/test-bundles/telemetry.user.wab/resources/WEB-INF/ibm-web-ext.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<web-ext
+	xmlns="http://websphere.ibm.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+	version="1.0">
+
+	<reload-interval value="3"/>
+	<context-root uri="telemetryuserfeature" />
+	<enable-directory-browsing value="false"/>
+	<enable-file-serving value="true"/>
+	<enable-reloading value="true"/>
+	<enable-serving-servlets-by-class-name value="false" />
+
+</web-ext>

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/test-bundles/telemetry.user.wab/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/test-bundles/telemetry.user.wab/resources/WEB-INF/web.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2024 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+<web-app id="WebApp_ID" version="3.0" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+  <display-name>health</display-name>
+  <description>The IBM Health Check APIs for the Liberty server</description>
+
+  <servlet>
+    <display-name>WabFeatureTestServlet</display-name>
+    <servlet-name>WabFeatureTestServlet</servlet-name>
+    <servlet-class>io.openliberty.telemetry.user.wab.WabFeatureTestServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>WabFeatureTestServlet</servlet-name>
+    <url-pattern>/servletInsideWab</url-pattern>
+  </servlet-mapping>
+
+</web-app>

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/test-bundles/telemetry.user.wab/src/io/openliberty/telemetry/user/wab/TelemetryServletContainerInitializer.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/test-bundles/telemetry.user.wab/src/io/openliberty/telemetry/user/wab/TelemetryServletContainerInitializer.java
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package io.openliberty.telemetry.user.feature;
+package io.openliberty.telemetry.user.wab;
 
 import static org.osgi.service.component.annotations.ConfigurationPolicy.IGNORE;
 
@@ -30,9 +30,10 @@ public class TelemetryServletContainerInitializer implements ServletContainerIni
     @Override
     public void onStartup(Set<Class<?>> c, ServletContext sc) throws ServletException {
         System.out.println("UserFeatureTest: Enable UserFeatureServletFilter");
-        FilterRegistration.Dynamic filterRegistration = sc.addFilter("io.openliberty.telemetry.user.feature.UserFeatureServletFilter",
-                                                                     UserFeatureServletFilter.class);
-        filterRegistration.addMappingForUrlPatterns(null, true, "/userfeature");
+        FilterRegistration.Dynamic filterRegistration = sc.addFilter("io.openliberty.telemetry.user.wab.WabFeatureServletFilter",
+                                                                     WabFeatureServletFilter.class);
+        filterRegistration.addMappingForUrlPatterns(null, true, "/servletInsideWab");
+        filterRegistration.addMappingForUrlPatterns(null, true, "/servletInsideApp");
         filterRegistration.setAsyncSupported(true);
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/test-bundles/telemetry.user.wab/src/io/openliberty/telemetry/user/wab/WabFeatureServletFilter.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/test-bundles/telemetry.user.wab/src/io/openliberty/telemetry/user/wab/WabFeatureServletFilter.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.telemetry.user.wab;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.ws.rs.ext.Provider;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+import io.openliberty.microprofile.telemetry.spi.OpenTelemetryAccessor;
+import io.openliberty.microprofile.telemetry.spi.OpenTelemetryInfo;
+
+@Provider
+public class WabFeatureServletFilter implements Filter {
+
+    private static final TraceComponent tc = Tr.register(WabFeatureServletFilter.class);
+
+    @Override
+    public void destroy() {
+        //do nothing
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        System.out.println("UserFeatureTest: Entering wab feature  doFilter");
+
+        //Test that OpenTelemetry doesn't crash if we call the accessor inside a WAB
+        //isEnabled will be true in runtimeMode and false in appMode. The test servlets will verify this
+        OpenTelemetryInfo openTelemetryInfo = OpenTelemetryAccessor.getOpenTelemetryInfo();
+        if (openTelemetryInfo.isEnabled()) {
+            request.setAttribute("telemetryEnabled", "true");
+        } else {
+            request.setAttribute("telemetryEnabled", "false");
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void init(FilterConfig arg0) throws ServletException {
+        //do nothing
+    }
+
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/test-bundles/telemetry.user.wab/src/io/openliberty/telemetry/user/wab/WabFeatureTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/test-bundles/telemetry.user.wab/src/io/openliberty/telemetry/user/wab/WabFeatureTestServlet.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.telemetry.user.wab;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import componenttest.app.FATServlet;
+
+public class WabFeatureTestServlet extends FATServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        ServletOutputStream sos = response.getOutputStream();
+        //we're just testing that a servlet inside a userfeature doesn't make the telemetry servlet filter crash
+        //And we'll check if open telemetry is enabled or not based on wheather we're in app mode or not.
+        System.out.println("Servlet inside user feature");
+        sos.println("telemetry enabled: " + request.getAttribute("telemetryEnabled"));
+    }
+}

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/user-wab.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/user-wab.bnd
@@ -1,0 +1,31 @@
+#*******************************************************************************
+# Copyright (c) 2024 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+Bundle-Name: User WAB To Test Open Telemetry SPI 
+Bundle-SymbolicName: telemetry.user.wab
+Bundle-Description: This bundle tests the telemetry spi; version=${bVersion}
+
+Import-Package: \
+  javax.ws.rs.ext;version="[2.0,3)",\
+  *
+
+Export-Package: \
+	io.openliberty.telemetry.user.wab;version=1.0.0
+
+Include-Resource: \
+    WEB-INF=test-bundles/telemetry.user.wab/resources/WEB-INF
+
+Web-ContextPath: telemetryuserwab
+
+-dsannotations-inherit: true
+-dsannotations \
+	io.openliberty.telemetry.user.wab.TelemetryServletContainerInitializer


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

OpenTelemetry is configured to throw an exception in app mode it is asked for an opentelemetry object for an app that never started; unless its part of internal code. However this exception triggers if a user feature has an web endpoint. So it must be removed

Resolves #29591
Also see skills case TS017200047 in salesforce