### PR TITLE
untimed invokeAny and invokeAll with virtual threads

### DIFF
--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -37,7 +37,7 @@ maxPolicy.desc=Indicates whether to loosely or strictly enforce maximum \
  if only invoking a single task, when using the untimed invokeAny method. \
  If the run-if-queue-full attribute is configured, tasks  can also\
  run on the task submitter's thread when using the execute and submit methods. \
- In all of these cases, this attribute determines whether or not running on the \
+ In all of these cases, this attribute determines whether running on the \
  submitter's thread counts against the maximum concurrency. Completion stage \
  tasks that run inline do not count against the maximum concurrency regardless \
  of the maximum policy.

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -30,9 +30,24 @@ max=Maximum concurrency
 max.desc=Specifies the maximum number of tasks that can run simultaneously. The default is Integer.MAX_VALUE. Maximum concurrency can be updated while tasks are in progress. If the maximum concurrency is reduced below the number of concurrently running tasks, the update goes into effect gradually as in-progress tasks complete, rather than canceling them.
 
 maxPolicy=Maximum policy
-maxPolicy.desc=Indicates whether to loosely or strictly enforce maximum concurrency for tasks that run on the task submitter's thread. Tasks can run on the task submitter's thread when using the untimed invokeAll method, or, if only invoking a single task, the untimed invokeAny method. If the run-if-queue-full attribute is configured, it is also possible for tasks to run the task submitter's thread when using the execute and submit methods. In all of these cases, this attribute determines whether or not running on the submitter's thread counts against the maximum concurrency.
-maxPolicy.loose.desc=Maximum concurrency is loosely enforced. Tasks are allowed to run on the task submitter's thread without counting against maximum concurrency.
-maxPolicy.strict.desc=Maximum concurrency is strictly enforced. Tasks that run on the task submitter's thread count towards maximum concurrency. This policy does not allow tasks to run on the task submitter's thread when already at maximum concurrency.
+maxPolicy.desc=Indicates whether to loosely or strictly enforce maximum \
+ concurrency for tasks that run on the task submitter's thread. If the \
+ concurrency policy is not configured to run tasks on virtual threads, tasks can \
+ run on the task submitter's thread when using the untimed invokeAll method, or, \
+ if only invoking a single task, when using the untimed invokeAny method. \
+ If the run-if-queue-full attribute is configured, it is also possible for tasks \
+ to run the task submitter's thread when using the execute and submit methods. \
+ In all of these cases, this attribute determines whether or not running on the \
+ submitter's thread counts against the maximum concurrency. Completion stage \
+ tasks that run inline do not count against the maximum concurrency regardless \
+ of the maximum policy.
+maxPolicy.loose.desc=Maximum concurrency is loosely enforced. \
+ Tasks are allowed to run on the task submitter's thread without \
+ counting against maximum concurrency.
+maxPolicy.strict.desc=Maximum concurrency is strictly enforced. \
+ Tasks that run on the task submitter's thread count towards maximum concurrency. \
+ This policy does not allow tasks to run on the task submitter's thread when \
+ already at maximum concurrency.
 
 maxQueueSize=Maximum queue size
 maxQueueSize.desc=Specifies the maximum number of tasks that can be in the queue waiting for execution. As tasks are started, canceled, or aborted, they are removed from the queue. When the queue is at capacity and another task is submitted, the behavior is determined by the maximum wait for enqueue and run-if-queue-full attributes. To ensure that a specific number of tasks can be queued within a short interval of time, use a maximum queue size that is at least as large as that amount. The default maximum queue size is Integer.MAX_VALUE. Maximum queue size can be updated while tasks are both in progress or queued for execution. If the maximum queue size is reduced below the current number of queued tasks, the update goes into effect gradually rather than automatically canceling the excess queued tasks.

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -35,7 +35,7 @@ maxPolicy.desc=Indicates whether to loosely or strictly enforce maximum \
  concurrency policy is not configured to run tasks on virtual threads, tasks can \
  run on the task submitter's thread when using the untimed invokeAll method, or, \
  if only invoking a single task, when using the untimed invokeAny method. \
- If the run-if-queue-full attribute is configured, it is also possible for tasks \
+ If the run-if-queue-full attribute is configured, tasks  can also\
  to run the task submitter's thread when using the execute and submit methods. \
  In all of these cases, this attribute determines whether or not running on the \
  submitter's thread counts against the maximum concurrency. Completion stage \

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -39,7 +39,7 @@ maxPolicy.desc=Indicates whether to loosely or strictly enforce maximum \
  run on the task submitter's thread when using the execute and submit methods. \
  In all of these cases, this attribute determines whether running on the \
  submitter's thread counts against the maximum concurrency. Completion stage \
- tasks that run inline do not count against the maximum concurrency regardless \
+ tasks that run inline do not count against the maximum concurrency, regardless \
  of the maximum policy.
 maxPolicy.loose.desc=Maximum concurrency is loosely enforced. \
  Tasks are allowed to run on the task submitter's thread without \

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -32,11 +32,12 @@ max.desc=Specifies the maximum number of tasks that can run simultaneously. The 
 maxPolicy=Maximum policy
 maxPolicy.desc=Indicates whether to loosely or strictly enforce maximum \
  concurrency for tasks that run on the task submitter's thread. If the \
- concurrency policy is not configured to run tasks on virtual threads, tasks can \
- run on the task submitter's thread when using the untimed invokeAll method, or, \
- if only invoking a single task, when using the untimed invokeAny method. \
- If the run-if-queue-full attribute is configured, tasks  can also\
- run on the task submitter's thread when using the execute and submit methods. \
+ concurrency policy is not configured to run tasks on virtual threads, the \
+ invokeAll and invokeAny methods can sometimes run tasks on the task submitter's \
+ thread. This happens when you use the untimed invokeAll method, or, \
+ if you only supply a single task, when you use the untimed invokeAny method. \
+ If the run-if-queue-full attribute is configured, tasks can also \
+ run on the task submitter's thread when you use the execute and submit methods. \
  In all of these cases, this attribute determines whether running on the \
  submitter's thread counts against the maximum concurrency. Completion stage \
  tasks that run inline do not count against the maximum concurrency, regardless \

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -36,7 +36,7 @@ maxPolicy.desc=Indicates whether to loosely or strictly enforce maximum \
  run on the task submitter's thread when using the untimed invokeAll method, or, \
  if only invoking a single task, when using the untimed invokeAny method. \
  If the run-if-queue-full attribute is configured, tasks  can also\
- to run the task submitter's thread when using the execute and submit methods. \
+ run on the task submitter's thread when using the execute and submit methods. \
  In all of these cases, this attribute determines whether or not running on the \
  submitter's thread counts against the maximum concurrency. Completion stage \
  tasks that run inline do not count against the maximum concurrency regardless \

--- a/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrency.policy/resources/OSGI-INF/l10n/metatype.properties
@@ -34,7 +34,7 @@ maxPolicy.desc=Indicates whether to loosely or strictly enforce maximum \
  concurrency for tasks that run on the task submitter's thread. If the \
  concurrency policy is not configured to run tasks on virtual threads, the \
  invokeAll and invokeAny methods can sometimes run tasks on the task submitter's \
- thread. This happens when you use the untimed invokeAll method, or, \
+ thread. This situation happens when you use the untimed invokeAll method, or, \
  if you only supply a single task, when you use the untimed invokeAny method. \
  If the run-if-queue-full attribute is configured, tasks can also \
  run on the task submitter's thread when you use the execute and submit methods. \

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -51,13 +51,6 @@ public interface PolicyExecutor extends ExecutorService {
          * This policy does not allow running on the submitter's thread if already at maximum concurrency.
          */
         strict
-
-        /*
-         * Leaving the policy unspecified indicates that the policy is to be chosen on a case-by-case basis
-         * based on whether the submitter thread is a virtual thread (try to avoid running on the submitter's thread)
-         * or a platform thread (use a policy of loose).
-         */
-        // unspecified
     }
 
     /**

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -803,14 +803,12 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         boolean havePermit = false;
         boolean useCurrentThread;
         MaxPolicy policy = maxPolicy;
-        if (policy == MaxPolicy.loose) // can always run inline
+        if (virtual) // always run asynchronously on new virtual thread
+            useCurrentThread = false;
+        else if (policy == MaxPolicy.loose) // can always run inline
             useCurrentThread = true;
-        else if (policy == MaxPolicy.strict) // must acquire a permit to run inline
+        else // policy == MaxPolicy.strict // must acquire a permit to run inline
             useCurrentThread = havePermit = taskCount > 0 && maxConcurrencyConstraint.tryAcquire();
-        else // can run inline on platform threads (loose); Never run inline on virtual threads
-            throw new UnsupportedOperationException("maxPolicy=null"); // currently unreachable, waiting for a pull that is blocked
-        // TODO:
-        // useCurrentThread = !(virtualThreadOps.isSupported() && virtualThreadOps.isVirtual(Thread.currentThread()));
 
         List<PolicyTaskFutureImpl<T>> futures = new ArrayList<PolicyTaskFutureImpl<T>>(taskCount);
         try {
@@ -983,14 +981,12 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             boolean havePermit = false;
             boolean useCurrentThread;
             MaxPolicy policy = maxPolicy;
-            if (policy == MaxPolicy.loose) // can always run inline
+            if (virtual) // always run asynchronously on new virtual thread
+                useCurrentThread = false;
+            else if (policy == MaxPolicy.loose) // can always run inline
                 useCurrentThread = true;
-            else if (policy == MaxPolicy.strict) // must acquire a permit to run inline
+            else // policy == MaxPolicy.strict // must acquire a permit to run inline
                 useCurrentThread = havePermit = maxConcurrencyConstraint.tryAcquire();
-            else // can run inline on platform threads (loose); Never run inline on virtual threads
-                throw new UnsupportedOperationException("maxPolicy=null"); // currently unreachable, waiting for a pull that is blocked
-            // TODO:
-            // useCurrentThread = !(virtualThreadOps.isSupported() && virtualThreadOps.isVirtual(Thread.currentThread()));
 
             if (useCurrentThread)
                 try {
@@ -1538,7 +1534,7 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         long u_maxWaitForEnqueue = (Long) props.get("maxWaitForEnqueue");
         boolean u_runIfQueueFull = (Boolean) props.get("runIfQueueFull");
         long u_startTimeout = null == (v = props.get("startTimeout")) ? -1l : (Long) v;
-        boolean useVirtualThreads = null == (v = props.get("virtual")) ? false : (Boolean) v;;
+        boolean useVirtualThreads = null == (v = props.get("virtual")) ? false : (Boolean) v;
 
         // Validation that cannot be performed by metatype:
         if (useVirtualThreads && !virtualThreadOps.isSupported()) {

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
@@ -219,11 +219,10 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
         concurrencyPolicyProps.put("maxWaitForEnqueue", 0L);
         concurrencyPolicyProps.put("runIfQueueFull", false);
 
-        if (Boolean.TRUE.equals(virtual) && JavaInfo.majorVersion() >= 21) { // only available in Concurrency 3.1+ and Java 21+
+        if (Boolean.TRUE.equals(virtual) && JavaInfo.majorVersion() >= 21) {
+            // only available in Concurrency 3.1+ and Java 21+
             concurrencyPolicyProps.put("virtual", virtual);
-            // maxPolicy unspecified makes the policy conditional on whether or not the submitter thread is virtual
-            // TODO remove the following once unspecified is supported
-            concurrencyPolicyProps.put("maxPolicy", "loose");
+            concurrencyPolicyProps.put("maxPolicy", "strict");
         } else {
             if (Boolean.TRUE.equals(virtual))
                 Tr.info(tc, "CWWKC1217.no.virtual.threads",

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
@@ -222,11 +222,10 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
         concurrencyPolicyProps.put("maxWaitForEnqueue", 0L);
         concurrencyPolicyProps.put("runIfQueueFull", false);
 
-        if (Boolean.TRUE.equals(virtual) && JavaInfo.majorVersion() >= 21) { // only available in Concurrency 3.1+ and Java 21+
+        if (Boolean.TRUE.equals(virtual) && JavaInfo.majorVersion() >= 21) {
+            // only available in Concurrency 3.1+ and Java 21+
             concurrencyPolicyProps.put("virtual", virtual);
-            // maxPolicy unspecified makes the policy conditional on whether or not the submitter thread is virtual
-            // TODO remove the following once unspecified is supported
-            concurrencyPolicyProps.put("maxPolicy", "loose");
+            concurrencyPolicyProps.put("maxPolicy", "strict");
         } else {
             if (Boolean.TRUE.equals(virtual))
                 Tr.info(tc, "CWWKC1217.no.virtual.threads",


### PR DESCRIPTION
Untimed invokeAny and invokeAll with virtual=true.
Comments in the code indicated a desire to choose the behavior based on whether the submitting thread is virtual or not, which would have been a good idea, but unfortunately would have been a breaking change because users can already request invokeAny and invokeAll from virtual threads due to Liberty already supporting Java 21.
The next best thing we could do was to make the decision based on the virtual=true setting for the managed executor, which is not yet GA function. In cases where both are virtual, this will work great. But it will not optimize the case where a virtual thread invokes invokeAny or invokeAll to run on platform threads because changing the default for that would be a breaking change to existing behavior.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
