### PR TITLE
Update Data TCK to generate valid certification adoc file

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -257,6 +257,8 @@ public class TCKRunner {
 
         List<String> dependencyOutput = runDependencyCmd();
         TCKJarInfo tckJarInfo = TCKUtilities.getTCKJarInfo(this.type, dependencyOutput);
+
+        //TODO validate resultsInfo especially certification file name prior to writing
         TCKResultsInfo resultsInfo = new TCKResultsInfo(this.type, this.specName, this.server, tckJarInfo);
         TCKResultsWriter.preparePublicationFile(resultsInfo);
     }

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
@@ -86,7 +86,7 @@ public class DataCoreTckLauncher {
         String bucketName = "io.openliberty.jakarta.data.1.0_fat_tck";
         String testName = this.getClass() + ":launchDataTckCorePersistence";
         Type type = Type.JAKARTA;
-        String specName = "Data (Core, Persistence)";
+        String specName = "Data (Core - Persistence)";
         String relativeTckRunner = "publish/tckRunner/platform/";
         TCKRunner.runTCK(persistenceServer, bucketName, testName, type, specName, null, relativeTckRunner, additionalProps);
     }
@@ -125,7 +125,7 @@ public class DataCoreTckLauncher {
         String bucketName = "io.openliberty.jakarta.data.1.0_fat_tck";
         String testName = this.getClass() + ":launchDataTckCoreNoSQL";
         Type type = Type.JAKARTA;
-        String specName = "Data (Core, NoSQL)";
+        String specName = "Data (Core - NoSQL)";
         String relativeTckRunner = "publish/tckRunner/platform/";
         TCKRunner.runTCK(noSQLServer, bucketName, testName, type, specName, null, relativeTckRunner, additionalProps);
     }

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataFullTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataFullTckLauncher.java
@@ -80,7 +80,7 @@ public class DataFullTckLauncher {
         String bucketName = "io.openliberty.jakarta.data.1.0_fat_tck";
         String testName = this.getClass() + ":launchDataTckFull";
         Type type = Type.JAKARTA;
-        String specName = "Data (Full, Persistence)";
+        String specName = "Data (Full - Persistence)";
         String relativeTckRunner = "publish/tckRunner/platform/";
         TCKRunner.runTCK(server, bucketName, testName, type, specName, null, relativeTckRunner, additionalProps);
     }

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataStandaloneTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataStandaloneTckLauncher.java
@@ -64,7 +64,7 @@ public class DataStandaloneTckLauncher {
         String bucketName = "io.openliberty.jakarta.data.1.0_fat_tck";
         String testName = this.getClass() + ":launchDataTckStandaloneNoSQL";
         Type type = Type.JAKARTA;
-        String specName = "Data (Standalone, NoSQL)";
+        String specName = "Data (Standalone - NoSQL)";
         String relativeTckRunner = "publish/tckRunner/standalone/";
         TCKRunner.runTCK(DONOTSTART, bucketName, testName, type, specName, null, relativeTckRunner, additionalProps);
     }

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
@@ -78,7 +78,7 @@ public class DataWebTckLauncher {
         String bucketName = "io.openliberty.jakarta.data.1.0_fat_tck";
         String testName = this.getClass() + ":launchDataTckWeb";
         Type type = Type.JAKARTA;
-        String specName = "Data (Web, Persistence)";
+        String specName = "Data (Web - Persistence)";
         String relativeTckRunner = "publish/tckRunner/platform/";
         TCKRunner.runTCK(server, bucketName, testName, type, specName, null, relativeTckRunner, additionalProps);
     }


### PR DESCRIPTION
The spec name gets appended to the certification adoc file and causes issues some some operating systems when that file is generated with a comma (,).  Avoid this for now, and add a TODO to validate and unit test this function in the future.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

