### PR TITLE
Fat okd service fix

### DIFF
--- a/dev/com.ibm.ws.security.social_fat.okdServiceLogin/test-applications/StubbedOKDServiceLogin/src/com/ibm/ws/fat/OKDServiceLogin/UserValidationApi.java
+++ b/dev/com.ibm.ws.security.social_fat.okdServiceLogin/test-applications/StubbedOKDServiceLogin/src/com/ibm/ws/fat/OKDServiceLogin/UserValidationApi.java
@@ -61,7 +61,7 @@ public class UserValidationApi extends HttpServlet {
                 String key = headerList.nextElement();
                 String val = req.getHeader(key);
                 logLine("Header element: " + key + " value: " + val);
-                if ("Authorization" == key) {
+                if ("Authorization".equalsIgnoreCase(key)) {
 
                     passedResponse = val.substring("Bearer ".length());
                     printJson(passedResponse);

--- a/dev/com.ibm.ws.security.social_fat.okdServiceLogin/test-applications/StubbedOKDServiceLogin/src/com/ibm/ws/fat/OKDServiceLogin/UserValidationApi.java
+++ b/dev/com.ibm.ws.security.social_fat.okdServiceLogin/test-applications/StubbedOKDServiceLogin/src/com/ibm/ws/fat/OKDServiceLogin/UserValidationApi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -61,7 +61,6 @@ public class UserValidationApi extends HttpServlet {
                 String key = headerList.nextElement();
                 String val = req.getHeader(key);
                 logLine("Header element: " + key + " value: " + val);
-                
                 if ("Authorization".equalsIgnoreCase(key)) {
 
                     passedResponse = val.substring("Bearer ".length());

--- a/dev/com.ibm.ws.security.social_fat.okdServiceLogin/test-applications/StubbedOKDServiceLogin/src/com/ibm/ws/fat/OKDServiceLogin/UserValidationApi.java
+++ b/dev/com.ibm.ws.security.social_fat.okdServiceLogin/test-applications/StubbedOKDServiceLogin/src/com/ibm/ws/fat/OKDServiceLogin/UserValidationApi.java
@@ -61,6 +61,7 @@ public class UserValidationApi extends HttpServlet {
                 String key = headerList.nextElement();
                 String val = req.getHeader(key);
                 logLine("Header element: " + key + " value: " + val);
+                
                 if ("Authorization".equalsIgnoreCase(key)) {
 
                     passedResponse = val.substring("Bearer ".length());


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

### This fix does not impact customer code, it is a FAT test fix. 

### Code change details:

The switch statement on the okdServiceLogin app is subject to receive null pointer exceptions due to the String comparison for the Authorization header. This PR addresses that bug. 

https://github.com/OpenLiberty/open-liberty/blob/c41289abc29b181875438c857fe0146e66071ac0/dev/com.ibm.ws.security.social_fat.okdServiceLogin/test-applications/StubbedOKDServiceLogin/src/com/ibm/ws/fat/OKDServiceLogin/UserValidationApi.java#L83 