### PR TITLE
Update globalhandler-1.0 protected feature for EE 11 toleration

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-2.1.feature
@@ -4,10 +4,9 @@ visibility=private
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.restfulWSClient-3.1)(osgi.identity=io.openliberty.restfulWSClient-4.0)))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpJwt-2.1))"
 IBM-Install-Policy: when-satisfied
--features= \
- io.openliberty.globalhandler1.0.internal.ee-10.0
 -bundles= \
  com.ibm.ws.security.mp.jwt.propagation, \
- io.openliberty.restfulWS.internal.globalhandler
+ io.openliberty.restfulWS.internal.globalhandler, \
+ io.openliberty.webservices.handler
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.globalhandler1.0.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.globalhandler1.0.internal.ee-11.0.feature
@@ -1,11 +1,11 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.globalhandler1.0.internal.ee-10.0
+symbolicName=io.openliberty.globalhandler1.0.internal.ee-11.0
 singleton=true
 visibility = private
 -features=\
-  com.ibm.websphere.appserver.servlet-6.0
+  com.ibm.websphere.appserver.servlet-6.1
 -bundles=\
   io.openliberty.webservices.handler
-kind=ga
+kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.ee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.ee-10.0.feature
@@ -4,9 +4,9 @@ singleton=true
 visibility = private
 -features=\
   io.openliberty.xmlWS-4.0, \
-  com.ibm.websphere.appserver.servlet-6.0; ibm.tolerates:="6.1", \
-  io.openliberty.globalhandler1.0.internal.ee-10.0
+  com.ibm.websphere.appserver.servlet-6.0; ibm.tolerates:="6.1"
 -bundles=\
+  io.openliberty.webservices.handler, \
   com.ibm.ws.wsat.common.jakarta; start-phase:=CONTAINER_LATE, \
   com.ibm.ws.wsat.webclient.jakarta, \
   com.ibm.ws.wsat.webservice.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/io.openliberty.globalhandler-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/io.openliberty.globalhandler-1.0.feature
@@ -5,8 +5,8 @@ IBM-App-ForceRestart: uninstall, \
  install
 IBM-SPI-Package: com.ibm.wsspi.webservices.handler
 -features=\
-  io.openliberty.globalhandler1.0.internal.ee-10.0, \
-  com.ibm.websphere.appserver.servlet-6.0; ibm.tolerates:="6.1"
+  io.openliberty.globalhandler1.0.internal.ee-10.0; ibm.tolerates:="11.0", \
+  io.openliberty.servlet.api-6.0; ibm.tolerates:="6.1"
 -jars=\
   io.openliberty.globalhandler.spi; location:=dev/spi/ibm/
 -files=\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -31,6 +31,8 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -308,7 +310,12 @@ public abstract class HTTPConduit
 
     static {
 
-        String autoRedirectPolicy = System.getProperty("jaxws.http.autoredirect");
+        String autoRedirectPolicy = AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return System.getProperty("jaxws.http.autoredirect");
+            }
+        });
         if (LOG.isLoggable(Level.FINEST)) {
             LOG.finest("jaxws.http.autoredirect property is set to " + autoRedirectPolicy);
         }

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3624,16 +3624,10 @@ public class LibertyServer implements LogMonitorClient {
 
                                                      "ContainerJSPServer", //io.openliberty.http.monitor_fat
 
-                                                     "RSTestServer", //io.openliberty.jaxrs.global.handler.internal_fat
-
                                                      "EnableSchemaValidationTestServer", //io.openliberty.jaxws.config_fat
                                                      "EnableSchemaValidationWebServiceTestServer", //io.openliberty.jaxws.config_fat
                                                      "IgnoreUnexpectedElementConfigTestServer", //io.openliberty.jaxws.config_fat
                                                      "GzipInterceptorsTestServer", //io.openliberty.jaxws.config_fat
-
-                                                     "AddNumbersTestServer", //io.openliberty.jaxws.global.handler.internal_fat
-                                                     "EJBServiceRefBndTestServer", //io.openliberty.jaxws.global.handler.internal_fat
-                                                     "HandlerChainTestServerAlternate", //io.openliberty.jaxws.global.handler.internal_fat
 
                                                      "simpleWar", //io.openliberty.jee.internal_fat
                                                      "simpleEar", //io.openliberty.jee.internal_fat

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021,2023 IBM Corporation and others.
+# Copyright (c) 2021,2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -47,7 +47,10 @@ tested.features= \
     xmlWS-3.0, \
     appSecurity-4.0, \
     pages-3.0, \
-    pages-3.1
+    pages-3.1, \
+    pages-4.0, \
+    restfulws-4.0, \
+    appSecurity-6.0
 
 -buildpath: \
 	io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/fat/src/com/ibm/ws/webservices/handler/fat/FATSuite.java
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/fat/src/com/ibm/ws/webservices/handler/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021,2023 IBM Corporation and others.
+ * Copyright (c) 2021,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -41,6 +41,7 @@ public class FATSuite {
     public static RepeatTests r = RepeatTests.withoutModificationInFullMode()
                                              .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
                                              .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                                             .andWith(FeatureReplacementAction.EE10_FEATURES()
-                                                      .alwaysAddFeature("servlet-6.0"));
+                                             .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                                             .andWith(FeatureReplacementAction.EE11_FEATURES());
+
 }

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/FaultProcessingInGlobalHandlers/WithFirstOne/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/FaultProcessingInGlobalHandlers/WithFirstOne/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:TestHandler3Feature3</feature>
     </featureManager>

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/GlobalHandlerFeatureOnly/WithUserBundle/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/GlobalHandlerFeatureOnly/WithUserBundle/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>usr:RSHandler1Feature</feature>
         <!-- <feature>globalWebservicesHandler-1.0</feature> -->
     </featureManager>

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/GlobalHandlerFeatureOnly/WithoutUserBundle/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/GlobalHandlerFeatureOnly/WithoutUserBundle/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <!--  <feature>globalWebservicesHandler-1.0</feature> -->
     </featureManager>
 

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/GlobalHandlerMessageContextAPI/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/GlobalHandlerMessageContextAPI/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:TestHandler5Feature5</feature>
     </featureManager>

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/GlobalHandlersOnlyWithoutJAXWSRS/WithFirstOne/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/GlobalHandlersOnlyWithoutJAXWSRS/WithFirstOne/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>usr:TestHandler3Feature3</feature>
     </featureManager>
 

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithFirstOne/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithFirstOne/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:TestHandler1Feature1</feature>
     </featureManager>

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithNone/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithNone/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
     </featureManager>
 

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithSecondOne/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithSecondOne/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:TestHandler2Feature2</feature>
     </featureManager>

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithTwo/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithTwo/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:TestHandler1Feature1</feature>
         <feature>usr:TestHandler2Feature2</feature>

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/servers/AddNumbersTestServer/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/servers/AddNumbersTestServer/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
     </featureManager>
 

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/servers/RSTestServer/server.xml
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/servers/RSTestServer/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxrs-2.0</feature>
     </featureManager>
 

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/bnd.bnd
@@ -65,7 +65,10 @@ tested.features=appSecurity-3.0, \
   cdi-4.0, \
   restfulwsclient-3.1, \
   jsonp-2.1, \
-  restfulws-3.1
+  restfulws-3.1, \
+  restfulws-4.0, \
+  appsecurity-6.0, \
+  pages-4.0
 
 -buildpath: \
 	io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/fat/src/com/ibm/ws/webservices/handler/fat/FATSuite.java
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/fat/src/com/ibm/ws/webservices/handler/fat/FATSuite.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -42,5 +42,6 @@ public class FATSuite {
     public static RepeatTests r = RepeatTests.withoutModificationInFullMode()
                                              .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
                                              .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("jaxwsTest-2.2").addFeature("xmlWSTest-3.0").conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                                             .andWith(FeatureReplacementAction.EE10_FEATURES().removeFeature("jaxwsTest-2.2").removeFeature("xmlWSTest-3.0").addFeature("xmlWSTest-4.0"));
+                                             .andWith(FeatureReplacementAction.EE10_FEATURES().removeFeature("jaxwsTest-2.2").removeFeature("xmlWSTest-3.0").addFeature("xmlWSTest-4.0").conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                                             .andWith(FeatureReplacementAction.EE11_FEATURES().removeFeature("jaxwsTest-2.2").removeFeature("xmlWSTest-3.0").addFeature("xmlWSTest-4.0"));
 }

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/FaultProcessingInGlobalHandlers/WithFirstOne/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/FaultProcessingInGlobalHandlers/WithFirstOne/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:TestHandler3Feature3</feature>
     </featureManager>

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/GlobalHandlerFeatureOnly/WithUserBundle/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/GlobalHandlerFeatureOnly/WithUserBundle/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>usr:RSHandler1Feature</feature>
         <!-- <feature>globalWebservicesHandler-1.0</feature> -->
     </featureManager>

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/GlobalHandlerFeatureOnly/WithoutUserBundle/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/GlobalHandlerFeatureOnly/WithoutUserBundle/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <!--  <feature>globalWebservicesHandler-1.0</feature> -->
     </featureManager>
 

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/GlobalHandlerMessageContextAPI/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/GlobalHandlerMessageContextAPI/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:TestHandler5Feature5</feature>
     </featureManager>

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/GlobalHandlersOnlyWithoutJAXWSRS/WithFirstOne/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/GlobalHandlersOnlyWithoutJAXWSRS/WithFirstOne/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>usr:TestHandler3Feature3</feature>
     </featureManager>
 

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithFirstOne/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithFirstOne/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:TestHandler1Feature1</feature>
     </featureManager>

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithNone/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithNone/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
     </featureManager>
 

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithSecondOne/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithSecondOne/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:TestHandler2Feature2</feature>
     </featureManager>

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithTwo/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/files/dynamicallyAddRemove/WithTwo/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:TestHandler1Feature1</feature>
         <feature>usr:TestHandler2Feature2</feature>

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/servers/AddNumbersTestServer/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/servers/AddNumbersTestServer/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
     </featureManager>
 

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/servers/EJBServiceRefBndTestServer/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/servers/EJBServiceRefBndTestServer/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
     	<feature>jsp-2.3</feature>
+    	<feature>servlet-3.1</feature>
         <feature>jaxwsTest-2.2</feature>
         <feature>ejbLite-3.2</feature>
         <feature>usr:TestHandler1Feature1</feature>

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/servers/HandlerChainTestServer/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/servers/HandlerChainTestServer/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:MyHandlerFeature</feature>
     </featureManager>

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/servers/HandlerChainTestServerAlternate/server.xml
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/publish/servers/HandlerChainTestServerAlternate/server.xml
@@ -1,6 +1,7 @@
 <server>
     <featureManager>
         <feature>jsp-2.3</feature>
+        <feature>servlet-3.1</feature>
         <feature>jaxws-2.2</feature>
         <feature>usr:MyHandlerFeature</feature>
     </featureManager>


### PR DESCRIPTION
- Instead of having user feature need to be updated to add in servlet-6.1, just do the toleration using private features like we do in other places.
- Update global handler fats to have EE 11 repeats in order to validate that this change works.
- Add missing doPriv for System.getProperty in static initializer
- Update server.xml files where it will choose servlet-3.1 when using jsp-2.3 for instance even if doing EE8 repeat
- Update LibertyServer exempt list for the servers that are now updated.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #29718 
