### PR TITLE
repository operation hung when persistence unit lacks a required entity

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -820,3 +820,12 @@ CWWKD1081.entity.general.err.explanation=An error prevents the \
  specified entity from being used.
 CWWKD1081.entity.general.err.useraction=Locate the entity and make \
  corrections if needed.
+
+CWWKD1082.entity.classes.missing=CWWKD1082E: The persistence unit for the \
+ {0} data store does not define one or more entity classes ({1}) \
+ that are required by one or more repository interfaces ({2}) \
+ that use the data store.
+CWWKD1082.entity.classes.missing.explanation=All entity classes that are \
+ used by the repositories must be defined in the persistence unit.
+CWWKD1082.entity.classes.missing.useraction=Include all of the entity classes \
+ in the persistence unit.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -823,7 +823,7 @@ CWWKD1081.entity.general.err.useraction=Locate the entity and make \
 
 CWWKD1082.entity.classes.missing=CWWKD1082E: The persistence unit for the \
  {0} data store does not define one or more entity classes ({1}) \
- that one or more repository interfaces ({2}) that use the data store require.
+ that one or more repository interfaces ({2}), which use the data store, require.
 CWWKD1082.entity.classes.missing.explanation=Repositories use entity classes \
  that must be defined in the persistence unit.
 CWWKD1082.entity.classes.missing.useraction=Include all entity classes \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -823,9 +823,8 @@ CWWKD1081.entity.general.err.useraction=Locate the entity and make \
 
 CWWKD1082.entity.classes.missing=CWWKD1082E: The persistence unit for the \
  {0} data store does not define one or more entity classes ({1}) \
- that are required by one or more repository interfaces ({2}) \
- that use the data store.
-CWWKD1082.entity.classes.missing.explanation=All entity classes that are \
- used by the repositories must be defined in the persistence unit.
-CWWKD1082.entity.classes.missing.useraction=Include all of the entity classes \
+ that one or more repository interfaces ({2}) that use the data store require.
+CWWKD1082.entity.classes.missing.explanation=Repositories use entity classes \
+ that must be defined in the persistence unit.
+CWWKD1082.entity.classes.missing.useraction=Include all entity classes \
  in the persistence unit.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -121,6 +121,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         this.provider = provider;
         this.repositoryClassLoader = repositoryClassLoader;
         this.dataStore = dataStore;
+        // TODO getModuleName will show wrong hash code, so suppress it from trace?
         this.moduleName = getModuleName(repositoryInterface, repositoryClassLoader, provider);
         this.namespace = Namespace.of(dataStore);
 
@@ -320,9 +321,13 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                         Tr.debug(this, tc, dataStore + " is the JNDI name for " + resource);
 
                     if (resource instanceof EntityManagerFactory)
-                        return new PUnitEMBuilder(provider, repositoryClassLoader, //
+                        return new PUnitEMBuilder(provider, //
+                                        repositoryClassLoader, //
+                                        repositoryInterfaces, //
                                         (EntityManagerFactory) resource, //
-                                        resourceName, metadataIdentifier, entityTypes);
+                                        resourceName, //
+                                        metadataIdentifier, //
+                                        entityTypes);
                 } else {
                     // Check for resource references and persistence unit references where java:comp/env/ is omitted:
                     String javaCompName = "java:comp/env/" + resourceName;
@@ -333,9 +338,12 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                             Tr.debug(this, tc, javaCompName + " is the JNDI name for " + resource);
 
                         if (resource instanceof EntityManagerFactory)
-                            return new PUnitEMBuilder(provider, repositoryClassLoader, //
+                            return new PUnitEMBuilder(provider, //
+                                            repositoryClassLoader, //
+                                            repositoryInterfaces, //
                                             (EntityManagerFactory) resource, //
-                                            javaCompName, metadataIdentifier, //
+                                            javaCompName, //
+                                            metadataIdentifier, //
                                             entityTypes);
 
                         if (resource instanceof DataSource)
@@ -356,10 +364,14 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
             boolean javacolon = namespace != null || // any java: namespace
                                 resourceName != dataStore; // implicit java:comp
 
-            return new DBStoreEMBuilder(provider, repositoryClassLoader, //
+            return new DBStoreEMBuilder(provider, //
+                            repositoryClassLoader, //
+                            repositoryInterfaces, //
                             resourceName, //
                             javacolon, //
-                            metadataIdentifier, jeeName, entityTypes);
+                            metadataIdentifier, //
+                            jeeName, //
+                            entityTypes);
         } catch (Throwable x) {
             // The error is logged to Tr.error rather than FFDC
             ComponentMetaData metadata = repoMetadata == null //

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
@@ -41,6 +41,7 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
      *
      * @param provider              OSGi service that provides the CDI extension.
      * @param repositoryClassLoader class loader of the repository interface.
+     * @param repositoryInterfaces  repository interfaces that use the entities.
      * @param emf                   entity manager factory.
      * @param pesistenceUnitRef     persistence unit reference.
      * @param metaDataIdentifier    metadata identifier for the class loader of the repository interface.
@@ -49,11 +50,15 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
      */
     public PUnitEMBuilder(DataProvider provider,
                           ClassLoader repositoryClassLoader,
+                          Set<Class<?>> repositoryInterfaces,
                           EntityManagerFactory emf,
                           String persistenceUnitRef,
                           String metadataIdentifier,
                           Set<Class<?>> entityTypes) throws Exception {
-        super(provider, repositoryClassLoader, persistenceUnitRef);
+        super(provider, //
+              repositoryClassLoader, //
+              repositoryInterfaces, //
+              persistenceUnitRef);
         this.emf = emf;
 
         collectEntityInfo(entityTypes);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -123,6 +123,7 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
      *
      * @param provider              OSGi service that provides the CDI extension.
      * @param repositoryClassLoader class loader of the repository interface.
+     * @param repositoryInterfaces  repository interfaces that use the entities.
      * @param dataStore             dataStore value from the Repository annotation,
      *                                  or the value with java:comp/env added.
      * @param isJNDIName            indicates if the dataStore name is a JNDI name (begins with java: or is inferred to be java:comp/env/...)
@@ -132,11 +133,15 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
      * @param entityTypes           entity classes as known by the user, not generated.
      * @throws Exception if an error occurs.
      */
-    public DBStoreEMBuilder(DataProvider provider, ClassLoader repositoryClassLoader,
-                            String dataStore, boolean isJNDIName,
-                            String metadataIdentifier, J2EEName jeeName,
+    public DBStoreEMBuilder(DataProvider provider,
+                            ClassLoader repositoryClassLoader,
+                            Set<Class<?>> repositoryInterfaces,
+                            String dataStore,
+                            boolean isJNDIName,
+                            String metadataIdentifier,
+                            J2EEName jeeName,
                             Set<Class<?>> entityTypes) throws Exception {
-        super(provider, repositoryClassLoader, dataStore);
+        super(provider, repositoryClassLoader, repositoryInterfaces, dataStore);
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         String qualifiedName = null;

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -43,6 +43,7 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1078E.*test.jakarta.data.errpaths.web.InvalidNonJNDIRepo",
                                    "CWWKD1079E.*test.jakarta.data.errpaths.web.InvalidJNDIRepo",
                                    "CWWKD1080E.*test.jakarta.data.errpaths.web.InvalidDatabaseRepo",
+                                   "CWWKD1082E.*test.jakarta.data.errpaths.web.WrongPersistenceUnitRefRepo",
                                    "CWWJP9991W.*4002" // 2 persistence units attempt to autocreate same table
                     };
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Volunteer.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Volunteer.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * A valid entity. But used in a repository that uses a persistence unit
+ * from which this entity is missing.
+ */
+@Entity
+public class Volunteer {
+
+    @Id
+    @Column(nullable = false)
+    public String name;
+
+    public String address;
+
+    @Column(nullable = false)
+    public LocalDate birthday;
+
+    public Volunteer() {
+    }
+
+    public Volunteer(String name, LocalDate birthday, String address) {
+        this.name = name;
+        this.address = address;
+        this.birthday = birthday;
+    }
+
+    @Override
+    public String toString() {
+        return "Volunteer " + name + " (" + birthday + ") @" + address;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/WrongPersistenceUnitRefRepo.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/WrongPersistenceUnitRefRepo.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository with a valid entity, but uses a persistence unit that does not
+ * have the entity.
+ */
+@Repository(dataStore = "java:app/env/WrongPersistenceUnitRef")
+public interface WrongPersistenceUnitRefRepo //
+                extends CrudRepository<Volunteer, String> {
+
+}


### PR DESCRIPTION
Detect when a persistence unit doesn't include all of the entities that a repository needs and raise an appropriate error to the user.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
