### PR TITLE
Throw error when entity attribute and embedded attribute have name clashes

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -64,12 +64,22 @@
     <dependency>
       <groupId>com.cloudant</groupId>
       <artifactId>cloudant-client</artifactId>
+      <version>2.20.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cloudant</groupId>
+      <artifactId>cloudant-client</artifactId>
       <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.cloudant</groupId>
       <artifactId>cloudant-http</artifactId>
       <version>2.16.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cloudant</groupId>
+      <artifactId>cloudant-http</artifactId>
+      <version>2.20.1</version>
     </dependency>
     <dependency>
       <groupId>com.cloudant</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -7,11 +7,11 @@ biz.aQute.bnd:biz.aQute.bnd:7.0.0
 cglib:cglib:3.3.0
 ch.qos.logback:logback-classic:1.2.3
 com.beust:jcommander:1.72
-com.cloudant:cloudant-client:2.20.1
 com.cloudant:cloudant-client:2.16.0
+com.cloudant:cloudant-client:2.20.1
 com.cloudant:cloudant-client:2.8.0
-com.cloudant:cloudant-http:2.20.1
 com.cloudant:cloudant-http:2.16.0
+com.cloudant:cloudant-http:2.20.1
 com.cloudant:cloudant-http:2.8.0
 com.fasterxml.jackson.core:jackson-annotations:2.15.2
 com.fasterxml.jackson.core:jackson-core:2.15.2

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -288,6 +288,10 @@ public abstract class EntityManagerBuilder {
                     if (trace & tc.isDebugEnabled())
                         Tr.debug(tc, "Unexpected exception caught while collecting entity information. The entity information will complete exceptionally", e);
                     collectionException = e;
+                    // TODO compute the userEntityClass earlier and completeExceptionally here.
+                    // Then move the EntityInfo creation and successful completion to before the catch.
+                    // That will also cover the possibility of EntityInfo constructor failing,
+                    // which can happen when it doesn't validate.
                 }
 
                 Class<?> jpaEntityClass = entityType.getJavaType();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -97,7 +97,10 @@ public abstract class EntityManagerBuilder {
      * @param entityTypes entity classes as known by the user, not generated.
      * @throws Exception if an error occurs.
      */
+    // Exceptions we expect to catch should ignore FFDC as they will be re-thrown upon CompletableFuture<EntityInfo>.get()
+    @FFDCIgnore({ MappingException.class })
     protected void collectEntityInfo(Set<Class<?>> entityTypes) throws Exception {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
         EntityManager em = createEntityManager();
         try {
             Metamodel model = em.getMetamodel();
@@ -106,6 +109,7 @@ public abstract class EntityManagerBuilder {
                 Map<String, List<Member>> attributeAccessors = new HashMap<>();
                 SortedSet<String> attributeNamesForUpdate = new TreeSet<>();
                 SortedMap<String, Class<?>> attributeTypes = new TreeMap<>();
+                SortedMap<String, Member> idClassAttributeAccessors = null;
                 Map<String, Class<?>> collectionElementTypes = new HashMap<>();
                 Map<Class<?>, List<String>> relationAttributeNames = new HashMap<>();
                 Queue<Attribute<?, ?>> relationships = new LinkedList<>();
@@ -115,168 +119,175 @@ public abstract class EntityManagerBuilder {
                 Class<?> idType = null;
                 String versionAttrName = null;
 
-                for (Attribute<?, ?> attr : entityType.getAttributes()) {
-                    String attributeName = attr.getName();
-                    PersistentAttributeType attributeType = attr.getPersistentAttributeType();
-                    switch (attributeType) {
-                        case BASIC:
-                        case ELEMENT_COLLECTION:
-                            attributeNamesForUpdate.add(attributeName);
-                            break;
-                        case EMBEDDED:
-                        case ONE_TO_ONE:
-                        case MANY_TO_ONE:
-                            relationAttributeNames.put(attr.getJavaType(), new ArrayList<>());
-                            relationships.add(attr);
-                            relationPrefixes.add(attributeName);
-                            relationAccessors.add(Collections.singletonList(attr.getJavaMember()));
-                            break;
-                        case ONE_TO_MANY:
-                        case MANY_TO_MANY:
-                            attributeNamesForUpdate.add(attributeName); // TODO is this correct?
-                            break;
-                        default:
-                            throw new RuntimeException(); // unreachable unless more types are added
-                    }
+                Exception collectionException = null;
 
-                    Member accessor = recordClass == null ? attr.getJavaMember() : recordClass.getMethod(attributeName);
-
-                    attributeNames.put(attributeName.toLowerCase(), attributeName);
-                    attributeAccessors.put(attributeName, Collections.singletonList(accessor));
-                    attributeTypes.put(attributeName, attr.getJavaType());
-                    if (attr.isCollection()) {
-                        if (attr instanceof PluralAttribute)
-                            collectionElementTypes.put(attributeName, ((PluralAttribute<?, ?, ?>) attr).getElementType().getJavaType());
-                    } else {
-                        SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute ? (SingularAttribute<?, ?>) attr : null;
-                        if (singleAttr != null && singleAttr.isId()) {
-                            attributeNames.put(ID, attributeName);
-                            idType = singleAttr.getJavaType();
-                        } else if (singleAttr != null && singleAttr.isVersion()) {
-                            versionAttrName = attributeName;
-                        } else if (Collection.class.isAssignableFrom(attr.getJavaType())) {
-                            // collection attribute that is not annotated with ElementCollection
-                            collectionElementTypes.put(attributeName, Object.class);
-                        }
-                    }
-                }
-
-                // Guard against recursive processing of OneToOne (and similar) relationships
-                // by tracking whether we have already processed each entity class involved.
-                Set<Class<?>> entityTypeClasses = new HashSet<>();
-                entityTypeClasses.add(entityType.getJavaType());
-
-                for (Attribute<?, ?> attr; (attr = relationships.poll()) != null;) {
-                    String prefix = relationPrefixes.poll();
-                    List<Member> accessors = relationAccessors.poll();
-                    ManagedType<?> relation = model.managedType(attr.getJavaType());
-                    if (relation instanceof EntityType && !entityTypeClasses.add(attr.getJavaType()))
-                        break;
-                    List<String> relAttributeList = relationAttributeNames.get(attr.getJavaType());
-                    for (Attribute<?, ?> relAttr : relation.getAttributes()) {
-                        String relationAttributeName = relAttr.getName();
-                        String fullAttributeName = prefix + '.' + relationAttributeName;
-                        List<Member> relAccessors = new LinkedList<>(accessors);
-                        relAccessors.add(relAttr.getJavaMember());
-                        relAttributeList.add(fullAttributeName);
-
-                        PersistentAttributeType attributeType = relAttr.getPersistentAttributeType();
+                try {
+                    for (Attribute<?, ?> attr : entityType.getAttributes()) {
+                        String attributeName = attr.getName();
+                        PersistentAttributeType attributeType = attr.getPersistentAttributeType();
                         switch (attributeType) {
                             case BASIC:
                             case ELEMENT_COLLECTION:
-                                attributeNamesForUpdate.add(fullAttributeName);
+                                attributeNamesForUpdate.add(attributeName);
                                 break;
                             case EMBEDDED:
                             case ONE_TO_ONE:
                             case MANY_TO_ONE:
-                                relationAttributeNames.put(relAttr.getJavaType(), new ArrayList<>());
-                                relationships.add(relAttr);
-                                relationPrefixes.add(fullAttributeName);
-                                relationAccessors.add(relAccessors);
+                                relationAttributeNames.put(attr.getJavaType(), new ArrayList<>());
+                                relationships.add(attr);
+                                relationPrefixes.add(attributeName);
+                                relationAccessors.add(Collections.singletonList(attr.getJavaMember()));
                                 break;
                             case ONE_TO_MANY:
                             case MANY_TO_MANY:
-                                attributeNamesForUpdate.add(fullAttributeName); // TODO is this correct?
+                                attributeNamesForUpdate.add(attributeName); // TODO is this correct?
                                 break;
                             default:
                                 throw new RuntimeException(); // unreachable unless more types are added
                         }
 
-                        // Allow a qualified name such as @OrderBy("address.street.name")
-                        // No chance of conflicts because attributes defined on the entity cannot have a period
-                        String fullAttributeNameLower = fullAttributeName.toLowerCase();
-                        attributeNames.put(fullAttributeNameLower, fullAttributeName);
+                        Member accessor = recordClass == null ? attr.getJavaMember() : recordClass.getMethod(attributeName);
 
-                        // Allow a qualified name such as findByAddress_Street_Name if it doesn't overlap
-                        // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
-                        String relationAttributeName_ = fullAttributeNameLower.replace('.', '_');
-                        String conflictingAttribute = attributeNames.putIfAbsent(relationAttributeName_, fullAttributeName);
-
-                        // TODO instead of failing here, we could fail during queryInfo.getAttributeName();
-                        if (conflictingAttribute != null)
-                            throw new MappingException("The entity " + entityType.getName() + " defines a basic attribute " + conflictingAttribute
-                                                       + " and a relational attribute " + prefix
-                                                       + " which results in an overloaded path expression " + relationAttributeName_
-                                                       + " necessary for queries and sorting."); //TODO NLS
-
-                        // Allow a qualified name such as findByAddressStreetName if it doesn't overlap
-                        // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
-                        String relationAttributeNameUndelimited = fullAttributeNameLower.replace(".", "");
-                        conflictingAttribute = attributeNames.putIfAbsent(relationAttributeNameUndelimited, fullAttributeName);
-
-                        // TODO instead of failing here, we could fail during queryInfo.getAttributeName();
-                        // but we then run the risk of eclipselink throwing an error instead when the attribute name happens to match column name of the table.
-                        // which could be more difficult for the user to debug.
-                        if (conflictingAttribute != null)
-                            throw new MappingException("The entity " + entityType.getName() + " defines a basic attribute " + conflictingAttribute
-                                                       + " and a relational attribute " + prefix
-                                                       + " which results in an overloaded path expression " + relationAttributeNameUndelimited
-                                                       + " necessary for queries and sorting."); //TODO NLS
-
-                        // Allow the simple attribute name if it doesn't overlap. For example: name, address.street.name
-                        // TODO document behavior not part of Jakarta Data Specification
-                        relationAttributeName = relationAttributeName.toLowerCase();
-                        attributeNames.putIfAbsent(relationAttributeName, fullAttributeName);
-
-                        attributeAccessors.put(fullAttributeName, relAccessors);
-
-                        attributeTypes.put(fullAttributeName, relAttr.getJavaType());
-                        if (relAttr.isCollection()) {
-                            if (relAttr instanceof PluralAttribute)
-                                collectionElementTypes.put(fullAttributeName, ((PluralAttribute<?, ?, ?>) relAttr).getElementType().getJavaType());
-                        } else if (relAttr instanceof SingularAttribute) {
-                            SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
-                            if (singleAttr.isId() && attributeNames.putIfAbsent(ID, fullAttributeName) == null) {
+                        attributeNames.put(attributeName.toLowerCase(), attributeName);
+                        attributeAccessors.put(attributeName, Collections.singletonList(accessor));
+                        attributeTypes.put(attributeName, attr.getJavaType());
+                        if (attr.isCollection()) {
+                            if (attr instanceof PluralAttribute)
+                                collectionElementTypes.put(attributeName, ((PluralAttribute<?, ?, ?>) attr).getElementType().getJavaType());
+                        } else {
+                            SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute ? (SingularAttribute<?, ?>) attr : null;
+                            if (singleAttr != null && singleAttr.isId()) {
+                                attributeNames.put(ID, attributeName);
                                 idType = singleAttr.getJavaType();
-                            } else if (singleAttr.isVersion()) {
-                                versionAttrName = relationAttributeName_; // to be suitable for query-by-method
+                            } else if (singleAttr != null && singleAttr.isVersion()) {
+                                versionAttrName = attributeName;
+                            } else if (Collection.class.isAssignableFrom(attr.getJavaType())) {
+                                // collection attribute that is not annotated with ElementCollection
+                                collectionElementTypes.put(attributeName, Object.class);
                             }
                         }
                     }
-                }
 
-                attributeNamesForUpdate.remove(ID);
-                String idAttrName = attributeNames.get(ID);
-                if (idAttrName != null)
-                    attributeNamesForUpdate.remove(idAttrName);
-                if (versionAttrName != null)
-                    attributeNamesForUpdate.remove(versionAttrName);
+                    // Guard against recursive processing of OneToOne (and similar) relationships
+                    // by tracking whether we have already processed each entity class involved.
+                    Set<Class<?>> entityTypeClasses = new HashSet<>();
+                    entityTypeClasses.add(entityType.getJavaType());
 
-                SortedMap<String, Member> idClassAttributeAccessors = null;
-                if (!entityType.hasSingleIdAttribute()) {
-                    // Per JavaDoc, the above means there is an IdClass.
-                    // An EclipseLink extension that allows an Id on an embeddable of an entity
-                    // is an exception to this, which we indicate with idClassType null.
-                    Type<?> idClassType = getIdType(entityType);
-                    if (idClassType != null) {
-                        @SuppressWarnings("unchecked")
-                        Set<SingularAttribute<?, ?>> idClassAttributes = (Set<SingularAttribute<?, ?>>) (Set<?>) entityType.getIdClassAttributes();
-                        if (idClassAttributes != null) {
-                            attributeNames.remove(ID);
-                            idType = idClassType.getJavaType();
-                            idClassAttributeAccessors = getIdClassAccessors(idType, idClassAttributes);
+                    for (Attribute<?, ?> attr; (attr = relationships.poll()) != null;) {
+                        String prefix = relationPrefixes.poll();
+                        List<Member> accessors = relationAccessors.poll();
+                        ManagedType<?> relation = model.managedType(attr.getJavaType());
+                        if (relation instanceof EntityType && !entityTypeClasses.add(attr.getJavaType()))
+                            break;
+                        List<String> relAttributeList = relationAttributeNames.get(attr.getJavaType());
+                        for (Attribute<?, ?> relAttr : relation.getAttributes()) {
+                            String relationAttributeName = relAttr.getName();
+                            String fullAttributeName = prefix + '.' + relationAttributeName;
+                            List<Member> relAccessors = new LinkedList<>(accessors);
+                            relAccessors.add(relAttr.getJavaMember());
+                            relAttributeList.add(fullAttributeName);
+
+                            PersistentAttributeType attributeType = relAttr.getPersistentAttributeType();
+                            switch (attributeType) {
+                                case BASIC:
+                                case ELEMENT_COLLECTION:
+                                    attributeNamesForUpdate.add(fullAttributeName);
+                                    break;
+                                case EMBEDDED:
+                                case ONE_TO_ONE:
+                                case MANY_TO_ONE:
+                                    relationAttributeNames.put(relAttr.getJavaType(), new ArrayList<>());
+                                    relationships.add(relAttr);
+                                    relationPrefixes.add(fullAttributeName);
+                                    relationAccessors.add(relAccessors);
+                                    break;
+                                case ONE_TO_MANY:
+                                case MANY_TO_MANY:
+                                    attributeNamesForUpdate.add(fullAttributeName); // TODO is this correct?
+                                    break;
+                                default:
+                                    throw new RuntimeException(); // unreachable unless more types are added
+                            }
+
+                            // Allow a qualified name such as @OrderBy("address.street.name")
+                            // No chance of conflicts because attributes defined on the entity cannot have a period
+                            String fullAttributeNameLower = fullAttributeName.toLowerCase();
+                            attributeNames.put(fullAttributeNameLower, fullAttributeName);
+
+                            // Allow a qualified name such as findByAddress_Street_Name if it doesn't overlap
+                            // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
+                            String relationAttributeName_ = fullAttributeNameLower.replace('.', '_');
+                            String conflictingAttribute = attributeNames.putIfAbsent(relationAttributeName_, fullAttributeName);
+
+                            if (conflictingAttribute != null)
+                                throw new MappingException("The entity " + entityType.getName() + " defines a basic attribute " + conflictingAttribute
+                                                           + " and a relational attribute " + prefix
+                                                           + " which results in an overloaded path expression " + relationAttributeName_
+                                                           + " necessary for queries and sorting."); //TODO NLS
+
+                            // Allow a qualified name such as findByAddressStreetName if it doesn't overlap
+                            // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
+                            String relationAttributeNameUndelimited = fullAttributeNameLower.replace(".", "");
+                            conflictingAttribute = attributeNames.putIfAbsent(relationAttributeNameUndelimited, fullAttributeName);
+
+                            // TODO need to handle the situation where a field name on the base entity conflicts with the column name
+                            // of an embeddable.  See issue: https://github.com/OpenLiberty/open-liberty/issues/29643
+
+                            if (conflictingAttribute != null && trace && tc.isWarningEnabled())
+                                Tr.debug(tc, "The entity " + entityType.getName() + " defines a basic attribute " + conflictingAttribute
+                                             + " and a relational attribute " + prefix
+                                             + " which results in an overloaded path expression " + relationAttributeNameUndelimited
+                                             + " the relational attribute will be ignored."); //TODO NLS swap to warning
+
+                            // TODO - remove this experimental behavior - not part of Jakarta Data Specification
+                            relationAttributeName = relationAttributeName.toLowerCase();
+                            attributeNames.putIfAbsent(relationAttributeName, fullAttributeName);
+
+                            attributeAccessors.put(fullAttributeName, relAccessors);
+
+                            attributeTypes.put(fullAttributeName, relAttr.getJavaType());
+                            if (relAttr.isCollection()) {
+                                if (relAttr instanceof PluralAttribute)
+                                    collectionElementTypes.put(fullAttributeName, ((PluralAttribute<?, ?, ?>) relAttr).getElementType().getJavaType());
+                            } else if (relAttr instanceof SingularAttribute) {
+                                SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
+                                if (singleAttr.isId() && attributeNames.putIfAbsent(ID, fullAttributeName) == null) {
+                                    idType = singleAttr.getJavaType();
+                                } else if (singleAttr.isVersion()) {
+                                    versionAttrName = relationAttributeName_; // to be suitable for query-by-method
+                                }
+                            }
                         }
                     }
+
+                    attributeNamesForUpdate.remove(ID);
+                    String idAttrName = attributeNames.get(ID);
+                    if (idAttrName != null)
+                        attributeNamesForUpdate.remove(idAttrName);
+                    if (versionAttrName != null)
+                        attributeNamesForUpdate.remove(versionAttrName);
+
+                    if (!entityType.hasSingleIdAttribute()) {
+                        // Per JavaDoc, the above means there is an IdClass.
+                        // An EclipseLink extension that allows an Id on an embeddable of an entity
+                        // is an exception to this, which we indicate with idClassType null.
+                        Type<?> idClassType = getIdType(entityType);
+                        if (idClassType != null) {
+                            @SuppressWarnings("unchecked")
+                            Set<SingularAttribute<?, ?>> idClassAttributes = (Set<SingularAttribute<?, ?>>) (Set<?>) entityType.getIdClassAttributes();
+                            if (idClassAttributes != null) {
+                                attributeNames.remove(ID);
+                                idType = idClassType.getJavaType();
+                                idClassAttributeAccessors = getIdClassAccessors(idType, idClassAttributes);
+                            }
+                        }
+                    }
+                } catch (MappingException e) {
+                    collectionException = e;
+                } catch (Exception e) {
+                    if (trace & tc.isDebugEnabled())
+                        Tr.debug(tc, "Unexpected exception caught while collecting entity information. The entity information will complete exceptionally", e);
+                    collectionException = e;
                 }
 
                 Class<?> jpaEntityClass = entityType.getJavaType();
@@ -297,7 +308,10 @@ public abstract class EntityManagerBuilder {
                                 versionAttrName, //
                                 this);
 
-                entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture).complete(entityInfo);
+                if (collectionException == null)
+                    entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture).complete(entityInfo);
+                else
+                    entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture).completeExceptionally(collectionException);
             }
         } finally {
             if (em != null)

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -411,7 +411,7 @@ public class DataExtension implements Extension {
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(this, tc, repositoryInterface.getName() + " has primary entity class " + primaryEntityClass,
+            Tr.debug(this, tc, repositoryInterface.getName() + " has primary entity " + primaryEntityClass,
                      "and methods that use the following entities:", queriesPerEntity);
 
         primaryEntityClassReturnValue[0] = primaryEntityClass;

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment.java
@@ -13,7 +13,8 @@
 package test.jakarta.data.web;
 
 /**
- * Has both a mapped superclass and an embedded class
+ * Entity with embeddable and mapped superclass
+ * Entity has a field with a colliding non-delimited attribute name with embeddable
  *
  * TODO extends here could indicate either a mapped superclass or inheritance
  * Today we treat this as a mapped superclass, but we could support inheritance but would need a way to distinguish between the two.
@@ -21,6 +22,8 @@ package test.jakarta.data.web;
 public class Apartment extends Residence {
 
     public long aptId;
+
+    public int quartersWidth;
 
     public Bedroom quarters;
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+/**
+ * Has both a mapped superclass and an embedded class
+ *
+ * TODO extends here could indicate either a mapped superclass or inheritance
+ * Today we treat this as a mapped superclass, but we could support inheritance but would need a way to distinguish between the two.
+ */
+public class Apartment extends Residence {
+
+    public long aptId;
+
+    public Bedroom quarters;
+
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment2.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment2.java
@@ -10,25 +10,18 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package test.jakarta.data.jpa.web;
-
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+package test.jakarta.data.web;
 
 /**
  * Entity with embeddable and mapped superclass
- * Entity has a field with a colliding non-delimited attribute name with embeddable
+ * Entity has a field with a colliding delimited attribute name with embeddable
  */
-@Entity
-public class Apartment extends Residence {
+public class Apartment2 extends Residence {
 
-    @Id
     public long aptId;
 
-    public int quartersWidth;
+    public int quarters_width;
 
-    @Embedded
     public Bedroom quarters;
 
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment3.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment3.java
@@ -10,25 +10,18 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package test.jakarta.data.jpa.web;
-
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+package test.jakarta.data.web;
 
 /**
  * Entity with embeddable and mapped superclass
- * Entity has a field with a colliding non-delimited attribute name with embeddable
+ * Entity has a field with a colliding delimited attribute name with mapped superclass.
  */
-@Entity
-public class Apartment extends Residence {
+public class Apartment3 extends Residence {
 
-    @Id
     public long aptId;
 
-    public int quartersWidth;
+    public boolean occupant_firstName;
 
-    @Embedded
     public Bedroom quarters;
 
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import java.util.List;
+
+import jakarta.data.Sort;
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface Apartments extends BasicRepository<Apartment, Long> {
+    @Delete
+    public void removeAll();
+
+    // Write queries using every possible persistence field name delimiter
+    // https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0#property-name-concatenation
+
+    // Parameter Name (_)
+    @Find
+    public List<Apartment> findApartmentsByBedroomWidth(int quarters_width);
+
+    // @By (_) (.)
+    @Find
+    public List<Apartment> findApartmentsByBedroom(@By("quarters_length") int length,
+                                                   @By("quarters.width") int width);
+
+    // @OrderBy (_) (.)
+    @Find
+    @OrderBy("quarters_length")
+    public List<Apartment> findAllOrderByBedroomLength();
+
+    @Find
+    @OrderBy("quarters.width")
+    public List<Apartment> findAllOrderByBedroomWidth();
+
+    // Query (.)
+    @Query("FROM Apartment WHERE quarters.length = ?1")
+    public List<Apartment> findApartmentsByBedroomLength(int length);
+
+    // Method Name (_) or no delimiter
+    public List<Apartment> findByQuarters_Width(int width);
+
+    public List<Apartment> findByQuartersLength(int length);
+
+    // Sort (_) (.)
+    @Find
+    public List<Apartment> findAllSorted(Sort<?> sort);
+
+    // Write query using mapped superclass field name
+    @Find
+    public List<Apartment> findByOccupied(@By("isOccupied") boolean state);
+
+    // Write query using embeddable in a mapped superclass
+    @Find
+    @OrderBy("occupant.firstName")
+    public List<Apartment> findByOccupantLastNameOrderByFirstName(@By("occupant_lastName") String lastName);
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
@@ -15,18 +15,29 @@ package test.jakarta.data.web;
 import java.util.List;
 
 import jakarta.data.Sort;
-import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
 
 @Repository
-public interface Apartments extends BasicRepository<Apartment, Long> {
+public interface Apartments {
     @Delete
     public void removeAll();
+
+    @Save
+    public List<Apartment> saveAll(List<Apartment> entities);
+
+    //Need to have a lifecycle methods for Apartment2 and Apartment3 otherwise
+    //Apartment2 and Apartment3 will not be considered entities
+    @Save
+    public Apartment2 saveAll(Apartment2 entity);
+
+    @Save
+    public Apartment3 saveAll(Apartment3 entity);
 
     // Write queries using every possible persistence field name delimiter
     // https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0#property-name-concatenation
@@ -70,4 +81,15 @@ public interface Apartments extends BasicRepository<Apartment, Long> {
     @Find
     @OrderBy("occupant.firstName")
     public List<Apartment> findByOccupantLastNameOrderByFirstName(@By("occupant_lastName") String lastName);
+
+    //  Write query using entity that has colliding non-delimited attribute name (quartersWidth)
+    @OrderBy("occupant.firstName")
+    public List<Apartment> findByQuartersWidth(int width);
+
+    // Write queries using entities that have colliding delimited attribute names
+    @Find
+    public List<Apartment2> findAllCollidingEmbeddable();
+
+    @Find
+    public List<Apartment3> findAllCollidingSuperclass();
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
@@ -26,7 +26,7 @@ import jakarta.data.repository.Save;
 @Repository
 public interface Apartments {
     @Delete
-    public void removeAll();
+    public List<Apartment> removeAll(); //Need to return List<Apartment> since this repository lacks a primary entity
 
     @Save
     public List<Apartment> saveAll(List<Apartment> entities);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Bedroom.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Bedroom.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+/**
+ * Unannotated embeddable
+ */
+public class Bedroom {
+
+    public int width;
+
+    public int length;
+
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3719,6 +3719,11 @@ public class DataTestServlet extends FATServlet {
         assertEquals(19L, nine.numberId);
     }
 
+    /**
+     * Tests entity attribute names from embeddables and MappedSuperclass that
+     * can have delimiters. Includes tests for name collisions with attributes from an
+     * embeddable or superinteface. This test uses unannotated entities.
+     */
     @Test
     public void testPersistentFieldNamesAndDelimiters() {
         apartments.removeAll();

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3720,7 +3720,7 @@ public class DataTestServlet extends FATServlet {
     }
 
     @Test
-    public void testPersistentFieldNamesWithDelimiters() {
+    public void testPersistentFieldNamesAndDelimiters() {
         apartments.removeAll();
 
         Apartment a101 = new Apartment();
@@ -3732,6 +3732,7 @@ public class DataTestServlet extends FATServlet {
         a101.quarters = new Bedroom();
         a101.quarters.length = 10;
         a101.quarters.width = 10;
+        a101.quartersWidth = 15;
 
         Apartment a102 = new Apartment();
         a102.occupant = new Occupant();
@@ -3742,6 +3743,7 @@ public class DataTestServlet extends FATServlet {
         a102.quarters = new Bedroom();
         a102.quarters.length = 11;
         a102.quarters.width = 11;
+        a102.quartersWidth = 15;
 
         Apartment a103 = new Apartment();
         a103.occupant = new Occupant();
@@ -3752,6 +3754,7 @@ public class DataTestServlet extends FATServlet {
         a103.quarters = new Bedroom();
         a103.quarters.length = 11;
         a103.quarters.width = 12;
+        a103.quartersWidth = 15;
 
         Apartment a104 = new Apartment();
         a104.occupant = new Occupant();
@@ -3762,6 +3765,7 @@ public class DataTestServlet extends FATServlet {
         a104.quarters = new Bedroom();
         a104.quarters.length = 12;
         a104.quarters.width = 11;
+        a104.quartersWidth = 15;
 
         apartments.saveAll(List.of(a101, a102, a103, a104));
 
@@ -3817,6 +3821,28 @@ public class DataTestServlet extends FATServlet {
         assertEquals("Brian", results.get(1).occupant.firstName);
         assertEquals("Kyle", results.get(2).occupant.firstName);
         assertEquals("Scott", results.get(3).occupant.firstName);
+
+        // Colliding non-delimited attribute name quartersWidth, ensure we use entity attribute and not embedded attribute for query
+        results = apartments.findByQuartersWidth(15);
+        assertEquals(4, results.size());
+        assertEquals("Brent", results.get(0).occupant.firstName);
+        assertEquals("Brian", results.get(1).occupant.firstName);
+        assertEquals("Kyle", results.get(2).occupant.firstName);
+        assertEquals("Scott", results.get(3).occupant.firstName);
+
+        try {
+            apartments.findAllCollidingEmbeddable();
+            fail("Should not have been able to execute query on an entity with colliding attibute name from embeddable");
+        } catch (MappingException e) {
+            //expected
+        }
+
+        try {
+            apartments.findAllCollidingSuperclass();
+            fail("Should not have been able to execute query on an entity with colliding attibute name from superclass");
+        } catch (MappingException e) {
+            // expected
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
@@ -55,6 +55,8 @@ public interface Houses {
 
     List<House> findByGarage_door_heightOrderByGarage_door_heightDesc(int garageDoorHeight);
 
+    List<House> findByArea(int area);
+
     @Find
     House findById(@By(ID) String parcel);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Residence.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Residence.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+/**
+ * Unannotated mapped superclass with embeddable
+ */
+public class Residence {
+
+    public Occupant occupant;
+
+    public boolean isOccupied;
+
+    public static class Occupant {
+        public String firstName;
+        public String lastName;
+    }
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Apartment extends Residence {
+
+    @Id
+    public long aptId;
+
+    @Embedded
+    public Bedroom quarters;
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment2.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment2.java
@@ -18,15 +18,15 @@ import jakarta.persistence.Id;
 
 /**
  * Entity with embeddable and mapped superclass
- * Entity has a field with a colliding non-delimited attribute name with embeddable
+ * Entity has a field with a colliding delimited attribute name with embeddable
  */
 @Entity
-public class Apartment extends Residence {
+public class Apartment2 extends Residence {
 
     @Id
     public long aptId;
 
-    public int quartersWidth;
+    public int quarters_width;
 
     @Embedded
     public Bedroom quarters;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment3.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment3.java
@@ -18,15 +18,15 @@ import jakarta.persistence.Id;
 
 /**
  * Entity with embeddable and mapped superclass
- * Entity has a field with a colliding non-delimited attribute name with embeddable
+ * Entity has a field with a colliding delimited attribute name with mapped superclass.
  */
 @Entity
-public class Apartment extends Residence {
+public class Apartment3 extends Residence {
 
     @Id
     public long aptId;
 
-    public int quartersWidth;
+    public boolean occupant_firstName;
 
     @Embedded
     public Bedroom quarters;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartments.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.List;
+
+import jakarta.data.Sort;
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface Apartments extends BasicRepository<Apartment, Long> {
+    @Delete
+    public void removeAll();
+
+    // Write queries using every possible persistence field name delimiter
+    // https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0#property-name-concatenation
+
+    // Parameter Name (_)
+    @Find
+    public List<Apartment> findApartmentsByBedroomWidth(int quarters_width);
+
+    // @By (_) (.)
+    @Find
+    public List<Apartment> findApartmentsByBedroom(@By("quarters_length") int length,
+                                                   @By("quarters.width") int width);
+
+    // @OrderBy (_) (.)
+    @Find
+    @OrderBy("quarters_length")
+    public List<Apartment> findAllOrderByBedroomLength();
+
+    @Find
+    @OrderBy("quarters.width")
+    public List<Apartment> findAllOrderByBedroomWidth();
+
+    // Query (.)
+    @Query("FROM Apartment WHERE quarters.length = ?1")
+    public List<Apartment> findApartmentsByBedroomLength(int length);
+
+    // Method Name (_) or no delimiter
+    public List<Apartment> findByQuarters_Width(int width);
+
+    public List<Apartment> findByQuartersLength(int length);
+
+    // Sort (_) (.)
+    @Find
+    public List<Apartment> findAllSorted(Sort<?> sort);
+
+    // Write query using mapped superclass field name
+    @Find
+    public List<Apartment> findByOccupied(@By("isOccupied") boolean state);
+
+    // Write query using embeddable in a mapped superclass
+    @Find
+    @OrderBy("occupant.firstName")
+    public List<Apartment> findByOccupantLastNameOrderByFirstName(@By("occupant_lastName") String lastName);
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartments.java
@@ -15,18 +15,21 @@ package test.jakarta.data.jpa.web;
 import java.util.List;
 
 import jakarta.data.Sort;
-import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
 
 @Repository
-public interface Apartments extends BasicRepository<Apartment, Long> {
+public interface Apartments {
     @Delete
     public void removeAll();
+
+    @Save
+    public List<Apartment> saveAll(List<Apartment> entities);
 
     // Write queries using every possible persistence field name delimiter
     // https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0#property-name-concatenation
@@ -70,4 +73,15 @@ public interface Apartments extends BasicRepository<Apartment, Long> {
     @Find
     @OrderBy("occupant.firstName")
     public List<Apartment> findByOccupantLastNameOrderByFirstName(@By("occupant_lastName") String lastName);
+
+    //  Write query using entity that has colliding non-delimited attribute name (quartersWidth)
+    @OrderBy("occupant.firstName")
+    public List<Apartment> findByQuartersWidth(int width);
+
+    // Write queries using entities that have colliding delimited attribute names
+    @Find
+    public List<Apartment2> findAllCollidingEmbeddable();
+
+    @Find
+    public List<Apartment3> findAllCollidingSuperclass();
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Bedroom.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Bedroom.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Bedroom {
+
+    public int width;
+
+    public int length;
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2932,6 +2932,11 @@ public class DataJPATestServlet extends FATServlet {
         drivers.deleteByFullNameEndsWith(" TestOneToOne");
     }
 
+    /**
+     * Tests entity attribute names from embeddables and MappedSuperclass that
+     * can have delimiters. Includes tests for name collisions with attributes from an
+     * embeddable or superinteface.
+     */
     @Test
     public void testPersistentFieldNamesAndDelimiters() {
         apartments.removeAll();

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2933,7 +2933,7 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     @Test
-    public void testPersistentFieldNamesWithDelimiters() {
+    public void testPersistentFieldNamesAndDelimiters() {
         apartments.removeAll();
 
         Apartment a101 = new Apartment();
@@ -2945,6 +2945,7 @@ public class DataJPATestServlet extends FATServlet {
         a101.quarters = new Bedroom();
         a101.quarters.length = 10;
         a101.quarters.width = 10;
+        a101.quartersWidth = 15;
 
         Apartment a102 = new Apartment();
         a102.occupant = new Occupant();
@@ -2955,6 +2956,7 @@ public class DataJPATestServlet extends FATServlet {
         a102.quarters = new Bedroom();
         a102.quarters.length = 11;
         a102.quarters.width = 11;
+        a102.quartersWidth = 15;
 
         Apartment a103 = new Apartment();
         a103.occupant = new Occupant();
@@ -2965,6 +2967,7 @@ public class DataJPATestServlet extends FATServlet {
         a103.quarters = new Bedroom();
         a103.quarters.length = 11;
         a103.quarters.width = 12;
+        a103.quartersWidth = 15;
 
         Apartment a104 = new Apartment();
         a104.occupant = new Occupant();
@@ -2975,6 +2978,7 @@ public class DataJPATestServlet extends FATServlet {
         a104.quarters = new Bedroom();
         a104.quarters.length = 12;
         a104.quarters.width = 11;
+        a104.quartersWidth = 15;
 
         apartments.saveAll(List.of(a101, a102, a103, a104));
 
@@ -3030,6 +3034,28 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals("Brian", results.get(1).occupant.firstName);
         assertEquals("Kyle", results.get(2).occupant.firstName);
         assertEquals("Scott", results.get(3).occupant.firstName);
+
+        // Colliding non-delimited attribute name quartersWidth, ensure we use entity attribute and not embedded attribute for query
+        results = apartments.findByQuartersWidth(15);
+        assertEquals(4, results.size());
+        assertEquals("Brent", results.get(0).occupant.firstName);
+        assertEquals("Brian", results.get(1).occupant.firstName);
+        assertEquals("Kyle", results.get(2).occupant.firstName);
+        assertEquals("Scott", results.get(3).occupant.firstName);
+
+        try {
+            apartments.findAllCollidingEmbeddable();
+            fail("Should not have been able to execute query on an entity with colliding attibute name from embeddable");
+        } catch (MappingException e) {
+            //expected
+        }
+
+        try {
+            apartments.findAllCollidingSuperclass();
+            fail("Should not have been able to execute query on an entity with colliding attibute name from superclass");
+        } catch (MappingException e) {
+            // expected
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Residence.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Residence.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public class Residence {
+
+    @Embedded
+    public Occupant occupant;
+
+    public boolean isOccupied;
+
+    @Embeddable
+    public static class Occupant {
+        public String firstName;
+        public String lastName;
+    }
+
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Handle and test the following scenarios: 
```java
public class Residence {
    public Occupant occupant;
    public boolean isOccupied;
    public static class Occupant {
        public String firstName;
        public String lastName;
    }
}
public class Apartment extends Residence {
    public long aptId;
    public int quartersWidth; // Warning - shadows the embedded class need to use delimited attribute name in query/order/sort
    public int quarters_width; // Failure - shadows the embedded class, user would be incapable of query/order/sort on embedded field
    public boolean occupant_firstName; // Failure - shadows the super-embedded class, user would be incapable of query/order/sort on super-embedded field
    public Bedroom quarters;
}
public class Bedroom {
    public int width;
    public int length;
}

```
