### PR TITLE
Update HTTP Metrics to correct improper behavior when handling JSF / Jakarta Faces requests.

### DIFF
--- a/dev/io.openliberty.http.monitor/bnd.bnd
+++ b/dev/io.openliberty.http.monitor/bnd.bnd
@@ -62,4 +62,5 @@ DynamicImport-Package: \
 	com.ibm.ws.channelfw;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.container.service,\
-	com.ibm.ws.kernel.boot.core;version=latest
+	com.ibm.ws.kernel.boot.core;version=latest,\
+	com.ibm.websphere.javaee.jsf.2.2

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletFilter.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletFilter.java
@@ -372,8 +372,7 @@ public class ServletFilter implements Filter {
 					else {
 						
 						/*
-						 * Hard coded to deal with the typical file extensions of JSF files : `.jsf`, `.faces` or `.xhtml`. This
-						 * is will catch.
+						 * Hard coded to deal with the typical file extensions of JSF files : `.jsf`, `.faces` or `.xhtml`.
 						 * 
 						 * Unfortunately, won't be able to catch any servlet mappings where they mapped the JSF servlet to some
 						 * random extension (i.e., *.abc)

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletFilter.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletFilter.java
@@ -12,6 +12,7 @@ package io.openliberty.http.monitor;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
 
 import javax.servlet.UnavailableException;
 
@@ -24,6 +25,7 @@ import com.ibm.ws.webcontainer.webapp.WebAppDispatcherContext;
 //import com.ibm.ws.webcontainer40.osgi.webapp.WebAppDispatcherContext40;
 import com.ibm.wsspi.webcontainer.webapp.IWebAppDispatcherContext;
 
+import javax.faces.context.FacesContext;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -46,7 +48,7 @@ public class ServletFilter implements Filter {
 	
     @Override
     public void init(FilterConfig config) {
-    	
+
     }
 	
 	@Override
@@ -267,7 +269,6 @@ public class ServletFilter implements Filter {
 		servletPath = (servletPath == null ) ? null : servletPath.trim();
 		String requestURI = srtServletRequest.getRequestURI();
 		requestURI = (requestURI == null ) ? null : requestURI.trim();
-	
 
 		/*
 		 * WebAppDispatcher used to get a "mapping" value
@@ -322,46 +323,82 @@ public class ServletFilter implements Filter {
 					}
 				}
 				
+				//Deal with resources loaded by JSF / Jakarta Faces
+				else if (servletPath.startsWith("/jakarta.faces.resource") || servletPath.startsWith("/javax.faces.resource")) {
+					String[] arr = servletPath.split("\\.");
+					String extension = arr[arr.length-1];
+					httpRoute = contextPath + "/*."+extension;
+				}
+
 				else {
 					/*
-					 * PATH INFO NULL
-					 * SERVLET NOT NULL
+					 * PATH INFO = NULL
+					 * SERVLET PATH = NOT NULL
+					 * 
 					 * We are dealing with a direct match.
 					 * OR a wild card servlet , but right on the node
 					 * ^ Can only resolve for EE8
 					 * e.g.
-					 * servlet path: /path/*
-					 * request path: /path
+					 * servlet path is specified as : /path/*
+					 * request path was requested as : /path
 					 *
 					 */
 
-					//Used by EE8 and above
+					/*
+					 *  Applies to Servlet 4 and up (EE8 and up ) as we are using the 'pattern' value
+					 *  that is only obtainable with WebAppDispatcherContext40.
+					 */
 					if (Servlet4Helper.isServlet4Up()) {
 
 						String pattern = Servlet4Helper.getPattern(iwadc);
-						//This resolves the /wild/* servlet path and the /wild is entered for EE8
-						if (pattern != null && pattern.endsWith("/*")) {
-							httpRoute = contextPath + pattern;
+						
+						/*
+						 * This resolves the /wild/* servlet path and the /wild is entered for EE8
+						 * Also if configured with *.<extension> (i.e., *.xhtml, *.jsf, *.abc)
+						 */
+						if (pattern != null && (pattern.endsWith("/*") || pattern.startsWith("*."))) {
+							httpRoute = contextPath + "/" + pattern;
 							//direct mtach for EE8
 						} else {
 							httpRoute = contextPath + servletPath;
 						}
 					}
-					//EE7 specifically
+					/*
+					 * Applies only to EE7 
+					 */
 					else {
-						/*
-						 * Simply a direct match.
-						 * 
-						 * Unfortunately, given a scenario where a servlet is set as /path/*
-						 * we cannot properly resolve the http route of hits to /path as /path/*
-						 * 
-						 * Constraint of EE7 where we have no "pattern" information
-						 */
-						httpRoute = contextPath + servletPath;
 						
+						/*
+						 * Hard coded to deal with the typical file extensions of JSF files : `.jsf`, `.faces` or `.xhtml`. This
+						 * is will catch.
+						 * 
+						 * Unfortunately, won't be able to catch any servlet mappings where they mapped the JSF servlet to some
+						 * random extension (i.e., *.abc)
+						 * 
+						 * In those cases, it'll just be handled as a direct match (i.e., the bottom else block)
+						 */
+						if (servletPath.endsWith(".jsf")) {
+							httpRoute = contextPath + "/*.jsf";
+						} else if (servletPath.endsWith(".faces")) {
+							httpRoute = contextPath + "/*.faces";
+						} else if (servletPath.endsWith(".xhtml")) {
+							httpRoute = contextPath + "/*.xhtml";
+						} else {
+							/*
+							 * Simply a direct match.
+							 * 
+							 * Unfortunately, given a scenario where a servlet is set as /path/*
+							 * we cannot properly resolve the http route of hits to /path as /path/*
+							 * 
+							 * Also scenario where mapping was made against JSF servlet that isn't the usual
+							 * file name extensions (as listed above) (e.g., *.abc)
+							 * 
+							 * Constraint of EE7 where we have no "pattern" information
+							 */
+							httpRoute = contextPath + servletPath;
+						}
 					}
 				}
-
 			}
 			/*
 			 *  SERVLETS WITH WILD CARD 

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletFilter.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/ServletFilter.java
@@ -22,10 +22,8 @@ import com.ibm.websphere.servlet.error.ServletErrorReport;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.webapp.WebAppDispatcherContext;
-//import com.ibm.ws.webcontainer40.osgi.webapp.WebAppDispatcherContext40;
 import com.ibm.wsspi.webcontainer.webapp.IWebAppDispatcherContext;
 
-import javax.faces.context.FacesContext;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -48,7 +46,6 @@ public class ServletFilter implements Filter {
 	
     @Override
     public void init(FilterConfig config) {
-
     }
 	
 	@Override
@@ -323,11 +320,17 @@ public class ServletFilter implements Filter {
 					}
 				}
 				
-				//Deal with resources loaded by JSF / Jakarta Faces
+				/*
+				 * Explicitly deal with resources loaded by JSF / Jakarta Faces
+				 * 
+				 * URL for resources request will end with the file extension of the original requesting 
+				 * 
+				 * i.e., page.xhtml -> /jakarta.faces.resource/someFile.file.xhtml
+				 */
 				else if (servletPath.startsWith("/jakarta.faces.resource") || servletPath.startsWith("/javax.faces.resource")) {
 					String[] arr = servletPath.split("\\.");
 					String extension = arr[arr.length-1];
-					httpRoute = contextPath + "/*."+extension;
+					httpRoute = contextPath + "/*." + extension;
 				}
 
 				else {

--- a/dev/io.openliberty.http.monitor_fat/.classpath
+++ b/dev/io.openliberty.http.monitor_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/JsfApp/src"/>
 	<classpathentry kind="src" path="test-applications/MBeanGetter/src"/>
 	<classpathentry kind="src" path="test-applications/WildCardServletApp/src"/>
 	<classpathentry kind="src" path="test-applications/ServletApp/src"/>

--- a/dev/io.openliberty.http.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.http.monitor_fat/bnd.bnd
@@ -50,7 +50,11 @@ tested.features:\
   pages-3.0,\
   jsp-2.3,\
   jsp-2.2,\
-  el-3.0
+  el-3.0,\
+  faces-4.1,\
+  faces-3.0,\
+  jsf-2.3,\
+  jsf-2.2
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true
@@ -69,4 +73,20 @@ fat.test.container.images: otel/opentelemetry-collector-contrib:0.103.0
 	io.openliberty.jakarta.cdi.4.0;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	io.openliberty.org.testcontainers;version=latest,\
-	io.openliberty.microprofile.telemetry.internal_fat.common
+	io.openliberty.microprofile.telemetry.internal_fat.common,\
+	net.sourceforge.htmlunit:htmlunit-cssparser;version=1.6.0,\
+	net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
+	com.ibm.ws.org.apache.httpcomponents;version=latest, \
+	net.sourceforge.htmlunit:neko-htmlunit;strategy=exact;version=2.44.0,\
+	net.sourceforge.htmlunit:webdriver;version=2.6,\
+	io.openliberty.org.apache.xercesImpl;version=latest,\
+	xml-apis:xml-apis;version=1.4.01
+    
+-testpath: \
+	net.sourceforge.htmlunit:htmlunit-cssparser;version=1.6.0,\
+	net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
+	net.sourceforge.htmlunit:neko-htmlunit;strategy=exact;version=2.44.0,\
+	com.ibm.ws.org.apache.httpcomponents;version=latest, \
+	net.sourceforge.htmlunit:webdriver;version=2.6,\
+	io.openliberty.org.apache.xercesImpl;version=latest,\
+	xml-apis:xml-apis;version=1.4.01

--- a/dev/io.openliberty.http.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.http.monitor_fat/bnd.bnd
@@ -81,12 +81,3 @@ fat.test.container.images: otel/opentelemetry-collector-contrib:0.103.0
 	net.sourceforge.htmlunit:webdriver;version=2.6,\
 	io.openliberty.org.apache.xercesImpl;version=latest,\
 	xml-apis:xml-apis;version=1.4.01
-    
--testpath: \
-	net.sourceforge.htmlunit:htmlunit-cssparser;version=1.6.0,\
-	net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
-	net.sourceforge.htmlunit:neko-htmlunit;strategy=exact;version=2.44.0,\
-	com.ibm.ws.org.apache.httpcomponents;version=latest, \
-	net.sourceforge.htmlunit:webdriver;version=2.6,\
-	io.openliberty.org.apache.xercesImpl;version=latest,\
-	xml-apis:xml-apis;version=1.4.01

--- a/dev/io.openliberty.http.monitor_fat/build.gradle
+++ b/dev/io.openliberty.http.monitor_fat/build.gradle
@@ -19,7 +19,20 @@ assemble.doLast {
 }
 
 dependencies {
-  requiredLibs project(':io.openliberty.microprofile.telemetry.internal_fat.common')
+  requiredLibs project(':io.openliberty.microprofile.telemetry.internal_fat.common'),
+      'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
+      'net.sourceforge.htmlunit:htmlunit:2.44.0',
+      'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
+      'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
+      'net.sourceforge.htmlunit:webdriver:2.6',
+      'org.apache.httpcomponents:httpmime:4.5.3',
+      project(':com.ibm.ws.org.apache.httpcomponents'),
+      'org.brotli:dec:0.1.2',
+      'org.apache.commons:commons-lang3:3.14.0',
+      project(':com.ibm.ws.org.apache.commons.io'),
+      project(':io.openliberty.org.apache.xercesImpl'),
+      'xalan:xalan:2.7.2',
+      'xml-apis:xml-apis:1.4.01'
 }
 
 addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
@@ -219,10 +219,10 @@ public abstract class BaseTestClass {
     }
 
     protected boolean validateMpMetricsHttp(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType) {
-        return validateMpMetricsHttp(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, null);
+        return validateMpMetricsHttp(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, null, null);
     }
 
-    protected boolean validateMpMetricsHttp(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType, String count) {
+    protected boolean validateMpMetricsHttp(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType, String expectedCount, String expectedSum) {
         if (errorType == null) {
             errorType = "";
         }
@@ -241,8 +241,8 @@ public abstract class BaseTestClass {
                                 + "\",http_route=\"" + route
                                 + "\",mp_scope=\"vendor\",network_protocol_version=\"1\\.[01]\",server_address=\"localhost\",server_port=\"[0-9]+\",url_scheme=\"http\",\\} ";
 
-        return validatePrometheusHTTPMetricCount(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, count, countMatchString) &&
-               validatePrometheusHTTPMetricSum(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, count, sumMatchString);
+        return validatePrometheusHTTPMetricCount(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, expectedCount, countMatchString) &&
+               validatePrometheusHTTPMetricSum(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, expectedSum, sumMatchString);
     }
 
     /*
@@ -253,11 +253,11 @@ public abstract class BaseTestClass {
     }
 
     protected boolean validateMpTelemetryHttp(String appName, String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType) {
-        return validateMpTelemetryHttp(appName, vendorMetricsOutput, route, responseStatus, requestMethod, errorType, null);
+        return validateMpTelemetryHttp(appName, vendorMetricsOutput, route, responseStatus, requestMethod, errorType, null, null);
     }
 
     protected boolean validateMpTelemetryHttp(String appName, String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType,
-                                              String count) {
+                                              String expectedCount, String expectedSum) {
         String countMatchString = null;
         String sumMatchString = null;
 
@@ -300,27 +300,39 @@ public abstract class BaseTestClass {
                              + "\",network_protocol_version=\"1\\.[01]\",server_address=\"localhost\",server_port=\"[0-9]+\",url_scheme=\"http\"\\} ";
         }
 
-        return validatePrometheusHTTPMetricCount(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, count, countMatchString)
-               && validatePrometheusHTTPMetricSum(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, count, sumMatchString);
+        return validatePrometheusHTTPMetricCount(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, expectedCount, countMatchString)
+               && validatePrometheusHTTPMetricSum(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, expectedSum, sumMatchString);
     }
 
     /*
      * For all
      */
-    private boolean validatePrometheusHTTPMetricCount(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType, String count,
+    private boolean validatePrometheusHTTPMetricCount(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType, String expectedCount,
                                                       String matchString) {
-        boolean isDefaultCountCheck = false;
+        boolean isGreaterThanCountCheck = false;
+        int greaterThanVal = 0;
 
         /*
          * Account for both MP Metrics (double)
          * and OTel Collector output (integer)
          */
-        if (count == null) {
-            count = "[0-9]+[.]?[0-9]*";
-            isDefaultCountCheck = true;
+        if (expectedCount == null || expectedCount.startsWith(">")) {
+
+            /*
+             * If the greater than check was specified, verify it is legitimate
+             * otherwise, we'll just check it's greater than 0 (i.e., default).
+             */
+            if (expectedCount != null && expectedCount.startsWith(">") && expectedCount.matches(">[0-9]+")) {
+                greaterThanVal = Integer.valueOf(expectedCount.split(">")[1]);
+            }
+
+            //Whether null or checking value is greater than 'x', we'll use same regex.
+            expectedCount = "[0-9]+[.]?[0-9]*";
+            isGreaterThanCountCheck = true;
+
         }
 
-        matchString += count;
+        matchString += expectedCount;
 
         Log.info(c, "validatePrometheusHTTPMetricCount", "Trying to match: " + matchString);
         try (Scanner sc = new Scanner(vendorMetricsOutput)) {
@@ -340,12 +352,12 @@ public abstract class BaseTestClass {
                      * If no custom count regex was supplied.
                      * We will check if value is greater than 0
                      */
-                    if (isDefaultCountCheck) {
+                    if (isGreaterThanCountCheck) {
                         String[] split = line.split(" "); // should be only one space at the very end.
                         assertEquals("Error. Expected 2 indexes from split " + Arrays.toString(split), split.length, 2);
 
                         double countVal = Double.parseDouble(split[1].trim());
-                        assertTrue("Expected count value to be greater than 0", countVal > 0);
+                        assertTrue(String.format("Expected count value to be greater than [%d]", greaterThanVal), countVal > greaterThanVal);
                     }
 
                     return true;
@@ -356,7 +368,7 @@ public abstract class BaseTestClass {
         return false;
     }
 
-    private boolean validatePrometheusHTTPMetricSum(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType, String count,
+    private boolean validatePrometheusHTTPMetricSum(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType, String expectedSum,
                                                     String matchString) {
 
         boolean isDefaultCountCheck = false;
@@ -365,12 +377,12 @@ public abstract class BaseTestClass {
          * For Open Telemetry, a zero would be 0.
          * The existence of a period indicates that something has been recorded
          */
-        if (count == null) {
-            count = "[0-9]+\\.[0-9]*[eE]?-?[0-9]+";
+        if (expectedSum == null) {
+            expectedSum = "[0-9]+\\.[0-9]*[eE]?-?[0-9]+";
             isDefaultCountCheck = true;
         }
 
-        matchString += count;
+        matchString += expectedSum;
 
         Log.info(c, "validatePrometheusHTTPMetricSum", "Trying to match: " + matchString);
         try (Scanner sc = new Scanner(vendorMetricsOutput)) {
@@ -394,8 +406,8 @@ public abstract class BaseTestClass {
                         String[] split = line.split(" "); // should be only one space at the very end.
                         assertEquals("Error. Expected 2 indexes from split " + Arrays.toString(split), split.length, 2);
 
-                        double countVal = Double.parseDouble(split[1].trim());
-                        assertTrue("Expected sum value to be greater than 0", countVal > 0);
+                        double sumVal = Double.parseDouble(split[1].trim());
+                        assertTrue("Expected sum value to be greater than 0", sumVal > 0);
                     }
 
                     return true;

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
@@ -211,18 +211,45 @@ public abstract class BaseTestClass {
         return containerCollectorMetrics;
     }
 
-    /*
-     * MP Metrics
+    /**
+     *
+     * @param vendorMetricsOutput Provide /metrics output to use for regex matching
+     * @param route               Specified http route to check in regex matching.
+     * @param responseStatus      Specified response status to check in regex matching.
+     * @param requestMethod       Specified requestMethod to check in regex matching.
+     * @return
      */
     protected boolean validateMpMetricsHttp(String vendorMetricsOutput, String route, String responseStatus, String requestMethod) {
         return validateMpMetricsHttp(vendorMetricsOutput, route, responseStatus, requestMethod, null);
     }
 
+    /**
+     *
+     * @param vendorMetricsOutput Provide /metrics output to use for regex matching
+     * @param route               Specified http route to check in regex matching.
+     * @param responseStatus      Specified response status to check in regex matching.
+     * @param requestMethod       Specified requestMethod to check in regex matching.
+     * @param errorType           Specified errorType to check in regex matching.
+     * @return
+     */
     protected boolean validateMpMetricsHttp(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType) {
         return validateMpMetricsHttp(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, null, null);
     }
 
-    protected boolean validateMpMetricsHttp(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType, String expectedCount, String expectedSum) {
+    /**
+     *
+     * @param vendorMetricsOutput Provide /metrics output to use for regex matching
+     * @param route               Specified http route to check in regex matching.
+     * @param responseStatus      Specified response status to check in regex matching.
+     * @param requestMethod       Specified requestMethod to check in regex matching.
+     * @param errorType           Specified errorType to check in regex matching.
+     * @param expectedCount       Specify the regex to match with or use ">number" (i.e., ">5") to check if value is greater than number. If null will default to checking greater
+     *                                than zero
+     * @param expectedSum         Specify the regex to match for the sum value of the http metric
+     * @return
+     */
+    protected boolean validateMpMetricsHttp(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType, String expectedCount,
+                                            String expectedSum) {
         if (errorType == null) {
             errorType = "";
         }
@@ -245,17 +272,46 @@ public abstract class BaseTestClass {
                validatePrometheusHTTPMetricSum(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, expectedSum, sumMatchString);
     }
 
-    /*
-     * MP Telemetry
+    /**
+     *
+     * @param appName             Specified app name (or service name)
+     * @param vendorMetricsOutput Provide /metrics output to use for regex matching
+     * @param route               Specified http route to check in regex matching.
+     * @param responseStatus      Specified response status to check in regex matching.
+     * @param requestMethod       Specified requestMethod to check in regex matching.
+     * @return
      */
     protected boolean validateMpTelemetryHttp(String appName, String vendorMetricsOutput, String route, String responseStatus, String requestMethod) {
         return validateMpTelemetryHttp(appName, vendorMetricsOutput, route, responseStatus, requestMethod, null);
     }
 
+    /**
+     *
+     * @param appName             Specified app name (or service name)
+     * @param vendorMetricsOutput Provide /metrics output to use for regex matching
+     * @param route               Specified http route to check in regex matching.
+     * @param responseStatus      Specified response status to check in regex matching.
+     * @param requestMethod       Specified requestMethod to check in regex matching.
+     * @param errorType           Specified errorType to check in regex matching.
+     * @return
+     */
     protected boolean validateMpTelemetryHttp(String appName, String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType) {
         return validateMpTelemetryHttp(appName, vendorMetricsOutput, route, responseStatus, requestMethod, errorType, null, null);
     }
 
+    /**
+     *
+     * @param appName             Specified app name (or service name)
+     * @param vendorMetricsOutput Provide /metrics output to use for regex matching
+     * @param route               Specified http route to check in regex matching.
+     * @param responseStatus      Specified response status to check in regex matching.
+     * @param requestMethod       Specified requestMethod to check in regex matching.
+     * @param errorType           Specified errorType to check in regex matching.
+     * @param expectedCount       Specify the regex to match with or use ">number" (i.e., ">5") to check if value is greater than number. If null will default to checking greater
+     *                                than zero
+     * @param expectedSum         Specify the regex to match for the sum value of the http metric
+     * @return
+     */
     protected boolean validateMpTelemetryHttp(String appName, String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType,
                                               String expectedCount, String expectedSum) {
         String countMatchString = null;
@@ -304,9 +360,6 @@ public abstract class BaseTestClass {
                && validatePrometheusHTTPMetricSum(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, expectedSum, sumMatchString);
     }
 
-    /*
-     * For all
-     */
     private boolean validatePrometheusHTTPMetricCount(String vendorMetricsOutput, String route, String responseStatus, String requestMethod, String errorType, String expectedCount,
                                                       String matchString) {
         boolean isGreaterThanCountCheck = false;

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/Constants.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/Constants.java
@@ -50,6 +50,10 @@ public class Constants {
     static final String JSP_APP = "jspApp";
     static final String JSP_CONTEXT_ROOT = "/jspApp";
 
+    //JSF / Jakarta Faces
+    static final String JSF_APP = "jsfApp";
+    static final String JSF_CONTEXT_ROOT = "/jsfApp";
+
     //other
     static final String UNKNOWN_SERVICE = "unknown_service:java";
 

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSFApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSFApplicationTest.java
@@ -1,0 +1,199 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.http.monitor.fat;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.containers.SimpleLogConsumer;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import jakarta.ws.rs.HttpMethod;
+
+@RunWith(FATRunner.class)
+public class ContainerJSFApplicationTest extends BaseTestClass {
+
+    private static Class<?> c = ContainerJSFApplicationTest.class;
+
+    private static final String SERVER_NAME = "ContainerJSFServer";
+    private static final String SERVICE_NAME = FATSuite.getAppNameOrUnknownService(Constants.JSF_APP);
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests rt = FATSuite.allMPRepeatsWithMPTel20OrLater(SERVER_NAME);
+
+    @ClassRule
+    public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
+                    .withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME)
+                                    .copy("/etc/otelcol-contrib/config.yaml", "/etc/otelcol-contrib/config.yaml"))
+                    .withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
+                    .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector-contrib"))
+                    .withExposedPorts(8888, 8889, 4317);
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        trustAll();
+        WebArchive testWAR = ShrinkWrap
+                        .create(WebArchive.class, "jsfApp.war")
+                        .addAsWebInfResource(new File("test-applications/JsfApp/resources/WEB-INF/web.xml"))
+                        .addAsWebInfResource(new File("test-applications/JsfApp/resources/WEB-INF/faces-config.xml"))
+                        .addAsWebInfResource(new File("test-applications/JsfApp/resources/WEB-INF/beans.xml"))
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/index.xhtml")), "/index.xhtml")
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/normal.html")), "/normal.html")
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/resources/css/style.css")), "/resources/css/style.css")
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/resources/js/script.js")), "/resources/js/script.js")
+                        .addPackage(
+                                    "io.openliberty.http.monitor.fat.jsfApp");
+
+        testWAR = FATSuite.setTelProperties(testWAR, server);
+
+        ShrinkHelper.exportDropinAppToServer(server, testWAR,
+                                             DeployOptions.SERVER_ONLY);
+
+        server.addEnvVar("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://" + container.getHost() + ":" + container.getMappedPort(4317));
+        server.startServer();
+
+        //Read to run a smarter planet
+        server.waitForStringInLogUsingMark("CWWKF0011I");
+        server.setMarkToEndOfLog();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        //catch if a server is still running.
+        if (server != null && server.isStarted()) {
+            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWPMI2006W", "CWMMC0013E", "CWWKG0033W", "SRVE0315E");
+        }
+    }
+
+    @Test
+    public void cjsf_testNormalHtml() throws Exception {
+
+        assertTrue(server.isStarted());
+
+        String route = Constants.JSF_CONTEXT_ROOT + "/normal.html";
+        String expectedRoute = Constants.JSF_CONTEXT_ROOT + "/\\*";
+        String requestMethod = HttpMethod.GET;
+        String responseStatus = "200";
+
+        String res = requestHttpServlet(route, server, requestMethod);
+
+        TimeUnit.SECONDS.sleep(4);
+        assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
+                                           requestMethod));
+    }
+
+    @Test
+    public void cjsf_testXHTMLext() throws Exception {
+
+        assertTrue(server.isStarted());
+
+        String routeXHTML = Constants.JSF_CONTEXT_ROOT + "/index.xhtml";
+        String routeJSF = Constants.JSF_CONTEXT_ROOT + "/index.jsf";
+        String routeFaces = Constants.JSF_CONTEXT_ROOT + "/index.faces";
+        String routeFacesNode = Constants.JSF_CONTEXT_ROOT + "/faces/index.xhtml";
+
+        String expectedRouteXHTML = Constants.JSF_CONTEXT_ROOT + "/\\*.xhtml";
+        String expectedRouteJSF = Constants.JSF_CONTEXT_ROOT + "/\\*.jsf";
+        String expectedRouteFaces = Constants.JSF_CONTEXT_ROOT + "/\\*.faces";
+        String expectedRouteFacesNode = Constants.JSF_CONTEXT_ROOT + "/faces/\\*";
+
+        String requestMethod = HttpMethod.GET;
+        String responseStatus = "200";
+
+        /*
+         * With JSF 2.2 (and only JSF 2.2) using the same WebClient object to hit all the URLs
+         * caches the resources. This means the first URL request will cause the 2 HTTP requests to load the JSF resource.
+         *
+         * However, with JSF 2.3 and above (and then facex-x.x), using the same WebClient object doe not cache
+         * and any subsequent hits will load the resources over and over.
+         *
+         * For uniformity across the FAT test repeats, we'll use new WebClient object for each request (that uses a different extension/mapping)
+         */
+
+        /*
+         * Load with .xhtml extension
+         */
+        WebClient webClient1 = new WebClient();
+        String urlXHTML = "http://" + server.getHostname() + ":"
+                          + server.getHttpDefaultPort() + routeXHTML;
+        HtmlPage page = (HtmlPage) webClient1.getPage(urlXHTML);
+        TimeUnit.SECONDS.sleep(4);
+
+        //Expected count 3 : 1 xhtml, 2 resource
+        assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteXHTML, responseStatus, requestMethod, null, ">2", null));
+
+        /*
+         * Load with .jsf extension
+         */
+        WebClient webClient2 = new WebClient();
+        String urlJSF = "http://" + server.getHostname() + ":"
+                        + server.getHttpDefaultPort() + routeJSF;
+        page = (HtmlPage) webClient2.getPage(urlJSF);
+        TimeUnit.SECONDS.sleep(4);
+
+        //Expected count 5 : + 2 resource loading (since xhtml loaded resources first, they continue to load form the /[jakarta.javax].faces.resource/*.xhtml path
+        assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteXHTML, responseStatus, requestMethod, null, ">4", null));
+        //We expect 1, default signature just checks for greater than 0
+        assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteJSF, responseStatus, requestMethod));
+
+        /*
+         * Load with .faces extension
+         */
+        WebClient webClient3 = new WebClient();
+        String urlFaces = "http://" + server.getHostname() + ":"
+                          + server.getHttpDefaultPort() + routeFaces;
+        page = (HtmlPage) webClient3.getPage(urlFaces);
+        TimeUnit.SECONDS.sleep(4);
+
+        //Expected count 7 : + 2 resource loading (since xhtml loaded resources first, they continue to load form the /[jakarta.javax].faces.resource/*.xhtml path
+        assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteXHTML, responseStatus, requestMethod, null, ">6", null));
+        //We expect 1, default signature just checks for greater than 0
+        assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteFaces, responseStatus, requestMethod));
+
+        /*
+         * Load with /faces/* mapping
+         */
+        WebClient webClient4 = new WebClient();
+        String urlFacesNode = "http://" + server.getHostname() + ":"
+                              + server.getHttpDefaultPort() + routeFacesNode;
+        page = (HtmlPage) webClient4.getPage(urlFacesNode);
+        TimeUnit.SECONDS.sleep(4);
+
+        //Expected count 9 : + 2 resource loading (since xhtml loaded resources first, they continue to load form the /[jakarta.javax].faces.resource/*.xhtml path
+        assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteXHTML, responseStatus, requestMethod, null, ">8", null));
+        //We expect 1, default signature just checks for greater than 0
+        assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteFacesNode, responseStatus, requestMethod));
+
+    }
+
+}

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSPApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSPApplicationTest.java
@@ -92,7 +92,7 @@ public class ContainerJSPApplicationTest extends BaseTestClass {
     }
 
     @Test
-    public void jsp_noWebXmlJSP() throws Exception {
+    public void cjsp_jsp_noWebXmlJSP() throws Exception {
 
         assertTrue(server.isStarted());
 
@@ -110,7 +110,7 @@ public class ContainerJSPApplicationTest extends BaseTestClass {
     }
 
     @Test
-    public void jsp_configredWebXmlJSP() throws Exception {
+    public void cjsp_jsp_configredWebXmlJSP() throws Exception {
 
         assertTrue(server.isStarted());
 
@@ -126,7 +126,7 @@ public class ContainerJSPApplicationTest extends BaseTestClass {
     }
 
     @Test
-    public void jsp_defaultHTML() throws Exception {
+    public void cjsp_jsp_defaultHTML() throws Exception {
 
         assertTrue(server.isStarted());
 

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/FATSuite.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/FATSuite.java
@@ -30,14 +30,17 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
                 ServletApplicationMBeanTest.class,
                 RestApplicationMbeanTest.class,
                 JSPApplicationMBeanTest.class,
+                JSFApplicationMBeanTest.class,
                 NoAppTest.class,
                 JSPApplicationTest.class,
                 RestApplicationTest.class,
                 ServletApplicationTest.class,
+                JSFApplicationTest.class,
                 ContainerServletApplicationTest.class,
                 ContainerJSPApplicationTest.class,
                 ContainerRestApplicationTest.class,
-                ContainerNoAppTest.class
+                ContainerNoAppTest.class,
+                ContainerJSFApplicationTest.class
 })
 
 public class FATSuite extends TestContainerSuite {

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/JSFApplicationMBeanTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/JSFApplicationMBeanTest.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.http.monitor.fat;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import jakarta.ws.rs.HttpMethod;
+
+@RunWith(FATRunner.class)
+public class JSFApplicationMBeanTest extends BaseTestClass {
+
+    private static Class<?> c = JSFApplicationMBeanTest.class;
+
+    public static final String SERVER_NAME = "MBeanServer";
+
+    @ClassRule
+    public static RepeatTests rt = FATSuite.testRepeatMBeanTests(SERVER_NAME);
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        trustAll();
+        WebArchive testWAR = ShrinkWrap
+                        .create(WebArchive.class, "jsfApp.war")
+                        .addAsWebInfResource(new File("test-applications/JsfApp/resources/WEB-INF/web.xml"))
+                        .addAsWebInfResource(new File("test-applications/JsfApp/resources/WEB-INF/faces-config.xml"))
+                        .addAsWebInfResource(new File("test-applications/JsfApp/resources/WEB-INF/beans.xml"))
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/index.xhtml")), "/index.xhtml")
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/normal.html")), "/normal.html")
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/resources/css/style.css")), "/resources/css/style.css")
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/resources/js/script.js")), "/resources/js/script.js")
+                        .addPackage(
+                                    "io.openliberty.http.monitor.fat.jsfApp");
+
+        WebArchive mbeanWar = ShrinkWrap
+                        .create(WebArchive.class, "MBeanGetter.war")
+                        .addPackage(
+                                    "io.openliberty.http.monitor.fat.mbeanGetter");
+
+        ShrinkHelper.exportDropinAppToServer(server, mbeanWar,
+                                             DeployOptions.SERVER_ONLY);
+
+        ShrinkHelper.exportDropinAppToServer(server, testWAR,
+                                             DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+
+        //Read to run a smarter planet
+        server.waitForStringInLogUsingMark("CWWKF0011I");
+        server.setMarkToEndOfLog();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        //catch if a server is still running.
+        if (server != null && server.isStarted()) {
+            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWPMI2006W", "CWMMC0013E", "CWWKG0033W", "SRVE0315E");
+        }
+    }
+
+    private void loadJSFPage(LibertyServer server, String route) throws FailingHttpStatusCodeException, MalformedURLException, IOException {
+        try (WebClient webClient = new WebClient()) {
+
+            String url = "http://" + server.getHostname() + ":"
+                         + server.getHttpDefaultPort() + route;
+            HtmlPage page = (HtmlPage) webClient.getPage(url);
+
+        }
+    }
+
+    @Test
+    public void testXHTML_mbean() throws Exception {
+
+        assertTrue(server.isStarted());
+
+        String route = Constants.JSF_CONTEXT_ROOT + "/index.xhtml";
+        String expectedRoute = Constants.JSF_CONTEXT_ROOT + "/\\*.xhtml";
+        String requestMethod = HttpMethod.GET;
+        String responseStatus = "200";
+
+        loadJSFPage(server, route);
+
+        String objectName = "WebSphere:type=HttpServerStats,name=\"method:" + requestMethod + ";status:" + responseStatus + ";httpRoute:" + expectedRoute + "\"";
+        checkMBeanRegistered(server, objectName);
+
+    }
+
+    @Test
+    public void testJSF_mbean() throws Exception {
+
+        assertTrue(server.isStarted());
+
+        String route = Constants.JSF_CONTEXT_ROOT + "/index.jsf";
+        String expectedRoute = Constants.JSF_CONTEXT_ROOT + "/\\*.jsf";
+        String requestMethod = HttpMethod.GET;
+        String responseStatus = "200";
+
+        loadJSFPage(server, route);
+
+        String objectName = "WebSphere:type=HttpServerStats,name=\"method:" + requestMethod + ";status:" + responseStatus + ";httpRoute:" + expectedRoute + "\"";
+        checkMBeanRegistered(server, objectName);
+
+    }
+
+    @Test
+    public void testFaces_mbean() throws Exception {
+
+        assertTrue(server.isStarted());
+
+        String route = Constants.JSF_CONTEXT_ROOT + "/index.faces";
+        String expectedRoute = Constants.JSF_CONTEXT_ROOT + "/\\*.faces";
+        String requestMethod = HttpMethod.GET;
+        String responseStatus = "200";
+
+        loadJSFPage(server, route);
+
+        String objectName = "WebSphere:type=HttpServerStats,name=\"method:" + requestMethod + ";status:" + responseStatus + ";httpRoute:" + expectedRoute + "\"";
+        checkMBeanRegistered(server, objectName);
+
+    }
+
+    @Test
+    public void testFacesNode_mbean() throws Exception {
+
+        assertTrue(server.isStarted());
+
+        String route = Constants.JSF_CONTEXT_ROOT + "/faces/index.xhtml";
+        String expectedRoute = Constants.JSF_CONTEXT_ROOT + "/faces/\\*";
+        String requestMethod = HttpMethod.GET;
+        String responseStatus = "200";
+
+        loadJSFPage(server, route);
+
+        String objectName = "WebSphere:type=HttpServerStats,name=\"method:" + requestMethod + ";status:" + responseStatus + ";httpRoute:" + expectedRoute + "\"";
+        checkMBeanRegistered(server, objectName);
+
+    }
+
+}

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/JSFApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/JSFApplicationTest.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.http.monitor.fat;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import jakarta.ws.rs.HttpMethod;
+
+@RunWith(FATRunner.class)
+public class JSFApplicationTest extends BaseTestClass {
+
+    private static Class<?> c = JSFApplicationTest.class;
+
+    @Server("JSFServer")
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests rt = FATSuite.testRepeatMPTMetrics5("JSFServer");
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        trustAll();
+        WebArchive testWAR = ShrinkWrap
+                        .create(WebArchive.class, "jsfApp.war")
+                        .addAsWebInfResource(new File("test-applications/JsfApp/resources/WEB-INF/web.xml"))
+                        .addAsWebInfResource(new File("test-applications/JsfApp/resources/WEB-INF/faces-config.xml"))
+                        .addAsWebInfResource(new File("test-applications/JsfApp/resources/WEB-INF/beans.xml"))
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/index.xhtml")), "/index.xhtml")
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/normal.html")), "/normal.html")
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/resources/css/style.css")), "/resources/css/style.css")
+                        .add(new FileAsset(new File("test-applications/JsfApp/resources/resources/js/script.js")), "/resources/js/script.js")
+                        .addPackage(
+                                    "io.openliberty.http.monitor.fat.jsfApp");
+
+        ShrinkHelper.exportDropinAppToServer(server, testWAR,
+                                             DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+
+        //Read to run a smarter planet
+        server.waitForStringInLogUsingMark("CWWKF0011I");
+        server.setMarkToEndOfLog();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        //catch if a server is still running.
+        if (server != null && server.isStarted()) {
+            server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWPMI2006W", "CWMMC0013E", "CWWKG0033W", "SRVE0315E");
+        }
+    }
+
+    @Test
+    public void jsf_testNormalHtml() throws Exception {
+
+        assertTrue(server.isStarted());
+
+        String route = Constants.JSF_CONTEXT_ROOT + "/normal.html";
+        String expectedRoute = Constants.JSF_CONTEXT_ROOT + "/\\*";
+        String requestMethod = HttpMethod.GET;
+        String responseStatus = "200";
+
+        String res = requestHttpServlet(route, server, requestMethod);
+
+        assertTrue(validateMpMetricsHttp(getVendorMetrics(server), expectedRoute, responseStatus, requestMethod));
+
+    }
+
+    @Test
+    public void jsf_testXHTMLext() throws Exception {
+
+        assertTrue(server.isStarted());
+
+        String routeXHTML = Constants.JSF_CONTEXT_ROOT + "/index.xhtml";
+        String routeJSF = Constants.JSF_CONTEXT_ROOT + "/index.jsf";
+        String routeFaces = Constants.JSF_CONTEXT_ROOT + "/index.faces";
+        String routeFacesNode = Constants.JSF_CONTEXT_ROOT + "/faces/index.xhtml";
+
+        String expectedRouteXHTML = Constants.JSF_CONTEXT_ROOT + "/\\*.xhtml";
+        String expectedRouteJSF = Constants.JSF_CONTEXT_ROOT + "/\\*.jsf";
+        String expectedRouteFaces = Constants.JSF_CONTEXT_ROOT + "/\\*.faces";
+        String expectedRouteFacesNode = Constants.JSF_CONTEXT_ROOT + "/faces/\\*";
+
+        String requestMethod = HttpMethod.GET;
+        String responseStatus = "200";
+
+        try (WebClient webClient = new WebClient()) {
+
+            String urlXHTML = "http://" + server.getHostname() + ":"
+                              + server.getHttpDefaultPort() + routeXHTML;
+            HtmlPage page = (HtmlPage) webClient.getPage(urlXHTML);
+
+            //Expected count 3 : 1 xhtml, 2 resource
+            assertTrue(validateMpMetricsHttp(getVendorMetrics(server), expectedRouteXHTML, responseStatus, requestMethod, null, ">2", null));
+
+            String urlJSF = "http://" + server.getHostname() + ":"
+                            + server.getHttpDefaultPort() + routeJSF;
+            page = (HtmlPage) webClient.getPage(urlJSF);
+
+            //Expected count 5 : + 2 resource loading (since xhtml loaded resources first, they continue to load form the /[jakarta.javax].faces.resource/*.xhtml path
+            assertTrue(validateMpMetricsHttp(getVendorMetrics(server), expectedRouteXHTML, responseStatus, requestMethod, null, ">4", null));
+            //We expect 1, default signature just checks for greater than 0
+            assertTrue(validateMpMetricsHttp(getVendorMetrics(server), expectedRouteJSF, responseStatus, requestMethod));
+
+            String urlFaces = "http://" + server.getHostname() + ":"
+                              + server.getHttpDefaultPort() + routeFaces;
+            page = (HtmlPage) webClient.getPage(urlFaces);
+
+            //Expected count 7 : + 2 resource loading (since xhtml loaded resources first, they continue to load form the /[jakarta.javax].faces.resource/*.xhtml path
+            assertTrue(validateMpMetricsHttp(getVendorMetrics(server), expectedRouteXHTML, responseStatus, requestMethod, null, ">6", null));
+            //We expect 1, default signature just checks for greater than 0
+            assertTrue(validateMpMetricsHttp(getVendorMetrics(server), expectedRouteFaces, responseStatus, requestMethod));
+
+            String urlFacesNode = "http://" + server.getHostname() + ":"
+                                  + server.getHttpDefaultPort() + routeFacesNode;
+            page = (HtmlPage) webClient.getPage(urlFacesNode);
+
+            //Expected count 9 : + 2 resource loading (since xhtml loaded resources first, they continue to load form the /[jakarta.javax].faces.resource/*.xhtml path
+            assertTrue(validateMpMetricsHttp(getVendorMetrics(server), expectedRouteXHTML, responseStatus, requestMethod, null, ">8", null));
+            //We expect 1, default signature just checks for greater than 0
+            assertTrue(validateMpMetricsHttp(getVendorMetrics(server), expectedRouteFacesNode, responseStatus, requestMethod));
+
+        }
+    }
+
+}

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJSFServer/bootstrap.properties
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJSFServer/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:io.openliberty.http.monitor.*=all

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJSFServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJSFServer/server.xml
@@ -1,7 +1,7 @@
 
 <server>
     <featureManager>
-        <feature>pages-3.1</feature>
+        <feature>faces-4.0</feature>
     	<feature>mpTelemetry-2.0</feature>
     </featureManager>
 
@@ -23,4 +23,7 @@
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
     
     <mpMetrics authentication="false"/>
+
+
+
 </server>

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJSFServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJSFServer/server.xml
@@ -21,9 +21,4 @@
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-    
-    <mpMetrics authentication="false"/>
-
-
-
 </server>

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJSPServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJSPServer/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJSPServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJSPServer/server.xml
@@ -21,6 +21,4 @@
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-    
-    <mpMetrics authentication="false"/>
 </server>

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJustServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJustServer/jvm.options
@@ -1,0 +1,5 @@
+-Dotel.metrics.exporter=otlp
+-Dotel.traces.exporter=none
+-Dotel.logs.exporter=none
+-Dotel.sdk.disabled=false
+-Dotel.metric.export.interval=500

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJustServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJustServer/jvm.options
@@ -1,6 +1,0 @@
--Dcom.ibm.ws.beta.edition=true
--Dotel.metrics.exporter=otlp
--Dotel.traces.exporter=none
--Dotel.logs.exporter=none
--Dotel.sdk.disabled=false
--Dotel.metric.export.interval=500

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJustServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJustServer/server.xml
@@ -21,9 +21,4 @@
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-    
-    <mpMetrics authentication="false"/>
-
-
-
 </server>

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJustServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerJustServer/server.xml
@@ -3,7 +3,6 @@
     <featureManager>
         <feature>restfulWS-3.1</feature>
     	<feature>mpTelemetry-2.0</feature>
-    	<feature>monitor-1.0</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml" />

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerRestServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerRestServer/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerRestServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerRestServer/server.xml
@@ -21,9 +21,4 @@
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-    
-    <mpMetrics authentication="false"/>
-
-
-
 </server>

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerRestServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerRestServer/server.xml
@@ -3,7 +3,6 @@
     <featureManager>
         <feature>restfulWS-3.1</feature>
     	<feature>mpTelemetry-2.0</feature>
-    	<feature>monitor-1.0</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml" />

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerServletServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerServletServer/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerServletServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerServletServer/server.xml
@@ -21,9 +21,4 @@
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-    
-    <mpMetrics authentication="false"/>
-
-
-
 </server>

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerServletServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/ContainerServletServer/server.xml
@@ -3,7 +3,6 @@
     <featureManager>
         <feature>servlet-6.1</feature>
     	<feature>mpTelemetry-2.0</feature>
-    	<feature>monitor-1.0</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml" />

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/JSFServer/bootstrap.properties
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/JSFServer/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:io.openliberty.http.monitor.*=all

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/JSFServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/JSFServer/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/JSFServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/JSFServer/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/JSFServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/JSFServer/server.xml
@@ -1,8 +1,8 @@
 
 <server>
     <featureManager>
-        <feature>pages-3.1</feature>
-    	<feature>mpTelemetry-2.0</feature>
+        <feature>faces-4.0</feature>
+    	<feature>mpMetrics-5.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml" />
@@ -23,4 +23,7 @@
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
     
     <mpMetrics authentication="false"/>
+
+
+
 </server>

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/JSPServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/JSPServer/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/MBeanServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/MBeanServer/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/MBeanServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/MBeanServer/server.xml
@@ -3,6 +3,7 @@
     <featureManager>
         <feature>servlet-6.0</feature>
     	<feature>pages-3.1</feature>
+    	<feature>faces-4.0</feature>
     	<feature>restfulWS-3.1</feature>
     	<feature>monitor-1.0</feature>
     </featureManager>

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/MBeanServer/server.xml
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/MBeanServer/server.xml
@@ -24,9 +24,4 @@
 
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
-    
-    <mpMetrics authentication="false"/>
-
-
-
 </server>

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/SimpleRestServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/SimpleRestServer/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.http.monitor_fat/publish/servers/SimpleServletServer/jvm.options
+++ b/dev/io.openliberty.http.monitor_fat/publish/servers/SimpleServletServer/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/WEB-INF/beans.xml
+++ b/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/WEB-INF/faces-config.xml
+++ b/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/WEB-INF/faces-config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+              http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
+</faces-config>

--- a/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/WEB-INF/web.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+ http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+	<context-param>
+		<param-name>javax.faces.STATE_SAVING_METHOD</param-name>
+		<param-value>server</param-value>
+	</context-param>
+	
+	<context-param>
+        <param-name>javax.faces.DEFAULT_SUFFIX</param-name>
+        <param-value>.xhtml</param-value>
+    </context-param>
+	
+	<servlet>
+		<servlet-name>Faces Servlet</servlet-name>
+		<servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+		<load-on-startup>1</load-on-startup>
+	</servlet>
+	
+	<servlet-mapping>
+		<servlet-name>Faces Servlet</servlet-name>
+		<url-pattern>*.xhtml</url-pattern>
+	</servlet-mapping>
+
+	<servlet-mapping>
+		<servlet-name>Faces Servlet</servlet-name>
+		<url-pattern>*.jsf</url-pattern>
+	</servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>Faces Servlet</servlet-name>
+		<url-pattern>/faces/*</url-pattern>
+	</servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>Faces Servlet</servlet-name>
+		<url-pattern>*.faces</url-pattern>
+	</servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>Faces Servlet</servlet-name>
+		<url-pattern>*.abb</url-pattern>
+	</servlet-mapping>
+
+
+</web-app>

--- a/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/index.xhtml
+++ b/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/index.xhtml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html
+	PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:f="http://xmlns.jcp.org/jsf/core" xmlns:custom="faces40.tag">
+<h:head>
+	<title>Test</title>
+	<h:outputStylesheet name="css/style.css" />
+	<h:outputScript name="js/script.js" />
+</h:head>
+<h:body>
+	<h2>Tester</h2>
+	<h:form> 
+		<h:commandButton id="button" value="button" action="#{confirmBean.confirm}"/>
+	</h:form>
+</h:body>
+</html>

--- a/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/normal.html
+++ b/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/normal.html
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<html>
+	<head>
+		<title>Test</title>
+	</head>
+	<body>
+		<h2>Tester</h2>
+	</body>
+</html>

--- a/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/resources/css/style.css
+++ b/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/resources/css/style.css
@@ -1,0 +1,4 @@
+* {
+  color:red;
+  background: url("#{resource['images/milo2.jpg']}");
+}

--- a/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/resources/js/script.js
+++ b/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/resources/resources/js/script.js
@@ -1,0 +1,1 @@
+console.log("working!");

--- a/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/src/io/openliberty/http/monitor/fat/jsfApp/ConfirmBean.java
+++ b/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/src/io/openliberty/http/monitor/fat/jsfApp/ConfirmBean.java
@@ -1,0 +1,15 @@
+package io.openliberty.http.monitor.fat.jsfApp;
+
+import java.io.Serializable;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+
+@RequestScoped
+@Named("confirmBean")
+public class ConfirmBean implements Serializable {
+
+    public void confirm() {
+        System.out.println("CONFIRMED!!!!");
+    }
+}

--- a/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/src/io/openliberty/http/monitor/fat/jsfApp/ConfirmBean.java
+++ b/dev/io.openliberty.http.monitor_fat/test-applications/JsfApp/src/io/openliberty/http/monitor/fat/jsfApp/ConfirmBean.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package io.openliberty.http.monitor.fat.jsfApp;
 
 import java.io.Serializable;


### PR DESCRIPTION
…Jakarta Faces requests.

Previously, the HTTP route/URL mapping for the JSF / Jakarta Faces would explicitly resolve URL to the mapped servlet (e.g., /context-root/myfile.xhtml). This has been updated to resolve it as /context-root/*.xhtml (xhtml used as example). Furthermore, previous behavior would resolve the explicit route of resources being loaded. This can create a large amount of metrics if their were many resources being loaded. These too are not resolved as '*.<extension>' where extension is the original file that loaded the resources.


Fixes #29822

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

#build