### PR TITLE
NLS messages for one or more repositories

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -600,10 +600,10 @@ CWWKD1060.name.out.of.scope.useraction=Update the Repository annotation to \
  specify a data store name that is visible to the module or library \
  providing the repository interface.
 
-CWWKD1061.comp.name.in.ejb=CWWKD1061E: The {0} repository interface which is \
- defined in the {1} enterprise bean module of the {2} application configures \
- a {2} value for the {3} attribute. However,  {4} names are not accessible to \
- enterprise bean modules. Use a name from one of the following \
+CWWKD1061.comp.name.in.ejb=CWWKD1061E: One or more repository interfaces ({0}) \
+ that are defined in the {1} enterprise bean module of the {2} application \
+ configure a {2} value for the {3} attribute. However, {4} names are not accessible \
+ to enterprise bean modules. Use a name from one of the following \
  namespaces: {5}.
 CWWKD1061.comp.name.in.ejb.explanation=The specified namespace is not accessible \
  to the enterprise bean module where the repository interface is defined.
@@ -633,24 +633,24 @@ CWWKD1064.datastore.error.explanation=An error occurred when attempting to obtai
 CWWKD1064.datastore.error.useraction=Ensure that the specified data store and all \
  other resources it depends on exist and are correctly configured.
 
-CWWKD1065.ddlgen.timeout=CWWKD1065E: DDL generation for the {0} repository \
- interface failed because the {1} data store did not complete DDL generation \
+CWWKD1065.ddlgen.timeout=CWWKD1065E: DDL generation for one or more repository \
+ interfaces ({0}) failed because the {1} data store did not complete DDL generation \
  within {2} seconds for the following entities: {3}.
 CWWKD1065.ddlgen.timeout.explanation=The DDL generation attempt timed out \
  and did not complete.
 CWWKD1065.ddlgen.timeout.useraction=Reattempt DDL generation \
  when the system and database are not under load.
 
-CWWKD1066.ddlgen.failed=CWWKD1066E: DDL generation for the {0} repository \
- interface that uses the {1} data store encountered an error when attempting \
+CWWKD1066.ddlgen.failed=CWWKD1066E: DDL generation for one or more repository \
+ interfaces ({0}) that use the {1} data store encountered an error when attempting \
  DDL generation for the following entities: {2}. The error is: {3}.
 CWWKD1066.ddlgen.failed.explanation=The DDL generation attempt failed \
  and did not complete.
 CWWKD1066.ddlgen.failed.useraction=Investigate the error and make corrections \
  to the repository interface, entities, data store configuration, or database.
 
-CWWKD1067.ddlgen.emf.timeout=CWWKD1067E: DDL generation for the {0} repository \
- interface failed because the {1} data store was not available or was unable \
+CWWKD1067.ddlgen.emf.timeout=CWWKD1067E: DDL generation for one or more repository \
+ interfaces ({0}) failed because the {1} data store was not available or was unable \
  to make the following entities available within {2} seconds: {3}.
 CWWKD1067.ddlgen.emf.timeout.explanation=Acquisition of the resources needed \
  for DDL generation timed out and did not complete.
@@ -686,16 +686,18 @@ CWWKD1070.record.convert.err.explanation=It is not possible to use the \
 CWWKD1070.record.convert.err.useraction=Define the entity as a Jakarta Persistence \
  entity instead of using a Java record entity.
 
-CWWKD1071.record.with.type.var=CWWKD1071E: The {0} record cannot be used as an \
- entity because it has one or more type variables: {1}.
+CWWKD1071.record.with.type.var=CWWKD1071E: The {0} record is used as an entity by \
+ one or more of the repository interfaces ({1}) in the {2} application artifact, \
+ but the record cannot be an entity because it has one or more type variables: {3}.
 CWWKD1071.record.with.type.var.explanation=Entity classes cannot have generic \
  type variables.
 CWWKD1071.record.with.type.var.useraction=Remove the type variables from the \
  record.
 
-CWWKD1072.record.comp.conflict=CWWKD1072E: The {0} record cannot be used as an \
- entity because its {1} component and {2} component both resolve to the same \
- entity property name.
+CWWKD1072.record.comp.conflict=CWWKD1072E: The {0} record is used as an entity by \
+ one or more of the repository interfaces ({1}) in the {2} application artifact, \
+ but the record cannot be an entity because its {3} component and {4} component \
+ both resolve to the same entity property name.
 CWWKD1072.record.comp.conflict.explanation=Entity property names must be \
  unique ignoring case.
 CWWKD1072.record.comp.conflict.useraction=Rename one of the record components \
@@ -734,8 +736,8 @@ CWWKD1076.repo.disposed.useraction=Ensure that the repository method is not \
  used outside of the scope of the application that defines the repository.
 
 CWWKD1077.defaultds.not.found=CWWKD1077E: The {0} application artifact \
- has a {1} repository interface that uses or defaults to the \
- {2} data store, which must be configured in server configuration \
+ has one or more repository interfaces ({1}) that use or default to the \
+ {2} data store. This data store must be configured in server configuration \
  by defining a dataSource element that has an identifier of \
  DefaultDataSource. For example, {3} \
  Alternatively, assign the dataStore value of the Repository annotation \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -642,7 +642,7 @@ CWWKD1065.ddlgen.timeout.useraction=Reattempt DDL generation \
  when the system and database are not under load.
 
 CWWKD1066.ddlgen.failed=CWWKD1066E: DDL generation for one or more repository \
- interfaces ({0}) that use the {1} data store encountered an error when attempting \
+ interfaces ({0}) that use the {1} data store encountered an error during \
  DDL generation for the following entities: {2}. The error is: {3}.
 CWWKD1066.ddlgen.failed.explanation=The DDL generation attempt failed \
  and did not complete.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -737,7 +737,7 @@ CWWKD1076.repo.disposed.useraction=Ensure that the repository method is not \
 
 CWWKD1077.defaultds.not.found=CWWKD1077E: The {0} application artifact \
  has one or more repository interfaces ({1}) that use or default to the \
- {2} data store. This data store must be configured in server configuration \
+ {2} data store. This data store must be configured in the server configuration \
  by defining a dataSource element that has an identifier of \
  DefaultDataSource. For example, {3} \
  Alternatively, assign the dataStore value of the Repository annotation \

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -214,7 +214,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
             // logging the error and raising an exception with the same message.
             throw exc(DataException.class,
                       "CWWKD1067.ddlgen.emf.timeout",
-                      repositoryInterfaces.stream().findFirst().get().getName(), // TODO revisit this and other NLS messages
+                      getClassNames(repositoryInterfaces),
                       dataStore,
                       DDLGEN_WAIT_TIME,
                       entityTypes.stream().map(Class::getName).collect(Collectors.toList()));
@@ -224,7 +224,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
             Throwable cause = (ex instanceof ExecutionException) ? ex.getCause() : ex;
             DataException dx = exc(DataException.class,
                                    "CWWKD1066.ddlgen.failed",
-                                   repositoryInterfaces.stream().findFirst().get().getName(), // TODO revisit this and other NLS messages
+                                   getClassNames(repositoryInterfaces),
                                    dataStore,
                                    entityTypes.stream() //
                                                    .map(Class::getName) //
@@ -250,7 +250,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
             // logging the error and raising an exception with the same message.
             throw exc(DataException.class,
                       "CWWKD1065.ddlgen.timeout",
-                      repositoryInterfaces.stream().findFirst().get().getName(), // TODO revisit this and other NLS messages
+                      getClassNames(repositoryInterfaces),
                       dataStore,
                       DDLGEN_WAIT_TIME,
                       entityTypes.stream().map(Class::getName).collect(Collectors.toList()));
@@ -260,7 +260,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
             Throwable cause = (ex instanceof ExecutionException) ? ex.getCause() : ex;
             DataException dx = exc(DataException.class,
                                    "CWWKD1066.ddlgen.failed",
-                                   repositoryInterfaces.stream().findFirst().get().getName(), // TODO revisit this and other NLS messages
+                                   getClassNames(repositoryInterfaces),
                                    dataStore,
                                    entityTypes.stream() //
                                                    .map(Class::getName) //
@@ -303,7 +303,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
             if (namespace == Namespace.COMP && metadataIdentifier.startsWith("EJB#"))
                 throw exc(DataException.class,
                           "CWWKD1061.comp.name.in.ejb",
-                          repositoryInterfaces.stream().findFirst().get().getName(), // TODO revisit this and other NLS messages
+                          getClassNames(repositoryInterfaces),
                           repoMetadata.getJ2EEName().getModule(),
                           repoMetadata.getJ2EEName().getApplication(),
                           resourceName,
@@ -521,7 +521,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         DataException x = exc(DataException.class,
                               "CWWKD1077.defaultds.not.found",
                               metadata.getJ2EEName(),
-                              repositoryInterfaces.stream().findFirst().get().getName(), // TODO revisit this and other NLS messages
+                              getClassNames(repositoryInterfaces),
                               dataStore,
                               dataSourceConfigExample,
                               databaseStoreConfigExample,

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -365,10 +365,19 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
                 String tableName = c.getSimpleName();
 
                 if (c.isRecord()) {
-                    String entityClassName = c.getName() + EntityInfo.RECORD_ENTITY_SUFFIX; // an entity class is generated for the record
-                    byte[] generatedEntityBytes = RecordTransformer.generateEntityClassBytes(c, entityClassName);
-                    generatedEntities.add(new InMemoryMappingFile(generatedEntityBytes, entityClassName.replace('.', '/') + ".class"));
-                    Class<?> generatedEntity = classDefiner.findLoadedOrDefineClass(getRepositoryClassLoader(), entityClassName, generatedEntityBytes);
+                    // an entity class is generated for the record
+                    String entityClassName = c.getName() + EntityInfo.RECORD_ENTITY_SUFFIX;
+                    byte[] generatedEntityBytes = RecordTransformer //
+                                    .generateEntityClassBytes(c,
+                                                              entityClassName,
+                                                              jeeName,
+                                                              repositoryInterfaces);
+                    String name = entityClassName.replace('.', '/') + ".class";
+                    generatedEntities.add(new InMemoryMappingFile(generatedEntityBytes, name));
+                    Class<?> generatedEntity = classDefiner //
+                                    .findLoadedOrDefineClass(getRepositoryClassLoader(),
+                                                             entityClassName,
+                                                             generatedEntityBytes);
                     generatedToRecordClass.put(generatedEntity, c);
                     c = generatedEntity;
                 }

--- a/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/service/GenerateEntityClassBytesTest.java
+++ b/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/service/GenerateEntityClassBytesTest.java
@@ -18,6 +18,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.lang.reflect.RecordComponent;
+import java.util.Set;
 
 import org.junit.Test;
 import org.objectweb.asm.ClassReader;
@@ -40,42 +41,66 @@ public class GenerateEntityClassBytesTest {
 
     @Test
     public void testPrimitive() throws Exception {
-        byte[] classBytes = RecordTransformer.generateEntityClassBytes(Primitive.class, Primitive.class.getName() + "Entity");
+        byte[] classBytes = RecordTransformer //
+                        .generateEntityClassBytes(Primitive.class,
+                                                  Primitive.class.getName() + "Entity",
+                                                  null,
+                                                  Set.of());
         assertClassBytes(classBytes);
         assertClassSignature(Primitive.class, classBytes);
     }
 
     @Test
     public void testBoxed() throws Exception {
-        byte[] classBytes = RecordTransformer.generateEntityClassBytes(Boxed.class, Boxed.class.getName() + "Entity");
+        byte[] classBytes = RecordTransformer //
+                        .generateEntityClassBytes(Boxed.class,
+                                                  Boxed.class.getName() + "Entity",
+                                                  null,
+                                                  Set.of());
         assertClassBytes(classBytes);
         assertClassSignature(Boxed.class, classBytes);
     }
 
     @Test
     public void testSpecial() throws Exception {
-        byte[] classBytes = RecordTransformer.generateEntityClassBytes(Special.class, Special.class.getName() + "Entity");
+        byte[] classBytes = RecordTransformer //
+                        .generateEntityClassBytes(Special.class,
+                                                  Special.class.getName() + "Entity",
+                                                  null,
+                                                  Set.of());
         assertClassBytes(classBytes);
         assertClassSignature(Special.class, classBytes);
     }
 
     @Test
     public void testEmpty() throws Exception {
-        byte[] classBytes = RecordTransformer.generateEntityClassBytes(Empty.class, Empty.class.getName() + "Entity");
+        byte[] classBytes = RecordTransformer //
+                        .generateEntityClassBytes(Empty.class,
+                                                  Empty.class.getName() + "Entity",
+                                                  null,
+                                                  Set.of());
         assertClassBytes(classBytes);
         assertClassSignature(Empty.class, classBytes);
     }
 
     @Test
     public void testNaming() throws Exception {
-        byte[] classBytes = RecordTransformer.generateEntityClassBytes(Naming.class, Naming.class.getName() + "Entity");
+        byte[] classBytes = RecordTransformer //
+                        .generateEntityClassBytes(Naming.class,
+                                                  Naming.class.getName() + "Entity",
+                                                  null,
+                                                  Set.of());
         assertClassBytes(classBytes);
         assertClassSignature(Naming.class, classBytes);
     }
 
     @Test
     public void testGeneric() throws Exception {
-        byte[] classBytes = RecordTransformer.generateEntityClassBytes(Generic.class, Generic.class.getName() + "Entity");
+        byte[] classBytes = RecordTransformer //
+                        .generateEntityClassBytes(Generic.class,
+                                                  Generic.class.getName() + "Entity",
+                                                  null,
+                                                  Set.of());
         assertClassBytes(classBytes);
         assertClassSignature(Generic.class, classBytes);
     }
@@ -83,7 +108,10 @@ public class GenerateEntityClassBytesTest {
     @Test
     public void testGenericInfer() throws Exception {
         try {
-            RecordTransformer.generateEntityClassBytes(GenericInfer.class, GenericInfer.class.getName() + "Entity");
+            RecordTransformer.generateEntityClassBytes(GenericInfer.class,
+                                                       GenericInfer.class.getName() + "Entity",
+                                                       null,
+                                                       Set.of());
             fail("Should not have created a entity class for: " + GenericInfer.class.getName());
         } catch (DataException e) {
             //expected
@@ -93,7 +121,10 @@ public class GenerateEntityClassBytesTest {
     @Test
     public void testAmbiguous() throws Exception {
         try {
-            RecordTransformer.generateEntityClassBytes(Ambiguous.class, Ambiguous.class.getName() + "Entity");
+            RecordTransformer.generateEntityClassBytes(Ambiguous.class,
+                                                       Ambiguous.class.getName() + "Entity",
+                                                       null,
+                                                       Set.of());
             fail("Should not have been able to create a well-formed entity class for: " + Ambiguous.class.getCanonicalName());
         } catch (DataException e) {
             //expected


### PR DESCRIPTION
Some of the NLS message for Jakarta Data were written before we were informed of the correct way to refer to the possibility of having one or more.  This PR goes back and updates those prior messages (all of which are new and have not gone into a release yet) to cover the possibility of one or more.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
