### PR TITLE
Dudedev 28117 add escaping information to usage text for security utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,13 @@ Our [CONTRIBUTING](https://github.com/OpenLiberty/open-liberty/blob/release/CONT
 
 2. Run a gradle build.
 
+   Pre-requisite - Environment variable `JAVA_21_HOME` must be set.
+
         cd open-liberty/dev
         ./gradlew cnf:initialize
         ./gradlew assemble
+
+    Troubleshoot - If `./gradlew assemble` shows Out of Memory error then you could increase the memory in `dev/gradle.properties` file. Stop gradle daemons after you change the memory using `./gradlew --stop`. If it does not help, then try cleaning up maven repository (using `rm -rf ~/.m2`) and gradle caches (using `rm -rf ~/.gradle/caches`).
     
 3. Run the unit or FAT tests.
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Our [CONTRIBUTING](https://github.com/OpenLiberty/open-liberty/blob/release/CONT
 
 2. Run a gradle build.
 
-   Pre-requisite - Environment variable `JAVA_21_HOME` must be set.
+   Prerequisite - Environment variable `JAVA_HOME` must point to a Java 17 or Java 21 SDK.  If setting `JAVA_HOME` to  Java 17, you will also need to set `JAVA_21_HOME` to a Java 21 SDK.
 
         cd open-liberty/dev
         ./gradlew cnf:initialize
         ./gradlew assemble
 
-    Troubleshoot - If `./gradlew assemble` shows Out of Memory error then you could increase the memory in `dev/gradle.properties` file. Stop gradle daemons after you change the memory using `./gradlew --stop`. If it does not help, then try cleaning up maven repository (using `rm -rf ~/.m2`) and gradle caches (using `rm -rf ~/.gradle/caches`).
+    Troubleshooting - If `./gradlew assemble` shows out of memory error, you can increase the memory in `dev/gradle.properties` file. Stop the gradle daemon after you change the memory setting by using `./gradlew --stop`. If it does not help the problem, try cleaning up your maven repository cache (using `rm -rf ~/.m2`) and gradle cache (using `rm -rf ~/.gradle/caches`).
     
 3. Run the unit or FAT tests.
 

--- a/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
+++ b/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010, 2020 IBM Corporation and others.
+# Copyright (c) 2010, 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
+++ b/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
@@ -56,7 +56,7 @@ encode.desc=\
 \tEncode the provided text.\n\n\
 \tIf your password includes special characters, you must escape each special character to help ensure that the password is properly encoded.\n\
 \tSpecial characters and escape characters might vary according to your operating system.\n\
-\tFor example, on Unix systems, pa$$W0rd must be provided as pa\\$\\$W0rd.\n\
+\tFor example, on UNIX systems, pa$$W0rd must be provided as pa\\$\\$W0rd.\n\
 \tFor more information, see the Open Liberty securityUtility encode documentation.
 #Note to translator the word "encode" should not be translated
 encode.usage.options=\

--- a/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
+++ b/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
@@ -53,7 +53,11 @@ help.usage.options=\
 #------------------------------\n at 72 chars Leading "\ \ \ \ "-------\n\#
 #------------------------------\n at 72 chars Leading "\t"-------------\n\#
 encode.desc=\
-\tEncode the provided text.
+\tEncode the provided text.\n\n\
+\tIf your password includes special characters, you must escape each special character to help ensure that the password is properly encoded.\n\
+\tSpecial characters and escape characters might vary according to your operating system.\n\
+\tFor example, on Unix systems, pa$$W0rd must be provided as pa\\$\\$W0rd.\n\
+\tFor more information, see the Open Liberty securityUtility encode documentation.
 #Note to translator the word "encode" should not be translated
 encode.usage.options=\
 \t{0} encode [options]

--- a/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
+++ b/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010, 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2010, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

It completes this task. https://github.com/OpenLiberty/open-liberty/issues/28117


For full details, please see this wiki page: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions
################################################################################################
