### PR TITLE
Reduce trace generated by HADB test servers

### DIFF
--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:\
-Transaction=all
+com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction/server.xml
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction/server.xml
@@ -33,9 +33,7 @@
       <!-- Properties modified by fat for database rotation -->
       <properties  createDatabase="create" databaseName="${shared.resource.dir}/data/tranlogdb" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
-    
-    <logging traceSpecification="*=info:JCDI=all:com.ibm.ws.webbeans*=all:org.apache.webbeans*=all:org.jboss.weld*=all:com.ibm.ws.cdi*=all:Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
-    
+
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.util.PropertyPermission" name="user.dir" actions="read"/>
     

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.fastcheck/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.fastcheck/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=Transaction=all:WAS.j2c=all:RRA=all:WAS.database=all:ClassLoadingService=all:SharedLibrary=all
-ds.loglevel=DEBUG
+com.ibm.ws.logging.trace.specification=Transaction=all
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.longleasecompete/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_ANYDBCLOUD001.longleasecompete/bootstrap.properties
@@ -1,5 +1,4 @@
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=Transaction=all
-ds.loglevel=DEBUG
 com.ibm.tx.auditRecovery=true
 osgi.console=5471

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_multipleretries/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_multipleretries/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:\
-Transaction=all
+com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_multipleretries/server.xml
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_multipleretries/server.xml
@@ -35,9 +35,7 @@
       <!-- Properties modified by fat for database rotation -->
       <properties  createDatabase="create" databaseName="${shared.resource.dir}/data/tranlogdb" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
-    
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
-    
+
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.util.PropertyPermission" name="user.dir" actions="read"/>
     

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_nonretriable/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_nonretriable/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:\
-Transaction=all
+com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_nonretriable/server.xml
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_nonretriable/server.xml
@@ -35,9 +35,7 @@
       <!-- Properties modified by fat for database rotation -->
       <properties  createDatabase="create" databaseName="${shared.resource.dir}/data/tranlogdb" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
-    
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
-    
+
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.util.PropertyPermission" name="user.dir" actions="read"/>
     

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_recover/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_recover/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:\
-Transaction=all
+com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_recover/server.xml
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_recover/server.xml
@@ -34,9 +34,7 @@
       <!-- Properties modified by fat for database rotation -->
       <properties  createDatabase="create" databaseName="${shared.resource.dir}/data/tranlogdb" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
-    
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
-    
+
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.util.PropertyPermission" name="user.dir" actions="read"/>
     

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_retriable/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_retriable/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:\
-Transaction=all
+com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_retriable/server.xml
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_retriable/server.xml
@@ -34,9 +34,7 @@
       <!-- Properties modified by fat for database rotation -->
       <properties  createDatabase="create" databaseName="${shared.resource.dir}/data/tranlogdb" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
-    
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
-    
+
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.util.PropertyPermission" name="user.dir" actions="read"/>
     

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_retriablecloud/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_retriablecloud/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:\
-Transaction=all
+com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_retriablecloud/server.xml
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_retriablecloud/server.xml
@@ -37,9 +37,7 @@
       <!-- Properties modified by fat for database rotation -->
       <properties  createDatabase="create" databaseName="${shared.resource.dir}/data/tranlogdb" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
-    
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
-    
+
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.util.PropertyPermission" name="user.dir" actions="read"/>
     

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_stalecloud/bootstrap.properties
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_stalecloud/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2023 IBM Corporation and others.
+# Copyright (c) 2023, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,5 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:\
-Transaction=all
+com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_stalecloud/server.xml
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/publish/servers/com.ibm.ws.transaction_stalecloud/server.xml
@@ -37,9 +37,7 @@
       <!-- Properties modified by fat for database rotation -->
       <properties  createDatabase="create" databaseName="${shared.resource.dir}/data/tranlogdb" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
-    
-    <logging traceSpecification="Transaction=all:com.ibm.ws.jdbc.*=all:RRA=all:logservice=all=enabled:*=info=enabled"/>
-    
+
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.security.AllPermission"/>
     <javaPermission codeBase="${server.config.dir}/apps/transaction.war" className="java.util.PropertyPermission" name="user.dir" actions="read"/>
     


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

#build
#spawn.fullfat.buckets=com.ibm.ws.transaction.hadb_fat.db2.1,com.ibm.ws.transaction.hadb_fat.db2.2,com.ibm.ws.transaction.hadb_fat.db2.lease,com.ibm.ws.transaction.hadb_fat.db2.retriablecodes,com.ibm.ws.transaction.hadb_fat.derby.1,com.ibm.ws.transaction.hadb_fat.derby.2,com.ibm.ws.transaction.hadb_fat.derby.lease,com.ibm.ws.transaction.hadb_fat.derby.retriablecodes,com.ibm.ws.transaction.hadb_fat.oracle.1,com.ibm.ws.transaction.hadb_fat.oracle.2,com.ibm.ws.transaction.hadb_fat.oracle.lease,com.ibm.ws.transaction.hadb_fat.oracle.retriablecodes,com.ibm.ws.transaction.hadb_fat.postgresql.1,com.ibm.ws.transaction.hadb_fat.postgresql.2,com.ibm.ws.transaction.hadb_fat.postgresql.lease,com.ibm.ws.transaction.hadb_fat.postgresql.retriablecodes,com.ibm.ws.transaction.hadb_fat.sqlserver.1,com.ibm.ws.transaction.hadb_fat.sqlserver.2,com.ibm.ws.transaction.hadb_fat.sqlserver.lease,com.ibm.ws.transaction.hadb_fat.sqlserver.retriablecodes,com