### PR TITLE
Don't wait infinitely for client run or server stop to complete (attempt #2)

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/Machine.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/Machine.java
@@ -235,9 +235,9 @@ public class Machine {
      * input path. Note that the actual file is not guaranteed to exist. The input path may
      * represent either a file or a directory.
      *
-     * @param  path The absolute path to a file on the remote device.
-     * @param encoding The character set the file is encoded in
-     * @return      A RemoteFile representing the input abstract path name
+     * @param  path     The absolute path to a file on the remote device.
+     * @param  encoding The character set the file is encoded in
+     * @return          A RemoteFile representing the input abstract path name
      */
     public RemoteFile getFile(String path, Charset encoding) {
         return new RemoteFile(this, path, encoding);
@@ -283,7 +283,7 @@ public class Machine {
                 params = new String[] { "-c", "\"cat", "/proc/version\"" };
             }
             Log.finer(c, method, "Command to get OS version: " + cmd + " " + Arrays.toString(params));
-            this.osVersion = LocalProvider.executeCommand(this, cmd, params, null, null).getStdout().trim();
+            this.osVersion = LocalProvider.executeCommand(this, cmd, params, null, null, 0).getStdout().trim();
         }
         Log.exiting(c, method, this.osVersion);
         return this.osVersion;
@@ -454,13 +454,7 @@ public class Machine {
      * @throws Exception
      */
     public ProgramOutput execute(String cmd, String[] parameters, String workDir, Properties envVars, int timeout) throws Exception {
-        // On iSeries, we should be adding the qsh -c flag to the start of any command.
-        // This means commands are executed in a native-like shell, rather than a
-        // PASE environment.
-        if (OperatingSystem.ISERIES.compareTo(getOperatingSystem()) == 0) {
-            cmd = "qsh -c " + cmd;
-        }
-        return LocalProvider.executeCommand(this, cmd, parameters, workDir, envVars);
+        return LocalProvider.executeCommand(this, cmd, parameters, workDir, envVars, timeout);
     }
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/common/apiservices/LocalMachine.java
+++ b/dev/fattest.simplicity/src/componenttest/common/apiservices/LocalMachine.java
@@ -16,7 +16,6 @@ import java.io.OutputStream;
 import java.util.Date;
 import java.util.Properties;
 
-import com.ibm.websphere.simplicity.AsyncProgramOutput;
 import com.ibm.websphere.simplicity.ConnectionInfo;
 import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.OperatingSystem;
@@ -53,20 +52,8 @@ public class LocalMachine extends Machine {
     @Override
     public void disconnect() throws Exception {}
 
-    @Override
-    public ProgramOutput execute(String cmd, String[] parameters,
-                                 String workDir, Properties envVars) throws Exception {
-        return LocalProvider.executeCommand(this, cmd, parameters, workDir,
-                                            envVars);
-    }
-
     public void executeAsync(String cmd, String[] parameters, String workDir, Properties envVars, OutputStream redirect) throws Exception {
         LocalProvider.executeCommandAsync(this, cmd, parameters, workDir, envVars, redirect);
-    }
-
-    @Override
-    public AsyncProgramOutput executeAsync(String cmd, String[] parameters) throws Exception {
-        return LocalProvider.executeCommandAsync(this, cmd, parameters, workDir, null);
     }
 
     @Override

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -764,7 +764,7 @@ public class LibertyClient {
             Log.info(c, method, "Started client process in debug mode");
             output = null;
         } else {
-            output = machine.execute(cmd, parameters, envVars);
+            output = machine.execute(cmd, parameters, machine.getWorkDir(), envVars, 300);
 
             int rc = output.getReturnCode();
             Log.info(c, method, "Response from script is: " + output.getStdout());

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3214,7 +3214,7 @@ public class LibertyServer implements LogMonitorClient {
             ProgramOutput output = null;
 
             if (!runAsAWindowService) {
-                output = machine.execute(cmd, parameters, useEnvVars);
+                output = machine.execute(cmd, parameters, machine.getWorkDir(), useEnvVars, 300);
             } else {
                 ArrayList<String> parametersList = new ArrayList<String>();
                 for (int i = 0; i < parameters.length; i++) {
@@ -3225,8 +3225,11 @@ public class LibertyServer implements LogMonitorClient {
                 String[] stopServiceParameters = stopServiceParmList.toArray(new String[] {});
                 String[] removeServiceParameters = removeServiceParmList.toArray(new String[] {});
 
-                output = machine.execute(cmd, stopServiceParameters, useEnvVars);
-                output = machine.execute(cmd, removeServiceParameters, useEnvVars);
+                try {
+                    output = machine.execute(cmd, stopServiceParameters, machine.getWorkDir(), useEnvVars, 300);
+                } finally {
+                    output = machine.execute(cmd, removeServiceParameters, machine.getWorkDir(), useEnvVars, 300);
+                }
             }
 
             String stdout = output.getStdout();


### PR DESCRIPTION
- Update LocalProvider to handle a timeout value
- Update LibertyClient to pass in a timeout of 300 seconds for a client to finish so it doesn't hang
- Update LibertyServer to pass in a timeout of 300 seconds for a server stop call to finish so it doesn't hang

Fixes #29642 
Re-introduces the changes from #29540 with additional changes to fix up some stuff when running on iSeries

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".