### PR TITLE
Fix CWWWC0002W warning message coming out when using mpGraphQL features

### DIFF
--- a/dev/com.ibm.ws.io.smallrye.graphql/src/com/ibm/ws/io/smallrye/graphql/component/GraphQLSecurityInitializer.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/com/ibm/ws/io/smallrye/graphql/component/GraphQLSecurityInitializer.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.io.smallrye.graphql.component;
+
+import javax.servlet.ServletContext;
+
+public interface GraphQLSecurityInitializer {
+    public void onStartup(ServletContext ctx);
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/VoidQueryTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/VoidQueryTest.java
@@ -59,6 +59,6 @@ public class VoidQueryTest {
     
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer("CWWWC0001W", "SRVE0190E", "CWMGQ0001E", "CWWWC0002W");
+        server.stopServer("CWWWC0001W", "SRVE0190E", "CWMGQ0001E");
     }
 }

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/GraphQLAuthorizationInitializer.java
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/GraphQLAuthorizationInitializer.java
@@ -13,35 +13,33 @@
 package com.ibm.ws.microprofile.graphql.authorization.component;
 
 import java.util.EnumSet;
-import java.util.Set;
 
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
-import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.io.smallrye.graphql.component.GraphQLServletContainerInitializer;
 
 import org.osgi.service.component.annotations.Component;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.io.smallrye.graphql.component.GraphQLSecurityInitializer;
+import com.ibm.ws.io.smallrye.graphql.component.GraphQLServletContainerInitializer;
+
 @Component(property = { "service.vendor=IBM" })
-public class GraphQLAuthorizationServletContainerInitializer implements ServletContainerInitializer {
-    private static final TraceComponent tc = Tr.register(GraphQLAuthorizationServletContainerInitializer.class);
+public class GraphQLAuthorizationInitializer implements GraphQLSecurityInitializer {
+    private static final TraceComponent tc = Tr.register(GraphQLAuthorizationInitializer.class);
     private static final String AUTH_FILTER_NAME = "AuthorizationFilter";
 
-    public void onStartup(Set<Class<?>> classes, ServletContext ctx) throws ServletException {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.entry(tc, "onStartup", new Object[] {classes, ctx, ctx.getServletContextName(), ctx.getContextPath()});
+    public void onStartup(ServletContext ctx) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
+            Tr.entry(tc, "onStartup", new Object[] {ctx, ctx.getServletContextName(), ctx.getContextPath()});
         }
 
         // add servlet filter for ExecutionServlet
         FilterRegistration.Dynamic filterReg = ctx.addFilter(AUTH_FILTER_NAME, AuthorizationFilter.getInstance());
         filterReg.addMappingForServletNames(EnumSet.of(DispatcherType.REQUEST), true, 
                 GraphQLServletContainerInitializer.EXECUTION_SERVLET_NAME);
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.exit(tc, "onStartup");
         }
     }

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/JakartaEE10Test.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/JakartaEE10Test.java
@@ -156,7 +156,6 @@ public class JakartaEE10Test extends FATServletClient {
         if (RepeatTestFilter.isRepeatActionActive(COMPAT_OL_FEATURES)) {
             toleratedWarnErrors = new String[] { "SRVE0280E", // TODO: SRVE0280E tracked by OpenLiberty issue #4857
                                                  "CWWKS5207W", // The remaining ones relate to config not done for the server / app
-                                                 "CWWWC0002W",
                                                  "CWMOT0010W",
                                                  "TRAS4352W" // Only happens when running with WebSphere Liberty image due to an auto feature
             };
@@ -164,7 +163,6 @@ public class JakartaEE10Test extends FATServletClient {
         } else if (RepeatTestFilter.isRepeatActionActive(COMPAT_WL_FEATURES)) {
             toleratedWarnErrors = new String[] { "SRVE0280E", // TODO: SRVE0280E tracked by OpenLiberty issue #4857
                                                  "CWWKS5207W", // The remaining ones relate to config not done for the server / app
-                                                 "CWWWC0002W",
                                                  "CWMOT0010W",
                                                  "CWWKG0033W", // related to missing config for collectives
                                                  "CWSJY0035E", // wmqJmsClient.rar.location variable not in the server.xml

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/JakartaEE11Test.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/JakartaEE11Test.java
@@ -128,7 +128,6 @@ public class JakartaEE11Test extends FATServletClient {
         if (RepeatTestFilter.isRepeatActionActive(COMPAT_OL_FEATURES)) {
             toleratedWarnErrors = new String[] { "SRVE0280E", // TODO: SRVE0280E tracked by OpenLiberty issue #4857
                                                  "CWWKS5207W", // The remaining ones relate to config not done for the server / app
-                                                 "CWWWC0002W",
                                                  "CWMOT0010W",
                                                  "CWWKE0701E", // TODO: Fix this or verify that it is expected
                                                  "TRAS4352W" // Only happens when running with WebSphere Liberty image due to an auto feature
@@ -137,7 +136,6 @@ public class JakartaEE11Test extends FATServletClient {
         } else if (RepeatTestFilter.isRepeatActionActive(COMPAT_WL_FEATURES)) {
             toleratedWarnErrors = new String[] { "SRVE0280E", // TODO: SRVE0280E tracked by OpenLiberty issue #4857
                                                  "CWWKS5207W", // The remaining ones relate to config not done for the server / app
-                                                 "CWWWC0002W",
                                                  "CWMOT0010W",
                                                  "CWWKE0701E", // TODO: Fix this or verify that it is expected
                                                  "CWWKG0033W", // related to missing config for collectives

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
@@ -156,7 +156,6 @@ public class JakartaEE9Test extends FATServletClient {
         if (RepeatTestFilter.isRepeatActionActive(COMPAT_OL_FEATURES)) {
             toleratedWarnErrors = new String[] { "SRVE0280E", // TODO: SRVE0280E tracked by OpenLiberty issue #4857
                                                  "CWWKS5207W", // The remaining ones relate to config not done for the server / app
-                                                 "CWWWC0002W",
                                                  "CWMOT0010W",
                                                  "TRAS4352W" // Only happens when running with WebSphere Liberty image due to an auto feature
             };
@@ -164,7 +163,6 @@ public class JakartaEE9Test extends FATServletClient {
         } else if (RepeatTestFilter.isRepeatActionActive(COMPAT_WL_FEATURES)) {
             toleratedWarnErrors = new String[] { "SRVE0280E", // TODO: SRVE0280E tracked by OpenLiberty issue #4857
                                                  "CWWKS5207W", // The remaining ones relate to config not done for the server / app
-                                                 "CWWWC0002W",
                                                  "CWMOT0010W",
                                                  "CWWKG0033W", // related to missing config for collectives
                                                  "CWSJY0035E", // wmqJmsClient.rar.location variable not in the server.xml

--- a/dev/io.openliberty.microprofile.internal_fat/fat/src/io/openliberty/microprofile/internal/test/suite/MPCompatibleTest.java
+++ b/dev/io.openliberty.microprofile.internal_fat/fat/src/io/openliberty/microprofile/internal/test/suite/MPCompatibleTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -272,10 +272,7 @@ public class MPCompatibleTest {
             server.startServer();
             runGetMethod(200, "/helloworld/helloworld", MESSAGE);
         } finally {
-            //I think CWWWC0002W is a configuration error and should not appear
-            //Should be removed by issue 15496
-            server.stopServer("CWMOT0010W", //CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
-                              "CWWWC0002W");//CWWWC0002W: No servlet definition is found for the ExecutionServlet servlet name in the AuthorizationFilter filter mapping.
+            server.stopServer("CWMOT0010W"); //CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
         }
     }
 
@@ -299,10 +296,7 @@ public class MPCompatibleTest {
             server.startServer();
             runGetMethod(200, "/helloworld/helloworld", MESSAGE);
         } finally {
-            //I think CWWWC0002W is a configuration error and should not appear
-            //Should be removed by issue 15496
-            server.stopServer("CWMOT0010W", //CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
-                              "CWWWC0002W");//CWWWC0002W: No servlet definition is found for the ExecutionServlet servlet name in the AuthorizationFilter filter mapping.
+            server.stopServer("CWMOT0010W"); //CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
         }
     }
 

--- a/dev/io.openliberty.microprofile7.internal_fat/fat/src/io/openliberty/microprofile7/internal/test/suite/MP7EE10CompatibleTest.java
+++ b/dev/io.openliberty.microprofile7.internal_fat/fat/src/io/openliberty/microprofile7/internal/test/suite/MP7EE10CompatibleTest.java
@@ -36,9 +36,7 @@ public class MP7EE10CompatibleTest {
 
     @AfterClass
     public static void cleanUp() throws Exception {
-        //I think CWWWC0002W is a mpGraphQL-1.0 bug and should not appear
-        //See issue 15496
-        MPCompatibilityTestUtils.cleanUp(server, "CWWWC0002W");
+        MPCompatibilityTestUtils.cleanUp(server);
     }
 
     /**

--- a/dev/io.openliberty.microprofile7.internal_fat/fat/src/io/openliberty/microprofile7/internal/test/suite/MP7EE11CompatibleTest.java
+++ b/dev/io.openliberty.microprofile7.internal_fat/fat/src/io/openliberty/microprofile7/internal/test/suite/MP7EE11CompatibleTest.java
@@ -38,9 +38,7 @@ public class MP7EE11CompatibleTest {
 
     @AfterClass
     public static void cleanUp() throws Exception {
-        //I think CWWWC0002W is a mpGraphQL-1.0 bug and should not appear
-        //See issue 15496
-        MPCompatibilityTestUtils.cleanUp(server, "CWWWC0002W");
+        MPCompatibilityTestUtils.cleanUp(server);
     }
 
     /**


### PR DESCRIPTION
- When using mpGraphQL features with appSecurity features and the application is not a GraphQL application, the CWWWC0002W message came out because the security logic for mpGraphQL unconditionally was adding a filter even when the application was not a GraphQL application.
- Updated to only add the filter if the application is determined to be a GraphQL application.
- Updated test cases that were ignoring the CWWWC0002W message on server stop to no longer have that ignore.

Fixes #15496 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
