### PR TITLE
Validation of qualifier annotations and add various NLS messages for Concurrency 3.1

### DIFF
--- a/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
@@ -62,7 +62,7 @@ CWWKC1103.skip.run.failed=CWWKC1103E: Execution of task {0}, which was submitted
 CWWKC1103.skip.run.failed.explanation=The skipRun operation for the Trigger has failed, causing the current execution attempt for the task to be skipped.
 CWWKC1103.skip.run.failed.useraction=Correct the cause of the failure and decide whether or not to resubmit the task.
 
-CWWKC1110.task.canceled=CWWKC1110I: The task {0}, which was submitted to executor service {1}, is canceled.
+CWWKC1110.task.canceled=CWWKC1110I: The {0} task, which was submitted to the {1} executor service, is canceled.
 CWWKC1110.task.canceled.explanation=The task was canceled.
 CWWKC1110.task.canceled.useraction=No action is required.
 

--- a/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
@@ -90,7 +90,7 @@ CWWKC1121.virtual.invalid.useraction=Update to a newer Java version that support
 CWWKC1122.mod.unavail=CWWKC1122E: The {0} application or its {1} module is not \
  available.
 CWWKC1122.mod.unavail.explanation=The application and module that define the \
- ManagedThreadFactory configuration must be available when obtaining a \
+ ManagedThreadFactory configuration must be available to obtain a \
  ManagedThreadFactory instance.
 CWWKC1122.mod.unavail.useraction=Ensure the application is started and that \
  the application includes the module that defines the ManagedThreadFactory \

--- a/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
@@ -63,7 +63,7 @@ CWWKC1103.skip.run.failed.explanation=The skipRun operation for the Trigger has 
 CWWKC1103.skip.run.failed.useraction=Correct the cause of the failure and decide whether or not to resubmit the task.
 
 CWWKC1110.task.canceled=CWWKC1110I: The task {0}, which was submitted to executor service {1}, is canceled.
-CWWKC1110.task.canceled.explanation=Execution of the task was canceled.
+CWWKC1110.task.canceled.explanation=The task was canceled.
 CWWKC1110.task.canceled.useraction=No action is required.
 
 CWWKC1111.task.invalid=CWWKC1111E: The task {0} is not valid.

--- a/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
@@ -50,10 +50,6 @@ CWWKC1100.resource.unavailable=CWWKC1100E: The resource {0} is unavailable.
 CWWKC1100.resource.unavailable.explanation=A resource might become unavailable due to the server shutting down or because of a configuration change, either to itself or another service upon which it depends.
 CWWKC1100.resource.unavailable.useraction=Verify the configuration of the resource and any resources upon which it depends.
 
-CWWKC1110.task.canceled=CWWKC1110I: The task {0}, which was submitted to executor service {1}, is canceled.
-CWWKC1110.task.canceled.explanation=Execution of the task has been canceled.
-CWWKC1110.task.canceled.useraction=No action is required.
-
 CWWKC1101.task.failed=CWWKC1101E: The task {0}, which was submitted to executor service {1}, failed with the following error: {2}.
 CWWKC1101.task.failed.explanation=A task submitted to an executor has failed. Refer to the exception message for the cause.
 CWWKC1101.task.failed.useraction=Correct the cause of the failure and resubmit the task.
@@ -66,6 +62,10 @@ CWWKC1103.skip.run.failed=CWWKC1103E: Execution of task {0}, which was submitted
 CWWKC1103.skip.run.failed.explanation=The skipRun operation for the Trigger has failed, causing the current execution attempt for the task to be skipped.
 CWWKC1103.skip.run.failed.useraction=Correct the cause of the failure and decide whether or not to resubmit the task.
 
+CWWKC1110.task.canceled=CWWKC1110I: The task {0}, which was submitted to executor service {1}, is canceled.
+CWWKC1110.task.canceled.explanation=Execution of the task has been canceled.
+CWWKC1110.task.canceled.useraction=No action is required.
+
 CWWKC1111.task.invalid=CWWKC1111E: The task {0} is not valid.
 CWWKC1111.task.invalid.explanation=The task cannot be submitted because it is not valid.
 CWWKC1111.task.invalid.useraction=Update the application to submit a valid task to the ExecutorService.
@@ -77,6 +77,24 @@ CWWKC1112.all.tasks.canceled.useraction=No action is required.
 CWWKC1120.future.get.rejected=CWWKC1120E: The Future supplied to ManagedTaskListener methods taskSubmitted and taskStarting cannot be used to wait for task completion.
 CWWKC1120.future.get.rejected.explanation=The ManagedTaskListener taskSubmitted and taskStarting methods run on the thread that will submit or start the task. Therefore, the Future supplied to these methods must not be used to wait for the task.
 CWWKC1120.future.get.rejected.useraction=Update the application to avoid invoking get on the Future that is supplied to taskSubmitted and taskStarting.
+
+CWWKC1121.virtual.invalid=CWWKC1121E: The {0} annotation or {1} deployment \
+ descriptor element that has the {0} name specifies virtual=true, \
+ but virtual threads are not available prior to Java 21. \
+ The Java level used is: {1}.
+CWWKC1121.virtual.invalid.explanation=Virtual threads are not available in the \
+ Java version that is used.
+CWWKC1121.virtual.invalid.useraction=Update to a newer Java version that supports \
+ virtual threads.
+
+CWWKC1122.mod.unavail=CWWKC1122E: The {0} application or its {1} module is not \
+ available.
+CWWKC1122.mod.unavail.explanation=The application and module that define the \
+ ManagedThreadFactory configuration must be available when obtaining a \
+ ManagedThreadFactory instance.
+CWWKC1122.mod.unavail.useraction=Ensure the application is started and that \
+ the application includes the module that defines the ManagedThreadFactory \
+ configuration.
 
 CWWKC1130.xprop.value.invalid=CWWKC1130E: A task submitted to managed executor {0} contains an execution property {1} with value {2} that is not valid for managed executors.
 CWWKC1130.xprop.value.invalid.explanation=Some execution property values are not valid for managed executors, but might be valid for other resource types such as context service or managed thread factory.

--- a/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
@@ -63,7 +63,7 @@ CWWKC1103.skip.run.failed.explanation=The skipRun operation for the Trigger has 
 CWWKC1103.skip.run.failed.useraction=Correct the cause of the failure and decide whether or not to resubmit the task.
 
 CWWKC1110.task.canceled=CWWKC1110I: The task {0}, which was submitted to executor service {1}, is canceled.
-CWWKC1110.task.canceled.explanation=Execution of the task has been canceled.
+CWWKC1110.task.canceled.explanation=Execution of the task was canceled.
 CWWKC1110.task.canceled.useraction=No action is required.
 
 CWWKC1111.task.invalid=CWWKC1111E: The task {0} is not valid.

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadFactoryService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadFactoryService.java
@@ -294,8 +294,14 @@ public class ManagedThreadFactoryService implements ResourceFactory, Application
                                                                " of type " + mData.getClass().getName()); // internal error
 
                         cData = webMetadataFactory.createComponentMetaData(webMetadataIdentifier);
-                        if (cData == null)
-                            throw new IllegalStateException("Web module " + mData.getJ2EEName() + " is not available."); // TODO NLS
+                        if (cData == null) {
+                            J2EEName jeeName = mData.getJ2EEName();
+                            String err = Tr.formatMessage(tc,
+                                                          "CWWKC1122.mod.unavail",
+                                                          jeeName.getModule(),
+                                                          jeeName.getApplication());
+                            throw new IllegalStateException(err);
+                        }
                     }
                 } else {
                     // Should be unreachable because mock ComponentMetaData is created for resources defined in application.xml.
@@ -308,9 +314,6 @@ public class ManagedThreadFactoryService implements ResourceFactory, Application
                 identifier = cData instanceof IdentifiableComponentMetaData //
                                 ? metadataIdentifierService.getMetaDataIdentifier(cData) //
                                 : null;
-                System.out.println("MTF createResource for " + identifier);
-                System.out.println("     with " + (cData == null ? null : cData.getClass().getSimpleName()) + " metadata " + cData);
-                System.out.println("     and class loader " + beanInfo.getDeclaringClassLoader());
 
                 // push class loader onto the thread for context capture
                 ClassLoader declaringClassLoader = beanInfo.getDeclaringClassLoader();
@@ -559,9 +562,12 @@ public class ManagedThreadFactoryService implements ResourceFactory, Application
 
         @Override
         public Thread newThread(Runnable r) {
-            throw new UnsupportedOperationException("The " + name + " ManagedThreadFactory is configured with" +
-                                                    " virtual=true, but virtual threads are not available prior" +
-                                                    " to Java 21."); // TODO NLS
+            throw new UnsupportedOperationException(Tr //
+                            .formatMessage(tc,
+                                           "CWWKC1121.virtual.invalid",
+                                           "ManagedThreadFactoryDefinition",
+                                           "managed-thread-factory",
+                                           name));
         }
     }
 }

--- a/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
@@ -46,9 +46,17 @@ CWWKC1204.not.serializable=CWWKC1204E: Cannot create a serializable contextual p
 CWWKC1204.not.serializable.explanation=Third-party thread context types are not compatible with serialization and cannot be configured to be propagated for serializable contextual proxies.
 CWWKC1204.not.serializable.useraction=Update the application to request a non-serializable contextual proxy or ensure that no third-party context types are configured to be propagated.
 
+CWWKC1205.qualifiers.require.cdi=CWWKC1205E: The {0} application artifact cannot \
+ specify the {1} qualifiers on the {2} annotation or {3} deployment descriptor \
+ element that has the {4} name because the {5} feature is not enabled.
+CWWKC1205.qualifiers.require.cdi.explanation=The CDI feature is a prerequisite of \
+ specifying qualifiers on a resource definition.
+CWWKC1205.qualifiers.require.cdi.useraction=Enable the CDI feature.
+
 CWWKC1217.no.virtual.threads=CWWKC1217I: The Concurrency specification requires \
- virtual=true to be ignored on the {0} {1} definition in the {2} application \
- artifact because Java {3} does not support virtual threads.
+ virtual=true to be ignored on the {0} application artifact's \
+ {1} annotation or {2} deployment descriptor element with the {3} name \
+ because Java {4} does not support virtual threads.
 CWWKC1217.no.virtual.threads.explanation=Virtual threads are available only \
  in Java 21 and later.
 CWWKC1217.no.virtual.threads.useraction=Update to Java 21 or later to enable the \

--- a/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
@@ -53,6 +53,27 @@ CWWKC1205.qualifiers.require.cdi.explanation=The CDI feature is a prerequisite o
  specifying qualifiers on a resource definition.
 CWWKC1205.qualifiers.require.cdi.useraction=Enable the CDI feature.
 
+CWWKC1206.qualifier.must.be.anno=CWWKC1206E: The {0} application artifact \
+ specifies a {1} annotation or {2} deployment descriptor element that has the \
+ {3} name and {4} qualifiers list. The qualifiers list includes a {5} value \
+ that is not an annotation. All elements in the list must be annotation classes \
+ that are annotated with @Qualifier and @Retention(RUNTIME). For example, {6}
+CWWKC1206.qualifier.must.be.anno.explanation=Each value in the qualifiers \
+ list must be an annotation class.
+CWWKC1206.qualifier.must.be.anno.useraction=Ensure that all values in the \
+ qualifiers list are annotation classes.
+
+CWWKC1207.lacks.qualifier.anno=CWWKC1207E: The {0} application artifact \
+ specifies a {1} annotation or {2} deployment descriptor element that has the \
+ {3} name and {4} qualifiers list. The qualifiers list includes the \
+ {5} annotation, which is not annotated with @jakarta.inject.Qualifier and \
+ @Retention(RUNTIME). An example of a valid qualifier is: {6}
+CWWKC1207.lacks.qualifier.anno.explanation=The Qualifier annotation indicates \
+ that the annotation is a qualifier. The Retention annotation controls the \
+ availability of annotations.
+CWWKC1207.lacks.qualifier.anno.useraction=Add the @Qualifier and \
+ @Retention(RUNTIME) annotations to the qualifier class.
+
 CWWKC1217.no.virtual.threads=CWWKC1217I: The Concurrency specification requires \
  virtual=true to be ignored on the {0} application artifact's \
  {1} annotation or {2} deployment descriptor element with the {3} name \

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ConcurrencyResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ConcurrencyResourceFactoryBuilder.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.concurrent.internal.processor;
+
+import java.lang.annotation.Annotation;
+
+import com.ibm.ws.resource.ResourceFactoryBuilder;
+
+/**
+ * Super interface for all ResourceFcatoryBuilders that are provided by the
+ * Concurrency component.
+ */
+public interface ConcurrencyResourceFactoryBuilder extends ResourceFactoryBuilder {
+    /**
+     * Returns the type of deployment descriptor element that this builder handles.
+     * For example: managed-executor
+     *
+     * @return the type of deployment descriptor element that this builder handles.
+     */
+    String getDDElementName();
+
+    /**
+     * Returns the type of resource definition annotation that this builder handles.
+     * For example: ManagedExecutorDefinition
+     *
+     * @return the type of resource definition annotation that this builder handles.
+     */
+    Class<? extends Annotation> getDefinitionAnnotationClass();
+}

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.processor;
 
+import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.HashMap;
@@ -55,7 +56,8 @@ import jakarta.enterprise.concurrent.ContextServiceDefinition;
 /**
  * Creates, modifies, and removes ContextService resource factories that are defined via ContextServiceDefinition.
  */
-public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuilder {
+public class ContextServiceResourceFactoryBuilder implements //
+                ConcurrencyResourceFactoryBuilder, ResourceFactoryBuilder {
     private static final TraceComponent tc = Tr.register(ContextServiceResourceFactoryBuilder.class);
 
     private static final String CONTEXT_PID_ZOS_WLM = "com.ibm.ws.zos.wlm.context";
@@ -404,8 +406,8 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
                                                    "CWWKC1205.qualifiers.require.cdi",
                                                    jeeName,
                                                    qualifierNames,
-                                                   ContextServiceDefinition.class.getSimpleName(),
-                                                   "context-service",
+                                                   getDefinitionAnnotationClass().getSimpleName(),
+                                                   getDDElementName(),
                                                    jndiName,
                                                    ContextServiceDefinitionProvider.getCDIFeatureName()));
 
@@ -458,6 +460,18 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
             }
         }
         return sb.append("contextService").append('[').append(jndiName).append(']').toString();
+    }
+
+    @Override
+    @Trivial
+    public final String getDDElementName() {
+        return "context-service";
+    }
+
+    @Override
+    @Trivial
+    public final Class<? extends Annotation> getDefinitionAnnotationClass() {
+        return ContextServiceDefinition.class;
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
@@ -398,11 +398,16 @@ public class ContextServiceResourceFactoryBuilder implements ResourceFactoryBuil
 
                 ServiceReference<QualifiedResourceFactories> ref = bundleContext.getServiceReference(QualifiedResourceFactories.class);
 
-                if (ref == null) // TODO message should include possibility of deployment descriptor element
-                    throw new UnsupportedOperationException("The " + jeeName + " application artifact cannot specify the " +
-                                                            qualifierNames + " qualifiers on the " +
-                                                            jndiName + " " + ContextServiceDefinition.class.getSimpleName() +
-                                                            " because the " + "CDI" + " feature is not enabled."); // TODO NLS
+                if (ref == null)
+                    throw new UnsupportedOperationException(Tr //
+                                    .formatMessage(tc,
+                                                   "CWWKC1205.qualifiers.require.cdi",
+                                                   jeeName,
+                                                   qualifierNames,
+                                                   ContextServiceDefinition.class.getSimpleName(),
+                                                   "context-service",
+                                                   jndiName,
+                                                   ContextServiceDefinitionProvider.getCDIFeatureName()));
 
                 QualifiedResourceFactories qrf = bundleContext.getService(ref);
                 qrf.add(jeeName, QualifiedResourceFactory.Type.ContextService, qualifierNames, factory);

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.processor;
 
+import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
@@ -29,6 +30,7 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrency.policy.ConcurrencyPolicy;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.kernel.service.util.JavaInfo;
@@ -50,7 +52,8 @@ import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
 /**
  * Creates, modifies, and removes ManagedExecutorService resource factories that are defined via ManagedExecutorDefinition.
  */
-public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBuilder {
+public class ManagedExecutorResourceFactoryBuilder implements //
+                ConcurrencyResourceFactoryBuilder, ResourceFactoryBuilder {
     private static final TraceComponent tc = Tr.register(ManagedExecutorResourceFactoryBuilder.class);
 
     /**
@@ -226,8 +229,8 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
             if (Boolean.TRUE.equals(virtual))
                 Tr.info(tc, "CWWKC1217.no.virtual.threads",
                         declaringMetadata.getName(),
-                        ManagedExecutorDefinition.class.getSimpleName(),
-                        "managed-executor",
+                        getDefinitionAnnotationClass().getSimpleName(),
+                        getDDElementName(),
                         jndiName,
                         JavaInfo.majorVersion());
 
@@ -273,8 +276,8 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
                                                    "CWWKC1205.qualifiers.require.cdi",
                                                    jeeName,
                                                    qualifierNames,
-                                                   ManagedExecutorDefinition.class.getSimpleName(),
-                                                   "managed-executor",
+                                                   getDefinitionAnnotationClass().getSimpleName(),
+                                                   getDDElementName(),
                                                    jndiName,
                                                    ContextServiceDefinitionProvider.getCDIFeatureName()));
 
@@ -303,6 +306,18 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
     protected void deactivate(ComponentContext context) {
         configAdminRef.deactivate(context);
         variableRegistryRef.deactivate(context);
+    }
+
+    @Override
+    @Trivial
+    public final String getDDElementName() {
+        return "managed-executor";
+    }
+
+    @Override
+    @Trivial
+    public final Class<? extends Annotation> getDefinitionAnnotationClass() {
+        return ManagedExecutorDefinition.class;
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
@@ -44,7 +44,6 @@ import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
-import jakarta.enterprise.concurrent.ManagedExecutorService;
 
 @Component(service = ResourceFactoryBuilder.class,
            property = "creates.objectClass=jakarta.enterprise.concurrent.ManagedExecutorService") //  TODO more types?
@@ -226,9 +225,10 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
         } else {
             if (Boolean.TRUE.equals(virtual))
                 Tr.info(tc, "CWWKC1217.no.virtual.threads",
-                        jndiName,
-                        ManagedExecutorService.class.getSimpleName(),
                         declaringMetadata.getName(),
+                        ManagedExecutorDefinition.class.getSimpleName(),
+                        "managed-executor",
+                        jndiName,
                         JavaInfo.majorVersion());
 
             // virtual = false is the default
@@ -267,11 +267,16 @@ public class ManagedExecutorResourceFactoryBuilder implements ResourceFactoryBui
 
                 ServiceReference<QualifiedResourceFactories> ref = concurrencyBundleCtx.getServiceReference(QualifiedResourceFactories.class);
 
-                if (ref == null) // TODO message should include possibility of deployment descriptor element
-                    throw new UnsupportedOperationException("The " + jeeName + " application artifact cannot specify the " +
-                                                            qualifierNames + " qualifiers on the " +
-                                                            jndiName + " " + ManagedExecutorDefinition.class.getSimpleName() +
-                                                            " because the " + "CDI" + " feature is not enabled."); // TODO NLS
+                if (ref == null)
+                    throw new UnsupportedOperationException(Tr //
+                                    .formatMessage(tc,
+                                                   "CWWKC1205.qualifiers.require.cdi",
+                                                   jeeName,
+                                                   qualifierNames,
+                                                   ManagedExecutorDefinition.class.getSimpleName(),
+                                                   "managed-executor",
+                                                   jndiName,
+                                                   ContextServiceDefinitionProvider.getCDIFeatureName()));
 
                 QualifiedResourceFactories qrf = concurrencyBundleCtx.getService(ref);
                 qrf.add(jeeName, QualifiedResourceFactory.Type.ManagedExecutorService, qualifierNames, factory);

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.processor;
 
+import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
@@ -29,6 +30,7 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrency.policy.ConcurrencyPolicy;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.kernel.service.util.JavaInfo;
@@ -50,7 +52,8 @@ import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
 /**
  * Creates, modifies, and removes ManagedScheduledExecutorService resource factories that are defined via ManagedScheduledExecutorDefinition.
  */
-public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceFactoryBuilder {
+public class ManagedScheduledExecutorResourceFactoryBuilder //
+                implements ConcurrencyResourceFactoryBuilder, ResourceFactoryBuilder {
     private static final TraceComponent tc = Tr.register(ManagedScheduledExecutorResourceFactoryBuilder.class);
 
     /**
@@ -229,8 +232,8 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
             if (Boolean.TRUE.equals(virtual))
                 Tr.info(tc, "CWWKC1217.no.virtual.threads",
                         declaringMetadata.getName(),
-                        ManagedScheduledExecutorDefinition.class.getSimpleName(),
-                        "managed-scheduled-executor",
+                        getDefinitionAnnotationClass().getSimpleName(),
+                        getDDElementName(),
                         jndiName,
                         JavaInfo.majorVersion());
 
@@ -276,8 +279,8 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
                                                    "CWWKC1205.qualifiers.require.cdi",
                                                    jeeName,
                                                    qualifierNames,
-                                                   ManagedScheduledExecutorDefinition.class.getSimpleName(),
-                                                   "managed-scheduled-executor",
+                                                   getDefinitionAnnotationClass().getSimpleName(),
+                                                   getDDElementName(),
                                                    jndiName,
                                                    ContextServiceDefinitionProvider.getCDIFeatureName()));
 
@@ -306,6 +309,18 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
     protected void deactivate(ComponentContext context) {
         configAdminRef.deactivate(context);
         variableRegistryRef.deactivate(context);
+    }
+
+    @Override
+    @Trivial
+    public final String getDDElementName() {
+        return "managed-scheduled-executor";
+    }
+
+    @Override
+    @Trivial
+    public final Class<? extends Annotation> getDefinitionAnnotationClass() {
+        return ManagedScheduledExecutorDefinition.class;
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
@@ -44,7 +44,6 @@ import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
-import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 
 @Component(service = ResourceFactoryBuilder.class,
            property = "creates.objectClass=jakarta.enterprise.concurrent.ManagedScheduledExecutorService") //  TODO more types?
@@ -229,9 +228,10 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
         } else {
             if (Boolean.TRUE.equals(virtual))
                 Tr.info(tc, "CWWKC1217.no.virtual.threads",
-                        jndiName,
-                        ManagedScheduledExecutorService.class.getSimpleName(),
                         declaringMetadata.getName(),
+                        ManagedScheduledExecutorDefinition.class.getSimpleName(),
+                        "managed-scheduled-executor",
+                        jndiName,
                         JavaInfo.majorVersion());
 
             // virtual = false is the default
@@ -270,11 +270,16 @@ public class ManagedScheduledExecutorResourceFactoryBuilder implements ResourceF
 
                 ServiceReference<QualifiedResourceFactories> ref = concurrencyBundleCtx.getServiceReference(QualifiedResourceFactories.class);
 
-                if (ref == null) // TODO message should include possibility of deployment descriptor element
-                    throw new UnsupportedOperationException("The " + jeeName + " application artifact cannot specify the " +
-                                                            qualifierNames + " qualifiers on the " +
-                                                            jndiName + " " + ManagedScheduledExecutorDefinition.class.getSimpleName() +
-                                                            " because the " + "CDI" + " feature is not enabled."); // TODO NLS
+                if (ref == null)
+                    throw new UnsupportedOperationException(Tr //
+                                    .formatMessage(tc,
+                                                   "CWWKC1205.qualifiers.require.cdi",
+                                                   jeeName,
+                                                   qualifierNames,
+                                                   ManagedScheduledExecutorDefinition.class.getSimpleName(),
+                                                   "managed-scheduled-executor",
+                                                   jndiName,
+                                                   ContextServiceDefinitionProvider.getCDIFeatureName()));
 
                 QualifiedResourceFactories qrf = concurrencyBundleCtx.getService(ref);
                 qrf.add(jeeName, QualifiedResourceFactory.Type.ManagedScheduledExecutorService, qualifierNames, factory);

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.processor;
 
+import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
@@ -29,6 +30,7 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.ws.resource.ResourceFactory;
@@ -49,7 +51,8 @@ import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
 /**
  * Creates, modifies, and removes ManagedThreadFactory resource factories that are defined via ManagedThreadFactoryDefinition.
  */
-public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFactoryBuilder {
+public class ManagedThreadFactoryResourceFactoryBuilder implements //
+                ConcurrencyResourceFactoryBuilder, ResourceFactoryBuilder {
     private static final TraceComponent tc = Tr.register(ManagedThreadFactoryResourceFactoryBuilder.class);
 
     /**
@@ -171,8 +174,8 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
             threadFactoryProps.put("virtual", Boolean.FALSE);
             Tr.info(tc, "CWWKC1217.no.virtual.threads",
                     declaringMetadata.getName(),
-                    ManagedThreadFactoryDefinition.class.getSimpleName(),
-                    "managed-thread-factory",
+                    getDefinitionAnnotationClass().getSimpleName(),
+                    getDDElementName(),
                     jndiName,
                     JavaInfo.majorVersion());
         }
@@ -239,8 +242,8 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
                                                    "CWWKC1205.qualifiers.require.cdi",
                                                    jeeName,
                                                    qualifierNames,
-                                                   ManagedThreadFactoryDefinition.class.getSimpleName(),
-                                                   "managed-thread-factory",
+                                                   getDefinitionAnnotationClass().getSimpleName(),
+                                                   getDDElementName(),
                                                    jndiName,
                                                    ContextServiceDefinitionProvider.getCDIFeatureName()));
 
@@ -269,6 +272,18 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
     protected void deactivate(ComponentContext context) {
         configAdminRef.deactivate(context);
         variableRegistryRef.deactivate(context);
+    }
+
+    @Override
+    @Trivial
+    public final String getDDElementName() {
+        return "managed-thread-factory";
+    }
+
+    @Override
+    @Trivial
+    public final Class<? extends Annotation> getDefinitionAnnotationClass() {
+        return ManagedThreadFactoryDefinition.class;
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
@@ -42,7 +42,6 @@ import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
-import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
 
 @Component(service = ResourceFactoryBuilder.class,
@@ -171,9 +170,10 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
             JavaInfo.majorVersion() < 21) {
             threadFactoryProps.put("virtual", Boolean.FALSE);
             Tr.info(tc, "CWWKC1217.no.virtual.threads",
-                    jndiName,
-                    ManagedThreadFactory.class.getSimpleName(),
                     declaringMetadata.getName(),
+                    ManagedThreadFactoryDefinition.class.getSimpleName(),
+                    "managed-thread-factory",
+                    jndiName,
                     JavaInfo.majorVersion());
         }
 
@@ -233,11 +233,16 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements ResourceFacto
 
                 ServiceReference<QualifiedResourceFactories> ref = bundleContext.getServiceReference(QualifiedResourceFactories.class);
 
-                if (ref == null) // TODO message should include possibility of deployment descriptor element
-                    throw new UnsupportedOperationException("The " + jeeName + " application artifact cannot specify the " +
-                                                            qualifierNames + " qualifiers on the " +
-                                                            jndiName + " " + ManagedThreadFactoryDefinition.class.getSimpleName() +
-                                                            " because the " + "CDI" + " feature is not enabled."); // TODO NLS
+                if (ref == null)
+                    throw new UnsupportedOperationException(Tr //
+                                    .formatMessage(tc,
+                                                   "CWWKC1205.qualifiers.require.cdi",
+                                                   jeeName,
+                                                   qualifierNames,
+                                                   ManagedThreadFactoryDefinition.class.getSimpleName(),
+                                                   "managed-thread-factory",
+                                                   jndiName,
+                                                   ContextServiceDefinitionProvider.getCDIFeatureName()));
 
                 QualifiedResourceFactories qrf = bundleContext.getService(ref);
                 qrf.add(jeeName, QualifiedResourceFactory.Type.ManagedThreadFactory, qualifierNames, factory);


### PR DESCRIPTION
Validation of qualifier annotations for Concurrency resource definitions.
Add NLS messages for these and other scenarios in Concurrency 3.1.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
