### PR TITLE
Fix Machine.getOSVersion()

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/Machine.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/Machine.java
@@ -273,14 +273,13 @@ public class Machine {
             String[] params = null;
             OperatingSystem os = getOperatingSystem();
             if (os == OperatingSystem.WINDOWS) {
-                cmd = "cmd.exe";
-                params = new String[] { "/C", "ver" };
+                cmd = "ver";
             } else if (os == OperatingSystem.MAC) {
-                cmd = "/bin/sh";
-                params = new String[] { "-c", "\"sysctl", "kern.version\"" };
+                cmd = "sysctl";
+                params = new String[] { "kern.version" };
             } else {
-                cmd = "/bin/sh";
-                params = new String[] { "-c", "\"cat", "/proc/version\"" };
+                cmd = "cat";
+                params = new String[] { "/proc/version" };
             }
             Log.finer(c, method, "Command to get OS version: " + cmd + " " + Arrays.toString(params));
             this.osVersion = LocalProvider.executeCommand(this, cmd, params, null, null, 0).getStdout().trim();


### PR DESCRIPTION
- Updates to not add /bin/sh -c or cmd.exe /C in the command passed to LocalProvider.executeCommand since it will take care of that for you and do it the right way.

This change is necessary after the changes done in #29654. 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
