### PR TITLE
Fix test failure when using EE 11 and MP 7.0

### DIFF
--- a/dev/io.openliberty.microprofile7.internal_fat/fat/src/io/openliberty/microprofile7/internal/test/suite/MP7EE11CompatibleTest.java
+++ b/dev/io.openliberty.microprofile7.internal_fat/fat/src/io/openliberty/microprofile7/internal/test/suite/MP7EE11CompatibleTest.java
@@ -38,7 +38,9 @@ public class MP7EE11CompatibleTest {
 
     @AfterClass
     public static void cleanUp() throws Exception {
-        MPCompatibilityTestUtils.cleanUp(server);
+        //I think CWWWC0002W is a mpGraphQL-1.0 bug and should not appear
+        //See issue 15496
+        MPCompatibilityTestUtils.cleanUp(server, "CWWWC0002W");
     }
 
     /**


### PR DESCRIPTION
- Add ignore for message now that graphql has full EE 11 support.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".