### PR TITLE
Match the TCCL between CDI extension observers and constructor

### DIFF
--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/threads/extension/CDIExtension.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/threads/extension/CDIExtension.java
@@ -34,45 +34,80 @@ import javax.enterprise.inject.spi.ProcessManagedBean;
 public class CDIExtension implements Extension {
 
     private final Set<String> duplicatesFilter = new HashSet<String>();
+    private final ClassLoader threadContextClassLoaderInConstructor;
+
+    public CDIExtension() {
+        threadContextClassLoaderInConstructor = Thread.currentThread().getContextClassLoader();
+    }
 
     public void eventListener(@Observes BeforeBeanDiscovery event) {
-        checkForBeanManagerInUnmanagedThread("BeforeBeanDiscovery");
+        String eventName = "BeforeBeanDiscovery";
+        checkForBeanManagerInUnmanagedThread(eventName);
+        checkTCCLMatches(eventName);
     }
 
     public void eventListener(@Observes ProcessAnnotatedType event) {
-        checkForBeanManagerInUnmanagedThread("ProcessAnnotatedType");
+        String eventName = "ProcessAnnotatedType";
+        checkForBeanManagerInUnmanagedThread(eventName);
+        checkTCCLMatches(eventName);
     }
 
     public void eventListener(@Observes AfterTypeDiscovery event) {
-        checkForBeanManagerInUnmanagedThread("AfterTypeDiscovery");
+        String eventName = "AfterTypeDiscovery";
+        checkForBeanManagerInUnmanagedThread(eventName);
+        checkTCCLMatches(eventName);
     }
 
     public void eventListener(@Observes ProcessInjectionTarget event) {
-        checkForBeanManagerInUnmanagedThread("ProcessInjectionTarget");
+        String eventName = "ProcessInjectionTarget";
+        checkForBeanManagerInUnmanagedThread(eventName);
+        checkTCCLMatches(eventName);
     }
 
     public void eventListener(@Observes ProcessInjectionPoint event) {
-        checkForBeanManagerInUnmanagedThread("ProcessInjectionPoint");
+        String eventName = "ProcessInjectionPoint";
+        checkForBeanManagerInUnmanagedThread(eventName);
+        checkTCCLMatches(eventName);
     }
 
     public void eventListener(@Observes ProcessBeanAttributes event) {
-        checkForBeanManagerInUnmanagedThread("ProcessBeanAttributes");
+        String eventName = "ProcessBeanAttributes";
+        checkForBeanManagerInUnmanagedThread(eventName);
+        checkTCCLMatches(eventName);
     }
 
     public void eventListener(@Observes ProcessBean event) {
-        checkForBeanManagerInUnmanagedThread("ProcessBean");
+        String eventName = "ProcessBean";
+        checkForBeanManagerInUnmanagedThread(eventName);
+        checkTCCLMatches(eventName);
     }
 
     public void eventListener(@Observes ProcessManagedBean event) {
-        checkForBeanManagerInUnmanagedThread("ProcessManagedBean");
+        String eventName = "ProcessManagedBean";
+        checkForBeanManagerInUnmanagedThread(eventName);
+        checkTCCLMatches(eventName);
     }
 
     public void eventListener(@Observes AfterBeanDiscovery event) {
-        checkForBeanManagerInUnmanagedThread("AfterBeanDiscovery");
+        String eventName = "AfterBeanDiscovery";
+        checkForBeanManagerInUnmanagedThread(eventName);
+        checkTCCLMatches(eventName);
     }
 
     public void eventListener(@Observes AfterDeploymentValidation event) {
-        checkForBeanManagerInUnmanagedThread("AfterDeploymentValidation");
+        String eventName = "AfterDeploymentValidation";
+        checkForBeanManagerInUnmanagedThread(eventName);
+        checkTCCLMatches(eventName);
+    }
+
+    private void checkTCCLMatches(String eventName) {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        if (!tccl.equals(threadContextClassLoaderInConstructor)) {
+            System.out.println("Found the wrong classloader in " + eventName + " Expected: " + threadContextClassLoaderInConstructor
+                               + " found: " + tccl);
+        } else {
+            System.out.println("Found the correct classloader in " + eventName);
+        }
     }
 
     private void checkForBeanManagerInUnmanagedThread(final String eventName) {

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/threads/extension/permissions.xml
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/threads/extension/permissions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+	version="7">
+	<permission>
+		<class-name>java.security.AllPermission</class-name>
+		<name>*</name>
+		<actions>*</actions>
+	</permission>
+</permissions>
+
+

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/tests/CDIAPITests.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/tests/CDIAPITests.java
@@ -180,7 +180,7 @@ public class CDIAPITests extends FATServletClient {
 
     @Test
     @Mode(TestMode.FULL)
-    public void testCDICurrentInUnmanagedThreads() throws Exception {
+    public void testCDICurrentInUnmanagedThreadsAndTCCLMatching() throws Exception {
 
         List<String> messages = new ArrayList<String>();
         messages.add("found beanmanager in ProcessAnnotatedType : true");
@@ -194,10 +194,22 @@ public class CDIAPITests extends FATServletClient {
         messages.add("found beanmanager in AfterBeanDiscovery : true");
         messages.add("found beanmanager in AfterDeploymentValidation : true");
 
+        messages.add("Found the correct classloader in ProcessAnnotatedType");
+        messages.add("Found the correct classloader in BeforeBeanDiscovery");
+        messages.add("Found the correct classloader in ProcessInjectionTarget");
+        messages.add("Found the correct classloader in ProcessBeanAttributes");
+        messages.add("Found the correct classloader in ProcessBean");
+        messages.add("Found the correct classloader in ProcessManagedBean");
+        messages.add("Found the correct classloader in ProcessInjectionPoint");
+        messages.add("Found the correct classloader in AfterTypeDiscovery");
+        messages.add("Found the correct classloader in AfterBeanDiscovery");
+        messages.add("Found the correct classloader in AfterDeploymentValidation");
+
         server.setMarkToEndOfLog();
 
         WebArchive cdiCurrentTheads = ShrinkWrap.create(WebArchive.class, CDI_CURRENT_THREADS_APP_NAME + ".war")
                                                 .addPackage(CDIExtension.class.getPackage());
+        cdiCurrentTheads.addAsManifestResource(CDIExtension.class.getPackage(), "permissions.xml", "permissions.xml");
         CDIArchiveHelper.addCDIExtensionFile(cdiCurrentTheads, CDIExtension.class.getPackage());
         ShrinkHelper.exportToServer(server, "dropins", cdiCurrentTheads, DeployOptions.SERVER_ONLY);
         server.waitForStringsInLogUsingMark(messages);

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
@@ -60,12 +60,18 @@ import com.ibm.ws.cdi.internal.interfaces.WebSphereBeanDeploymentArchive;
 import com.ibm.ws.cdi.internal.interfaces.WebSphereCDIDeployment;
 import com.ibm.ws.cdi.internal.interfaces.WeldDevelopmentMode;
 import com.ibm.ws.cdi.liberty.ExtensionMetaData;
+import com.ibm.ws.classloading.LibertyClassLoadingService;
+import com.ibm.ws.kernel.service.util.ServiceCaller;
 import com.ibm.wsspi.injectionengine.InjectionException;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
 
 public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
 
     private static final TraceComponent tc = Tr.register(WebSphereCDIDeploymentImpl.class);
+
+    @SuppressWarnings("rawtypes")
+    private static final ServiceCaller<LibertyClassLoadingService> classLoadingServiceCaller = new ServiceCaller<LibertyClassLoadingService>(WebSphereCDIDeploymentImpl.class,
+                                                                                                                                             LibertyClassLoadingService.class);
 
     private final String id;
     private final Map<String, WebSphereBeanDeploymentArchive> deploymentDBAs = new HashMap<String, WebSphereBeanDeploymentArchive>();
@@ -473,12 +479,24 @@ public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
             ClassLoader oldCL = null;
 
             try {
-                for (ClassLoader classLoader : extensionClassLoaders) {
+                for (final ClassLoader classLoader : extensionClassLoaders) {
+
+                    //We had a customer who wishes to ensure the TCCL is the same in the constructor and in the observer methods.
+                    //This is only possible for one TCCL per application due to limitations in weld.
+                    boolean matchesAppTCCL = classLoadingServiceCaller.run((@SuppressWarnings("rawtypes") LibertyClassLoadingService cl) -> {
+                        return cl.isThreadContextClassLoaderForAppClassLoader(application.getTCCL(), classLoader);
+                    }).orElseThrow(() -> new IllegalStateException("ClassLoadingService missing"));;
+
+                    ClassLoader newTCCL = classLoader;
+                    if (matchesAppTCCL) {
+                        newTCCL = application.getTCCL();
+                    }
+
                     //This ensures that oldCL will be set to the TCCL from before the first itteration of the loop
                     if (oldCL != null) {
-                        CDIUtils.getAndSetLoader(classLoader);
+                        CDIUtils.getAndSetLoader(newTCCL);
                     } else {
-                        oldCL = CDIUtils.getAndSetLoader(classLoader);
+                        oldCL = CDIUtils.getAndSetLoader(newTCCL);
                     }
 
                     Iterable<Metadata<Extension>> extensionIt = bootstrap.loadExtensions(classLoader);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

resolve #29788

In CDIRuntimeImpl we get a classloader from the application, then we call the libertyClassLoadingService.createThreadContextClassLoader() which creates a UnifiedClassLoader that warps the classLoader we got from the application.

WebSphereCDIDeploymentImpl loops through all the app ClassLoaders, puts sets them as the TCCL and starts their CDI Extensions.

What the new code does is checks the ClassLoader about to be set as the TCCL is the same CL that CDIRuntimeImpl wrapped in a UnifiedClassLoader, and if so it sets that UnifiedClassLoader as the TCCL instead so the extension will have the same TCCL for its constructor and observer methods. (At least as much as possible given that CDIRuntimeImpl can only set one TCCL for all modules).

This fufills a customer request to have the TCCL match at all points in an observer's life cycle.