### PR TITLE
table name for record entities and allow nullable embeddables

### DIFF
--- a/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/DDLGenTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/DDLGenTestServlet.java
@@ -49,7 +49,7 @@ public class DDLGenTestServlet extends FATServlet {
     public void executeDDL() throws SQLException {
         // TODO read from ddlgen output file
         String[] ddl = new String[] {
-                                      "CREATE TABLE dbuser.TESTPartEntity (NAME VARCHAR(255), PRICE FLOAT NOT NULL, VERSION INTEGER NOT NULL, ID_VENDOR VARCHAR(255) NOT NULL, ID_PARTNUM VARCHAR(255) NOT NULL, PRIMARY KEY (ID_VENDOR, ID_PARTNUM))"
+                                      "CREATE TABLE dbuser.TESTPart (NAME VARCHAR(255), PRICE FLOAT NOT NULL, VERSION INTEGER NOT NULL, ID_VENDOR VARCHAR(255) NOT NULL, ID_PARTNUM VARCHAR(255) NOT NULL, PRIMARY KEY (ID_VENDOR, ID_PARTNUM))"
         };
         try (Connection con = adminDataSource.getConnection()) {
             Statement stmt = con.createStatement();


### PR DESCRIPTION
Updates to generated orm.xml to use a table name based on the record name for record entities, rather than the name of the generated stand-in class, which is internal to the implementation and not something users should need to see on their database table. Users will be expecting the name based on the record entity that they supplied.

Also, avoid writing nullable=false to the orm.xml for attributes of embeddables because the persistence provider might need those to be null in the database in order to indicate a null embeddable instance.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

