### PR TITLE
remove workaround and implmement update of entity with IdClass

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -62,10 +62,13 @@ public class EntityInfo {
     // lower case attribute name --> properly cased/qualified JPQL attribute name
     final Map<String, String> attributeNames;
 
-    // names of attributes to use for entity update.
-    // excludes id and version.
-    // excludes inner relation attributes, such as location.address when there is also a location.address.zipcode
-    // TODO updates (and probably deletes) of entities with an embeddable id is not implemented yet.
+    /**
+     * Names of attributes to use for entity update,
+     * or null if em.merge must be used instead.
+     * Excludes id and version.
+     * Excludes inner relation attributes, such as location.address
+     * when there is also a location.address.zipcode
+     */
     final SortedSet<String> attributeNamesForEntityUpdate;
 
     // properly cased/qualified JPQL attribute name --> type

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -158,11 +158,14 @@ public abstract class EntityManagerBuilder {
                         switch (attributeType) {
                             case BASIC:
                             case ELEMENT_COLLECTION:
-                                attributeNamesForUpdate.add(attributeName);
+                                if (attributeNamesForUpdate != null)
+                                    attributeNamesForUpdate.add(attributeName);
                                 break;
-                            case EMBEDDED:
                             case ONE_TO_ONE:
                             case MANY_TO_ONE:
+                                attributeNamesForUpdate = null; // must use merge instead
+                                // continue
+                            case EMBEDDED:
                                 relationAttributeNames.put(attr.getJavaType(), new ArrayList<>());
                                 relationships.add(attr);
                                 relationPrefixes.add(attributeName);
@@ -170,7 +173,7 @@ public abstract class EntityManagerBuilder {
                                 break;
                             case ONE_TO_MANY:
                             case MANY_TO_MANY:
-                                attributeNamesForUpdate.add(attributeName); // TODO is this correct?
+                                attributeNamesForUpdate = null; // must use merge instead
                                 break;
                             default:
                                 throw new RuntimeException(); // unreachable unless more types are added
@@ -221,11 +224,14 @@ public abstract class EntityManagerBuilder {
                             switch (attributeType) {
                                 case BASIC:
                                 case ELEMENT_COLLECTION:
-                                    attributeNamesForUpdate.add(fullAttributeName);
+                                    if (attributeNamesForUpdate != null)
+                                        attributeNamesForUpdate.add(fullAttributeName);
                                     break;
-                                case EMBEDDED:
                                 case ONE_TO_ONE:
                                 case MANY_TO_ONE:
+                                    attributeNamesForUpdate = null; // must use merge instead
+                                    // continue
+                                case EMBEDDED:
                                     relationAttributeNames.put(relAttr.getJavaType(), new ArrayList<>());
                                     relationships.add(relAttr);
                                     relationPrefixes.add(fullAttributeName);
@@ -233,7 +239,7 @@ public abstract class EntityManagerBuilder {
                                     break;
                                 case ONE_TO_MANY:
                                 case MANY_TO_MANY:
-                                    attributeNamesForUpdate.add(fullAttributeName); // TODO is this correct?
+                                    attributeNamesForUpdate = null; // must use merge instead
                                     break;
                                 default:
                                     throw new RuntimeException(); // unreachable unless more types are added
@@ -291,12 +297,15 @@ public abstract class EntityManagerBuilder {
                         }
                     }
 
-                    attributeNamesForUpdate.remove(ID);
                     String idAttrName = attributeNames.get(ID);
-                    if (idAttrName != null)
-                        attributeNamesForUpdate.remove(idAttrName);
-                    if (versionAttrName != null)
-                        attributeNamesForUpdate.remove(versionAttrName);
+
+                    if (attributeNamesForUpdate != null) {
+                        attributeNamesForUpdate.remove(ID);
+                        if (idAttrName != null)
+                            attributeNamesForUpdate.remove(idAttrName);
+                        if (versionAttrName != null)
+                            attributeNamesForUpdate.remove(versionAttrName);
+                    }
 
                     if (!entityType.hasSingleIdAttribute()) {
                         // Per JavaDoc, the above means there is an IdClass.
@@ -375,7 +384,7 @@ public abstract class EntityManagerBuilder {
      * @return an alphabetized comma-delimited list of the class names as text.
      */
     @Trivial
-    private static final String getClassNames(Iterable<Class<?>> classes) {
+    public static final String getClassNames(Iterable<Class<?>> classes) {
         TreeSet<String> names = new TreeSet<>();
         for (Class<?> c : classes)
             names.add(c.getName());

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1906,7 +1906,8 @@ public class QueryInfo {
         String o_ = entityVar_;
         StringBuilder q;
 
-        if (UPDATE_COUNT_TYPES.contains(singleType)) {
+        if (entityInfo.attributeNamesForEntityUpdate != null &&
+            UPDATE_COUNT_TYPES.contains(singleType)) {
             setType(Update.class, Type.UPDATE_WITH_ENTITY_PARAM);
 
             q = new StringBuilder(100) //
@@ -1924,8 +1925,9 @@ public class QueryInfo {
                 q.append(o_).append(name).append("=?").append(++paramCount);
             }
         } else {
-            // Update that returns an entity
-            // Perform a find operation first so that em.merge can be used
+            // Update that returns an entity. And also used when an entity
+            // has relation attributes that require using em.merge.
+            // Perform a find operation first so that em.merge can be used.
             setType(Update.class, Type.UPDATE_WITH_ENTITY_PARAM_AND_RESULT);
 
             q = new StringBuilder(100) //
@@ -3471,22 +3473,26 @@ public class QueryInfo {
     /**
      * Sets query parameters for DELETE_WITH_ENTITY_PARAM where the entity has an IdClass.
      *
-     * @param query   the query
-     * @param entity  the entity
-     * @param version the version if versioned, otherwise null.
+     * @param startingParamIndex index of first parameter to set.
+     * @param query              the query
+     * @param entity             the entity
+     * @param version            the version if versioned, otherwise null.
      * @throws Exception if an error occurs
      */
-    void setParametersFromIdClassAndVersion(jakarta.persistence.Query query, Object entity, Object version) throws Exception {
+    void setParametersFromIdClassAndVersion(int startingParamIndex,
+                                            jakarta.persistence.Query query,
+                                            Object entity,
+                                            Object version) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
-        int p = 0;
+        int p = startingParamIndex;
         for (String idClassAttr : entityInfo.idClassAttributeAccessors.keySet())
-            setParameter(++p, query, entity, getAttributeName(idClassAttr, true));
+            setParameter(p++, query, entity, getAttributeName(idClassAttr, true));
 
         if (version != null) {
             if (trace && tc.isDebugEnabled())
-                Tr.debug(this, tc, "set ?" + (p + 1) + ' ' + version);
-            query.setParameter(++p, version);
+                Tr.debug(this, tc, "set ?" + p + ' ' + version);
+            query.setParameter(p++, version);
         }
     }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence.cdi;
 
+import static io.openliberty.data.internal.persistence.EntityManagerBuilder.getClassNames;
 import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
 
 import java.io.Writer;
@@ -121,7 +122,6 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         this.provider = provider;
         this.repositoryClassLoader = repositoryClassLoader;
         this.dataStore = dataStore;
-        // TODO getModuleName will show wrong hash code, so suppress it from trace?
         this.moduleName = getModuleName(repositoryInterface, repositoryClassLoader, provider);
         this.namespace = Namespace.of(dataStore);
 
@@ -389,8 +389,8 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
             } else {
                 throw (DataException) exc(DataException.class,
                                           "CWWKD1080.datastore.general.err",
-                                          repositoryInterfaces.stream().findFirst().get().getName(), // TODO revisit this and other NLS messages
-                                          metadata,
+                                          getClassNames(repositoryInterfaces),
+                                          metadata.getName(),
                                           dataStore,
                                           x.getMessage()).initCause(x);
             }
@@ -458,8 +458,8 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
 
         DataException x = exc(DataException.class,
                               "CWWKD1078.datastore.not.found",
-                              repositoryInterfaces.stream().findFirst().get().getName(), // TODO revisit this and other NLS messages
-                              metadata.getJ2EEName(),
+                              getClassNames(repositoryInterfaces),
+                              metadata.getName(),
                               dataStore,
                               dataSourceConfigExample,
                               databaseStoreConfigExample,
@@ -576,8 +576,8 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
 
         DataException x = exc(DataException.class,
                               "CWWKD1079.jndi.not.found",
-                              repositoryInterfaces.stream().findFirst().get().getName(), // TODO revisit this and other NLS messages
-                              metadata.getJ2EEName(),
+                              getClassNames(repositoryInterfaces),
+                              metadata.getName(),
                               dataStore,
                               "@Resource(name=\"java:app/env/jdbc/dsRef\",lookup=\"jdbc/ds\")",
                               "jndiName=\"jdbc/ds\"",
@@ -665,13 +665,18 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
     @Override
     @Trivial
     public String toString() {
-        int len = 27 + dataStore.length() +
+        int len = 40 + dataStore.length() +
                   (application == null ? 4 : application.length()) +
                   (module == null ? 4 : module.length());
+        // Both hashCode and identityHashCode are included so that we can correlate
+        // output in Liberty trace, which prints toString for values and method args
+        // but uses uses identityHashCode (id=...) when printing trace for a class
         StringBuilder b = new StringBuilder(len) //
                         .append("FutureEMBuilder@") //
                         .append(Integer.toHexString(hashCode())) //
-                        .append(":").append(dataStore) //
+                        .append("(id=") //
+                        .append(Integer.toHexString(System.identityHashCode(this))) //
+                        .append(") ").append(dataStore) //
                         .append(' ').append(application) //
                         .append('#').append(module);
         return b.toString();

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -254,7 +254,12 @@ public interface Primes {
     Page<String> lengthBasedQuery(PageRequest pageRequest);
 
     @OrderBy(ID)
-    @Query("SELECT ID(THIS) FROM Prime o WHERE (o.name = :numberName OR :numeral=o.romanNumeral OR o.hex =:hex OR ID(THIS)=:num)")
+    @Query("SELECT ID(THIS)" +
+           "  FROM Prime" +
+           " WHERE (name = :numberName" +
+           "     OR :numeral=romanNumeral" +
+           "     OR hex =:hex" +
+           "     OR ID(THIS)=:num)")
     long[] matchAny(long num, String numeral, String hex, String numberName);
 
     @OrderBy(ID)

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -30,6 +30,7 @@ import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
+import jakarta.data.repository.Update;
 
 /**
  *
@@ -42,6 +43,12 @@ public interface Cities {
     @Find
     @OrderBy("name")
     Stream<AreaInfo> areaInfo(String stateName);
+
+    @Query("SELECT VERSION(THIS) WHERE name = ?1 AND stateName = ?2")
+    long currentVersion(String city, String state);
+    // TODO: IdClass as query parameter
+    //@Query("SELECT VERSION(THIS) WHERE ID(THIS) = ?1")
+    //long currentVersion(CityId id);
 
     @Delete
     void delete(City city); // copied from BasicRepository
@@ -107,6 +114,12 @@ public interface Cities {
     @OrderBy("stateName")
     @OrderBy("name")
     Stream<CityId> ids();
+
+    @Update
+    City[] modifyData(City... citiesToUpdate);
+
+    @Update
+    void modifyStats(City... citiesToUpdate);
 
     @Delete
     void remove(City city);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -27,6 +27,7 @@ import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 
@@ -101,6 +102,11 @@ public interface Cities {
     CursoredPage<City> findByStateNameNotStartsWith(String prefix, PageRequest pagination);
 
     CityId findFirstByNameOrderByPopulationDesc(String name);
+
+    @Query("SELECT " + ID)
+    @OrderBy("stateName")
+    @OrderBy("name")
+    Stream<CityId> ids();
 
     @Delete
     void remove(City city);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/City.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/City.java
@@ -12,15 +12,13 @@ package test.jakarta.data.jpa.web;
 
 import java.util.Set;
 
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Version;
 
 /**
- *
+ * Entity with a composite id (using IdClass) and version.
  */
 @Entity
 @IdClass(CityId.class)
@@ -48,6 +46,12 @@ public class City {
         this.stateName = state;
         this.population = population;
         this.areaCodes = areaCodes;
+    }
+
+    static City of(CityId id, int population, Set<Integer> areaCodes, long version) {
+        City city = new City(id.name, id.getStateName(), population, areaCodes);
+        city.changeCount = version;
+        return city;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
@@ -84,6 +84,9 @@ public interface CreditCards extends DataRepository<CreditCard, CardId> {
     @Update
     CreditCard replace(CreditCard newCard);
 
+    @Update
+    void revert(CreditCard previousCard);
+
     @Save
     void save(CreditCard... cards);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
@@ -23,6 +23,7 @@ import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
+import jakarta.data.repository.Update;
 
 import test.jakarta.data.jpa.web.CreditCard.CardId;
 import test.jakarta.data.jpa.web.CreditCard.Issuer;
@@ -79,6 +80,9 @@ public interface CreditCards extends DataRepository<CreditCard, CardId> {
     @Query("SELECT o FROM CreditCard o WHERE EXTRACT (MONTH FROM o.issuedOn) IN ?1")
     @OrderBy("number")
     Stream<CreditCard> issuedInMonth(Iterable<Integer> months);
+
+    @Update
+    CreditCard replace(CreditCard newCard);
 
     @Save
     void save(CreditCard... cards);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Drivers.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Drivers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Update;
 
 /**
  * Repository for testing OneToOne relationship between Driver and DriversLicense entities.
@@ -42,4 +43,7 @@ public interface Drivers extends BasicRepository<Driver, Integer> {
     Driver findByLicense_licenseNum(String licenseNumber);
 
     Stream<Driver> findByLicenseStateNameOrderByLicenseExpiresOnDesc(String state);
+
+    @Update
+    void setInfo(Driver updatedDriverInfo);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
@@ -74,4 +74,9 @@ public interface Orders extends CrudRepository<PurchaseOrder, UUID> {
 
     @Update
     PurchaseOrder modifyOne(PurchaseOrder orders);
+
+    @Query("SELECT VERSION(THIS)")
+    @OrderBy("version(this)")
+    @OrderBy("versionNum")
+    List<Integer> versions();
 }


### PR DESCRIPTION
This PR removes the workarounds for 28925 and adds implementation of various update and update-and-retrieve scenarios, involving IdClass with or without version. It also covers updates with association attributes, which were not working.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
