### PR TITLE
AttributeOverrides to allow multiple of same embeddable

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -20,7 +20,6 @@ import static jakarta.data.repository.By.ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static test.jakarta.data.jpa.web.Assertions.assertArrayEquals;
 import static test.jakarta.data.jpa.web.Assertions.assertIterableEquals;
@@ -1178,8 +1177,7 @@ public class DataJPATestServlet extends FATServlet {
     /**
      * Use an entity with embeddable attributes that are Java records.
      */
-    // TODO enable once #29459 is fixed
-    // @Test
+    @Test
     public void testEmbeddableRecord() {
         Segment s1 = new Segment();
         s1.pointA = new Point(0, 0);
@@ -1213,29 +1211,31 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(3, segments.countByPointAXLessThan(1));
 
-        assertEquals(List.of(s3.id, s4.id, s2.id, s1.id),
-                     segments.endingSouthOf(100)
-                                     .map(s -> s.id)
-                                     .collect(Collectors.toList()));
+        // TODO enable once #29460 is fixed
+        //assertEquals(List.of(s3.id, s4.id, s2.id, s1.id),
+        //             segments.endingSouthOf(100)
+        //                             .map(s -> s.id)
+        //                             .collect(Collectors.toList()));
 
-        assertEquals(List.of(-20, 0, 24),
-                     segments.longerThan(200, Sort.asc("pointA.x"))
-                                     .stream()
-                                     .map(s -> s.pointA.x())
-                                     .collect(Collectors.toList()));
+        //assertEquals(List.of(-20, 0, 24),
+        //             segments.longerThan(200, Sort.asc("pointA.x"))
+        //                             .stream()
+        //                             .map(s -> s.pointA.x())
+        //                             .collect(Collectors.toList()));
 
-        s3.pointB = new Point(s3.pointB.x() - s3.pointA.x(), s3.pointB.y() - s3.pointA.y());
-        s3.pointA = new Point(0, 0);
-        s3 = segments.addOrModify(s3);
+        //s3.pointB = new Point(s3.pointB.x() - s3.pointA.x(), s3.pointB.y() - s3.pointA.y());
+        //s3.pointA = new Point(0, 0);
+        //s3 = segments.addOrModify(s3);
 
         // removes s1 and s3
-        assertEquals(2L, segments.removeStartingAt(0, 0));
+        //assertEquals(2L, segments.removeStartingAt(0, 0));
 
-        Point s2pointB = segments.terminalPoint(s2.id).orElseThrow();
-        assertEquals(120, s2pointB.x());
-        assertEquals(171, s2pointB.y());
+        //Point s2pointB = segments.terminalPoint(s2.id).orElseThrow();
+        //assertEquals(120, s2pointB.x());
+        //assertEquals(171, s2pointB.y());
 
-        assertEquals(4L, segments.erase());
+        assertEquals(6L, // TODO change to 4L, once #29460 is fixed
+                     segments.erase());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Segment.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Segment.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -28,10 +30,18 @@ public class Segment {
 
     @Embedded
     @Column(nullable = false)
+    @AttributeOverrides( // TODO remove once #29459 is fixed (if it is valid)
+    { @AttributeOverride(name = "x", column = @Column(name = "POINTAX")),
+      @AttributeOverride(name = "y", column = @Column(name = "POINTAY"))
+    })
     public Point pointA;
 
     @Embedded
     @Column(nullable = false)
+    @AttributeOverrides( // TODO remove once #29459 is fixed (if it is valid)
+    { @AttributeOverride(name = "x", column = @Column(name = "POINTBX")),
+      @AttributeOverride(name = "y", column = @Column(name = "POINTBY"))
+    })
     public Point pointB;
 
     @Override


### PR DESCRIPTION
The AttributeOverrides and AttributeOverride annotations from Jakarta Persistence can be used to override the column names of embeddable attributes, which is useful to distinguish multiple embeddable attributes of the same type.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
