### PR TITLE
propagation of custom context type to virtual ManagedThreadFactory thread

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/.classpath
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/Concurrency31TestWeb/src"/>
+	<classpathentry kind="src" path="test-libraries/TimeZoneContext/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/bnd.bnd
@@ -15,7 +15,8 @@ bVersion=1.0
 
 src: \
 	fat/src,\
-	test-applications/Concurrency31TestWeb/src
+	test-applications/Concurrency31TestWeb/src,\
+	test-libraries/TimeZoneContext/src
 
 javac.source: 17
 javac.target: 17
@@ -23,8 +24,8 @@ javac.target: 17
 fat.minimum.java.level: 17
 fat.project: true
 
-# Include com.ibm.ws.concurrent_fat_jakarta for test-library/* classes
-# Avoid importing FATSuite and test classes from com.ibm.ws.concurrent_fat_jakarta
+# Include com.ibm.ws.concurrent_fat_jakarta_11 for test-library/* classes
+# Avoid importing FATSuite and test classes from test.jakarta.concurrency
 Import-Package:\
     !test.jakarta.concurrency,\
     *

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/fat/src/test/jakarta/concurrency/Concurrency31Test.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/fat/src/test/jakarta/concurrency/Concurrency31Test.java
@@ -55,27 +55,12 @@ public class Concurrency31Test extends FATServletClient {
         ShrinkHelper.exportAppToServer(server, Concurrency31TestApp);
 
         // fake third-party library that also includes a thread context provider
-        JavaArchive locationUtilsContextProviderJar = ShrinkWrap.create(JavaArchive.class, "location-utils.jar")
-                        .addPackage("test.context.location")
+        JavaArchive timeZoneContextProviderJar = ShrinkWrap //
+                        .create(JavaArchive.class, "time-zone-context.jar")
+                        .addPackage("test.context.timezone")
                         .addAsServiceProvider(ThreadContextProvider.class.getName(),
-                                              "test.context.location.ZipCodeContextProvider");
-        ShrinkHelper.exportToServer(server, "lib", locationUtilsContextProviderJar);
-
-        // fake thread context provider on its own (this will be made available via a bell)
-        JavaArchive priorityContextProviderJar = ShrinkWrap.create(JavaArchive.class, "priority-context.jar")
-                        .addPackage("test.context.priority")
-                        .addAsServiceProvider(ThreadContextProvider.class.getName(),
-                                              "test.context.priority.PriorityContextProvider");
-        ShrinkHelper.exportToServer(server, "lib", priorityContextProviderJar);
-
-        // fake third-party library that includes multiple thread context providers
-        JavaArchive statUtilsContextProviderJar = ShrinkWrap.create(JavaArchive.class, "stat-utils.jar")
-                        .addPackage("test.context.list")
-                        .addPackage("test.context.timing")
-                        .addAsServiceProvider(ThreadContextProvider.class.getName(),
-                                              "test.context.list.ListContextProvider",
-                                              "test.context.timing.TimestampContextProvider");
-        ShrinkHelper.exportToServer(server, "lib", statUtilsContextProviderJar);
+                                              "test.context.timezone.TimeZoneContextProvider");
+        ShrinkHelper.exportToServer(server, "lib", timeZoneContextProviderJar);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/publish/servers/com.ibm.ws.concurrent.fat.jakarta.ee11/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/publish/servers/com.ibm.ws.concurrent.fat.jakarta.ee11/server.xml
@@ -26,15 +26,8 @@
     <classloader commonLibraryRef="ThirdPartyLibrariesWithCustomContext"/>
   </application>
 
-  <!-- third-party context provider that is available to all applications -->
-  <bell>
-    <library id="PriorityContextLib">
-      <file name="${server.config.dir}/lib/priority-context.jar"/>
-    </library>
-  </bell>
-
   <library id="ThirdPartyLibrariesWithCustomContext">
-    <fileset dir="${server.config.dir}/lib" include="location-utils.jar,stat-utils.jar"/>
+    <fileset dir="${server.config.dir}/lib" include="time-zone-context.jar"/>
   </library>
 
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-applications/Concurrency31TestWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-applications/Concurrency31TestWeb/resources/WEB-INF/web.xml
@@ -16,6 +16,19 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 	xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd">
 
+  <env-entry>
+    <env-entry-name>java:comp/env/TestEntry</env-entry-name>
+    <env-entry-type>java.lang.String</env-entry-type>
+    <env-entry-value>TestValue1</env-entry-value>
+  </env-entry>
+
+  <context-service>
+    <name>java:app/concurrent/AppAndTimeZoneCtx</name>
+    <propagated>Application</propagated>
+    <propagated>TimeZone</propagated>
+    <unchanged>Remaining</unchanged>
+  </context-service>
+
   <!-- TODO concurrency resources with virtual=true -->
 
   <managed-thread-factory>
@@ -26,6 +39,7 @@
 
   <managed-thread-factory>
     <name>java:comp/concurrent/webdd/virtual-thread-factory</name>
+    <context-service-ref>java:app/concurrent/AppAndTimeZoneCtx</context-service-ref>
     <virtual>true</virtual>
   </managed-thread-factory>
 

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-libraries/TimeZoneContext/src/test/context/timezone/TimeZone.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-libraries/TimeZoneContext/src/test/context/timezone/TimeZone.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.context.timezone;
+
+import java.time.ZoneId;
+
+/**
+ * Example third-party thread context.
+ * Associates a ZoneId with a thread.
+ */
+public class TimeZone {
+    public static final String CONTEXT_NAME = "TimeZone";
+
+    /**
+     * The null value indicates uninitialized and signals the
+     * ThreadContextRestorer to remove the ThreadLocal value
+     * so that it does not remain on virtual threads.
+     */
+    static ThreadLocal<ZoneId> local = ThreadLocal //
+                    .withInitial(() -> null);
+
+    // API methods:
+
+    public static ZoneId get() {
+        return local.get();
+    }
+
+    public static void remove() {
+        local.remove();
+    }
+
+    public static void set(ZoneId zoneId) {
+        local.set(zoneId);
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-libraries/TimeZoneContext/src/test/context/timezone/TimeZoneContextProvider.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-libraries/TimeZoneContext/src/test/context/timezone/TimeZoneContextProvider.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.context.timezone;
+
+import java.util.Map;
+
+import jakarta.enterprise.concurrent.spi.ThreadContextProvider;
+import jakarta.enterprise.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * Example third-party thread context provider, to be used for testing purposes.
+ * This context associates a ZoneId with a thread.
+ */
+public class TimeZoneContextProvider implements ThreadContextProvider {
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return new TimeZoneContextSnapshot(null);
+    }
+
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        return new TimeZoneContextSnapshot(TimeZone.local.get());
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return TimeZone.CONTEXT_NAME;
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-libraries/TimeZoneContext/src/test/context/timezone/TimeZoneContextRestorer.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-libraries/TimeZoneContext/src/test/context/timezone/TimeZoneContextRestorer.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.context.timezone;
+
+import java.time.ZoneId;
+
+import jakarta.enterprise.concurrent.spi.ThreadContextRestorer;
+
+/**
+ * Example third-party thread context provider, to be used for testing purposes.
+ * This context associates a ZoneId with a thread.
+ */
+public class TimeZoneContextRestorer implements ThreadContextRestorer {
+    private boolean restored;
+    private final ZoneId zoneId;
+
+    TimeZoneContextRestorer(ZoneId zoneId) {
+        this.zoneId = zoneId;
+    }
+
+    @Override
+    public void endContext() {
+        if (restored)
+            throw new IllegalStateException("thread context was already restored");
+        if (zoneId == null)
+            TimeZone.local.remove();
+        else
+            TimeZone.local.set(zoneId);
+        restored = true;
+    }
+
+    @Override
+    public String toString() {
+        return "TimeZoneContextRestorer@" +
+               Integer.toHexString(hashCode()) + ": " +
+               (zoneId == null ? null : zoneId.getId());
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-libraries/TimeZoneContext/src/test/context/timezone/TimeZoneContextSnapshot.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_11/test-libraries/TimeZoneContext/src/test/context/timezone/TimeZoneContextSnapshot.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.context.timezone;
+
+import java.time.ZoneId;
+
+import jakarta.enterprise.concurrent.spi.ThreadContextRestorer;
+import jakarta.enterprise.concurrent.spi.ThreadContextSnapshot;
+
+/**
+ * Example third-party thread context provider, to be used for testing purposes.
+ * This context associates a ZoneId with a thread.
+ */
+public class TimeZoneContextSnapshot implements ThreadContextSnapshot {
+    private final int hashCode;
+    private final ZoneId zoneId;
+
+    TimeZoneContextSnapshot(ZoneId zoneId) {
+        this.hashCode = zoneId == null ? 0 : zoneId.getId().hashCode();
+        this.zoneId = zoneId;
+    }
+
+    @Override
+    public ThreadContextRestorer begin() {
+        ThreadContextRestorer restorer = //
+                        new TimeZoneContextRestorer(TimeZone.local.get());
+        TimeZone.local.set(zoneId);
+        return restorer;
+    }
+
+    @Override
+    public final int hashCode() {
+        return hashCode;
+    }
+
+    @Override
+    public String toString() {
+        return "TimeZoneContextSnapshot@" +
+               Integer.toHexString(hashCode()) + ": " +
+               (zoneId == null ? null : zoneId.getId());
+    }
+}


### PR DESCRIPTION
A ManagedThreadFactory can be configured to propagate a custom context type and must be able to do so to virtual threads that it creates.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
