### PR TITLE
Tolerate slow systems in EJB timer FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryWeb.war/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/web/NpTimerConfigRetryServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryWeb.war/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/web/NpTimerConfigRetryServlet.java
@@ -331,6 +331,7 @@ public class NpTimerConfigRetryServlet extends FATServlet {
 
         svLogger.info("Waiting for timer to fail and expected retries to occur...");
         driverBean.waitForTimersAndCancel(0);
+        long completedTime = System.currentTimeMillis();
 
         svLogger.info("Waking up and checking results...");
         Properties props = driverBean.getResults();
@@ -338,9 +339,22 @@ public class NpTimerConfigRetryServlet extends FATServlet {
         @SuppressWarnings("unchecked")
         ArrayList<Long> timestamps = (ArrayList<Long>) props.get(TimerRetryDriverBean.TIMESTAMP_KEY);
         boolean timerExists = ((Boolean) props.get(TimerRetryDriverBean.TIMER_EXISTS)).booleanValue();
-        assertEquals("Timeout count **" + count + "** was not the expected value of 2. Interval Timer failing at max retries is not rescheduling!", 2, count);
-        assertEquals("Timestamps size **" + timestamps.size() + "** was not the expected value of 2.", 2, timestamps.size());
+        @SuppressWarnings("unchecked")
+        ArrayList<Long> nextTimes = (ArrayList<Long>) props.get(TimerRetryDriverBean.NEXTTIMEOUT_KEY);
+
+        // Tolerate the timer running a 3rd time on slow hardware due to catch-up timeouts
+        long expectedCount = 2;
+        if (nextTimes.get(nextTimes.size() - 1) <= completedTime && count == 3) {
+            expectedCount = 3;
+        }
+
+        assertEquals("Timeout count **" + count + "** was not the expected value of " + expectedCount + ". Interval Timer failing at max retries is not rescheduling!",
+                     expectedCount, count);
+        assertEquals("Timestamps size **" + timestamps.size() + "** was not the expected value of " + expectedCount + ".", expectedCount, timestamps.size());
         assertTrue("Timer did not exist after max retries", timerExists);
+        // TODO: Issue #29851 : Timer should be rescheduled for next interval; not 2x next interval
+        assertTrue("NextTimeout not scheduled correctly: " + (nextTimes.get(1).longValue() - nextTimes.get(0).longValue()),
+                   (nextTimes.get(1).longValue() - nextTimes.get(0).longValue()) == 2 * TimerRetryDriverBean.TIMER_INTERVAL);
     }
 
     /**


### PR DESCRIPTION
- Tolerate the timer running a 3rd time on slow hardware due to catch-up timeouts

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
