### PR TITLE
Issue #24916: Update ddlgen for future EntityManager builders

### DIFF
--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/DDLGenerationParticipant.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/DDLGenerationParticipant.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,7 +23,7 @@ public interface DDLGenerationParticipant {
     /**
      * Called when the user requests DDL generation. Any DDL needed by
      * this service should be written to the provided Writer class.
-     * 
+     *
      * @param out The writer which should be passed to the persistence
      *            service for DDL generation.
      * @throws Exception if an error occurs.
@@ -32,21 +32,22 @@ public interface DDLGenerationParticipant {
 
     /**
      * <p>Returns the name of the file (not including the file extension) into which DDL should be generated.
-     * If multiple DDLGenerationParticipants specify the same file name, only one will be chosen to generate DDL.
-     * This can be done intentionally if multiple instances point to the same databaseStore.
-     * 
+     * If multiple DDLGenerationParticipants specify the same file name, all will be used in an undefined
+     * order and allowed to append to the same file. If null is returned, the DDLGenerationParticipant will
+     * not be used to generate DDL.
+     *
      * <p>The following conventions are recommended for file names.
      * <ul>
      * <li>If the databaseStore is a nested element, it is recommended to have the file name be the
      * config.displayId of the databaseStore. For example,
      * persistentExecutor[MyExecutor]/databaseStore[default-0]
      * <li>If the databaseStore is a top level element, it is recommended to have the file name be the
-     * config.displayId of the databaseStore with an underscore character and the config element name
+     * config.displayId of the databaseStore with an underscore character and the configuration element name
      * of the DDLGenerationParticipant appended to the end. For example,
      * databaseStore[MyDBStore]_persistentExecutor
      * </ul>
-     * 
-     * @return the name of the file to use.
+     *
+     * @return the name of the file to use, or null if there is no DDL to generate.
      */
     public String getDDLFileName();
 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -14,17 +14,27 @@ package io.openliberty.data.internal.persistence.cdi;
 
 import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
 
+import java.io.Writer;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 
 import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.ras.Tr;
@@ -35,19 +45,22 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.runtime.metadata.ApplicationMetaData;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
+import com.ibm.wsspi.persistence.DDLGenerationParticipant;
 
 import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.EntityManagerBuilder;
 import io.openliberty.data.internal.persistence.provider.PUnitEMBuilder;
 import io.openliberty.data.internal.persistence.service.DBStoreEMBuilder;
+import jakarta.data.exceptions.DataException;
 import jakarta.persistence.EntityManagerFactory;
 
 /**
  * A completable future for an EntityManagerBuilder that can be
  * completed by invoking the createEMBuilder method.
  */
-public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> {
+public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> implements DDLGenerationParticipant {
     private static final TraceComponent tc = Tr.register(FutureEMBuilder.class);
+    private static final long DDLGEN_WAIT_TIME = 15;
 
     /**
      * These are present only if needed to disambiguate a JNDI name
@@ -146,6 +159,91 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> {
             Tr.debug(this, tc, "add: " + entityClass.getName());
 
         entityTypes.add(entityClass);
+    }
+
+    /**
+     * Registers this future with the DDL generation MBean so that the ddlgen command
+     * will generate DDL for the EntityManagerBuilder produced by this future. <p>
+     *
+     * Not all EntityManagerBuilder instances will participate in DDL generation;
+     * only those that use the Persistence Service. This is not determined until the
+     * EntityManagerBuilder has been created. If not participating, a null DDL file
+     * name will be provided and the DDL generation command will skip generation.
+     *
+     * @param appName application name
+     */
+    public void registerDDLGenerationParticipant(String appName) {
+        // Register as a DDL generator for use by the ddlGen command and add to list for cleanup on application stop
+        BundleContext thisbc = FrameworkUtil.getBundle(getClass()).getBundleContext();
+        ServiceRegistration<DDLGenerationParticipant> ddlgenreg = thisbc.registerService(DDLGenerationParticipant.class, this, null);
+        Queue<ServiceRegistration<DDLGenerationParticipant>> ddlgenRegistrations = provider.ddlgeneratorsAllApps.get(appName);
+        if (ddlgenRegistrations == null) {
+            Queue<ServiceRegistration<DDLGenerationParticipant>> empty = new ConcurrentLinkedQueue<>();
+            if ((ddlgenRegistrations = provider.ddlgeneratorsAllApps.putIfAbsent(appName, empty)) == null)
+                ddlgenRegistrations = empty;
+        }
+        ddlgenRegistrations.add(ddlgenreg);
+    }
+
+    @Override
+    public String getDDLFileName() {
+        try {
+            EntityManagerBuilder builder = get(DDLGEN_WAIT_TIME, TimeUnit.SECONDS);
+            if (builder instanceof DDLGenerationParticipant) {
+                return ((DDLGenerationParticipant) builder).getDDLFileName();
+            }
+        } catch (TimeoutException e) {
+            // TODO : translate message for exception & error (or warning)
+            // DDL generation MBean does not log errors; participants must provide meaningful messages.
+            // Log a useful error informing user to try again later after builder creation completes.
+            Tr.error(tc, "CWWKD10xxE.ddlgen.timeout", dataStore, DDLGEN_WAIT_TIME);
+
+            // Throw exception with same message so DDL generation MBean reports that a failure occurred.
+            throw new DataException("DDL file not generated for Jakarta Data repositories associated with the " + dataStore
+                                    + " DatabaseStore. The EntityManagerFactory was not created in " + DDLGEN_WAIT_TIME + " seconds. Try DDL generation again at a later time.");
+        } catch (Throwable ex) {
+            // TODO : translate message for exception & error
+            // DDL generation MBean does not log errors; participants must provide meaningful messages.
+            // Log a useful error informing user to correct problems reported in the cause.
+            Throwable cause = (ex instanceof ExecutionException) ? ex.getCause() : ex;
+            Tr.error(tc, "CWWKD10xyE.ddlgen.failed.create", dataStore, cause);
+
+            // Throw exception with same message so DDL generation MBean reports that a failure occurred.
+            throw new DataException("DDL file not generated for Jakarta Data repositories associated with the " + dataStore
+                                    + " DatabaseStore. An error occurred creating the EntityManagerFactory.", cause);
+        }
+
+        // Not using persistence service; return null and DDL generation will skip this future
+        return null;
+    }
+
+    @Override
+    public void generate(Writer out) throws Exception {
+        try {
+            EntityManagerBuilder builder = get(DDLGEN_WAIT_TIME, TimeUnit.SECONDS);
+            if (builder instanceof DDLGenerationParticipant) {
+                ((DDLGenerationParticipant) builder).generate(out);
+            }
+        } catch (TimeoutException e) {
+            // TODO : translate message for exception & error (or warning)
+            // DDL generation MBean does not log errors; participants must provide meaningful messages.
+            // Log a useful error informing user to try again later after builder creation completes.
+            Tr.error(tc, "CWWKD10xxE.ddlgen.timeout", dataStore, DDLGEN_WAIT_TIME);
+
+            // Throw exception with same message so DDL generation MBean reports that a failure occurred.
+            throw new DataException("DDL file not generated for Jakarta Data repositories associated with the " + dataStore
+                                    + " DatabaseStore. The EntityManagerFactory was not created in " + DDLGEN_WAIT_TIME + " seconds. Try DDL generation again at a later time.");
+        } catch (Throwable ex) {
+            // TODO : translate message for exception & error (or warning)
+            // DDL generation MBean does not log errors; participants must provide meaningful messages.
+            // Log a useful error informing user to correct problems reported in the cause.
+            Throwable cause = (ex instanceof ExecutionException) ? ex.getCause() : ex;
+            Tr.error(tc, "CWWKD10xyE.ddlgen.failed.create", dataStore, cause);
+
+            // Throw exception with same message so DDL generation MBean reports that a failure occurred.
+            throw new DataException("DDL file not generated for Jakarta Data repositories associated with the " + dataStore
+                                    + " DatabaseStore. An error occurred creating the EntityManagerFactory.", cause);
+        }
     }
 
     /**


### PR DESCRIPTION
- Jakarta Data EMBuilders are created asynchonously, so may not exist if ddlgen invoked to soon
  - resolve by registering the futures with DDL MBean rather than the EMBuilders
- Jakarta Data does not determine if using persistence service until Builder created, so all futures must be registered, not just the ones that will participate
- Updated ddlgen MBean to skip DDLGenerationParticpants if they return null for file name
- Updated ddlgen MBean to handle exceptions that occur obtaining file name, as this is most likely when Jakarta Data would see an error
- Improved exception handling for Jakarta Data DDL gen; identified where errors should be logged


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

for #24916 