### PR TITLE
Switch to 8 core cpu shortlist

### DIFF
--- a/.ci-orchestrator/compilePersonal.properties
+++ b/.ci-orchestrator/compilePersonal.properties
@@ -13,7 +13,7 @@ dhe.server=w3-transfer.boulder.ibm.com
 disable.run.createDocumentation=true
 # Normally 100. Used internally by the EBC to adjust the order builds are queued in.
 ebc.priority=100
-ebc.shortlist=parentbuild-personal.yml
+ebc.shortlist=parentbuild-large.yml
 # Marvin will mail the requestor with his analysis of the build.
 enable.predelivery.checking=true
 fail.gradle.on.error=false


### PR DESCRIPTION
- Launch parent steps in an 8 core machine to take advantage of parallel threads in Gradle.