### PR TITLE
Removed older versions of EclipseLink from oss_ibm_maven for EclipseLink B03 and Enabled tests which are passing

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -55,11 +55,6 @@ io.openliberty.org.codehaus.jackson:jackson-core-asl:1.9.13.1
 io.openliberty.org.codehaus.jackson:jackson-jaxrs:1.9.13.1
 io.openliberty.org.codehaus.jackson:jackson-mapper-asl:1.9.13.1
 io.openliberty.org.codehaus.jackson:jackson-xc:1.9.13.1
-io.openliberty.org.eclipse.persistence:org.eclipse.persistence.core:5.0.0.20240820
-io.openliberty.org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:5.0.0.20240820
-io.openliberty.org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:5.0.0.20240820
-io.openliberty.org.eclipse.persistence:org.eclipse.persistence.jpa:5.0.0.20240820
-io.openliberty.org.eclipse.persistence:org.eclipse.persistence.json:5.0.0.20240820
 io.openliberty.yoko:yoko-core:1.5.0.e02a8760ae
 io.openliberty.yoko:yoko-osgi:1.5.0.e02a8760ae
 io.openliberty.yoko:yoko-rmi-impl:1.5.0.e02a8760ae

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Item.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Item.java
@@ -28,7 +28,7 @@ public class Item {
     @GeneratedValue
     public UUID pk; // Do not add Id to this name. It should be detectable based on type alone.
 
-    public float price;
+    public double price;
 
     public long version;
 

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Rebate.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/Rebate.java
@@ -55,8 +55,8 @@ public class Rebate {
     public LocalDateTime updatedAt;
 
     @Version
-    Integer version;
-
+    public Integer version;
+    public Rebate(){}
     public static Rebate of(double amount, String customerId, LocalTime purchaseMadeAt, LocalDate purchaseMadeOn, Status status, LocalDateTime updatedAt, int version) {
         Rebate inst = new Rebate();
         inst.amount = amount;
@@ -69,7 +69,17 @@ public class Rebate {
 
         return inst;
     }
-
+    public Rebate(Integer id, double amount, String customerId, LocalTime purchaseMadeAt, LocalDate purchaseMadeOn, Status status, LocalDateTime updatedAt, Integer version){
+        Rebate inst = new Rebate();
+        inst.id=id;
+        inst.amount = amount;
+        inst.customerId = customerId;
+        inst.purchaseMadeAt = purchaseMadeAt;
+        inst.purchaseMadeOn = purchaseMadeOn;
+        inst.status = status;
+        inst.updatedAt = updatedAt;
+        inst.version = version;
+    }
     public static enum Status {
         DENIED, SUBMITTED, VERIFIED, PAID
     }


### PR DESCRIPTION
Removed older versions of EclipseLink from oss_ibm_maven for EclipseLink B03 and Enabled tests which are passing
for #[29457](https://github.com/OpenLiberty/open-liberty/issues/29457)
for #[28928](https://github.com/OpenLiberty/open-liberty/issues/28928)
for #[28908](https://github.com/OpenLiberty/open-liberty/issues/28908)
for #[28913](https://github.com/OpenLiberty/open-liberty/issues/28913)