### PR TITLE
Backport MWRAPPER-150

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/mvnw
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/mvnw
@@ -260,7 +260,7 @@ done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
 if [ -n "$wrapperSha256Sum" ]; then
   wrapperSha256Result=false
   if command -v sha256sum > /dev/null; then
-    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c > /dev/null 2>&1; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c - > /dev/null 2>&1; then
       wrapperSha256Result=true
     fi
   elif command -v shasum > /dev/null; then


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################r

esolves https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=302037

This backports the code change at https://github.com/apache/maven-wrapper/pull/155/files that fixes https://issues.apache.org/jira/browse/MWRAPPER-150

An issue that's been causing mass tck failures in our builds.

The fix updates the sha256sum command to fit the expected syntax on OSX