### PR TITLE
Fix incremental build for autoFVT tasks

### DIFF
--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -155,6 +155,20 @@ task autoFVT {
   dependsOn ':fattest.simplicity:jar'
   enabled project.file('fat').exists()
 
+  inputs.dir(compileJava.destinationDir)
+  inputs.dir(buildDir)
+  inputs.file(project.file('ddl'))
+  inputs.dir(new File(project(':fattest.simplicity').projectDir, '/autoFVT-defaults'))
+  inputs.dir(new File(project(':fattest.simplicity').buildDir, '/autoFVT-defaults'))
+  inputs.dir(project.file('override/autoFVT/src/ant'))
+  inputs.dir(project(':fattest.simplicity').buildDir)
+  inputs.dir(project.file('publish/files'))
+  inputs.dir(new File(publishDir, 'files'))
+  inputs.dir(project.file('publish'))
+  inputs.dir(projectDir)
+  inputs.dir(new File(project.buildDir, 'gitRepos'))
+  outputs.dir(autoFvtDir)
+
   ext.getFeature = { line ->
     def fStart = line.indexOf('<feature>')
     if (fStart == -1)
@@ -354,7 +368,6 @@ task autoFVT {
       from gitReposDir
       into new File(autoFvtDir, 'publish/gitRepos/')
     }
-    delete gitReposDir
 
     // Produce a list of features tested by this FAT
     def featureDeps = [] as Set
@@ -658,7 +671,6 @@ build {
 }
 
 buildfat {
-  dependsOn cleanFat
   dependsOn assemble
   dependsOn build
   dependsOn zipProjectFVT


### PR DESCRIPTION
- Current behavior is that the Gradle autoFVT task runs every time that a user runs buildfat for a FAT bucket. The reason it does is because we clean the directory where autoFVT outputs into on every run, whether there was a change or not, and we do not define inputs or outputs for the ad-hoc task.
- Expected behavior is the build shouldn't clean the autoFVTDir unless there was a change in the inputs, and the autoFVT task needs inputs and outputs defined correctly to determine when to run the clean.
- Saves time in re-builds locally, and could save time in remote builds if we restore caches of `~/.gradle` and FAT's `build/` directories.