### PR TITLE
Issue #24916: Update ddlgen for future EntityManager builders

### DIFF
--- a/dev/build.image/publish/BETA_NOTICES
+++ b/dev/build.image/publish/BETA_NOTICES
@@ -2,11 +2,11 @@ Begin NOTICES AND INFORMATION FOR Open Liberty @LIBERTY_VERSION@
 Copyright 1999-2024 IBM Corporation and others
 This product includes software developed at
 The Open Liberty @LIBERTY_VERSION@ Project (https://openliberty.io/).
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TABLE OF CONTENTS
 
-THIS IBM NOTICES FILE CONSISTS OF THE FOLLOWING SECTIONS:
+THIS NOTICES FILE CONSISTS OF THE FOLLOWING SECTIONS:
 
 Apache License, Version 2.0 (APACHE V2)
 BSD 2 Clause license (BSD-2-CLAUSE)
@@ -28,34 +28,34 @@ The Program includes some or all of the following that IBM obtained
 under the Apache License, Version 2.0:
 
 @carbon/telemetry [telemetry-0.1.0.tgz],
-@swagger-api/apidom-ast [apidom-ast-0.99.2.tgz],
-@swagger-api/apidom-core [apidom-core-0.99.2.tgz],
-@swagger-api/apidom-error [apidom-error-0.99.0.tgz],
-@swagger-api/apidom-json-pointer [apidom-json-pointer-0.99.2.tgz],
-@swagger-api/apidom-ns-api-design-systems [apidom-ns-api-design-systems-0.99.2.tgz],
-@swagger-api/apidom-ns-asyncapi-2 [apidom-ns-asyncapi-2-0.99.2.tgz],
-@swagger-api/apidom-ns-json-schema-draft-4 [apidom-ns-json-schema-draft-4-0.99.2.tgz],
-@swagger-api/apidom-ns-json-schema-draft-6 [apidom-ns-json-schema-draft-6-0.99.2.tgz],
-@swagger-api/apidom-ns-json-schema-draft-7 [apidom-ns-json-schema-draft-7-0.99.2.tgz],
-@swagger-api/apidom-ns-openapi-2 [apidom-ns-openapi-2-0.99.2.tgz],
-@swagger-api/apidom-ns-openapi-3-0 [apidom-ns-openapi-3-0-0.99.2.tgz],
-@swagger-api/apidom-ns-openapi-3-1 [apidom-ns-openapi-3-1-0.99.2.tgz],
-@swagger-api/apidom-ns-workflows-1 [apidom-ns-workflows-1-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-api-design-systems-json [apidom-parser-adapter-api-design-systems-json-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-api-design-systems-yaml [apidom-parser-adapter-api-design-systems-yaml-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-asyncapi-json-2 [apidom-parser-adapter-asyncapi-json-2-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-asyncapi-yaml-2 [apidom-parser-adapter-asyncapi-yaml-2-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-json [apidom-parser-adapter-json-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-json-2 [apidom-parser-adapter-openapi-json-2-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-json-3-0 [apidom-parser-adapter-openapi-json-3-0-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-json-3-1 [apidom-parser-adapter-openapi-json-3-1-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-yaml-2 [apidom-parser-adapter-openapi-yaml-2-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-yaml-3-0 [apidom-parser-adapter-openapi-yaml-3-0-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-yaml-3-1 [apidom-parser-adapter-openapi-yaml-3-1-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-workflows-json-1 [apidom-parser-adapter-workflows-json-1-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-workflows-yaml-1 [apidom-parser-adapter-workflows-yaml-1-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-yaml-1-2 [apidom-parser-adapter-yaml-1-2-0.99.2.tgz],
-@swagger-api/apidom-reference [apidom-reference-0.99.2.tgz],
+@swagger-api/apidom-ast [apidom-ast-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-core [apidom-core-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-error [apidom-error-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-json-pointer [apidom-json-pointer-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-api-design-systems [apidom-ns-api-design-systems-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-asyncapi-2 [apidom-ns-asyncapi-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-json-schema-draft-4 [apidom-ns-json-schema-draft-4-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-json-schema-draft-6 [apidom-ns-json-schema-draft-6-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-json-schema-draft-7 [apidom-ns-json-schema-draft-7-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-openapi-2 [apidom-ns-openapi-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-openapi-3-0 [apidom-ns-openapi-3-0-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-openapi-3-1 [apidom-ns-openapi-3-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-workflows-1 [apidom-ns-workflows-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-api-design-systems-json [apidom-parser-adapter-api-design-systems-json-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-api-design-systems-yaml [apidom-parser-adapter-api-design-systems-yaml-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-asyncapi-json-2 [apidom-parser-adapter-asyncapi-json-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-asyncapi-yaml-2 [apidom-parser-adapter-asyncapi-yaml-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-json [apidom-parser-adapter-json-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-json-2 [apidom-parser-adapter-openapi-json-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-json-3-0 [apidom-parser-adapter-openapi-json-3-0-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-json-3-1 [apidom-parser-adapter-openapi-json-3-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-yaml-2 [apidom-parser-adapter-openapi-yaml-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-yaml-3-0 [apidom-parser-adapter-openapi-yaml-3-0-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-yaml-3-1 [apidom-parser-adapter-openapi-yaml-3-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-workflows-json-1 [apidom-parser-adapter-workflows-json-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-workflows-yaml-1 [apidom-parser-adapter-workflows-yaml-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-yaml-1-2 [apidom-parser-adapter-yaml-1-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-reference [apidom-reference-1.0.0-alpha.8.tgz],
 Apache Ant Core [ant], Apache Ant Launcher [ant-launcher],
 Apache Aries JMX API [org.apache.aries.jmx.api],
 Apache Aries JMX Core [org.apache.aries.jmx.core],
@@ -163,6 +163,7 @@ Kotlin Stdlib Jdk7 [kotlin-stdlib-jdk7], Kotlin Stdlib Jdk8 [kotlin-stdlib-jdk8]
 LRA Client [lra-client], LRA Proxy API [lra-proxy-api], LZ4 and xxHash [lz4-java],
 Metrics Core [metrics-core], MicroProfile Config API [microprofile-config-api],
 MicroProfile Context Propagation [microprofile-context-propagation-api],
+MicroProfile Fault Tolerance API [microprofile-fault-tolerance-api],
 MicroProfile GraphQL :: API [microprofile-graphql-api],
 MicroProfile Health API [microprofile-health-api],
 MicroProfile JWT Auth API [microprofile-jwt-auth-api],
@@ -213,6 +214,7 @@ OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-annotation
 OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-api],
 OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-api-incubator],
 OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-annotations-support],
+OpenTelemetry Instrumentation for Java [opentelemetry-resources],
 OpenTelemetry Java [opentelemetry-exporter-otlp-common],
 OpenTelemetry Java [opentelemetry-exporter-jaeger],
 OpenTelemetry Java [opentelemetry-context],
@@ -266,6 +268,11 @@ OpenTelemetry Java [opentelemetry-exporter-logging],
 OpenTelemetry Java [opentelemetry-sdk-extension-autoconfigure],
 OpenTelemetry Java [opentelemetry-sdk-extension-autoconfigure-spi],
 OpenTelemetry Java [opentelemetry-exporter-common],
+OpenTelemetry Java [opentelemetry-exporter-sender-okhttp],
+OpenTelemetry Java [opentelemetry-exporter-otlp],
+OpenTelemetry Java [opentelemetry-exporter-zipkin],
+OpenTelemetry Java [opentelemetry-exporter-otlp-common],
+OpenTelemetry Java [opentelemetry-extension-trace-propagators],
 OpenTelemetry Semantic Conventions Java [opentelemetry-semconv-incubating],
 OpenTelemetry Semantic Conventions Java [opentelemetry-semconv],
 OpenTracing API [opentracing-api], OpenTracing-noop [opentracing-noop],
@@ -336,7 +343,6 @@ acme4j Utils [acme4j-utils], asm, asm-analysis, asm-commons, asm-tree, asm-util,
 asyncutil, carbon-components [carbon-components-10.42.0-rc.0.min.js],
 carbon-components [carbon-components-10.58.3.tgz],
 classfilewriter [jboss-classfilewriter], detect-libc [detect-libc-2.0.3.tgz],
-dompurify [dompurify-3.1.2.tgz],
 error-prone annotations [error_prone_annotations], fastinfoset [FastInfoset],
 geronimo-annotation_1.1_spec, geronimo-ejb_3.1_spec-alt,
 geronimo-interceptor_1.1_spec, geronimo-validation, guice,
@@ -353,7 +359,8 @@ micrometer-registry-prometheus, microprofile-fault-tolerance-api,
 microprofile-metrics-api, microprofile-opentracing-api,
 microprofile-rest-client-api, nekohtml, okhttp, okio [okio-jvm], okio,
 okio [okio-jvm], okio,
-openapi-path-templating [openapi-path-templating-1.5.1.tgz],
+openapi-path-templating [openapi-path-templating-1.6.0.tgz],
+openapi-server-url-templating [openapi-server-url-templating-1.1.0.tgz],
 org.apache.aries.blueprint, org.apache.aries.jndi.core, org.apache.bval.bundle,
 org.osgi.core,
 org.osgi:org.osgi.annotation.versioning [org.osgi.annotation.versioning],
@@ -374,10 +381,10 @@ org.osgi:osgi.annotation [osgi.annotation], org.osgi:osgi.core [osgi.core],
 perfmark:perfmark-api [perfmark-api], proto-google-common-protos, resolver,
 short-unique-id [short-unique-id-5.2.0.tgz], smallrye-reactive-converter-api,
 smallrye-reactive-messaging-provider, smallrye-reactive-streams-operators,
-snappy-java, swagger-client [swagger-client-3.27.9.tgz],
-swagger-ui [swagger-ui-5.17.9.tgz], tomcat-el-api, tomcat-jasper-el,
+snappy-java, swagger-client [swagger-client-3.28.3.tgz],
+swagger-ui [swagger-ui-5.17.14.tgz], tomcat-el-api, tomcat-jasper-el,
 ts-toolbelt [ts-toolbelt-9.6.0.tgz], tunnel-agent [tunnel-agent-0.6.0.tgz],
-vertx-codegen, yoko-core, yoko-osgi, yoko-rmi-impl, yoko-rmi-spec,
+vertx-codegen,yoko-core, yoko-osgi, yoko-rmi-impl, yoko-rmi-spec,
 yoko-spec-corba, yoko-util
 
 
@@ -569,7 +576,7 @@ under the BSD 2 Clause license:
 HdrHistogram (Copyright 2012-2013 2014, 2015, 2016 Gil Tene) (Copyright 2014 Matt Warren) (Copyright 2014 Michael Barker)
 Stax2 API [stax2-api] (Copyright 2008 FasterXML LLC <info@fasterxml.com>)
 Stax2 API [stax2-api](Copyright Not Found)
-apg-lite [apg-lite-1.0.3.tgz] (Copyright 2023 Lowell D. Thomas<br>)
+apg-lite [apg-lite-1.0.4.tgz] (Copyright 2023 Lowell D. Thomas<br>)
 crac(Copyright Not Found)
 rc [rc-1.2.8.tgz] (Copyright 2011 Dominic Tarr) (Copyright 2013 Dominic Tarr)
 zstd-jni(Copyright Not Found)
@@ -709,8 +716,8 @@ istack common utility code tools [istack-commons-tools] (Copyright 1997-2022 Ora
 jakarta.xml.bind-api (Copyright 2017-2018 Oracle and/or its affiliates) (Copyright 2018 Oracle and/or its affiliates)
 management-api (Copyright 2007 Eclipse Foundation, Inc. and its licensors) (Copyright 2011-2020 Oracle and/or its affiliates) (Copyright 2018 Oracle and/or its affiliates)
 org.eclipse.persistence.core(Copyright Not Found)
-qs [qs-6.12.1.tgz] (Copyright 2014 Nathan LaFreniere and other "contributors" (https://github.com/ljharb/qs/graphs/contributors))
-ramda-adjunct [ramda-adjunct-5.0.0.tgz] (Copyright 2017-2019 Vladim)
+qs [qs-6.13.0.tgz] (Copyright 2014 Nathan LaFreniere and other "contributors" (https://github.com/ljharb/qs/graphs/contributors))
+ramda-adjunct [ramda-adjunct-5.0.1.tgz] (Copyright 2017-2019 Vladim)
 redux-immutable [redux-immutable-4.0.0.tgz] (Copyright 2016 Gajus Kuizinas (http://gajus.com/))
 relaxngDatatype(Copyright Not Found)
 sprintf-js [sprintf-js-1.0.3.tgz] (Copyright 2014 Alexandru Marasteanu)
@@ -836,7 +843,6 @@ Old JAXB XJC [jaxb-xjc] https://repo.maven.apache.org/maven2/com/sun/xml/bind/ja
 Streaming API for XML [stax-api] https://repo.maven.apache.org/maven2/javax/xml/stream/stax-api/1.0-2
 TXW2 Runtime [txw2] http://txw.java.net/
 WebSocket server API [javax.websocket-api] http://websocket-spec.java.net
-activation http://dist.wso2.org/maven2/javax/activation/activation/1.1
 istack common utility code runtime [istack-commons-runtime] https://repo.maven.apache.org/maven2/com/sun/istack/istack-commons-runtime/2.4
 javax.annotation API [javax.annotation-api] http://jcp.org/en/jsr/detail?id=250
 javax.ejb API [javax.ejb-api] http://ejb-spec.java.net
@@ -848,7 +854,6 @@ javax.ws.rs-api http://jax-rs-spec.java.net
 javax.ws.rs-api http://www.oracle.com/
 javax.xml.soap API [javax.xml.soap-api] https://javaee.github.io/javaee-spec/
 jdeparser http://www.jboss.org
-jsr181-api https://www.ebi.ac.uk/intact/maven/nexus/content/repositories/public/javax/jws/jsr181-api/1.0-MR1
 jsr181-api (https://github.com/javaee/javax.jws)
 policy http://policy.java.net/
 saaj-impl https://repo.maven.apache.org/maven2/com/sun/xml/messaging/saaj/saaj-impl/1.4.0
@@ -896,8 +901,6 @@ Console plug-in [org.eclipse.equinox.console] http://www.eclipse.org/platform
 Coordinator [org.eclipse.equinox.coordinator] http://www.eclipse.org/platform
 Eclipse Compiler for Java(TM) [ecj] http://www.eclipse.org/jdt
 Eclipse Compiler for Java(TM) [ecj] https://projects.eclipse.org/projects/eclipse.jdt
-Eclipse Parsson [parsson] https://repo.maven.apache.org/maven2/org/eclipse/parsson/parsson/1.1.0
-Eclipse Parsson [parsson] https://repo.maven.apache.org/maven2/org/eclipse/parsson/parsson/1.1.4
 EclipseLink ASM [org.eclipse.persistence.asm] http://www.eclipse.org/eclipselink
 EclipseLink Core [org.eclipse.persistence.core] http://www.eclipse.org/eclipselink
 EclipseLink Hermes Parser [org.eclipse.persistence.jpa.jpql] http://www.eclipse.org/eclipselink
@@ -941,7 +944,6 @@ OSGi System Bundle [org.eclipse.osgi] https://projects.eclipse.org/projects/ecli
 OSGi resource locator [osgi-resource-locator] https://repo.maven.apache.org/maven2/org/glassfish/hk2/osgi-resource-locator/1.0.3
 RESTEasy Tracing API [resteasy-tracing-api] https://resteasy.github.io/
 Region Digraph [org.eclipse.equinox.region] http://www.eclipse.org/platform
-Yasson [yasson] https://projects.eclipse.org/projects/ee4j.yasson
 che-lib7.0.0-rc-4.0 [che-lib] https://github.com/eclipse-che/che-lib.git
 jakarta.enterprise.concurrent-api https://github.com/eclipse-ee4j/concurrency-api
 jakarta.json (https://github.com/jakartaee/jsonp-api)
@@ -972,7 +974,7 @@ inherits [inherits-2.0.4.tgz] (Copyright Isaac Z. Schlueter and Contributors)
 ini [ini-1.3.8.tgz] (Copyright Isaac Z. Schlueter and Contributors)
 minimatch [minimatch-7.4.6.tgz] (Copyright 2011-2023 Isaac Z. Schlueter and Contributors)
 once [once-1.4.0.tgz] (Copyright Isaac Z. Schlueter and Contributors)
-semver [semver-7.6.2.tgz] (Copyright Isaac Z. Schlueter and Contributors) (Copyright Isaac Z. Schlueter and Contributors)
+semver [semver-7.6.3.tgz] (Copyright Isaac Z. Schlueter and Contributors) (Copyright Isaac Z. Schlueter and Contributors)
 wrappy [wrappy-1.0.2.tgz] (Copyright Isaac Z. Schlueter and Contributors)
 
 
@@ -999,11 +1001,11 @@ MIT license
 The Program includes some or all of the following that IBM obtained
 under the MIT license:
 
-@babel/runtime [runtime-7.24.5.tgz] (Copyright 2014 Sebastian McKenzie and other contributors)
-@babel/runtime-corejs3 [runtime-corejs3-7.24.5.tgz] (Copyright 2014 Sebastian McKenzie and other contributors)
-@braintree/sanitize-url [sanitize-url-7.0.1.tgz] (Copyright 2017 Braintree)
+@babel/runtime [runtime-7.25.0.tgz] (Copyright 2014 Sebastian McKenzie and other contributors)
+@babel/runtime-corejs3 [runtime-corejs3-7.25.0.tgz] (Copyright 2014 Sebastian McKenzie and other contributors)
+@braintree/sanitize-url [sanitize-url-7.0.2.tgz] (Copyright 2017 Braintree)
 @types/hast [hast-2.3.10.tgz] (Copyright Microsoft Corporation)
-@types/ramda [ramda-0.29.12.tgz] (Copyright Microsoft Corporation)
+@types/ramda [ramda-0.30.1.tgz] (Copyright Microsoft Corporation)
 @types/unist [unist-2.0.10.tgz] (Copyright Microsoft Corporation)
 @types/use-sync-external-store [use-sync-external-store-0.0.3.tgz] (Copyright Microsoft Corporation)
 Animal Sniffer Annotations [animal-sniffer-annotations] (Copyright 2009 codehaus.org)
@@ -1014,7 +1016,6 @@ SLF4J API Module [slf4j-api](Copyright Not Found)
 SLF4J JDK14 Binding [slf4j-jdk14](Copyright Not Found)
 argparse [argparse-1.0.10.tgz] (Copyright 2012 "Vitaly Puzrin" (https://github.com/puzrin)) (Copyright 2012 [Vitaly Puzrin](https://github.com/puzrin)) (Copyright 2012 by Vitaly Puzrin)
 autolinker [autolinker-3.16.2.tgz] (Copyright 2014 Gregory Jacobs (http://greg-jacobs.com))
-axios [axios-0.0.0.tgz](Copyright Not Found)
 balanced-match [balanced-match-1.0.2.tgz] (Copyright 2013 Julian Gruber <julian@juliangruber.com>)
 base64-js [base64-js-1.5.1.tgz] (Copyright 2014 Jameson Little)
 bl [bl-4.1.0.tgz] (Copyright 2013-2019 bl contributors)
@@ -1030,8 +1031,8 @@ classnames [classnames-2.5.1.tgz] (Copyright 2018 Jed Watson)
 comma-separated-tokens [comma-separated-tokens-1.0.8.tgz] (Copyright 2016 Titus Wormer <tituswormer@gmail.com>)
 cookie [cookie-0.6.0.tgz] (Copyright 2012-2014 Roman Shtylman <shtylman@gmail.com>) (Copyright 2015 Douglas Christopher Wilson <doug@somethingdoug.com>)
 copy-to-clipboard [copy-to-clipboard-3.3.3.tgz] (Copyright 2017 sudodoki <smd.deluzion@gmail.com>)
-core-js [core-js-3.37.1.tgz] (Copyright 2014-2024 Denis Pushkarev)
-core-js-pure [core-js-pure-3.37.1.tgz] (Copyright 2014-2024 Denis Pushkarev)
+core-js [core-js-3.38.0.tgz] (Copyright 2014-2024 Denis Pushkarev)
+core-js-pure [core-js-pure-3.38.0.tgz] (Copyright 2014-2024 Denis Pushkarev)
 crypto-js [enc-base64-min-3.1.2.js] (Copyright 2009-2013 by Jeff Mott)
 crypto-js [sha256-3.1.2.js] (Copyright 2009-2013 by Jeff Mott)
 css.escape [css.escape-1.5.1.tgz] (Copyright Mathias Bynens <https://mathiasbynens.be/>)
@@ -1066,7 +1067,6 @@ is-alphabetical [is-alphabetical-1.0.4.tgz] (Copyright 2016 Titus Wormer <titusw
 is-alphanumerical [is-alphanumerical-1.0.4.tgz] (Copyright 2016 Titus Wormer <tituswormer@gmail.com>)
 is-decimal [is-decimal-1.0.4.tgz] (Copyright 2016 Titus Wormer <tituswormer@gmail.com>)
 is-hexadecimal [is-hexadecimal-1.0.4.tgz] (Copyright 2016 Titus Wormer <tituswormer@gmail.com>)
-is-plain-object [is-plain-object-5.0.0.tgz] (Copyright 2014-2017 Jon Schlinkert) (Copyright 2019 "Jon Schlinkert" (https://github.com/jonschlinkert))
 jquery [jquery-3.5.1.min.js] (Copyright 2020 OpenJS Foundation and jQuery contributors)
 jquery [jquery-3.6.3.tgz] (Copyright OpenJS Foundation and other contributors, https://openjsf.org/) (Copyright jQuery Foundation and other contributors, https://jquery.org/)
 js-file-download [js-file-download-0.4.12.tgz] (Copyright 2017 Kenneth Jiang)
@@ -1080,24 +1080,22 @@ mimic-response [mimic-response-3.1.0.tgz] (Copyright Sindre Sorhus <sindresorhus
 minim [minim-0.23.8.tgz] (Copyright 2014 Stephen Mizell)
 minimist [minimist-1.2.8.tgz](Copyright Not Found)
 mkdirp-classic [mkdirp-classic-0.5.3.tgz] (Copyright 2020 James Halliday (mail@substack.net) and Mathias Buus)
-nan [nan-2.19.0.tgz] (Copyright 2018 NAN WG Members / Collaborators (listed above)) (Copyright 2018 NAN contributors" (https://github.com/nodejs/nan#wg-members--collaborators)) (Copyright The contribution was provided directly to me by some other) (Copyright and I have not modified)
+nan [nan-2.20.0.tgz] (Copyright 2018 NAN WG Members / Collaborators (listed above)) (Copyright 2018 NAN contributors" (https://github.com/nodejs/nan#wg-members--collaborators)) (Copyright The contribution was provided directly to me by some other) (Copyright and I have not modified)
 napi-build-utils [napi-build-utils-1.0.2.tgz] (Copyright 2018 inspiredware)
-node-abi [node-abi-3.62.0.tgz] (Copyright 2016 Lukas Geiger)
+node-abi [node-abi-3.65.0.tgz] (Copyright 2016 Lukas Geiger)
 node-abort-controller [node-abort-controller-3.1.1.tgz] (Copyright 2019 Steve Faulkner)
 node-domexception [node-domexception-1.0.0.tgz] (Copyright 2021 Jimmy WÃ¤rting)
 node-fetch-commonjs [node-fetch-commonjs-3.3.2.tgz] (Copyright 2016-2020 Node Fetch Team)
 object-assign [object-assign-4.1.1.tgz] (Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com))
-object-inspect [object-inspect-1.13.1.tgz] (Copyright 2013 James Halliday)
+object-inspect [object-inspect-1.13.2.tgz] (Copyright 2013 James Halliday)
 parse-entities [parse-entities-2.0.0.tgz] (Copyright 2015 Titus Wormer <mailto:tituswormer@gmail.com>)
 prebuild-install [prebuild-install-7.1.2.tgz] (Copyright 2015 Mathias Buus)
-prismjs [prismjs-1.27.0.tgz] (Copyright 2012 Lea Verou)
-prismjs [prismjs-1.29.0.tgz] (Copyright 2012 Lea Verou)
 process [process-0.11.10.tgz] (Copyright 2013 Roman Shtylman <shtylman@gmail.com>)
 prop-types [prop-types-15.8.1.tgz] (Copyright 2013 Facebook, Inc)
 property-information [property-information-5.6.0.tgz] (Copyright 2013-2015 Facebook, Inc) (Copyright 2015 Titus Wormer <mailto:tituswormer@gmail.com>)
 pump [pump-3.0.0.tgz] (Copyright 2014 Mathias Buus)
 querystringify [querystringify-2.2.0.tgz] (Copyright 2015 Unshift.io, Arnout Kazemier,  the Contributors)
-ramda [ramda-0.30.0.tgz] (Copyright 2013-2024 Scott Sauyet and Michael Hurley) (Copyright 2014 J. C. Phillipps)
+ramda [ramda-0.30.1.tgz] (Copyright 2013-2024 Scott Sauyet and Michael Hurley) (Copyright 2014 J. C. Phillipps)
 randexp [randexp-0.5.3.tgz] (Copyright 2011 by fent)
 randombytes [randombytes-2.1.0.tgz] (Copyright 2017 crypto-browserify)
 react [react-18.3.1.tgz] (Copyright Facebook, Inc. and its affiliates)
@@ -1119,7 +1117,7 @@ remarkable [remarkable-2.0.1.tgz] (Copyright 2014 Jon Schlinkert, Vitaly Puzrin)
 repeat-string [repeat-string-1.6.1.tgz] (Copyright 2014-2015 Jon Schlinkert) (Copyright 2014-2016 Jon Schlinkert) (Copyright 2016 "Jon Schlinkert" (http://github.com/jonschlinkert)) (Copyright 2016 [Jon Schlinkert](http://github.com/jonschlinkert))
 require.js [require-2.1.15.min.js](Copyright Not Found)
 requires-port [requires-port-1.0.0.tgz] (Copyright 2015 Unshift.io, Arnout Kazemier,  the Contributors)
-reselect [reselect-5.1.0.tgz] (Copyright 2015-2018 Reselect Contributors)
+reselect [reselect-5.1.1.tgz] (Copyright 2015-2018 Reselect Contributors)
 ret [ret-0.2.2.tgz] (Copyright 2011 by fent)
 safe-buffer [safe-buffer-5.2.1.tgz] (Copyright Feross Aboukhadijeh)
 scheduler [scheduler-0.23.2.tgz] (Copyright Facebook, Inc. and its affiliates)
@@ -1130,7 +1128,6 @@ side-channel [side-channel-1.0.6.tgz] (Copyright 2019 Jordan Harband)
 simple-concat [simple-concat-1.0.1.tgz] (Copyright Feross Aboukhadijeh)
 simple-get [simple-get-4.0.1.tgz] (Copyright Feross Aboukhadijeh)
 space-separated-tokens [space-separated-tokens-1.1.5.tgz] (Copyright 2016 Titus Wormer <tituswormer@gmail.com>)
-stampit [stampit-4.3.2.tgz] (Copyright 2013 Eric Elliott)
 stream-browserify [stream-browserify-3.0.0.tgz] (Copyright James Halliday)
 string_decoder [string_decoder-1.3.0.tgz] (Copyright Node.js contributors)
 strip-json-comments [strip-json-comments-2.0.1.tgz] (Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com))
@@ -1143,7 +1140,7 @@ tree-sitter-json [tree-sitter-json-0.20.2.tgz] (Copyright 2014 Max Brunsfeld)
 tree-sitter-yaml [tree-sitter-yaml-0.5.0.tgz] (Copyright Ika <ikatyang@gmail.com> (https://github.com/ikatyang))
 ts-mixer [ts-mixer-6.0.4.tgz] (Copyright 2024 Tanner Nielsen)
 type-fest [type-fest-0.20.2.tgz] (Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:/sindresorhus.com))
-types-ramda [types-ramda-0.29.10.tgz] (Copyright 2013-2023 Scott Sauyet and Michael Hurley)
+types-ramda [types-ramda-0.30.1.tgz] (Copyright 2013-2023 Scott Sauyet and Michael Hurley)
 unraw [unraw-3.0.0.tgz] (Copyright 2019 Ian Sanders)
 url-parse [url-parse-1.5.10.tgz] (Copyright 2015 Unshift.io, Arnout Kazemier,  the Contributors)
 use-sync-external-store [use-sync-external-store-1.2.2.tgz] (Copyright Facebook, Inc. and its affiliates)
@@ -1337,7 +1334,6 @@ END OF Python License, Version 2 NOTICES AND INFORMATION
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 END OF THE OPEN LIBERTY BETA PROJECT NOTICES AND INFORMATION
-
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 END OF NOTICES AND INFORMATION FILE

--- a/dev/build.image/publish/NOTICES
+++ b/dev/build.image/publish/NOTICES
@@ -6,7 +6,7 @@ The Open Liberty @LIBERTY_VERSION@ Project (https://openliberty.io/).
 
 TABLE OF CONTENTS
 
-THIS IBM NOTICES FILE CONSISTS OF THE FOLLOWING SECTIONS:
+THIS NOTICES FILE CONSISTS OF THE FOLLOWING SECTIONS:
 
 Apache License, Version 2.0 (APACHE V2)
 BSD 2 Clause license (BSD-2-CLAUSE)
@@ -28,34 +28,34 @@ The Program includes some or all of the following that IBM obtained
 under the Apache License, Version 2.0:
 
 @carbon/telemetry [telemetry-0.1.0.tgz],
-@swagger-api/apidom-ast [apidom-ast-0.99.2.tgz],
-@swagger-api/apidom-core [apidom-core-0.99.2.tgz],
-@swagger-api/apidom-error [apidom-error-0.99.0.tgz],
-@swagger-api/apidom-json-pointer [apidom-json-pointer-0.99.2.tgz],
-@swagger-api/apidom-ns-api-design-systems [apidom-ns-api-design-systems-0.99.2.tgz],
-@swagger-api/apidom-ns-asyncapi-2 [apidom-ns-asyncapi-2-0.99.2.tgz],
-@swagger-api/apidom-ns-json-schema-draft-4 [apidom-ns-json-schema-draft-4-0.99.2.tgz],
-@swagger-api/apidom-ns-json-schema-draft-6 [apidom-ns-json-schema-draft-6-0.99.2.tgz],
-@swagger-api/apidom-ns-json-schema-draft-7 [apidom-ns-json-schema-draft-7-0.99.2.tgz],
-@swagger-api/apidom-ns-openapi-2 [apidom-ns-openapi-2-0.99.2.tgz],
-@swagger-api/apidom-ns-openapi-3-0 [apidom-ns-openapi-3-0-0.99.2.tgz],
-@swagger-api/apidom-ns-openapi-3-1 [apidom-ns-openapi-3-1-0.99.2.tgz],
-@swagger-api/apidom-ns-workflows-1 [apidom-ns-workflows-1-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-api-design-systems-json [apidom-parser-adapter-api-design-systems-json-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-api-design-systems-yaml [apidom-parser-adapter-api-design-systems-yaml-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-asyncapi-json-2 [apidom-parser-adapter-asyncapi-json-2-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-asyncapi-yaml-2 [apidom-parser-adapter-asyncapi-yaml-2-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-json [apidom-parser-adapter-json-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-json-2 [apidom-parser-adapter-openapi-json-2-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-json-3-0 [apidom-parser-adapter-openapi-json-3-0-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-json-3-1 [apidom-parser-adapter-openapi-json-3-1-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-yaml-2 [apidom-parser-adapter-openapi-yaml-2-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-yaml-3-0 [apidom-parser-adapter-openapi-yaml-3-0-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-openapi-yaml-3-1 [apidom-parser-adapter-openapi-yaml-3-1-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-workflows-json-1 [apidom-parser-adapter-workflows-json-1-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-workflows-yaml-1 [apidom-parser-adapter-workflows-yaml-1-0.99.2.tgz],
-@swagger-api/apidom-parser-adapter-yaml-1-2 [apidom-parser-adapter-yaml-1-2-0.99.2.tgz],
-@swagger-api/apidom-reference [apidom-reference-0.99.2.tgz],
+@swagger-api/apidom-ast [apidom-ast-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-core [apidom-core-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-error [apidom-error-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-json-pointer [apidom-json-pointer-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-api-design-systems [apidom-ns-api-design-systems-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-asyncapi-2 [apidom-ns-asyncapi-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-json-schema-draft-4 [apidom-ns-json-schema-draft-4-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-json-schema-draft-6 [apidom-ns-json-schema-draft-6-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-json-schema-draft-7 [apidom-ns-json-schema-draft-7-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-openapi-2 [apidom-ns-openapi-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-openapi-3-0 [apidom-ns-openapi-3-0-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-openapi-3-1 [apidom-ns-openapi-3-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-ns-workflows-1 [apidom-ns-workflows-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-api-design-systems-json [apidom-parser-adapter-api-design-systems-json-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-api-design-systems-yaml [apidom-parser-adapter-api-design-systems-yaml-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-asyncapi-json-2 [apidom-parser-adapter-asyncapi-json-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-asyncapi-yaml-2 [apidom-parser-adapter-asyncapi-yaml-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-json [apidom-parser-adapter-json-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-json-2 [apidom-parser-adapter-openapi-json-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-json-3-0 [apidom-parser-adapter-openapi-json-3-0-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-json-3-1 [apidom-parser-adapter-openapi-json-3-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-yaml-2 [apidom-parser-adapter-openapi-yaml-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-yaml-3-0 [apidom-parser-adapter-openapi-yaml-3-0-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-openapi-yaml-3-1 [apidom-parser-adapter-openapi-yaml-3-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-workflows-json-1 [apidom-parser-adapter-workflows-json-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-workflows-yaml-1 [apidom-parser-adapter-workflows-yaml-1-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-parser-adapter-yaml-1-2 [apidom-parser-adapter-yaml-1-2-1.0.0-alpha.8.tgz],
+@swagger-api/apidom-reference [apidom-reference-1.0.0-alpha.8.tgz],
 Apache Ant Core [ant], Apache Ant Launcher [ant-launcher],
 Apache Aries JMX API [org.apache.aries.jmx.api],
 Apache Aries JMX Core [org.apache.aries.jmx.core],
@@ -200,6 +200,13 @@ OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-api-semcon
 OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-api],
 OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-annotations-support],
 OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-annotations],
+OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-api-semconv],
+OpenTelemetry Instrumentation for Java [opentelemetry-runtime-telemetry-java8],
+OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-annotations],
+OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-api],
+OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-api-incubator],
+OpenTelemetry Instrumentation for Java [opentelemetry-instrumentation-annotations-support],
+OpenTelemetry Instrumentation for Java [opentelemetry-resources],
 OpenTelemetry Java [opentelemetry-exporter-otlp-common],
 OpenTelemetry Java [opentelemetry-exporter-jaeger],
 OpenTelemetry Java [opentelemetry-context],
@@ -240,6 +247,25 @@ OpenTelemetry Java [opentelemetry-exporter-logging],
 OpenTelemetry Java [opentelemetry-exporter-zipkin],
 OpenTelemetry Java [opentelemetry-context],
 OpenTelemetry Java [opentelemetry-api],
+OpenTelemetry Java [opentelemetry-extension-incubator],
+OpenTelemetry Java [opentelemetry-context],
+OpenTelemetry Java [opentelemetry-api],
+OpenTelemetry Java [opentelemetry-api-incubator],
+OpenTelemetry Java [opentelemetry-sdk-logs],
+OpenTelemetry Java [opentelemetry-sdk-common],
+OpenTelemetry Java [opentelemetry-sdk-trace],
+OpenTelemetry Java [opentelemetry-sdk-metrics],
+OpenTelemetry Java [opentelemetry-sdk],
+OpenTelemetry Java [opentelemetry-exporter-logging],
+OpenTelemetry Java [opentelemetry-sdk-extension-autoconfigure],
+OpenTelemetry Java [opentelemetry-sdk-extension-autoconfigure-spi],
+OpenTelemetry Java [opentelemetry-exporter-common],
+OpenTelemetry Java [opentelemetry-exporter-sender-okhttp],
+OpenTelemetry Java [opentelemetry-exporter-otlp],
+OpenTelemetry Java [opentelemetry-exporter-zipkin],
+OpenTelemetry Java [opentelemetry-exporter-otlp-common],
+OpenTelemetry Java [opentelemetry-extension-trace-propagators],
+OpenTelemetry Semantic Conventions Java [opentelemetry-semconv-incubating],
 OpenTelemetry Semantic Conventions Java [opentelemetry-semconv],
 OpenTracing API [opentracing-api], OpenTracing-noop [opentracing-noop],
 OpenTracing-util [opentracing-util], Prometheus Java Simpleclient [simpleclient],
@@ -307,7 +333,6 @@ acme4j Utils [acme4j-utils], asm, asm-analysis, asm-commons, asm-tree, asm-util,
 asyncutil, carbon-components [carbon-components-10.42.0-rc.0.min.js],
 carbon-components [carbon-components-10.58.3.tgz],
 classfilewriter [jboss-classfilewriter], detect-libc [detect-libc-2.0.3.tgz],
-dompurify [dompurify-3.1.2.tgz],
 error-prone annotations [error_prone_annotations], fastinfoset [FastInfoset],
 geronimo-annotation_1.1_spec, geronimo-ejb_3.1_spec-alt,
 geronimo-interceptor_1.1_spec, geronimo-validation, guice,
@@ -324,7 +349,8 @@ micrometer-registry-prometheus, microprofile-fault-tolerance-api,
 microprofile-metrics-api, microprofile-opentracing-api,
 microprofile-rest-client-api, nekohtml, okhttp, okio [okio-jvm], okio,
 okio [okio-jvm], okio,
-openapi-path-templating [openapi-path-templating-1.5.1.tgz],
+openapi-path-templating [openapi-path-templating-1.6.0.tgz],
+openapi-server-url-templating [openapi-server-url-templating-1.1.0.tgz],
 org.apache.aries.blueprint, org.apache.aries.jndi.core, org.apache.bval.bundle,
 org.osgi.core,
 org.osgi:org.osgi.annotation.versioning [org.osgi.annotation.versioning],
@@ -345,12 +371,11 @@ org.osgi:osgi.annotation [osgi.annotation], org.osgi:osgi.core [osgi.core],
 perfmark:perfmark-api [perfmark-api], proto-google-common-protos, resolver,
 short-unique-id [short-unique-id-5.2.0.tgz], smallrye-reactive-converter-api,
 smallrye-reactive-messaging-provider, smallrye-reactive-streams-operators,
-snappy-java, swagger-client [swagger-client-3.27.9.tgz],
-swagger-ui [swagger-ui-5.17.9.tgz], tomcat-el-api, tomcat-jasper-el,
+snappy-java, swagger-client [swagger-client-3.28.3.tgz],
+swagger-ui [swagger-ui-5.17.14.tgz], tomcat-el-api, tomcat-jasper-el,
 ts-toolbelt [ts-toolbelt-9.6.0.tgz], tunnel-agent [tunnel-agent-0.6.0.tgz],
 vertx-codegen, yoko-core, yoko-osgi, yoko-rmi-impl, yoko-rmi-spec,
 yoko-spec-corba, yoko-util
-
 
 Apache License
 Version 2.0, January 2004
@@ -540,7 +565,7 @@ under the BSD 2 Clause license:
 HdrHistogram (Copyright 2012-2013 2014, 2015, 2016 Gil Tene) (Copyright 2014 Matt Warren) (Copyright 2014 Michael Barker)
 Stax2 API [stax2-api] (Copyright 2008 FasterXML LLC <info@fasterxml.com>)
 Stax2 API [stax2-api](Copyright Not Found)
-apg-lite [apg-lite-1.0.3.tgz] (Copyright 2023 Lowell D. Thomas<br>)
+apg-lite [apg-lite-1.0.4.tgz] (Copyright 2023 Lowell D. Thomas<br>)
 crac(Copyright Not Found)
 rc [rc-1.2.8.tgz] (Copyright 2011 Dominic Tarr) (Copyright 2013 Dominic Tarr)
 zstd-jni(Copyright Not Found)
@@ -679,8 +704,8 @@ istack common utility code tools [istack-commons-tools] (Copyright 1997-2022 Ora
 jakarta.xml.bind-api (Copyright 2017-2018 Oracle and/or its affiliates) (Copyright 2018 Oracle and/or its affiliates)
 management-api (Copyright 2007 Eclipse Foundation, Inc. and its licensors) (Copyright 2011-2020 Oracle and/or its affiliates) (Copyright 2018 Oracle and/or its affiliates)
 org.eclipse.persistence.core(Copyright Not Found)
-qs [qs-6.12.1.tgz] (Copyright 2014 Nathan LaFreniere and other "contributors" (https://github.com/ljharb/qs/graphs/contributors))
-ramda-adjunct [ramda-adjunct-5.0.0.tgz] (Copyright 2017-2019 Vladim)
+qs [qs-6.13.0.tgz] (Copyright 2014 Nathan LaFreniere and other "contributors" (https://github.com/ljharb/qs/graphs/contributors))
+ramda-adjunct [ramda-adjunct-5.0.1.tgz] (Copyright 2017-2019 Vladim)
 redux-immutable [redux-immutable-4.0.0.tgz] (Copyright 2016 Gajus Kuizinas (http://gajus.com/))
 relaxngDatatype(Copyright Not Found)
 sprintf-js [sprintf-js-1.0.3.tgz] (Copyright 2014 Alexandru Marasteanu)
@@ -793,6 +818,7 @@ Java EE Security API [javax.security.enterprise-api] https://repo.maven.apache.o
 Java Servlet API [javax.servlet-api] http://servlet-spec.java.net
 Java Servlet API [javax.servlet-api] https://javaee.github.io/servlet-spec/
 Java(TM) EE Interceptors 1.2 API [jboss-interceptors-api_1.2_spec] http://www.jboss.org
+JavaBeans Activation Framework (JAF) [activation] http://java.sun.com/products/javabeans/jaf/index.jsp
 JavaBeans Activation Framework [javax.activation] https://repo.maven.apache.org/maven2/com/sun/activation/javax.activation/1.2.0
 JavaMail API [javax.mail] http://javaee.github.io/javamail
 JavaMail API [javax.mail] http://javamail.java.net
@@ -805,7 +831,6 @@ Old JAXB XJC [jaxb-xjc] https://repo.maven.apache.org/maven2/com/sun/xml/bind/ja
 Streaming API for XML [stax-api] https://repo.maven.apache.org/maven2/javax/xml/stream/stax-api/1.0-2
 TXW2 Runtime [txw2] http://txw.java.net/
 WebSocket server API [javax.websocket-api] http://websocket-spec.java.net
-activation http://dist.wso2.org/maven2/javax/activation/activation/1.1
 istack common utility code runtime [istack-commons-runtime] https://repo.maven.apache.org/maven2/com/sun/istack/istack-commons-runtime/2.4
 javax.annotation API [javax.annotation-api] http://jcp.org/en/jsr/detail?id=250
 javax.ejb API [javax.ejb-api] http://ejb-spec.java.net
@@ -864,8 +889,6 @@ Console plug-in [org.eclipse.equinox.console] http://www.eclipse.org/platform
 Coordinator [org.eclipse.equinox.coordinator] http://www.eclipse.org/platform
 Eclipse Compiler for Java(TM) [ecj] http://www.eclipse.org/jdt
 Eclipse Compiler for Java(TM) [ecj] https://projects.eclipse.org/projects/eclipse.jdt
-Eclipse Parsson [parsson] https://repo.maven.apache.org/maven2/org/eclipse/parsson/parsson/1.1.0
-Eclipse Parsson [parsson] https://repo.maven.apache.org/maven2/org/eclipse/parsson/parsson/1.1.4
 EclipseLink ASM [org.eclipse.persistence.asm] http://www.eclipse.org/eclipselink
 EclipseLink Core [org.eclipse.persistence.core] http://www.eclipse.org/eclipselink
 EclipseLink Hermes Parser [org.eclipse.persistence.jpa.jpql] http://www.eclipse.org/eclipselink
@@ -909,7 +932,6 @@ OSGi System Bundle [org.eclipse.osgi] https://projects.eclipse.org/projects/ecli
 OSGi resource locator [osgi-resource-locator] https://repo.maven.apache.org/maven2/org/glassfish/hk2/osgi-resource-locator/1.0.3
 RESTEasy Tracing API [resteasy-tracing-api] https://resteasy.github.io/
 Region Digraph [org.eclipse.equinox.region] http://www.eclipse.org/platform
-Yasson [yasson] https://projects.eclipse.org/projects/ee4j.yasson
 che-lib7.0.0-rc-4.0 [che-lib] https://github.com/eclipse-che/che-lib.git
 jakarta.enterprise.concurrent-api https://github.com/eclipse-ee4j/concurrency-api
 jakarta.json (https://github.com/jakartaee/jsonp-api)
@@ -926,7 +948,6 @@ org.eclipse.persistence.jpa (https://github.com/jakartaee/persistence)
 org.eclipse.yasson [yasson] https://projects.eclipse.org/projects/ee4j.yasson
 
 
-
 END OF ECLIPSE PUBLIC LICENSE, VERSION 2 NOTICES AND INFORMATION
 
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -940,7 +961,7 @@ inherits [inherits-2.0.4.tgz] (Copyright Isaac Z. Schlueter and Contributors)
 ini [ini-1.3.8.tgz] (Copyright Isaac Z. Schlueter and Contributors)
 minimatch [minimatch-7.4.6.tgz] (Copyright 2011-2023 Isaac Z. Schlueter and Contributors)
 once [once-1.4.0.tgz] (Copyright Isaac Z. Schlueter and Contributors)
-semver [semver-7.6.2.tgz] (Copyright Isaac Z. Schlueter and Contributors) (Copyright Isaac Z. Schlueter and Contributors)
+semver [semver-7.6.3.tgz] (Copyright Isaac Z. Schlueter and Contributors) (Copyright Isaac Z. Schlueter and Contributors)
 wrappy [wrappy-1.0.2.tgz] (Copyright Isaac Z. Schlueter and Contributors)
 
 
@@ -967,11 +988,11 @@ MIT license
 The Program includes some or all of the following that IBM obtained
 under the MIT license:
 
-@babel/runtime [runtime-7.24.5.tgz] (Copyright 2014 Sebastian McKenzie and other contributors)
-@babel/runtime-corejs3 [runtime-corejs3-7.24.5.tgz] (Copyright 2014 Sebastian McKenzie and other contributors)
-@braintree/sanitize-url [sanitize-url-7.0.1.tgz] (Copyright 2017 Braintree)
+@babel/runtime [runtime-7.25.0.tgz] (Copyright 2014 Sebastian McKenzie and other contributors)
+@babel/runtime-corejs3 [runtime-corejs3-7.25.0.tgz] (Copyright 2014 Sebastian McKenzie and other contributors)
+@braintree/sanitize-url [sanitize-url-7.0.2.tgz] (Copyright 2017 Braintree)
 @types/hast [hast-2.3.10.tgz] (Copyright Microsoft Corporation)
-@types/ramda [ramda-0.29.12.tgz] (Copyright Microsoft Corporation)
+@types/ramda [ramda-0.30.1.tgz] (Copyright Microsoft Corporation)
 @types/unist [unist-2.0.10.tgz] (Copyright Microsoft Corporation)
 @types/use-sync-external-store [use-sync-external-store-0.0.3.tgz] (Copyright Microsoft Corporation)
 Animal Sniffer Annotations [animal-sniffer-annotations] (Copyright 2009 codehaus.org)
@@ -982,7 +1003,6 @@ SLF4J API Module [slf4j-api](Copyright Not Found)
 SLF4J JDK14 Binding [slf4j-jdk14](Copyright Not Found)
 argparse [argparse-1.0.10.tgz] (Copyright 2012 "Vitaly Puzrin" (https://github.com/puzrin)) (Copyright 2012 [Vitaly Puzrin](https://github.com/puzrin)) (Copyright 2012 by Vitaly Puzrin)
 autolinker [autolinker-3.16.2.tgz] (Copyright 2014 Gregory Jacobs (http://greg-jacobs.com))
-axios [axios-0.0.0.tgz](Copyright Not Found)
 balanced-match [balanced-match-1.0.2.tgz] (Copyright 2013 Julian Gruber <julian@juliangruber.com>)
 base64-js [base64-js-1.5.1.tgz] (Copyright 2014 Jameson Little)
 bl [bl-4.1.0.tgz] (Copyright 2013-2019 bl contributors)
@@ -998,8 +1018,8 @@ classnames [classnames-2.5.1.tgz] (Copyright 2018 Jed Watson)
 comma-separated-tokens [comma-separated-tokens-1.0.8.tgz] (Copyright 2016 Titus Wormer <tituswormer@gmail.com>)
 cookie [cookie-0.6.0.tgz] (Copyright 2012-2014 Roman Shtylman <shtylman@gmail.com>) (Copyright 2015 Douglas Christopher Wilson <doug@somethingdoug.com>)
 copy-to-clipboard [copy-to-clipboard-3.3.3.tgz] (Copyright 2017 sudodoki <smd.deluzion@gmail.com>)
-core-js [core-js-3.37.1.tgz] (Copyright 2014-2024 Denis Pushkarev)
-core-js-pure [core-js-pure-3.37.1.tgz] (Copyright 2014-2024 Denis Pushkarev)
+core-js [core-js-3.38.0.tgz] (Copyright 2014-2024 Denis Pushkarev)
+core-js-pure [core-js-pure-3.38.0.tgz] (Copyright 2014-2024 Denis Pushkarev)
 crypto-js [enc-base64-min-3.1.2.js] (Copyright 2009-2013 by Jeff Mott)
 crypto-js [sha256-3.1.2.js] (Copyright 2009-2013 by Jeff Mott)
 css.escape [css.escape-1.5.1.tgz] (Copyright Mathias Bynens <https://mathiasbynens.be/>)
@@ -1034,7 +1054,6 @@ is-alphabetical [is-alphabetical-1.0.4.tgz] (Copyright 2016 Titus Wormer <titusw
 is-alphanumerical [is-alphanumerical-1.0.4.tgz] (Copyright 2016 Titus Wormer <tituswormer@gmail.com>)
 is-decimal [is-decimal-1.0.4.tgz] (Copyright 2016 Titus Wormer <tituswormer@gmail.com>)
 is-hexadecimal [is-hexadecimal-1.0.4.tgz] (Copyright 2016 Titus Wormer <tituswormer@gmail.com>)
-is-plain-object [is-plain-object-5.0.0.tgz] (Copyright 2014-2017 Jon Schlinkert) (Copyright 2019 "Jon Schlinkert" (https://github.com/jonschlinkert))
 jquery [jquery-3.5.1.min.js] (Copyright 2020 OpenJS Foundation and jQuery contributors)
 jquery [jquery-3.6.3.tgz] (Copyright OpenJS Foundation and other contributors, https://openjsf.org/) (Copyright jQuery Foundation and other contributors, https://jquery.org/)
 js-file-download [js-file-download-0.4.12.tgz] (Copyright 2017 Kenneth Jiang)
@@ -1048,24 +1067,22 @@ mimic-response [mimic-response-3.1.0.tgz] (Copyright Sindre Sorhus <sindresorhus
 minim [minim-0.23.8.tgz] (Copyright 2014 Stephen Mizell)
 minimist [minimist-1.2.8.tgz](Copyright Not Found)
 mkdirp-classic [mkdirp-classic-0.5.3.tgz] (Copyright 2020 James Halliday (mail@substack.net) and Mathias Buus)
-nan [nan-2.19.0.tgz] (Copyright 2018 NAN WG Members / Collaborators (listed above)) (Copyright 2018 NAN contributors" (https://github.com/nodejs/nan#wg-members--collaborators)) (Copyright The contribution was provided directly to me by some other) (Copyright and I have not modified)
+nan [nan-2.20.0.tgz] (Copyright 2018 NAN WG Members / Collaborators (listed above)) (Copyright 2018 NAN contributors" (https://github.com/nodejs/nan#wg-members--collaborators)) (Copyright The contribution was provided directly to me by some other) (Copyright and I have not modified)
 napi-build-utils [napi-build-utils-1.0.2.tgz] (Copyright 2018 inspiredware)
-node-abi [node-abi-3.62.0.tgz] (Copyright 2016 Lukas Geiger)
+node-abi [node-abi-3.65.0.tgz] (Copyright 2016 Lukas Geiger)
 node-abort-controller [node-abort-controller-3.1.1.tgz] (Copyright 2019 Steve Faulkner)
 node-domexception [node-domexception-1.0.0.tgz] (Copyright 2021 Jimmy WÃ¤rting)
 node-fetch-commonjs [node-fetch-commonjs-3.3.2.tgz] (Copyright 2016-2020 Node Fetch Team)
 object-assign [object-assign-4.1.1.tgz] (Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com))
-object-inspect [object-inspect-1.13.1.tgz] (Copyright 2013 James Halliday)
+object-inspect [object-inspect-1.13.2.tgz] (Copyright 2013 James Halliday)
 parse-entities [parse-entities-2.0.0.tgz] (Copyright 2015 Titus Wormer <mailto:tituswormer@gmail.com>)
 prebuild-install [prebuild-install-7.1.2.tgz] (Copyright 2015 Mathias Buus)
-prismjs [prismjs-1.27.0.tgz] (Copyright 2012 Lea Verou)
-prismjs [prismjs-1.29.0.tgz] (Copyright 2012 Lea Verou)
 process [process-0.11.10.tgz] (Copyright 2013 Roman Shtylman <shtylman@gmail.com>)
 prop-types [prop-types-15.8.1.tgz] (Copyright 2013 Facebook, Inc)
 property-information [property-information-5.6.0.tgz] (Copyright 2013-2015 Facebook, Inc) (Copyright 2015 Titus Wormer <mailto:tituswormer@gmail.com>)
 pump [pump-3.0.0.tgz] (Copyright 2014 Mathias Buus)
 querystringify [querystringify-2.2.0.tgz] (Copyright 2015 Unshift.io, Arnout Kazemier,  the Contributors)
-ramda [ramda-0.30.0.tgz] (Copyright 2013-2024 Scott Sauyet and Michael Hurley) (Copyright 2014 J. C. Phillipps)
+ramda [ramda-0.30.1.tgz] (Copyright 2013-2024 Scott Sauyet and Michael Hurley) (Copyright 2014 J. C. Phillipps)
 randexp [randexp-0.5.3.tgz] (Copyright 2011 by fent)
 randombytes [randombytes-2.1.0.tgz] (Copyright 2017 crypto-browserify)
 react [react-18.3.1.tgz] (Copyright Facebook, Inc. and its affiliates)
@@ -1087,7 +1104,7 @@ remarkable [remarkable-2.0.1.tgz] (Copyright 2014 Jon Schlinkert, Vitaly Puzrin)
 repeat-string [repeat-string-1.6.1.tgz] (Copyright 2014-2015 Jon Schlinkert) (Copyright 2014-2016 Jon Schlinkert) (Copyright 2016 "Jon Schlinkert" (http://github.com/jonschlinkert)) (Copyright 2016 [Jon Schlinkert](http://github.com/jonschlinkert))
 require.js [require-2.1.15.min.js](Copyright Not Found)
 requires-port [requires-port-1.0.0.tgz] (Copyright 2015 Unshift.io, Arnout Kazemier,  the Contributors)
-reselect [reselect-5.1.0.tgz] (Copyright 2015-2018 Reselect Contributors)
+reselect [reselect-5.1.1.tgz] (Copyright 2015-2018 Reselect Contributors)
 ret [ret-0.2.2.tgz] (Copyright 2011 by fent)
 safe-buffer [safe-buffer-5.2.1.tgz] (Copyright Feross Aboukhadijeh)
 scheduler [scheduler-0.23.2.tgz] (Copyright Facebook, Inc. and its affiliates)
@@ -1098,7 +1115,6 @@ side-channel [side-channel-1.0.6.tgz] (Copyright 2019 Jordan Harband)
 simple-concat [simple-concat-1.0.1.tgz] (Copyright Feross Aboukhadijeh)
 simple-get [simple-get-4.0.1.tgz] (Copyright Feross Aboukhadijeh)
 space-separated-tokens [space-separated-tokens-1.1.5.tgz] (Copyright 2016 Titus Wormer <tituswormer@gmail.com>)
-stampit [stampit-4.3.2.tgz] (Copyright 2013 Eric Elliott)
 stream-browserify [stream-browserify-3.0.0.tgz] (Copyright James Halliday)
 string_decoder [string_decoder-1.3.0.tgz] (Copyright Node.js contributors)
 strip-json-comments [strip-json-comments-2.0.1.tgz] (Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com))
@@ -1111,7 +1127,7 @@ tree-sitter-json [tree-sitter-json-0.20.2.tgz] (Copyright 2014 Max Brunsfeld)
 tree-sitter-yaml [tree-sitter-yaml-0.5.0.tgz] (Copyright Ika <ikatyang@gmail.com> (https://github.com/ikatyang))
 ts-mixer [ts-mixer-6.0.4.tgz] (Copyright 2024 Tanner Nielsen)
 type-fest [type-fest-0.20.2.tgz] (Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:/sindresorhus.com))
-types-ramda [types-ramda-0.29.10.tgz] (Copyright 2013-2023 Scott Sauyet and Michael Hurley)
+types-ramda [types-ramda-0.30.1.tgz] (Copyright 2013-2023 Scott Sauyet and Michael Hurley)
 unraw [unraw-3.0.0.tgz] (Copyright 2019 Ian Sanders)
 url-parse [url-parse-1.5.10.tgz] (Copyright 2015 Unshift.io, Arnout Kazemier,  the Contributors)
 use-sync-external-store [use-sync-external-store-1.2.2.tgz] (Copyright Facebook, Inc. and its affiliates)
@@ -1302,9 +1318,8 @@ PERFORMANCE OF THIS SOFTWARE.
 
 END OF Python License, Version 2 NOTICES AND INFORMATION
 
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-END OF THE OPEN LIBERTY PROJECT NOTICES AND INFORMATION
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+END OF THE OPEN LIBERTY ROJECT NOTICES AND INFORMATION
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 END OF NOTICES AND INFORMATION FILE

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -64,12 +64,22 @@
     <dependency>
       <groupId>com.cloudant</groupId>
       <artifactId>cloudant-client</artifactId>
+      <version>2.20.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cloudant</groupId>
+      <artifactId>cloudant-client</artifactId>
       <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.cloudant</groupId>
       <artifactId>cloudant-http</artifactId>
       <version>2.16.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cloudant</groupId>
+      <artifactId>cloudant-http</artifactId>
+      <version>2.20.1</version>
     </dependency>
     <dependency>
       <groupId>com.cloudant</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -7,11 +7,11 @@ biz.aQute.bnd:biz.aQute.bnd:7.0.0
 cglib:cglib:3.3.0
 ch.qos.logback:logback-classic:1.2.3
 com.beust:jcommander:1.72
-com.cloudant:cloudant-client:2.20.1
 com.cloudant:cloudant-client:2.16.0
+com.cloudant:cloudant-client:2.20.1
 com.cloudant:cloudant-client:2.8.0
-com.cloudant:cloudant-http:2.20.1
 com.cloudant:cloudant-http:2.16.0
+com.cloudant:cloudant-http:2.20.1
 com.cloudant:cloudant-http:2.8.0
 com.fasterxml.jackson.core:jackson-annotations:2.15.2
 com.fasterxml.jackson.core:jackson-core:2.15.2

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -79,23 +79,31 @@ public class TCKResultsWriter {
             specURL = "https://jakarta.ee/specifications/" + specName + "/" + specVersion;
             tckURL = "https://download.eclipse.org/ee4j/" + specName + "/jakartaee10/promoted/eftl/" + specName + "-tck-" + specVersion + ".zip"; //just a placeholder, needs to be manually updated
         }
-        String filename = null;
+        // Replace the "_" with "-" in the directory name to keep consistency
+        String filename = (openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + "-TCKResults.adoc").replace("_", "-");
+
+        String redeableRepeatName = "";
+        //Adoc file for certification is added to results/REPEAT_ID/
         if (repeat.contains("FeatureReplacementAction")) {
-            String newRepeat = repeat.replaceAll("FeatureReplacementAction.*REMOVE", "remove")
+            redeableRepeatName = repeat.replaceAll("FeatureReplacementAction.*REMOVE", "remove")
                             .replaceAll("\\[", "")
                             .replaceAll("\\]", "")
                             .replaceAll("ADD", "add")
                             .replaceAll("  ", " ")
                             .replaceAll(",","-")
                             .replaceAll(" ", "_");
-            filename = (openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + newRepeat + "-TCKResults.adoc").replace("_", "-");
         } else {
-            filename = (openLibertyVersion + "-" + fullSpecName.replace(" ", "-") + "-Java" + javaMajorVersion + repeat + "-TCKResults.adoc").replace("_", "-");
+            redeableRepeatName = repeat;
         }
-        // Replace the "_" with "-" in filename to keep consistency
+        Path outputDirectory = Paths.get("results/" + "TCK_Results_Certifications" + redeableRepeatName);
+        Path outputPath = Paths.get("results/" + "TCK_Results_Certifications" + redeableRepeatName, filename);
 
-        Path outputPath = Paths.get("results", filename);
         File outputFile = outputPath.toFile();
+        File outputDir = outputDirectory.toFile();
+
+        if(!outputDir.exists()){
+            outputDir.mkdir();
+        }
 
         String timestamp = Instant.now()
                         .truncatedTo(ChronoUnit.SECONDS)
@@ -141,7 +149,7 @@ public class TCKResultsWriter {
         // Note that this copying *only* occurs in CI Orchestrator environments as the code wrapping FAT execution is responsible for performing the upload to LibFS.
         // The use case here is to make .adoc files available in the build directory without having to extract them from the FAT output zip every time.
         try {
-            Path extrasPath = Paths.get("extras", filename);
+            Path extrasPath = Paths.get("extras/" + "TCK_Results_Certifications" + redeableRepeatName, filename);
             Files.createDirectories(extrasPath.getParent());
             Files.copy(outputPath, extrasPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -74,6 +74,7 @@ tested.features: \
         microProfile-4.1,\
         microProfile-5.0,\
         microProfile-6.0,\
+        microProfile-7.0,\
         mpConfig-3.1,\
         mpMetrics-5.1,\
         mpOpenAPI-2.0,\
@@ -202,12 +203,14 @@ tested.features: \
 	org.testng,\
 	com.ibm.ws.jmx,\
 	com.ibm.ws.kernel.service,\
-	io.opentelemetry:opentelemetry-opentracing-shim;version=1.19.0.alpha,\
-	io.opentracing:opentracing-api;version=0.33.0,\
+	io.opentelemetry:opentelemetry-opentracing-shim;version='1.19.0.alpha',\
+	io.opentracing:opentracing-api;version='0.33.0',\
 	com.ibm.ws.kernel.boot.core;version=latest,\
 	com.ibm.ws.kernel.boot.common;version=latest,\
 	com.ibm.ws.microprofile.openapi;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.openapi.1.0;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.config.1.2.1;version=latest
+	com.ibm.websphere.org.eclipse.microprofile.config.1.2.1;version=latest,\
+	io.openliberty.com.fasterxml.jackson,\
+	com.fasterxml.jackson.core.jackson-databind
 
 -sub: *.bnd

--- a/dev/io.openliberty.checkpoint_fat/build.gradle
+++ b/dev/io.openliberty.checkpoint_fat/build.gradle
@@ -70,7 +70,9 @@ dependencies {
   jsonbapi 'javax.json.bind:javax.json.bind-api:1.0',
   project(':com.ibm.ws.security.registry_test.servlet'),
   project(':com.ibm.ws.org.apache.directory.server')
+  requiredLibs project(':io.openliberty.com.fasterxml.jackson')
   requiredLibs project(':com.ibm.ws.microprofile.openapi')
+  requiredLibs project(':io.openliberty.org.eclipse.microprofile')
   requiredLibs project(path: ':com.ibm.websphere.org.eclipse.microprofile', configuration: 'openapi10')
 }
 

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
@@ -203,8 +203,10 @@ public class FATSuite {
 
     public static RepeatTests defaultMPRepeat(String serverName) {
         return MicroProfileActions.repeat(serverName,
-                                          MicroProfileActions.MP61, // first test in LITE mode
-                                          MicroProfileActions.MP41, // rest are FULL mode
+                                          MicroProfileActions.MP70_EE10, // first test in LITE mode
+                                          MicroProfileActions.MP70_EE11, // rest are FULL mode
+                                          MicroProfileActions.MP61,
+                                          MicroProfileActions.MP41,
                                           MicroProfileActions.MP50);
     }
 }

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/OpenAPIConfigTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/OpenAPIConfigTest.java
@@ -31,7 +31,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.testcontainers.shaded.org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/OpenAPIConfigTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/OpenAPIConfigTest.java
@@ -13,14 +13,16 @@ import static io.openliberty.checkpoint.fat.FATSuite.configureEnvVariable;
 import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodNameOnly;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
@@ -29,7 +31,12 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.testcontainers.shaded.org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
@@ -161,8 +168,29 @@ public class OpenAPIConfigTest extends FATServletClient {
     private void assertDocumentPath(String path) throws Exception {
         // Check that it parses as a model and contains the expected path from the test
         // app
-        OpenAPI model = new OpenAPIConnection(server, path).downloadModel();
-        assertThat(model.getPaths().toString(), containsString("/configTestPath"));
+        String doc = new OpenAPIConnection(server, path).download();
+        JsonNode model = readYamlTree(doc);
+        checkPaths(model, 1, "/configTestPath");
+    }
+
+    public static void checkPaths(JsonNode root,
+                                  int expectedCount,
+                                  String... containedPaths) {
+        JsonNode pathsNode = root.get("paths");
+        assertNotNull(pathsNode);
+        assertTrue(pathsNode.isObject());
+        ObjectNode paths = (ObjectNode) pathsNode;
+
+        assertEquals("FAIL: Found incorrect number of server objects.", expectedCount, paths.size());
+        List<String> expected = Arrays.asList(containedPaths);
+        expected.stream()
+                        .forEach(path -> assertNotNull("FAIL: OpenAPI document does not contain the expected path " + path,
+                                                       paths.get(path)));
+    }
+
+    public static JsonNode readYamlTree(String contents) {
+        org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(new SafeConstructor(new LoaderOptions()));
+        return new ObjectMapper().convertValue(yaml.load(contents), JsonNode.class);
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -288,6 +288,10 @@ public abstract class EntityManagerBuilder {
                     if (trace & tc.isDebugEnabled())
                         Tr.debug(tc, "Unexpected exception caught while collecting entity information. The entity information will complete exceptionally", e);
                     collectionException = e;
+                    // TODO compute the userEntityClass earlier and completeExceptionally here.
+                    // Then move the EntityInfo creation and successful completion to before the catch.
+                    // That will also cover the possibility of EntityInfo constructor failing,
+                    // which can happen when it doesn't validate.
                 }
 
                 Class<?> jpaEntityClass = entityType.getJavaType();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -97,7 +97,10 @@ public abstract class EntityManagerBuilder {
      * @param entityTypes entity classes as known by the user, not generated.
      * @throws Exception if an error occurs.
      */
+    // Exceptions we expect to catch should ignore FFDC as they will be re-thrown upon CompletableFuture<EntityInfo>.get()
+    @FFDCIgnore({ MappingException.class })
     protected void collectEntityInfo(Set<Class<?>> entityTypes) throws Exception {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
         EntityManager em = createEntityManager();
         try {
             Metamodel model = em.getMetamodel();
@@ -106,6 +109,7 @@ public abstract class EntityManagerBuilder {
                 Map<String, List<Member>> attributeAccessors = new HashMap<>();
                 SortedSet<String> attributeNamesForUpdate = new TreeSet<>();
                 SortedMap<String, Class<?>> attributeTypes = new TreeMap<>();
+                SortedMap<String, Member> idClassAttributeAccessors = null;
                 Map<String, Class<?>> collectionElementTypes = new HashMap<>();
                 Map<Class<?>, List<String>> relationAttributeNames = new HashMap<>();
                 Queue<Attribute<?, ?>> relationships = new LinkedList<>();
@@ -115,168 +119,175 @@ public abstract class EntityManagerBuilder {
                 Class<?> idType = null;
                 String versionAttrName = null;
 
-                for (Attribute<?, ?> attr : entityType.getAttributes()) {
-                    String attributeName = attr.getName();
-                    PersistentAttributeType attributeType = attr.getPersistentAttributeType();
-                    switch (attributeType) {
-                        case BASIC:
-                        case ELEMENT_COLLECTION:
-                            attributeNamesForUpdate.add(attributeName);
-                            break;
-                        case EMBEDDED:
-                        case ONE_TO_ONE:
-                        case MANY_TO_ONE:
-                            relationAttributeNames.put(attr.getJavaType(), new ArrayList<>());
-                            relationships.add(attr);
-                            relationPrefixes.add(attributeName);
-                            relationAccessors.add(Collections.singletonList(attr.getJavaMember()));
-                            break;
-                        case ONE_TO_MANY:
-                        case MANY_TO_MANY:
-                            attributeNamesForUpdate.add(attributeName); // TODO is this correct?
-                            break;
-                        default:
-                            throw new RuntimeException(); // unreachable unless more types are added
-                    }
+                Exception collectionException = null;
 
-                    Member accessor = recordClass == null ? attr.getJavaMember() : recordClass.getMethod(attributeName);
-
-                    attributeNames.put(attributeName.toLowerCase(), attributeName);
-                    attributeAccessors.put(attributeName, Collections.singletonList(accessor));
-                    attributeTypes.put(attributeName, attr.getJavaType());
-                    if (attr.isCollection()) {
-                        if (attr instanceof PluralAttribute)
-                            collectionElementTypes.put(attributeName, ((PluralAttribute<?, ?, ?>) attr).getElementType().getJavaType());
-                    } else {
-                        SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute ? (SingularAttribute<?, ?>) attr : null;
-                        if (singleAttr != null && singleAttr.isId()) {
-                            attributeNames.put(ID, attributeName);
-                            idType = singleAttr.getJavaType();
-                        } else if (singleAttr != null && singleAttr.isVersion()) {
-                            versionAttrName = attributeName;
-                        } else if (Collection.class.isAssignableFrom(attr.getJavaType())) {
-                            // collection attribute that is not annotated with ElementCollection
-                            collectionElementTypes.put(attributeName, Object.class);
-                        }
-                    }
-                }
-
-                // Guard against recursive processing of OneToOne (and similar) relationships
-                // by tracking whether we have already processed each entity class involved.
-                Set<Class<?>> entityTypeClasses = new HashSet<>();
-                entityTypeClasses.add(entityType.getJavaType());
-
-                for (Attribute<?, ?> attr; (attr = relationships.poll()) != null;) {
-                    String prefix = relationPrefixes.poll();
-                    List<Member> accessors = relationAccessors.poll();
-                    ManagedType<?> relation = model.managedType(attr.getJavaType());
-                    if (relation instanceof EntityType && !entityTypeClasses.add(attr.getJavaType()))
-                        break;
-                    List<String> relAttributeList = relationAttributeNames.get(attr.getJavaType());
-                    for (Attribute<?, ?> relAttr : relation.getAttributes()) {
-                        String relationAttributeName = relAttr.getName();
-                        String fullAttributeName = prefix + '.' + relationAttributeName;
-                        List<Member> relAccessors = new LinkedList<>(accessors);
-                        relAccessors.add(relAttr.getJavaMember());
-                        relAttributeList.add(fullAttributeName);
-
-                        PersistentAttributeType attributeType = relAttr.getPersistentAttributeType();
+                try {
+                    for (Attribute<?, ?> attr : entityType.getAttributes()) {
+                        String attributeName = attr.getName();
+                        PersistentAttributeType attributeType = attr.getPersistentAttributeType();
                         switch (attributeType) {
                             case BASIC:
                             case ELEMENT_COLLECTION:
-                                attributeNamesForUpdate.add(fullAttributeName);
+                                attributeNamesForUpdate.add(attributeName);
                                 break;
                             case EMBEDDED:
                             case ONE_TO_ONE:
                             case MANY_TO_ONE:
-                                relationAttributeNames.put(relAttr.getJavaType(), new ArrayList<>());
-                                relationships.add(relAttr);
-                                relationPrefixes.add(fullAttributeName);
-                                relationAccessors.add(relAccessors);
+                                relationAttributeNames.put(attr.getJavaType(), new ArrayList<>());
+                                relationships.add(attr);
+                                relationPrefixes.add(attributeName);
+                                relationAccessors.add(Collections.singletonList(attr.getJavaMember()));
                                 break;
                             case ONE_TO_MANY:
                             case MANY_TO_MANY:
-                                attributeNamesForUpdate.add(fullAttributeName); // TODO is this correct?
+                                attributeNamesForUpdate.add(attributeName); // TODO is this correct?
                                 break;
                             default:
                                 throw new RuntimeException(); // unreachable unless more types are added
                         }
 
-                        // Allow a qualified name such as @OrderBy("address.street.name")
-                        // No chance of conflicts because attributes defined on the entity cannot have a period
-                        String fullAttributeNameLower = fullAttributeName.toLowerCase();
-                        attributeNames.put(fullAttributeNameLower, fullAttributeName);
+                        Member accessor = recordClass == null ? attr.getJavaMember() : recordClass.getMethod(attributeName);
 
-                        // Allow a qualified name such as findByAddress_Street_Name if it doesn't overlap
-                        // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
-                        String relationAttributeName_ = fullAttributeNameLower.replace('.', '_');
-                        String conflictingAttribute = attributeNames.putIfAbsent(relationAttributeName_, fullAttributeName);
-
-                        // TODO instead of failing here, we could fail during queryInfo.getAttributeName();
-                        if (conflictingAttribute != null)
-                            throw new MappingException("The entity " + entityType.getName() + " defines a basic attribute " + conflictingAttribute
-                                                       + " and a relational attribute " + prefix
-                                                       + " which results in an overloaded path expression " + relationAttributeName_
-                                                       + " necessary for queries and sorting."); //TODO NLS
-
-                        // Allow a qualified name such as findByAddressStreetName if it doesn't overlap
-                        // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
-                        String relationAttributeNameUndelimited = fullAttributeNameLower.replace(".", "");
-                        conflictingAttribute = attributeNames.putIfAbsent(relationAttributeNameUndelimited, fullAttributeName);
-
-                        // TODO instead of failing here, we could fail during queryInfo.getAttributeName();
-                        // but we then run the risk of eclipselink throwing an error instead when the attribute name happens to match column name of the table.
-                        // which could be more difficult for the user to debug.
-                        if (conflictingAttribute != null)
-                            throw new MappingException("The entity " + entityType.getName() + " defines a basic attribute " + conflictingAttribute
-                                                       + " and a relational attribute " + prefix
-                                                       + " which results in an overloaded path expression " + relationAttributeNameUndelimited
-                                                       + " necessary for queries and sorting."); //TODO NLS
-
-                        // Allow the simple attribute name if it doesn't overlap. For example: name, address.street.name
-                        // TODO document behavior not part of Jakarta Data Specification
-                        relationAttributeName = relationAttributeName.toLowerCase();
-                        attributeNames.putIfAbsent(relationAttributeName, fullAttributeName);
-
-                        attributeAccessors.put(fullAttributeName, relAccessors);
-
-                        attributeTypes.put(fullAttributeName, relAttr.getJavaType());
-                        if (relAttr.isCollection()) {
-                            if (relAttr instanceof PluralAttribute)
-                                collectionElementTypes.put(fullAttributeName, ((PluralAttribute<?, ?, ?>) relAttr).getElementType().getJavaType());
-                        } else if (relAttr instanceof SingularAttribute) {
-                            SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
-                            if (singleAttr.isId() && attributeNames.putIfAbsent(ID, fullAttributeName) == null) {
+                        attributeNames.put(attributeName.toLowerCase(), attributeName);
+                        attributeAccessors.put(attributeName, Collections.singletonList(accessor));
+                        attributeTypes.put(attributeName, attr.getJavaType());
+                        if (attr.isCollection()) {
+                            if (attr instanceof PluralAttribute)
+                                collectionElementTypes.put(attributeName, ((PluralAttribute<?, ?, ?>) attr).getElementType().getJavaType());
+                        } else {
+                            SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute ? (SingularAttribute<?, ?>) attr : null;
+                            if (singleAttr != null && singleAttr.isId()) {
+                                attributeNames.put(ID, attributeName);
                                 idType = singleAttr.getJavaType();
-                            } else if (singleAttr.isVersion()) {
-                                versionAttrName = relationAttributeName_; // to be suitable for query-by-method
+                            } else if (singleAttr != null && singleAttr.isVersion()) {
+                                versionAttrName = attributeName;
+                            } else if (Collection.class.isAssignableFrom(attr.getJavaType())) {
+                                // collection attribute that is not annotated with ElementCollection
+                                collectionElementTypes.put(attributeName, Object.class);
                             }
                         }
                     }
-                }
 
-                attributeNamesForUpdate.remove(ID);
-                String idAttrName = attributeNames.get(ID);
-                if (idAttrName != null)
-                    attributeNamesForUpdate.remove(idAttrName);
-                if (versionAttrName != null)
-                    attributeNamesForUpdate.remove(versionAttrName);
+                    // Guard against recursive processing of OneToOne (and similar) relationships
+                    // by tracking whether we have already processed each entity class involved.
+                    Set<Class<?>> entityTypeClasses = new HashSet<>();
+                    entityTypeClasses.add(entityType.getJavaType());
 
-                SortedMap<String, Member> idClassAttributeAccessors = null;
-                if (!entityType.hasSingleIdAttribute()) {
-                    // Per JavaDoc, the above means there is an IdClass.
-                    // An EclipseLink extension that allows an Id on an embeddable of an entity
-                    // is an exception to this, which we indicate with idClassType null.
-                    Type<?> idClassType = getIdType(entityType);
-                    if (idClassType != null) {
-                        @SuppressWarnings("unchecked")
-                        Set<SingularAttribute<?, ?>> idClassAttributes = (Set<SingularAttribute<?, ?>>) (Set<?>) entityType.getIdClassAttributes();
-                        if (idClassAttributes != null) {
-                            attributeNames.remove(ID);
-                            idType = idClassType.getJavaType();
-                            idClassAttributeAccessors = getIdClassAccessors(idType, idClassAttributes);
+                    for (Attribute<?, ?> attr; (attr = relationships.poll()) != null;) {
+                        String prefix = relationPrefixes.poll();
+                        List<Member> accessors = relationAccessors.poll();
+                        ManagedType<?> relation = model.managedType(attr.getJavaType());
+                        if (relation instanceof EntityType && !entityTypeClasses.add(attr.getJavaType()))
+                            break;
+                        List<String> relAttributeList = relationAttributeNames.get(attr.getJavaType());
+                        for (Attribute<?, ?> relAttr : relation.getAttributes()) {
+                            String relationAttributeName = relAttr.getName();
+                            String fullAttributeName = prefix + '.' + relationAttributeName;
+                            List<Member> relAccessors = new LinkedList<>(accessors);
+                            relAccessors.add(relAttr.getJavaMember());
+                            relAttributeList.add(fullAttributeName);
+
+                            PersistentAttributeType attributeType = relAttr.getPersistentAttributeType();
+                            switch (attributeType) {
+                                case BASIC:
+                                case ELEMENT_COLLECTION:
+                                    attributeNamesForUpdate.add(fullAttributeName);
+                                    break;
+                                case EMBEDDED:
+                                case ONE_TO_ONE:
+                                case MANY_TO_ONE:
+                                    relationAttributeNames.put(relAttr.getJavaType(), new ArrayList<>());
+                                    relationships.add(relAttr);
+                                    relationPrefixes.add(fullAttributeName);
+                                    relationAccessors.add(relAccessors);
+                                    break;
+                                case ONE_TO_MANY:
+                                case MANY_TO_MANY:
+                                    attributeNamesForUpdate.add(fullAttributeName); // TODO is this correct?
+                                    break;
+                                default:
+                                    throw new RuntimeException(); // unreachable unless more types are added
+                            }
+
+                            // Allow a qualified name such as @OrderBy("address.street.name")
+                            // No chance of conflicts because attributes defined on the entity cannot have a period
+                            String fullAttributeNameLower = fullAttributeName.toLowerCase();
+                            attributeNames.put(fullAttributeNameLower, fullAttributeName);
+
+                            // Allow a qualified name such as findByAddress_Street_Name if it doesn't overlap
+                            // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
+                            String relationAttributeName_ = fullAttributeNameLower.replace('.', '_');
+                            String conflictingAttribute = attributeNames.putIfAbsent(relationAttributeName_, fullAttributeName);
+
+                            if (conflictingAttribute != null)
+                                throw new MappingException("The entity " + entityType.getName() + " defines a basic attribute " + conflictingAttribute
+                                                           + " and a relational attribute " + prefix
+                                                           + " which results in an overloaded path expression " + relationAttributeName_
+                                                           + " necessary for queries and sorting."); //TODO NLS
+
+                            // Allow a qualified name such as findByAddressStreetName if it doesn't overlap
+                            // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
+                            String relationAttributeNameUndelimited = fullAttributeNameLower.replace(".", "");
+                            conflictingAttribute = attributeNames.putIfAbsent(relationAttributeNameUndelimited, fullAttributeName);
+
+                            // TODO need to handle the situation where a field name on the base entity conflicts with the column name
+                            // of an embeddable.  See issue: https://github.com/OpenLiberty/open-liberty/issues/29643
+
+                            if (conflictingAttribute != null && trace && tc.isWarningEnabled())
+                                Tr.debug(tc, "The entity " + entityType.getName() + " defines a basic attribute " + conflictingAttribute
+                                             + " and a relational attribute " + prefix
+                                             + " which results in an overloaded path expression " + relationAttributeNameUndelimited
+                                             + " the relational attribute will be ignored."); //TODO NLS swap to warning
+
+                            // TODO - remove this experimental behavior - not part of Jakarta Data Specification
+                            relationAttributeName = relationAttributeName.toLowerCase();
+                            attributeNames.putIfAbsent(relationAttributeName, fullAttributeName);
+
+                            attributeAccessors.put(fullAttributeName, relAccessors);
+
+                            attributeTypes.put(fullAttributeName, relAttr.getJavaType());
+                            if (relAttr.isCollection()) {
+                                if (relAttr instanceof PluralAttribute)
+                                    collectionElementTypes.put(fullAttributeName, ((PluralAttribute<?, ?, ?>) relAttr).getElementType().getJavaType());
+                            } else if (relAttr instanceof SingularAttribute) {
+                                SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
+                                if (singleAttr.isId() && attributeNames.putIfAbsent(ID, fullAttributeName) == null) {
+                                    idType = singleAttr.getJavaType();
+                                } else if (singleAttr.isVersion()) {
+                                    versionAttrName = relationAttributeName_; // to be suitable for query-by-method
+                                }
+                            }
                         }
                     }
+
+                    attributeNamesForUpdate.remove(ID);
+                    String idAttrName = attributeNames.get(ID);
+                    if (idAttrName != null)
+                        attributeNamesForUpdate.remove(idAttrName);
+                    if (versionAttrName != null)
+                        attributeNamesForUpdate.remove(versionAttrName);
+
+                    if (!entityType.hasSingleIdAttribute()) {
+                        // Per JavaDoc, the above means there is an IdClass.
+                        // An EclipseLink extension that allows an Id on an embeddable of an entity
+                        // is an exception to this, which we indicate with idClassType null.
+                        Type<?> idClassType = getIdType(entityType);
+                        if (idClassType != null) {
+                            @SuppressWarnings("unchecked")
+                            Set<SingularAttribute<?, ?>> idClassAttributes = (Set<SingularAttribute<?, ?>>) (Set<?>) entityType.getIdClassAttributes();
+                            if (idClassAttributes != null) {
+                                attributeNames.remove(ID);
+                                idType = idClassType.getJavaType();
+                                idClassAttributeAccessors = getIdClassAccessors(idType, idClassAttributes);
+                            }
+                        }
+                    }
+                } catch (MappingException e) {
+                    collectionException = e;
+                } catch (Exception e) {
+                    if (trace & tc.isDebugEnabled())
+                        Tr.debug(tc, "Unexpected exception caught while collecting entity information. The entity information will complete exceptionally", e);
+                    collectionException = e;
                 }
 
                 Class<?> jpaEntityClass = entityType.getJavaType();
@@ -297,7 +308,10 @@ public abstract class EntityManagerBuilder {
                                 versionAttrName, //
                                 this);
 
-                entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture).complete(entityInfo);
+                if (collectionException == null)
+                    entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture).complete(entityInfo);
+                else
+                    entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture).completeExceptionally(collectionException);
             }
         } finally {
             if (em != null)

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -411,7 +411,7 @@ public class DataExtension implements Extension {
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(this, tc, repositoryInterface.getName() + " has primary entity class " + primaryEntityClass,
+            Tr.debug(this, tc, repositoryInterface.getName() + " has primary entity " + primaryEntityClass,
                      "and methods that use the following entities:", queriesPerEntity);
 
         primaryEntityClassReturnValue[0] = primaryEntityClass;

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment.java
@@ -13,7 +13,8 @@
 package test.jakarta.data.web;
 
 /**
- * Has both a mapped superclass and an embedded class
+ * Entity with embeddable and mapped superclass
+ * Entity has a field with a colliding non-delimited attribute name with embeddable
  *
  * TODO extends here could indicate either a mapped superclass or inheritance
  * Today we treat this as a mapped superclass, but we could support inheritance but would need a way to distinguish between the two.
@@ -21,6 +22,8 @@ package test.jakarta.data.web;
 public class Apartment extends Residence {
 
     public long aptId;
+
+    public int quartersWidth;
 
     public Bedroom quarters;
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+/**
+ * Has both a mapped superclass and an embedded class
+ *
+ * TODO extends here could indicate either a mapped superclass or inheritance
+ * Today we treat this as a mapped superclass, but we could support inheritance but would need a way to distinguish between the two.
+ */
+public class Apartment extends Residence {
+
+    public long aptId;
+
+    public Bedroom quarters;
+
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment2.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment2.java
@@ -10,25 +10,18 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package test.jakarta.data.jpa.web;
-
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+package test.jakarta.data.web;
 
 /**
  * Entity with embeddable and mapped superclass
- * Entity has a field with a colliding non-delimited attribute name with embeddable
+ * Entity has a field with a colliding delimited attribute name with embeddable
  */
-@Entity
-public class Apartment extends Residence {
+public class Apartment2 extends Residence {
 
-    @Id
     public long aptId;
 
-    public int quartersWidth;
+    public int quarters_width;
 
-    @Embedded
     public Bedroom quarters;
 
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment3.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment3.java
@@ -10,25 +10,18 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package test.jakarta.data.jpa.web;
-
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+package test.jakarta.data.web;
 
 /**
  * Entity with embeddable and mapped superclass
- * Entity has a field with a colliding non-delimited attribute name with embeddable
+ * Entity has a field with a colliding delimited attribute name with mapped superclass.
  */
-@Entity
-public class Apartment extends Residence {
+public class Apartment3 extends Residence {
 
-    @Id
     public long aptId;
 
-    public int quartersWidth;
+    public boolean occupant_firstName;
 
-    @Embedded
     public Bedroom quarters;
 
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import java.util.List;
+
+import jakarta.data.Sort;
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface Apartments extends BasicRepository<Apartment, Long> {
+    @Delete
+    public void removeAll();
+
+    // Write queries using every possible persistence field name delimiter
+    // https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0#property-name-concatenation
+
+    // Parameter Name (_)
+    @Find
+    public List<Apartment> findApartmentsByBedroomWidth(int quarters_width);
+
+    // @By (_) (.)
+    @Find
+    public List<Apartment> findApartmentsByBedroom(@By("quarters_length") int length,
+                                                   @By("quarters.width") int width);
+
+    // @OrderBy (_) (.)
+    @Find
+    @OrderBy("quarters_length")
+    public List<Apartment> findAllOrderByBedroomLength();
+
+    @Find
+    @OrderBy("quarters.width")
+    public List<Apartment> findAllOrderByBedroomWidth();
+
+    // Query (.)
+    @Query("FROM Apartment WHERE quarters.length = ?1")
+    public List<Apartment> findApartmentsByBedroomLength(int length);
+
+    // Method Name (_) or no delimiter
+    public List<Apartment> findByQuarters_Width(int width);
+
+    public List<Apartment> findByQuartersLength(int length);
+
+    // Sort (_) (.)
+    @Find
+    public List<Apartment> findAllSorted(Sort<?> sort);
+
+    // Write query using mapped superclass field name
+    @Find
+    public List<Apartment> findByOccupied(@By("isOccupied") boolean state);
+
+    // Write query using embeddable in a mapped superclass
+    @Find
+    @OrderBy("occupant.firstName")
+    public List<Apartment> findByOccupantLastNameOrderByFirstName(@By("occupant_lastName") String lastName);
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
@@ -15,18 +15,29 @@ package test.jakarta.data.web;
 import java.util.List;
 
 import jakarta.data.Sort;
-import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
 
 @Repository
-public interface Apartments extends BasicRepository<Apartment, Long> {
+public interface Apartments {
     @Delete
     public void removeAll();
+
+    @Save
+    public List<Apartment> saveAll(List<Apartment> entities);
+
+    //Need to have a lifecycle methods for Apartment2 and Apartment3 otherwise
+    //Apartment2 and Apartment3 will not be considered entities
+    @Save
+    public Apartment2 saveAll(Apartment2 entity);
+
+    @Save
+    public Apartment3 saveAll(Apartment3 entity);
 
     // Write queries using every possible persistence field name delimiter
     // https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0#property-name-concatenation
@@ -70,4 +81,15 @@ public interface Apartments extends BasicRepository<Apartment, Long> {
     @Find
     @OrderBy("occupant.firstName")
     public List<Apartment> findByOccupantLastNameOrderByFirstName(@By("occupant_lastName") String lastName);
+
+    //  Write query using entity that has colliding non-delimited attribute name (quartersWidth)
+    @OrderBy("occupant.firstName")
+    public List<Apartment> findByQuartersWidth(int width);
+
+    // Write queries using entities that have colliding delimited attribute names
+    @Find
+    public List<Apartment2> findAllCollidingEmbeddable();
+
+    @Find
+    public List<Apartment3> findAllCollidingSuperclass();
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
@@ -26,7 +26,7 @@ import jakarta.data.repository.Save;
 @Repository
 public interface Apartments {
     @Delete
-    public void removeAll();
+    public List<Apartment> removeAll(); //Need to return List<Apartment> since this repository lacks a primary entity
 
     @Save
     public List<Apartment> saveAll(List<Apartment> entities);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Bedroom.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Bedroom.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+/**
+ * Unannotated embeddable
+ */
+public class Bedroom {
+
+    public int width;
+
+    public int length;
+
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3756,6 +3756,11 @@ public class DataTestServlet extends FATServlet {
         assertEquals(19L, nine.numberId);
     }
 
+    /**
+     * Tests entity attribute names from embeddables and MappedSuperclass that
+     * can have delimiters. Includes tests for name collisions with attributes from an
+     * embeddable or superinteface. This test uses unannotated entities.
+     */
     @Test
     public void testPersistentFieldNamesAndDelimiters() {
         apartments.removeAll();

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3757,7 +3757,7 @@ public class DataTestServlet extends FATServlet {
     }
 
     @Test
-    public void testPersistentFieldNamesWithDelimiters() {
+    public void testPersistentFieldNamesAndDelimiters() {
         apartments.removeAll();
 
         Apartment a101 = new Apartment();
@@ -3769,6 +3769,7 @@ public class DataTestServlet extends FATServlet {
         a101.quarters = new Bedroom();
         a101.quarters.length = 10;
         a101.quarters.width = 10;
+        a101.quartersWidth = 15;
 
         Apartment a102 = new Apartment();
         a102.occupant = new Occupant();
@@ -3779,6 +3780,7 @@ public class DataTestServlet extends FATServlet {
         a102.quarters = new Bedroom();
         a102.quarters.length = 11;
         a102.quarters.width = 11;
+        a102.quartersWidth = 15;
 
         Apartment a103 = new Apartment();
         a103.occupant = new Occupant();
@@ -3789,6 +3791,7 @@ public class DataTestServlet extends FATServlet {
         a103.quarters = new Bedroom();
         a103.quarters.length = 11;
         a103.quarters.width = 12;
+        a103.quartersWidth = 15;
 
         Apartment a104 = new Apartment();
         a104.occupant = new Occupant();
@@ -3799,6 +3802,7 @@ public class DataTestServlet extends FATServlet {
         a104.quarters = new Bedroom();
         a104.quarters.length = 12;
         a104.quarters.width = 11;
+        a104.quartersWidth = 15;
 
         apartments.saveAll(List.of(a101, a102, a103, a104));
 
@@ -3854,6 +3858,28 @@ public class DataTestServlet extends FATServlet {
         assertEquals("Brian", results.get(1).occupant.firstName);
         assertEquals("Kyle", results.get(2).occupant.firstName);
         assertEquals("Scott", results.get(3).occupant.firstName);
+
+        // Colliding non-delimited attribute name quartersWidth, ensure we use entity attribute and not embedded attribute for query
+        results = apartments.findByQuartersWidth(15);
+        assertEquals(4, results.size());
+        assertEquals("Brent", results.get(0).occupant.firstName);
+        assertEquals("Brian", results.get(1).occupant.firstName);
+        assertEquals("Kyle", results.get(2).occupant.firstName);
+        assertEquals("Scott", results.get(3).occupant.firstName);
+
+        try {
+            apartments.findAllCollidingEmbeddable();
+            fail("Should not have been able to execute query on an entity with colliding attibute name from embeddable");
+        } catch (MappingException e) {
+            //expected
+        }
+
+        try {
+            apartments.findAllCollidingSuperclass();
+            fail("Should not have been able to execute query on an entity with colliding attibute name from superclass");
+        } catch (MappingException e) {
+            // expected
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -95,6 +95,7 @@ import org.junit.Test;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
+import test.jakarta.data.web.Residence.Occupant;
 
 @DataSourceDefinition(name = "java:app/jdbc/DerbyDataSource",
                       className = "org.apache.derby.jdbc.EmbeddedXADataSource",
@@ -105,6 +106,9 @@ import componenttest.app.FATServlet;
 @WebServlet("/*")
 public class DataTestServlet extends FATServlet {
     private final long TIMEOUT_MINUTES = 2;
+
+    @Inject
+    Apartments apartments;
 
     @Inject
     EmptyRepository emptyRepo;
@@ -1219,6 +1223,28 @@ public class DataTestServlet extends FATServlet {
         assertEquals(1, found.size());
 
         h = found.get(0);
+        assertEquals("TestEmbeddable-404-4418-40", h.parcelId);
+        assertEquals(2400, h.area);
+        assertNotNull(h.garage);
+        assertEquals(220, h.garage.area);
+        assertEquals(Garage.Type.Detached, h.garage.type);
+        assertNotNull(h.garage.door);
+        assertEquals(9, h.garage.door.getHeight());
+        assertEquals(13, h.garage.door.getWidth());
+        assertNotNull(h.kitchen);
+        assertEquals(16, h.kitchen.length);
+        assertEquals(14, h.kitchen.width);
+        assertEquals(0.24f, h.lotSize, 0.001f);
+        assertEquals(5, h.numBedrooms);
+        assertEquals(204000f, h.purchasePrice, 0.001f);
+        assertEquals(Year.of(2022), h.sold);
+
+        // Query by attributes on base entity that could conflict with embedded attributes
+
+        List<House> hs = houses.findByArea(2400);
+        assertEquals(1, hs.size());
+
+        h = hs.get(0);
         assertEquals("TestEmbeddable-404-4418-40", h.parcelId);
         assertEquals(2400, h.area);
         assertNotNull(h.garage);
@@ -3728,6 +3754,106 @@ public class DataTestServlet extends FATServlet {
     public void testParameterAnnotationTakesPrecedenceOverMethodPrefix() {
         Prime nine = primes.findByBinary("10011").orElseThrow();
         assertEquals(19L, nine.numberId);
+    }
+
+    @Test
+    public void testPersistentFieldNamesWithDelimiters() {
+        apartments.removeAll();
+
+        Apartment a101 = new Apartment();
+        a101.occupant = new Occupant();
+        a101.occupant.firstName = "Kyle";
+        a101.occupant.lastName = "Smith";
+        a101.isOccupied = true;
+        a101.aptId = 101L;
+        a101.quarters = new Bedroom();
+        a101.quarters.length = 10;
+        a101.quarters.width = 10;
+
+        Apartment a102 = new Apartment();
+        a102.occupant = new Occupant();
+        a102.occupant.firstName = "Brent";
+        a102.occupant.lastName = "Smith";
+        a102.isOccupied = false;
+        a102.aptId = 102L;
+        a102.quarters = new Bedroom();
+        a102.quarters.length = 11;
+        a102.quarters.width = 11;
+
+        Apartment a103 = new Apartment();
+        a103.occupant = new Occupant();
+        a103.occupant.firstName = "Brian";
+        a103.occupant.lastName = "Smith";
+        a103.isOccupied = false;
+        a103.aptId = 103L;
+        a103.quarters = new Bedroom();
+        a103.quarters.length = 11;
+        a103.quarters.width = 12;
+
+        Apartment a104 = new Apartment();
+        a104.occupant = new Occupant();
+        a104.occupant.firstName = "Scott";
+        a104.occupant.lastName = "Smith";
+        a104.isOccupied = false;
+        a104.aptId = 104L;
+        a104.quarters = new Bedroom();
+        a104.quarters.length = 12;
+        a104.quarters.width = 11;
+
+        apartments.saveAll(List.of(a101, a102, a103, a104));
+
+        List<Apartment> results;
+
+        results = apartments.findApartmentsByBedroomWidth(12);
+        assertEquals(1, results.size());
+        assertEquals("Brian", results.get(0).occupant.firstName);
+
+        results = apartments.findApartmentsByBedroom(11, 11);
+        assertEquals(1, results.size());
+        assertEquals("Brent", results.get(0).occupant.firstName);
+
+        results = apartments.findAllOrderByBedroomLength();
+        assertEquals(4, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+        assertEquals("Scott", results.get(3).occupant.firstName);
+
+        results = apartments.findAllOrderByBedroomWidth();
+        assertEquals(4, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+        assertEquals("Brian", results.get(3).occupant.firstName);
+
+        results = apartments.findApartmentsByBedroomLength(10);
+        assertEquals(1, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+
+        results = apartments.findByQuarters_Width(12);
+        assertEquals(1, results.size());
+        assertEquals("Brian", results.get(0).occupant.firstName);
+
+        results = apartments.findByQuartersLength(12);
+        assertEquals(1, results.size());
+        assertEquals("Scott", results.get(0).occupant.firstName);
+
+        results = apartments.findAllSorted(Sort.asc("quarters.length"));
+        assertEquals(4, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+        assertEquals("Scott", results.get(3).occupant.firstName);
+
+        results = apartments.findAllSorted(Sort.asc("quarters_width"));
+        assertEquals(4, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+        assertEquals("Brian", results.get(3).occupant.firstName);
+
+        results = apartments.findByOccupied(true);
+        assertEquals(1, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+
+        results = apartments.findByOccupantLastNameOrderByFirstName("Smith");
+        assertEquals(4, results.size());
+        assertEquals("Brent", results.get(0).occupant.firstName);
+        assertEquals("Brian", results.get(1).occupant.firstName);
+        assertEquals("Kyle", results.get(2).occupant.firstName);
+        assertEquals("Scott", results.get(3).occupant.firstName);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
@@ -55,6 +55,8 @@ public interface Houses {
 
     List<House> findByGarage_door_heightOrderByGarage_door_heightDesc(int garageDoorHeight);
 
+    List<House> findByArea(int area);
+
     @Find
     House findById(@By(ID) String parcel);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Residence.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Residence.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+/**
+ * Unannotated mapped superclass with embeddable
+ */
+public class Residence {
+
+    public Occupant occupant;
+
+    public boolean isOccupied;
+
+    public static class Occupant {
+        public String firstName;
+        public String lastName;
+    }
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Apartment extends Residence {
+
+    @Id
+    public long aptId;
+
+    @Embedded
+    public Bedroom quarters;
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment2.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment2.java
@@ -18,15 +18,15 @@ import jakarta.persistence.Id;
 
 /**
  * Entity with embeddable and mapped superclass
- * Entity has a field with a colliding non-delimited attribute name with embeddable
+ * Entity has a field with a colliding delimited attribute name with embeddable
  */
 @Entity
-public class Apartment extends Residence {
+public class Apartment2 extends Residence {
 
     @Id
     public long aptId;
 
-    public int quartersWidth;
+    public int quarters_width;
 
     @Embedded
     public Bedroom quarters;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment3.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartment3.java
@@ -18,15 +18,15 @@ import jakarta.persistence.Id;
 
 /**
  * Entity with embeddable and mapped superclass
- * Entity has a field with a colliding non-delimited attribute name with embeddable
+ * Entity has a field with a colliding delimited attribute name with mapped superclass.
  */
 @Entity
-public class Apartment extends Residence {
+public class Apartment3 extends Residence {
 
     @Id
     public long aptId;
 
-    public int quartersWidth;
+    public boolean occupant_firstName;
 
     @Embedded
     public Bedroom quarters;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartments.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.List;
+
+import jakarta.data.Sort;
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface Apartments extends BasicRepository<Apartment, Long> {
+    @Delete
+    public void removeAll();
+
+    // Write queries using every possible persistence field name delimiter
+    // https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0#property-name-concatenation
+
+    // Parameter Name (_)
+    @Find
+    public List<Apartment> findApartmentsByBedroomWidth(int quarters_width);
+
+    // @By (_) (.)
+    @Find
+    public List<Apartment> findApartmentsByBedroom(@By("quarters_length") int length,
+                                                   @By("quarters.width") int width);
+
+    // @OrderBy (_) (.)
+    @Find
+    @OrderBy("quarters_length")
+    public List<Apartment> findAllOrderByBedroomLength();
+
+    @Find
+    @OrderBy("quarters.width")
+    public List<Apartment> findAllOrderByBedroomWidth();
+
+    // Query (.)
+    @Query("FROM Apartment WHERE quarters.length = ?1")
+    public List<Apartment> findApartmentsByBedroomLength(int length);
+
+    // Method Name (_) or no delimiter
+    public List<Apartment> findByQuarters_Width(int width);
+
+    public List<Apartment> findByQuartersLength(int length);
+
+    // Sort (_) (.)
+    @Find
+    public List<Apartment> findAllSorted(Sort<?> sort);
+
+    // Write query using mapped superclass field name
+    @Find
+    public List<Apartment> findByOccupied(@By("isOccupied") boolean state);
+
+    // Write query using embeddable in a mapped superclass
+    @Find
+    @OrderBy("occupant.firstName")
+    public List<Apartment> findByOccupantLastNameOrderByFirstName(@By("occupant_lastName") String lastName);
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Apartments.java
@@ -15,18 +15,21 @@ package test.jakarta.data.jpa.web;
 import java.util.List;
 
 import jakarta.data.Sort;
-import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
 
 @Repository
-public interface Apartments extends BasicRepository<Apartment, Long> {
+public interface Apartments {
     @Delete
     public void removeAll();
+
+    @Save
+    public List<Apartment> saveAll(List<Apartment> entities);
 
     // Write queries using every possible persistence field name delimiter
     // https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0#property-name-concatenation
@@ -70,4 +73,15 @@ public interface Apartments extends BasicRepository<Apartment, Long> {
     @Find
     @OrderBy("occupant.firstName")
     public List<Apartment> findByOccupantLastNameOrderByFirstName(@By("occupant_lastName") String lastName);
+
+    //  Write query using entity that has colliding non-delimited attribute name (quartersWidth)
+    @OrderBy("occupant.firstName")
+    public List<Apartment> findByQuartersWidth(int width);
+
+    // Write queries using entities that have colliding delimited attribute names
+    @Find
+    public List<Apartment2> findAllCollidingEmbeddable();
+
+    @Find
+    public List<Apartment3> findAllCollidingSuperclass();
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Bedroom.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Bedroom.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Bedroom {
+
+    public int width;
+
+    public int length;
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2933,6 +2933,11 @@ public class DataJPATestServlet extends FATServlet {
         drivers.deleteByFullNameEndsWith(" TestOneToOne");
     }
 
+    /**
+     * Tests entity attribute names from embeddables and MappedSuperclass that
+     * can have delimiters. Includes tests for name collisions with attributes from an
+     * embeddable or superinteface.
+     */
     @Test
     public void testPersistentFieldNamesAndDelimiters() {
         apartments.removeAll();

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -92,6 +92,7 @@ import componenttest.app.FATServlet;
 import test.jakarta.data.jpa.web.CreditCard.CardId;
 import test.jakarta.data.jpa.web.CreditCard.Issuer;
 import test.jakarta.data.jpa.web.Mobile.OS;
+import test.jakarta.data.jpa.web.Residence.Occupant;
 
 @DataSourceDefinition(name = "java:module/jdbc/RepositoryDataStore",
                       className = "${repository.datasource.class.name}",
@@ -107,6 +108,9 @@ public class DataJPATestServlet extends FATServlet {
 
     @Inject
     Accounts accounts;
+
+    @Inject
+    Apartments apartments;
 
     @Inject
     Businesses businesses;
@@ -2927,6 +2931,106 @@ public class DataJPATestServlet extends FATServlet {
                                              .collect(Collectors.toList()));
 
         drivers.deleteByFullNameEndsWith(" TestOneToOne");
+    }
+
+    @Test
+    public void testPersistentFieldNamesWithDelimiters() {
+        apartments.removeAll();
+
+        Apartment a101 = new Apartment();
+        a101.occupant = new Occupant();
+        a101.occupant.firstName = "Kyle";
+        a101.occupant.lastName = "Smith";
+        a101.isOccupied = true;
+        a101.aptId = 101L;
+        a101.quarters = new Bedroom();
+        a101.quarters.length = 10;
+        a101.quarters.width = 10;
+
+        Apartment a102 = new Apartment();
+        a102.occupant = new Occupant();
+        a102.occupant.firstName = "Brent";
+        a102.occupant.lastName = "Smith";
+        a102.isOccupied = false;
+        a102.aptId = 102L;
+        a102.quarters = new Bedroom();
+        a102.quarters.length = 11;
+        a102.quarters.width = 11;
+
+        Apartment a103 = new Apartment();
+        a103.occupant = new Occupant();
+        a103.occupant.firstName = "Brian";
+        a103.occupant.lastName = "Smith";
+        a103.isOccupied = false;
+        a103.aptId = 103L;
+        a103.quarters = new Bedroom();
+        a103.quarters.length = 11;
+        a103.quarters.width = 12;
+
+        Apartment a104 = new Apartment();
+        a104.occupant = new Occupant();
+        a104.occupant.firstName = "Scott";
+        a104.occupant.lastName = "Smith";
+        a104.isOccupied = false;
+        a104.aptId = 104L;
+        a104.quarters = new Bedroom();
+        a104.quarters.length = 12;
+        a104.quarters.width = 11;
+
+        apartments.saveAll(List.of(a101, a102, a103, a104));
+
+        List<Apartment> results;
+
+        results = apartments.findApartmentsByBedroomWidth(12);
+        assertEquals(1, results.size());
+        assertEquals("Brian", results.get(0).occupant.firstName);
+
+        results = apartments.findApartmentsByBedroom(11, 11);
+        assertEquals(1, results.size());
+        assertEquals("Brent", results.get(0).occupant.firstName);
+
+        results = apartments.findAllOrderByBedroomLength();
+        assertEquals(4, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+        assertEquals("Scott", results.get(3).occupant.firstName);
+
+        results = apartments.findAllOrderByBedroomWidth();
+        assertEquals(4, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+        assertEquals("Brian", results.get(3).occupant.firstName);
+
+        results = apartments.findApartmentsByBedroomLength(10);
+        assertEquals(1, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+
+        results = apartments.findByQuarters_Width(12);
+        assertEquals(1, results.size());
+        assertEquals("Brian", results.get(0).occupant.firstName);
+
+        results = apartments.findByQuartersLength(12);
+        assertEquals(1, results.size());
+        assertEquals("Scott", results.get(0).occupant.firstName);
+
+        results = apartments.findAllSorted(Sort.asc("quarters.length"));
+        assertEquals(4, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+        assertEquals("Scott", results.get(3).occupant.firstName);
+
+        results = apartments.findAllSorted(Sort.asc("quarters_width"));
+        assertEquals(4, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+        assertEquals("Brian", results.get(3).occupant.firstName);
+
+        results = apartments.findByOccupied(true);
+        assertEquals(1, results.size());
+        assertEquals("Kyle", results.get(0).occupant.firstName);
+
+        results = apartments.findByOccupantLastNameOrderByFirstName("Smith");
+        assertEquals(4, results.size());
+        assertEquals("Brent", results.get(0).occupant.firstName);
+        assertEquals("Brian", results.get(1).occupant.firstName);
+        assertEquals("Kyle", results.get(2).occupant.firstName);
+        assertEquals("Scott", results.get(3).occupant.firstName);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2934,7 +2934,7 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     @Test
-    public void testPersistentFieldNamesWithDelimiters() {
+    public void testPersistentFieldNamesAndDelimiters() {
         apartments.removeAll();
 
         Apartment a101 = new Apartment();
@@ -2946,6 +2946,7 @@ public class DataJPATestServlet extends FATServlet {
         a101.quarters = new Bedroom();
         a101.quarters.length = 10;
         a101.quarters.width = 10;
+        a101.quartersWidth = 15;
 
         Apartment a102 = new Apartment();
         a102.occupant = new Occupant();
@@ -2956,6 +2957,7 @@ public class DataJPATestServlet extends FATServlet {
         a102.quarters = new Bedroom();
         a102.quarters.length = 11;
         a102.quarters.width = 11;
+        a102.quartersWidth = 15;
 
         Apartment a103 = new Apartment();
         a103.occupant = new Occupant();
@@ -2966,6 +2968,7 @@ public class DataJPATestServlet extends FATServlet {
         a103.quarters = new Bedroom();
         a103.quarters.length = 11;
         a103.quarters.width = 12;
+        a103.quartersWidth = 15;
 
         Apartment a104 = new Apartment();
         a104.occupant = new Occupant();
@@ -2976,6 +2979,7 @@ public class DataJPATestServlet extends FATServlet {
         a104.quarters = new Bedroom();
         a104.quarters.length = 12;
         a104.quarters.width = 11;
+        a104.quartersWidth = 15;
 
         apartments.saveAll(List.of(a101, a102, a103, a104));
 
@@ -3031,6 +3035,28 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals("Brian", results.get(1).occupant.firstName);
         assertEquals("Kyle", results.get(2).occupant.firstName);
         assertEquals("Scott", results.get(3).occupant.firstName);
+
+        // Colliding non-delimited attribute name quartersWidth, ensure we use entity attribute and not embedded attribute for query
+        results = apartments.findByQuartersWidth(15);
+        assertEquals(4, results.size());
+        assertEquals("Brent", results.get(0).occupant.firstName);
+        assertEquals("Brian", results.get(1).occupant.firstName);
+        assertEquals("Kyle", results.get(2).occupant.firstName);
+        assertEquals("Scott", results.get(3).occupant.firstName);
+
+        try {
+            apartments.findAllCollidingEmbeddable();
+            fail("Should not have been able to execute query on an entity with colliding attibute name from embeddable");
+        } catch (MappingException e) {
+            //expected
+        }
+
+        try {
+            apartments.findAllCollidingSuperclass();
+            fail("Should not have been able to execute query on an entity with colliding attibute name from superclass");
+        } catch (MappingException e) {
+            // expected
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Residence.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Residence.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public class Residence {
+
+    @Embedded
+    public Occupant occupant;
+
+    public boolean isOccupied;
+
+    @Embeddable
+    public static class Occupant {
+        public String firstName;
+        public String lastName;
+    }
+
+}


### PR DESCRIPTION
- Jakarta Data EMBuilders are created asynchonously, so may not exist if ddlgen invoked to soon
  - resolve by registering the futures with DDL MBean rather than the EMBuilders
- Jakarta Data does not determine if using persistence service until Builder created, so all futures must be registered, not just the ones that will participate
- Updated ddlgen MBean to skip DDLGenerationParticpants if they return null for file name
- Updated ddlgen MBean to handle exceptions that occur obtaining file name, as this is most likely when Jakarta Data would see an error
- Improved exception handling for Jakarta Data DDL gen; identified where errors should be logged


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

for #24916
