### PR TITLE
NLS messages for various remaining Jakarta Data error paths

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -700,3 +700,35 @@ CWWKD1072.record.comp.conflict.explanation=Entity property names must be \
  unique ignoring case.
 CWWKD1072.record.comp.conflict.useraction=Rename one of the record components \
  to avoid the conflict.
+
+CWWKD1073.offset.exceeds.max=CWWKD1073E: The {0} starting point of the \
+ {1} limit that is supplied to the {2} method of the {3} repository interface \
+ exceeds the maximum allowed value of {4}.
+CWWKD1073.offset.exceeds.max.explanation=The starting point for the limit is \
+ too large.
+CWWKD1073.offset.exceeds.max.useraction=Add restrictions to the query to reduce \
+ the number of matching results.
+
+CWWKD1074.qbmn.incompat.keywords=CWWKD1074E: The {0} method of the {1} repository \
+ interface must not combine the {2} keyword with the {3} keyword on the same \
+ Query by Method Name condition.
+CWWKD1074.qbmn.incompat.keywords.explanation=The specified Query by Method Name \
+ keywords are not compatible with each other.
+CWWKD1074.qbmn.incompat.keywords.useraction=Rename the method to not combine \
+ the keywords on the same condition.
+
+CWWKD1075.entity.prop.conflict=CWWKD1075E: The {0} entity cannot have a property \
+ named {1} and a property named {2} because the Jakarta Data specification \
+ considers these names to be aliases for the same entity property.
+CWWKD1075.entity.prop.conflict.explanation=There is a collision between the \
+ names of two entity properties due to the underscore character.
+CWWKD1075.entity.prop.conflict.useraction=Do not use the underscore character \
+ in entity property names.
+
+CWWKD1076.repo.disposed=CWWKD1076E: The {0} method of the {1} repository \
+ interface cannot be invoked because the application that defines the repository \
+ has stopped. The repository instance is {2}.
+CWWKD1076.repo.disposed.explanation=Repository methods must not be used outside \
+ of the lifecycle of the application that defines the repository.
+CWWKD1076.repo.disposed.useraction=Ensure that the repository method is not \
+ used outside of the scope of the application that defines the repository.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -772,8 +772,10 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
                             xml.append(name.toUpperCase()) //
                                             .append("\"/>").append(EOLN);
                             xml.append("    </attribute-override>").append(EOLN);
-                            // TODO reject column name collisions?
-                            // collisions are currently only possible if an attribute name includes _
+
+                            // Table name collision detection is unnecessary because
+                            // the same collisions would already be caught by entity
+                            // attribute name collision detection.
                         } else {
                             Map<String, Class<?>> a = embeddableTypes.get(type);
                             if (a == null)

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -57,7 +57,9 @@ public class DataTest extends FATServletClient {
                                    "CWWKD1046E.*minMaxSumCountAverageFloat",
                                    "CWWKD1046E.*singleHexDigit",
                                    "CWWKD1047E.*numberAsByte",
-                                   "CWWKD1049E.*countAsBooleanByNumberIdLessThan"
+                                   "CWWKD1049E.*countAsBooleanByNumberIdLessThan",
+                                   "CWWKD1075E.*Apartment2",
+                                   "CWWKD1075E.*Apartment3"
                     };
 
     @ClassRule

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
@@ -53,6 +53,8 @@ public class DataJPATest extends FATServletClient {
                                    "CWWKD1046E.*numFullTimeWorkersAsDouble",
                                    "CWWKD1046E.*numFullTimeWorkersAsFloat",
                                    "CWWKD1046E.*numFullTimeWorkersAsShort",
+                                   "CWWKD1075E.*Apartment2",
+                                   "CWWKD1075E.*Apartment3"
                     };
 
     @ClassRule


### PR DESCRIPTION
This PR adds translatable messages for various error paths in Jakarta Data, including:
- Incompatible Query by Method Name condition kewords
- Repository used outside of the life cycle of the application
- Limit with startAt value that exceeds the maximum possible for EclipseLink
- Conflicting entity property names

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
