### PR TITLE
FutureEMBuilder output full exception for caught throwable

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -364,7 +364,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                                           repositoryInterface.getName(),
                                           metadata,
                                           dataStore,
-                                          x.getMessage()).initCause(x);
+                                          x).initCause(x);
             }
         }
     }

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/logging.properties
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/logging.properties
@@ -4,12 +4,17 @@ handlers=java.util.logging.FileHandler,java.util.logging.ConsoleHandler
 #Global logger - By default only log warnings
 .level=WARNING
 
-#Jakarta Data TCK logger - By default log everything for ee.jakarta.tck.data
+# Jakarta Data TCK logger - By default log everything for ee.jakarta.tck.data
 ee.jakarta.tck.data.level=ALL
 
-# Arquillian and JNoSQL - By default log everything, might reduce after development is complete.
+# Arquillian - By default log everything, might reduce after development is complete.
 org.jboss.arquillian.level=ALL
+
+# JNoSQL - By default log everything, might reduce after development is complete.
 org.eclipse.jnosql.level=ALL
+
+# Liberty Arquillian plugin - By default log everything, might reduce after development is complete.
+io.openliberty.arquillian.level=ALL
 
 #Formatting for the simple formatter
 java.util.logging.SimpleFormatter.class.log=true


### PR DESCRIPTION
If the caught throwable has a message of null, then debugging the exception will be impossible. Instead, output the full exception message/stack.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
