### PR TITLE
don't save origtuwrapper in derivedtu custom property set to false for debugging memory leak

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/OutgoingSipServletResponse.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/servlets/OutgoingSipServletResponse.java
@@ -45,6 +45,8 @@ import com.ibm.ws.sip.container.router.SipRouter;
 import com.ibm.ws.sip.container.transaction.ServerTransaction;
 import com.ibm.ws.sip.container.tu.TransactionUserWrapper;
 import com.ibm.ws.sip.container.util.SipUtil;
+import com.ibm.ws.sip.properties.CoreProperties;
+import com.ibm.ws.sip.container.properties.PropertiesStore;
 
 /**
  * @author Amir Perlman, Feb 24, 2003
@@ -221,7 +223,10 @@ public class OutgoingSipServletResponse extends SipServletResponseImpl
     		c_logger.traceDebug(this,"continueToSend1",getCallId() + " ,status = " + getStatus());
     	}
 
-    	sendOnOriginalRatherOnDerivedTCK_SIP_SERVLET_1_1();
+
+		if(PropertiesStore.getInstance().getProperties().getBoolean(CoreProperties.SAVE_ORIGTUWRAPPER_IN_DERIVEDTUWRAPPER)){
+    		sendOnOriginalRatherOnDerivedTCK_SIP_SERVLET_1_1();
+		}
     	
     	TransactionUserWrapper transactionUser = getTransactionUser();
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserWrapper.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserWrapper.java
@@ -385,8 +385,11 @@ ClientTransactionListener, Serializable, SipServletInvokerListener,SipDialogCont
     	// set the flag to indicate that this transaction is derived
     	_derived = true;
     	
+    	if(PropertiesStore.getInstance().getProperties().getBoolean(CoreProperties.SAVE_ORIGTUWRAPPER_IN_DERIVEDTUWRAPPER))
+    	{
     	// Save the original TUWrapper
     	_origTUWrapper = originalTU;
+    	}
     }
 	
     

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/properties/CoreProperties.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/properties/CoreProperties.java
@@ -30,6 +30,11 @@ public class CoreProperties
 	private static final transient LogMgr c_logger = Log
 			.get(CoreProperties.class);
 	/**
+	 * Save original TUwrapper in derived TUwrapper
+	 */
+	public static final String SAVE_ORIGTUWRAPPER_IN_DERIVEDTUWRAPPER = "saveOriginalTUWrapperInDerivedTUWrapper";
+	public static final boolean SAVE_ORIGTUWRAPPER_IN_DERIVEDTUWRAPPER_DEFAULT = false;
+	/**
 	 * Maximum sipAppSessions allowed. 
 	 */
 	 public static final String MAX_APP_SESSIONS = "maxAppSessions";
@@ -790,8 +795,9 @@ public class CoreProperties
 			c_logger.traceEntry(CoreProperties.class.getName(),
 					"loadDefaultProperties");
 		}
-    	
-    	properties.setInt(MAX_APP_SESSIONS, MAX_APP_SESSIONS_DEFAULT,CustPropSource.DEFAULT);
+    	properties.setBoolean(SAVE_ORIGTUWRAPPER_IN_DERIVEDTUWRAPPER, SAVE_ORIGTUWRAPPER_IN_DERIVEDTUWRAPPER_DEFAULT, CustPropSource.DEFAULT);
+    	    	
+		properties.setInt(MAX_APP_SESSIONS, MAX_APP_SESSIONS_DEFAULT,CustPropSource.DEFAULT);
 		properties.setInt(MAX_MESSAGE_RATE, MAX_MESSAGE_RATE_DEFAULT,CustPropSource.DEFAULT);
 		properties.setInt(MAX_RESPONSE_TIME, MAX_RESPONSE_TIME_DEFAULT,CustPropSource.DEFAULT);
 		properties.setInt(STAT_UPDATE_RANGE, STAT_UPDATE_RANGE_DEFAULT,CustPropSource.DEFAULT);


### PR DESCRIPTION
This is a debug build only, I am not expecting to deliver these changes