### PR TITLE
eighth batch of jakarta data messages

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -658,7 +658,7 @@ CWWKD1067.ddlgen.emf.timeout.useraction=Reattempt DDL generation \
  when the system and database are not under load.
 
 CWWKD1068.entity.name.conflict=CWWKD1068E: The {0} repository interface has \
- multiple entities named {1} which are provided by different classes: {2}. \
+ multiple entities named {1} that are provided by different classes: {2}. \
  Use the following Jakarta Persistence entity annotations to assign a unique \
  entity name and table name to each entity class: {3}.
 CWWKD1068.entity.name.conflict.explanation=Entity names and tables names are \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -656,3 +656,24 @@ CWWKD1067.ddlgen.emf.timeout.explanation=Acquisition of the resources needed \
  for DDL generation timed out and did not complete.
 CWWKD1067.ddlgen.emf.timeout.useraction=Reattempt DDL generation at a later time \
  when the system and database are not under load.
+
+CWWKD1068.entity.name.conflict=CWWKD1068E: The {0} repository interface has \
+ multiple entities named {1} which are provided by different classes: {2}. \
+ Use the following Jakarta Persistence entity annotations to assign a unique \
+ entity name and table name to each entity class: {3}.
+CWWKD1068.entity.name.conflict.explanation=Entity names and tables names are \
+ inferred from the unqualified class name or assigned by Jakarta Persistence \
+ annotations.
+CWWKD1068.entity.name.conflict.useraction=Rename the entities or add \
+ Jakarta Persistence annotations to explicitly resolve the name conflict.
+
+CWWKD1069.record.entity.name.conflict=CWWKD1069E: The {0} repository interface \
+ has multiple entities named {1} which are provided by different classes: {2}. \
+ When Java records are used as entities, it must also be possible to append \
+ a suffix of Entity to the entity name without resulting in a name conflict. \
+ For example: {2}.
+CWWKD1069.record.entity.name.conflict.explanation=Entity names and tables names \
+ are inferred from the unqualified class name or assigned by Jakarta Persistence \
+ annotations.
+CWWKD1069.record.entity.name.conflict.useraction=Rename the entities or switch \
+ to Jakarta Persistence entities to resolve the name conflict.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -624,3 +624,11 @@ CWWKD1063.unsupported.resource.explanation=The Jakarta Persistence provider does
  not support the unwrap operation returning the specified resource type.
 CWWKD1063.unsupported.resource.useraction=Remove the unsupported resource accessor \
  method from the repository interface.
+
+CWWKD1064.datastore.error=CWWKD1064E: The {0} method of the {1} repository \
+ interface is unable to obtain the {2} data store for the repository due to \
+ the following error: {3}.
+CWWKD1064.datastore.error.explanation=An error occurred when attempting to obtain \
+ the data store.
+CWWKD1064.datastore.error.useraction=Ensure that the specified data store and all \
+ other resources it depends on exist and are correctly configured.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -638,7 +638,7 @@ CWWKD1065.ddlgen.timeout=CWWKD1065E: DDL generation for the {0} repository \
  within {2} seconds for the following entities: {3}.
 CWWKD1065.ddlgen.timeout.explanation=The DDL generation attempt timed out \
  and did not complete.
-CWWKD1065.ddlgen.timeout.useraction=Reattempt DDL generation at a later time \
+CWWKD1065.ddlgen.timeout.useraction=Reattempt DDL generation \
  when the system and database are not under load.
 
 CWWKD1066.ddlgen.failed=CWWKD1066E: DDL generation for the {0} repository \
@@ -654,7 +654,7 @@ CWWKD1067.ddlgen.emf.timeout=CWWKD1067E: DDL generation for the {0} repository \
  to make the following entities available within {2} seconds: {3}.
 CWWKD1067.ddlgen.emf.timeout.explanation=Acquisition of the resources needed \
  for DDL generation timed out and did not complete.
-CWWKD1067.ddlgen.emf.timeout.useraction=Reattempt DDL generation at a later time \
+CWWKD1067.ddlgen.emf.timeout.useraction=Reattempt DDL generation \
  when the system and database are not under load.
 
 CWWKD1068.entity.name.conflict=CWWKD1068E: The {0} repository interface has \
@@ -668,7 +668,7 @@ CWWKD1068.entity.name.conflict.useraction=Rename the entities or add \
  Jakarta Persistence annotations to explicitly resolve the name conflict.
 
 CWWKD1069.record.entity.name.conflict=CWWKD1069E: The {0} repository interface \
- has multiple entities named {1} which are provided by different classes: {2}. \
+ has multiple entities named {1} that are provided by different classes: {2}. \
  When Java records are used as entities, it must also be possible to append \
  a suffix of Entity to the entity name without resulting in a name conflict. \
  For example: {2}.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -632,3 +632,27 @@ CWWKD1064.datastore.error.explanation=An error occurred when attempting to obtai
  the data store.
 CWWKD1064.datastore.error.useraction=Ensure that the specified data store and all \
  other resources it depends on exist and are correctly configured.
+
+CWWKD1065.ddlgen.timeout=CWWKD1065E: DDL generation for the {0} repository \
+ interface failed because the {1} data store did not complete DDL generation \
+ within {2} seconds for the following entities: {3}.
+CWWKD1065.ddlgen.timeout.explanation=The DDL generation attempt timed out \
+ and did not complete.
+CWWKD1065.ddlgen.timeout.useraction=Reattempt DDL generation at a later time \
+ when the system and database are not under load.
+
+CWWKD1066.ddlgen.failed=CWWKD1066E: DDL generation for the {0} repository \
+ interface that uses the {1} data store encountered an error when attempting \
+ DDL generation for the following entities: {2}. The error is: {3}.
+CWWKD1066.ddlgen.failed.explanation=The DDL generation attempt failed \
+ and did not complete.
+CWWKD1066.ddlgen.failed.useraction=Investigate the error and make corrections \
+ to the repository interface, entities, data store configuration, or database.
+
+CWWKD1067.ddlgen.emf.timeout=CWWKD1067E: DDL generation for the {0} repository \
+ interface failed because the {1} data store was not available or was unable \
+ to make the following entities available within {2} seconds: {3}.
+CWWKD1067.ddlgen.emf.timeout.explanation=Acquisition of the resources needed \
+ for DDL generation timed out and did not complete.
+CWWKD1067.ddlgen.emf.timeout.useraction=Reattempt DDL generation at a later time \
+ when the system and database are not under load.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -677,3 +677,26 @@ CWWKD1069.record.entity.name.conflict.explanation=Entity names and tables names 
  annotations.
 CWWKD1069.record.entity.name.conflict.useraction=Rename the entities or switch \
  to Jakarta Persistence entities to resolve the name conflict.
+
+CWWKD1070.record.convert.err=CWWKD1070E: The {0} record that is supplied to the \
+ {1} method of the {2} repository interface cannot be used as an entity due to \
+ the following error: {3}.
+CWWKD1070.record.convert.err.explanation=It is not possible to use the \
+ Java record as an entity.
+CWWKD1070.record.convert.err.useraction=Define the entity as a Jakarta Persistence \
+ entity instead of using a Java record entity.
+
+CWWKD1071.record.with.type.var=CWWKD1071E: The {0} record cannot be used as an \
+ entity because it has one or more type variables: {1}.
+CWWKD1071.record.with.type.var.explanation=Entity classes cannot have generic \
+ type variables.
+CWWKD1071.record.with.type.var.useraction=Remove the type variables from the \
+ record.
+
+CWWKD1072.record.comp.conflict=CWWKD1072E: The {0} record cannot be used as an \
+ entity because its {1} component and {2} component both resolve to the same \
+ entity property name.
+CWWKD1072.record.comp.conflict.explanation=Entity property names must be \
+ unique ignoring case.
+CWWKD1072.record.comp.conflict.useraction=Rename one of the record components \
+ to avoid the conflict.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1053,11 +1053,6 @@ public class QueryInfo {
             throw new MappingException("Entity property name is missing."); // TODO possibly combine with unknown entity property name
 
         String name = getAttributeName(attribute, true);
-        if (name == null) {
-            if (entityInfo.idClassAttributeAccessors != null && ID.equals(attribute))
-                generateConditionsForIdClass(condition, ignoreCase, negated, q);
-            return;
-        }
 
         StringBuilder attributeExpr = new StringBuilder();
         if (function != null)
@@ -1133,51 +1128,6 @@ public class QueryInfo {
                 q.append(attributeExpr).append(negated ? " NOT " : "").append(condition.operator);
                 generateParam(q, ignoreCase, ++paramCount);
         }
-    }
-
-    /**
-     * Generates JPQL for a *By condition on the IdClass, which expands to multiple conditions in JPQL.
-     */
-    private void generateConditionsForIdClass(Condition condition, boolean ignoreCase, boolean negate, StringBuilder q) {
-
-        String o_ = entityVar_;
-
-        q.append(negate ? "NOT (" : "(");
-
-        int count = 0;
-        for (String idClassAttr : entityInfo.idClassAttributeAccessors.keySet()) {
-            if (++count != 1)
-                q.append(" AND ");
-
-            String name = getAttributeName(idClassAttr, true);
-            if (ignoreCase)
-                q.append("LOWER(").append(o_).append(name).append(')');
-            else
-                q.append(o_).append(name);
-
-            switch (condition) {
-                case EQUALS:
-                case NOT_EQUALS:
-                    q.append(condition.operator);
-                    generateParam(q, ignoreCase, ++paramCount);
-                    if (count != 1)
-                        paramAddedCount++;
-                    break;
-                case NULL:
-                case EMPTY:
-                    q.append(Condition.NULL.operator);
-                    break;
-                case NOT_NULL:
-                case NOT_EMPTY:
-                    q.append(Condition.NOT_NULL.operator);
-                    break;
-                default:
-                    throw new MappingException("Repository keyword " + condition.name() +
-                                               " cannot be used when the Id of the entity is an IdClass."); // TODO NLS
-            }
-        }
-
-        q.append(')');
     }
 
     /**
@@ -1435,10 +1385,17 @@ public class QueryInfo {
                                 //    generateUpdatesForIdClass(queryInfo, update, first, q);
                                 throw new UnsupportedOperationException("@Assign IdClass"); // TODO
                             } else {
-                                throw new MappingException("One or more of the " + Arrays.toString(annosForAllParams[p]) +
-                                                           " annotations specifes an operation that cannot be used on parameter " +
-                                                           (p + 1) + " of the " + method.getName() + " method of the " +
-                                                           repositoryInterface.getName() + " repository when the Id is an IdClass."); // TODO NLS
+                                // Unreachable in version 1.0 and uncertain what
+                                // will be added to the spec. Deferring NLS message
+                                // until then.
+                                throw new MappingException("One or more of the " +
+                                                           Arrays.toString(annosForAllParams[p]) +
+                                                           " annotations specifes an operation" +
+                                                           " that cannot be used on parameter " +
+                                                           (p + 1) + " of the " + method.getName() +
+                                                           " method of the " +
+                                                           repositoryInterface.getName() +
+                                                           " repository when the Id is an IdClass.");
                             }
                         } else {
                             String attribute = attrAndOp[0];
@@ -1600,8 +1557,15 @@ public class QueryInfo {
         if (selections == null || selections.length == 0) {
             cols = null;
         } else if (type == Type.FIND_AND_DELETE) {
-            // TODO NLS message for error path once selections are supported function
-            throw new UnsupportedOperationException();
+            // Unreachable in version 1.0 and uncertain what will be added to
+            // the spec regarding selections. Deferring NLS message until then.
+            throw new UnsupportedOperationException //
+            ("The " + method.getName() + " method of the " +
+             repositoryInterface.getName() + " repository has a " +
+             method.getGenericReturnType().getTypeName() + " return type and" +
+             " specifies to return the " + selections + " entity properties," +
+             " but delete operations can only return void, a deletion count," +
+             " a boolean deletion indicator, or the removed entities.");
         } else {
             cols = new String[selections.length];
             for (int i = 0; i < cols.length; i++) {
@@ -1831,9 +1795,14 @@ public class QueryInfo {
                 if (op == '=') {
                     generateUpdatesForIdClass(first, q);
                 } else {
+                    // Unreachable in version 1.0 and uncertain which operations
+                    // will be chosen in future. Deferring NLS message until then.
                     String opName = op == '+' ? "Add" : op == '*' ? "Multiply" : "Divide";
-                    throw new MappingException("The " + opName +
-                                               " repository update operation cannot be used on the Id of the entity when the Id is an IdClass."); // TODO NLS
+                    throw new UnsupportedOperationException("The " + opName +
+                                                            " repository update operation" +
+                                                            " cannot be used on the Id" +
+                                                            " of the entity when the" +
+                                                            " Id is an IdClass.");
                 }
             } else {
                 q.append(first ? " " : ", ").append(o_).append(name).append("=");

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -193,24 +194,27 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                 return ((DDLGenerationParticipant) builder).getDDLFileName();
             }
         } catch (TimeoutException e) {
-            // TODO : translate message for exception & error (or warning)
-            // DDL generation MBean does not log errors; participants must provide meaningful messages.
-            // Log a useful error informing user to try again later after builder creation completes.
-            Tr.error(tc, "CWWKD10xxE.ddlgen.timeout", dataStore, DDLGEN_WAIT_TIME);
-
-            // Throw exception with same message so DDL generation MBean reports that a failure occurred.
-            throw new DataException("DDL file not generated for Jakarta Data repositories associated with the " + dataStore
-                                    + " DatabaseStore. The EntityManagerFactory was not created in " + DDLGEN_WAIT_TIME + " seconds. Try DDL generation again at a later time.");
+            // DDL generation MBean does not log errors; The following covers both
+            // logging the error and raising an exception with the same message.
+            throw exc(DataException.class,
+                      "CWWKD1067.ddlgen.emf.timeout",
+                      repositoryInterface.getName(),
+                      dataStore,
+                      DDLGEN_WAIT_TIME,
+                      entityTypes.stream().map(Class::getName).collect(Collectors.toList()));
         } catch (Throwable ex) {
-            // TODO : translate message for exception & error
-            // DDL generation MBean does not log errors; participants must provide meaningful messages.
-            // Log a useful error informing user to correct problems reported in the cause.
+            // DDL generation MBean does not log errors; The following covers both
+            // logging the error and raising an exception with the same message.
             Throwable cause = (ex instanceof ExecutionException) ? ex.getCause() : ex;
-            Tr.error(tc, "CWWKD10xyE.ddlgen.failed.create", dataStore, cause);
-
-            // Throw exception with same message so DDL generation MBean reports that a failure occurred.
-            throw new DataException("DDL file not generated for Jakarta Data repositories associated with the " + dataStore
-                                    + " DatabaseStore. An error occurred creating the EntityManagerFactory.", cause);
+            DataException dx = exc(DataException.class,
+                                   "CWWKD1066.ddlgen.failed",
+                                   repositoryInterface.getName(),
+                                   dataStore,
+                                   entityTypes.stream() //
+                                                   .map(Class::getName) //
+                                                   .collect(Collectors.toList()),
+                                   cause.getMessage());
+            throw (DataException) dx.initCause(ex);
         }
 
         // Not using persistence service; return null and DDL generation will skip this future
@@ -225,24 +229,27 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                 ((DDLGenerationParticipant) builder).generate(out);
             }
         } catch (TimeoutException e) {
-            // TODO : translate message for exception & error (or warning)
-            // DDL generation MBean does not log errors; participants must provide meaningful messages.
-            // Log a useful error informing user to try again later after builder creation completes.
-            Tr.error(tc, "CWWKD10xxE.ddlgen.timeout", dataStore, DDLGEN_WAIT_TIME);
-
-            // Throw exception with same message so DDL generation MBean reports that a failure occurred.
-            throw new DataException("DDL file not generated for Jakarta Data repositories associated with the " + dataStore
-                                    + " DatabaseStore. The EntityManagerFactory was not created in " + DDLGEN_WAIT_TIME + " seconds. Try DDL generation again at a later time.");
+            // DDL generation MBean does not log errors; The following covers both
+            // logging the error and raising an exception with the same message.
+            throw exc(DataException.class,
+                      "CWWKD1065.ddlgen.timeout",
+                      repositoryInterface.getName(),
+                      dataStore,
+                      DDLGEN_WAIT_TIME,
+                      entityTypes.stream().map(Class::getName).collect(Collectors.toList()));
         } catch (Throwable ex) {
-            // TODO : translate message for exception & error (or warning)
-            // DDL generation MBean does not log errors; participants must provide meaningful messages.
-            // Log a useful error informing user to correct problems reported in the cause.
+            // DDL generation MBean does not log errors; The following covers both
+            // logging the error and raising an exception with the same message.
             Throwable cause = (ex instanceof ExecutionException) ? ex.getCause() : ex;
-            Tr.error(tc, "CWWKD10xyE.ddlgen.failed.create", dataStore, cause);
-
-            // Throw exception with same message so DDL generation MBean reports that a failure occurred.
-            throw new DataException("DDL file not generated for Jakarta Data repositories associated with the " + dataStore
-                                    + " DatabaseStore. An error occurred creating the EntityManagerFactory.", cause);
+            DataException dx = exc(DataException.class,
+                                   "CWWKD1066.ddlgen.failed",
+                                   repositoryInterface.getName(),
+                                   dataStore,
+                                   entityTypes.stream() //
+                                                   .map(Class::getName) //
+                                                   .collect(Collectors.toList()),
+                                   cause.getMessage());
+            throw (DataException) dx.initCause(ex);
         }
     }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -631,7 +631,17 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
 
             return (DataSource) dsFactory.createResource(resRef);
         } catch (Exception x) {
-            throw new DataException(x); // TODO NLS
+            if (x instanceof RuntimeException &&
+                x.getMessage() != null &&
+                x.getMessage().startsWith("CWWKD"))
+                throw (RuntimeException) x;
+
+            throw (DataException) exc(DataException.class,
+                                      "CWWKD1064.datastore.error",
+                                      repoMethod.getName(),
+                                      repoInterface.getName(),
+                                      databaseStoreId,
+                                      x.getMessage()).initCause(x);
         }
     }
 


### PR DESCRIPTION
Translatable messages for Jakarta Data for:
createResource failure
DDL generation errors
Entity name collisions
Various issues with record entities

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
