### PR TITLE
Support CDI.current() in threads that were not created by Jakarta Concurrency.

### DIFF
--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/CDICurrentTestServlet.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/CDICurrentTestServlet.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -41,8 +41,8 @@ public class CDICurrentTestServlet extends FATServlet {
 
     private static final long serialVersionUID = 1L;
 
+    //Must be manually cleared at the end of a test
     private static Boolean wasCDICurrentFound = null;
-    private static volatile Boolean wasCDICurrentFoundViaMES = null;
 
     @Inject
     private SharedLibBean sharedLibBean;
@@ -70,27 +70,59 @@ public class CDICurrentTestServlet extends FATServlet {
      * context onto a newly created thread. This test ensures that works correctly and CDI.current() returns a value
      * when called from a new thread.
      *
-     * Note that threads created via new Thread() will not have the required context and CDI.current() will return null
      */
     @Test
     public void testCDICurrentViaMES() throws Exception {
-        long startTime = System.nanoTime();
+        try {
+            long startTime = System.nanoTime();
 
-        assertNotNull(CDI.current()); //Test outside a new thread just for completeness.
+            assertNotNull(CDI.current()); //Test outside a new thread just for completeness.
 
-        LOGGER.info("calling managedExecutorService");
-        managedExecutorService.submit(new CallCDICurrent());
+            LOGGER.info("calling managedExecutorService");
+            managedExecutorService.submit(new CallCDICurrent());
 
-        while (System.nanoTime() - startTime < Duration.of(10, SECONDS).toNanos()) {
-            if (wasCDICurrentFoundViaMES != null) {
-                assertTrue("CDI.current returned null when called in a new Thread", wasCDICurrentFoundViaMES);
-                return;
+            while (System.nanoTime() - startTime < Duration.of(10, SECONDS).toNanos()) {
+                if (wasCDICurrentFound != null) {
+                    assertTrue("CDI.current returned null when called in a new Managed Thread", wasCDICurrentFound);
+                    return;
+                }
+                Thread.sleep(15);
             }
-            Thread.sleep(15);
-        }
 
-        LOGGER.info("About to throw exception");
-        assertTrue("The thread with CDI.current never completed", false);
+            LOGGER.info("About to throw exception");
+            assertTrue("The thread with CDI.current never completed", false);
+        } finally {
+            wasCDICurrentFound = false;
+        }
+    }
+
+    /*
+     * We have implemented a fallback that allows CDI.current() to work if you call a new thread
+     * without propagating context via a ManagedExecutorService, this tests that code.
+     */
+    @Test
+    public void testCDICurrentViaNewThread() throws Exception {
+        try {
+            long startTime = System.nanoTime();
+
+            assertNotNull(CDI.current()); //Test outside a new thread just for completeness.
+            LOGGER.info("calling managedExecutorService");
+            Thread thread = new Thread(new CallCDICurrent());
+            thread.run();
+
+            while (System.nanoTime() - startTime < Duration.of(10, SECONDS).toNanos()) {
+                if (wasCDICurrentFound != null) {
+                    assertTrue("CDI.current returned null when called in a new Thread", wasCDICurrentFound);
+                    return;
+                }
+                Thread.sleep(15);
+            }
+
+            LOGGER.info("About to throw exception");
+            assertTrue("The thread with CDI.current never completed", false);
+        } finally {
+            wasCDICurrentFound = false;
+        }
     }
 
     @Test
@@ -99,10 +131,8 @@ public class CDICurrentTestServlet extends FATServlet {
     }
 
     public static void setWasCDICurrentFound(boolean b) {
-
-        wasCDICurrentFoundViaMES = b;
+        wasCDICurrentFound = b;
         LOGGER.info("Set test variable");
-
     }
 
     public class CallCDICurrent implements Runnable {
@@ -113,10 +143,9 @@ public class CDICurrentTestServlet extends FATServlet {
             LOGGER.info("Found CDI " + cdi);
             if (cdi != null) {
                 CDICurrentTestServlet.setWasCDICurrentFound(true);
-                LOGGER.info("Calling setter for test variable");
+                LOGGER.info("Calling setter for test variable with true");
             } else {
-                System.out.println("GREP 1 " + java.time.LocalDateTime.now());
-                LOGGER.info("Calling setter for test variable");
+                LOGGER.info("Calling setter for test variable with false");
             }
         }
     }

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/threads/extension/CDIExtension.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/threads/extension/CDIExtension.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.api.fat.apps.threads.extension;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.AfterDeploymentValidation;
+import javax.enterprise.inject.spi.AfterTypeDiscovery;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.CDI;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.ProcessBean;
+import javax.enterprise.inject.spi.ProcessBeanAttributes;
+import javax.enterprise.inject.spi.ProcessInjectionPoint;
+import javax.enterprise.inject.spi.ProcessInjectionTarget;
+import javax.enterprise.inject.spi.ProcessManagedBean;
+
+/**
+ *
+ */
+@SuppressWarnings("rawtypes")
+public class CDIExtension implements Extension {
+
+    private final Set<String> duplicatesFilter = new HashSet<String>();
+
+    public void eventListener(@Observes BeforeBeanDiscovery event) {
+        checkForBeanManagerInUnmanagedThread("BeforeBeanDiscovery");
+    }
+
+    public void eventListener(@Observes ProcessAnnotatedType event) {
+        checkForBeanManagerInUnmanagedThread("ProcessAnnotatedType");
+    }
+
+    public void eventListener(@Observes AfterTypeDiscovery event) {
+        checkForBeanManagerInUnmanagedThread("AfterTypeDiscovery");
+    }
+
+    public void eventListener(@Observes ProcessInjectionTarget event) {
+        checkForBeanManagerInUnmanagedThread("ProcessInjectionTarget");
+    }
+
+    public void eventListener(@Observes ProcessInjectionPoint event) {
+        checkForBeanManagerInUnmanagedThread("ProcessInjectionPoint");
+    }
+
+    public void eventListener(@Observes ProcessBeanAttributes event) {
+        checkForBeanManagerInUnmanagedThread("ProcessBeanAttributes");
+    }
+
+    public void eventListener(@Observes ProcessBean event) {
+        checkForBeanManagerInUnmanagedThread("ProcessBean");
+    }
+
+    public void eventListener(@Observes ProcessManagedBean event) {
+        checkForBeanManagerInUnmanagedThread("ProcessManagedBean");
+    }
+
+    public void eventListener(@Observes AfterBeanDiscovery event) {
+        checkForBeanManagerInUnmanagedThread("AfterBeanDiscovery");
+    }
+
+    public void eventListener(@Observes AfterDeploymentValidation event) {
+        checkForBeanManagerInUnmanagedThread("AfterDeploymentValidation");
+    }
+
+    private void checkForBeanManagerInUnmanagedThread(final String eventName) {
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    BeanManager bm = CDI.current().getBeanManager();
+                    String s = "found beanmanager in " + eventName + " : " + (bm instanceof BeanManager);
+                    if (duplicatesFilter.add(s)) {
+                        System.out.println(s);
+                    }
+                } catch (Exception e) {
+                    String s = "failed to find beanmanager in " + eventName + " : " + e.toString();
+                    if (duplicatesFilter.add(s)) {
+                        System.out.println(s);
+                        e.printStackTrace(System.out);
+                    }
+                }
+            }
+        };
+
+        thread.start();
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/threads/extension/SimpleBean.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/threads/extension/SimpleBean.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.api.fat.apps.threads.extension;
+
+import javax.enterprise.context.Dependent;
+
+import com.ibm.ws.cdi.api.fat.apps.current.sharedLib.ISimpleBean;
+
+/**
+ *
+ */
+@Dependent
+public class SimpleBean implements ISimpleBean {
+
+    public static final String MSG = "bean exists";
+
+    /** {@inheritDoc} */
+    @Override
+    public String test() {
+        return MSG;
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/threads/extension/javax.enterprise.inject.spi.Extension
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/threads/extension/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+com.ibm.ws.cdi.api.fat.apps.threads.extension.CDIExtension

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/tests/CDIAPITests.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/tests/CDIAPITests.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -46,6 +48,7 @@ import com.ibm.ws.cdi.api.fat.apps.injectInjectionPoint.InjectInjectionPointServ
 import com.ibm.ws.cdi.api.fat.apps.injectInjectionPointBeansXML.InjectInjectionPointBeansXMLServlet;
 import com.ibm.ws.cdi.api.fat.apps.injectInjectionPointParam.InjectInjectionPointAsParamServlet;
 import com.ibm.ws.cdi.api.fat.apps.injectInjectionPointXML.InjectInjectionPointXMLServlet;
+import com.ibm.ws.cdi.api.fat.apps.threads.extension.CDIExtension;
 import com.ibm.ws.fat.util.browser.WebBrowser;
 import com.ibm.ws.fat.util.browser.WebBrowserFactory;
 import com.ibm.ws.fat.util.browser.WebResponse;
@@ -71,6 +74,7 @@ public class CDIAPITests extends FATServletClient {
     public static final String SERVER_NAME = "cdi12APIServer";
 
     public static final String CDI_CURRENT_APP_NAME = "cdiCurrentTest";
+    public static final String CDI_CURRENT_THREADS_APP_NAME = "cdiCurrentThreadsTest";
     public static final String ALTERABLE_CONTEXT_APP_NAME = "alterableContextsApp";
     public static final String CONVERSATION_FILTER_APP_NAME = "appConversationFilter";
     public static final String INJECT_IP_AS_PARAM_APP_NAME = "injectInjectionPointAsParam";
@@ -172,6 +176,33 @@ public class CDIAPITests extends FATServletClient {
         response = browser.request(HttpUtils.createURL(server, "/appConversationFilter/test?op=status&cid=" + cid).toString());
         String status = response.getResponseBody();
         assertEquals("Wrong status", Boolean.FALSE.toString(), status);
+    }
+
+    @Test
+    @Mode(TestMode.FULL)
+    public void testCDICurrentInUnmanagedThreads() throws Exception {
+
+        List<String> messages = new ArrayList<String>();
+        messages.add("found beanmanager in ProcessAnnotatedType : true");
+        messages.add("found beanmanager in BeforeBeanDiscovery : true");
+        messages.add("found beanmanager in ProcessInjectionTarget : true");
+        messages.add("found beanmanager in ProcessBeanAttributes : true");
+        messages.add("found beanmanager in ProcessBean : true");
+        messages.add("found beanmanager in ProcessManagedBean : true");
+        messages.add("found beanmanager in ProcessInjectionPoint : true");
+        messages.add("found beanmanager in AfterTypeDiscovery : true");
+        messages.add("found beanmanager in AfterBeanDiscovery : true");
+        messages.add("found beanmanager in AfterDeploymentValidation : true");
+
+        server.setMarkToEndOfLog();
+
+        WebArchive cdiCurrentTheads = ShrinkWrap.create(WebArchive.class, CDI_CURRENT_THREADS_APP_NAME + ".war")
+                                                .addPackage(CDIExtension.class.getPackage());
+        CDIArchiveHelper.addCDIExtensionFile(cdiCurrentTheads, CDIExtension.class.getPackage());
+        ShrinkHelper.exportToServer(server, "dropins", cdiCurrentTheads, DeployOptions.SERVER_ONLY);
+        server.waitForStringsInLogUsingMark(messages);
+
+        server.getApplicationMBean(CDI_CURRENT_THREADS_APP_NAME).stop();
     }
 
     @Test

--- a/dev/com.ibm.ws.cdi.internal/src/com/ibm/ws/cdi/internal/archive/liberty/RuntimeFactory.java
+++ b/dev/com.ibm.ws.cdi.internal/src/com/ibm/ws/cdi/internal/archive/liberty/RuntimeFactory.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,8 @@
 package com.ibm.ws.cdi.internal.archive.liberty;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -128,6 +130,10 @@ public class RuntimeFactory {
      */
     public CDILibertyRuntime getServices() {
         return services;
+    }
+
+    public Collection<Application> getApplications() {
+        return Collections.unmodifiableCollection(applications.values());
     }
 
 }

--- a/dev/com.ibm.ws.cdi.weld/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.weld/bnd.bnd
@@ -125,8 +125,9 @@ WS-TraceGroup: JCDI
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.kernel.boot,\
 	com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
-	com.ibm.ws.org.jboss.weld;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.org.jboss.weld;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.kernel.service
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/AbstractCDIRuntime.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/AbstractCDIRuntime.java
@@ -13,6 +13,9 @@
 package com.ibm.ws.cdi.impl;
 
 import java.lang.annotation.Annotation;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 
@@ -28,21 +31,34 @@ import com.ibm.websphere.csi.J2EEName;
 import com.ibm.ws.cdi.CDIException;
 import com.ibm.ws.cdi.CDIService;
 import com.ibm.ws.cdi.impl.weld.WebSphereEEModuleDescriptor;
+import com.ibm.ws.cdi.internal.archive.liberty.RuntimeFactory;
+import com.ibm.ws.cdi.internal.interfaces.Application;
 import com.ibm.ws.cdi.internal.interfaces.ArchiveType;
 import com.ibm.ws.cdi.internal.interfaces.CDIArchive;
 import com.ibm.ws.cdi.internal.interfaces.CDIRuntime;
 import com.ibm.ws.cdi.internal.interfaces.CDIUtils;
 import com.ibm.ws.cdi.internal.interfaces.WebSphereBeanDeploymentArchive;
 import com.ibm.ws.cdi.internal.interfaces.WebSphereCDIDeployment;
+import com.ibm.ws.classloading.LibertyClassLoadingService;
+import com.ibm.ws.kernel.service.util.ServiceCaller;
 import com.ibm.ws.runtime.metadata.ApplicationMetaData;
 import com.ibm.ws.runtime.metadata.ModuleMetaData;
+import com.ibm.ws.util.ThreadContextAccessor;
 
 /**
  * This abstract class generally holds methods which simply pass through to the CDIContainerImpl
  */
 public abstract class AbstractCDIRuntime implements CDIService, CDIRuntime, CDIProvider {
 
+    private final static ThreadContextAccessor THREAD_CONTEXT_ACCESSOR = ThreadContextAccessor.getThreadContextAccessor();
+
+    //Using this because it should have better performance than the getServiceWithException paradigm on CDIRuntimeImpl
+    @SuppressWarnings("rawtypes")
+    private static final ServiceCaller<LibertyClassLoadingService> classLoadingServiceCaller = new ServiceCaller<LibertyClassLoadingService>(AbstractCDIRuntime.class,
+                                                                                                                                             LibertyClassLoadingService.class);
+
     private CDIContainerImpl cdiContainer;
+    protected RuntimeFactory runtimeFactory;
 
     protected void start() {
         this.cdiContainer = new CDIContainerImpl(this);
@@ -156,12 +172,33 @@ public abstract class AbstractCDIRuntime implements CDIService, CDIRuntime, CDIP
     }
 
     /** {@inheritDoc} */
+    @SuppressWarnings({ "removal", "deprecation" })
     @Override
     public CDI<Object> getCDI() {
         CDI<Object> cdi = null;
         WebSphereCDIDeployment deployment = getCDIContainer().getCurrentDeployment();
         if (deployment != null) {
             cdi = deployment.getCDI();
+        }
+
+        //If we can't get CDI from the thread context metadata, fallback to matching the TCCL against apps.
+        if (cdi == null) {
+            Collection<Application> applications = runtimeFactory.getApplications();
+
+            ClassLoader tccl = AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
+                return THREAD_CONTEXT_ACCESSOR.getContextClassLoader(Thread.currentThread());
+            });
+
+            //Doing it this way for performance reasons. Saves us spinning up a lambda every loop iteration
+            LibertyClassLoadingService<?> classLoadingService = classLoadingServiceCaller.current().get();
+            for (Application application : applications) {
+                if (application.getClassLoader().equals(tccl)
+                    || classLoadingService.isThreadContextClassLoaderForAppClassLoader(tccl, application.getClassLoader())) {
+                    WebSphereCDIDeployment deploymnet = cdiContainer.getDeployment(application);
+                    cdi = deploymnet.getCDI();
+                    break;
+                }
+            }
         }
 
         if (cdi == null) {

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIContainerImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIContainerImpl.java
@@ -62,6 +62,7 @@ import com.ibm.ws.cdi.internal.interfaces.WeldDevelopmentMode;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.runtime.metadata.ApplicationMetaData;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaDataSlot;
 import com.ibm.ws.runtime.metadata.ModuleMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.injectionengine.InjectionException;
@@ -522,6 +523,10 @@ public class CDIContainerImpl implements CDIContainer, InjectionMetaDataListener
 
     public BeanManager getCurrentBeanManager() {
         WebSphereCDIDeployment cdiDeployment = getCurrentDeployment();
+        return getCurrentBeanManager(cdiDeployment);
+    }
+
+    public BeanManager getCurrentBeanManager(WebSphereCDIDeployment cdiDeployment) {
 
         // Try to walk the stack back to find the bean class and lookup the bean manager via the class.
         BeanManager beanManager = getCurrentBeanManagerViaStackWalk(cdiDeployment);
@@ -791,7 +796,8 @@ public class CDIContainerImpl implements CDIContainer, InjectionMetaDataListener
     public WebSphereCDIDeployment getDeployment(ApplicationMetaData applicationMetaData) {
         WebSphereCDIDeployment deployment = null;
         if (applicationMetaData != null) {
-            deployment = (WebSphereCDIDeployment) applicationMetaData.getMetaData(cdiRuntime.getApplicationSlot());
+            MetaDataSlot slot = cdiRuntime.getApplicationSlot();
+            deployment = (WebSphereCDIDeployment) applicationMetaData.getMetaData(slot);
         }
         return deployment;
     }
@@ -858,7 +864,8 @@ public class CDIContainerImpl implements CDIContainer, InjectionMetaDataListener
 
     public void setDeployment(Application application, WebSphereCDIDeployment webSphereCDIDeployment) throws CDIException {
         ApplicationMetaData applicationMetaData = application.getApplicationMetaData();
-        applicationMetaData.setMetaData(cdiRuntime.getApplicationSlot(), webSphereCDIDeployment);
+        MetaDataSlot slot = cdiRuntime.getApplicationSlot();
+        applicationMetaData.setMetaData(slot, webSphereCDIDeployment);
     }
 
     public void unsetDeployment(Application application) throws CDIException {

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIImpl.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,22 +16,27 @@ import javax.enterprise.inject.spi.BeanManager;
 
 import org.jboss.weld.AbstractCDI;
 
-import com.ibm.ws.cdi.CDIService;
+import com.ibm.ws.cdi.internal.interfaces.CDIRuntime;
+import com.ibm.ws.cdi.internal.interfaces.WebSphereCDIDeployment;
 
 /**
  * IBM implementation of CDI
  */
 public class CDIImpl extends AbstractCDI<Object> {
-    private final CDIService cdiService;
+    private final CDIRuntime cdiRuntime;
+    private final WebSphereCDIDeployment parent;
 
-    public CDIImpl(CDIService cdiService) {
-        this.cdiService = cdiService;
+    public CDIImpl(CDIRuntime cdiRuntime, WebSphereCDIDeployment parent) {
+        this.cdiRuntime = cdiRuntime;
+        this.parent = parent;
     }
 
     /** {@inheritDoc} */
     @Override
     public BeanManager getBeanManager() {
-        return cdiService.getCurrentBeanManager();
+        //TOOD is there a reason why this isn't on the interface?
+        CDIContainerImpl cdiContainer = (CDIContainerImpl) cdiRuntime.getCDIContainer();
+        return cdiContainer.getCurrentBeanManager(parent);
     }
 
     public static void clear() {

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
@@ -116,7 +116,7 @@ public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
         //create a resource injection service for this deployment
         this.injectionServices = new WebSphereInjectionServicesImpl(this);
         this.cdiRuntime = cdiRuntime;
-        this.cdi = new CDIImpl(cdiRuntime);
+        this.cdi = new CDIImpl(cdiRuntime, this);
     }
 
     /**

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/liberty/CDIRuntimeImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/liberty/CDIRuntimeImpl.java
@@ -143,7 +143,6 @@ public class CDIRuntimeImpl extends AbstractCDIRuntime implements ApplicationSta
 
     private MetaDataSlot applicationSlot;
     private boolean isClientProcess;
-    private RuntimeFactory runtimeFactory;
     private ProxyServicesImpl proxyServices;
 
     public void activate(ComponentContext cc) {

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/LibertyClassLoadingService.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/LibertyClassLoadingService.java
@@ -44,4 +44,14 @@ public interface LibertyClassLoadingService<CL extends ClassLoader & LibertyClas
 
     @Override
     CL createThreadContextClassLoader(ClassLoader applicationClassLoader);
+    
+    /**
+     * This method returns whether or not the provided ClassLoader is a ThreadContextClassLoader
+     * and if the second provided ClassLoader is an AppClassLoader. And if the TCCL is for the AppClassLoader 
+     *
+     * @param tccl The thread context class loader object to analyze.
+     * @param appClassLoader The app class loader object to analyze.
+     * @return true if tccl is a ThreadContextClassLoader for an app classloader appClassLoader
+     */
+    boolean isThreadContextClassLoaderForAppClassLoader(ClassLoader tccl, ClassLoader appClassLoader);
 }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoadingServiceImpl.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoadingServiceImpl.java
@@ -935,4 +935,19 @@ public class ClassLoadingServiceImpl implements LibertyClassLoadingService<Liber
         for (ApplicationExtensionLibrary appExt : appExtLibs)
             config.addSharedLibraries(appExt.getReference().id());
     }
+
+    @Override
+    public boolean isThreadContextClassLoaderForAppClassLoader(ClassLoader tccl, ClassLoader appClassLoader) {
+       if (! isThreadContextClassLoader(tccl)) {
+           return false;
+       }
+       
+       if (! isAppClassLoader(appClassLoader)) {
+           return false;
+       }
+       
+       ThreadContextClassLoader castedTCCL = (ThreadContextClassLoader) tccl;
+       
+       return castedTCCL.isFor(appClassLoader);
+    }
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

zero migration - this is only going to occur as a fallback method, if we reach the new code it means the old code wasn't working.

Resolves #29493