### PR TITLE
Disable MP Health 2.0 FAT traces

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/ApplicationStateHealthCheck/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/ApplicationStateHealthCheck/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:com.ibm.ws.webcontainer.extension.*=all
+#com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:com.ibm.ws.webcontainer.extension.*=all
 osgi.console=7771

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/ApplicationStateHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/ApplicationStateHealthCheck/server.xml
@@ -10,7 +10,9 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
 
-    <logging traceSpecification="*=info:HEALTH=all"/>
+    <!-- Enable trace for debug purposes only.-->
+    <!--logging traceSpecification="*=info:HEALTH=all"/-->
+    
     <webContainer deferServletLoad="false"/>
     
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DelayedHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DelayedHealthCheck/server.xml
@@ -10,7 +10,8 @@
         <feature>componenttest-1.0</feature>
     </featureManager>
 	
-	<logging traceSpecification="*=info:HEALTH=all"/>
+	<!-- Enable trace for debug purposes only.-->
+	<!--logging traceSpecification="*=info:HEALTH=all"/-->
 
 	<application location="DelayedHealthCheckApp.war"/>
     <webContainer deferServletLoad="false"/>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DifferentAppNameHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/DifferentAppNameHealthCheck/server.xml
@@ -9,7 +9,8 @@
         <feature>mpHealth-2.0</feature>
     </featureManager>
 	
-	<logging traceSpecification="*=info:HEALTH=all"/>
+	<!-- Enable trace for debug purposes only.-->
+	<!--logging traceSpecification="*=info:HEALTH=all"/-->
 
 	<application name="DifferentAppNameHealthCheckApp-2.0" type="war" location="DifferentAppNameHealthCheckApp.war" autoStart="true"></application>
 	

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/FailedApplicationStateHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/FailedApplicationStateHealthCheck/server.xml
@@ -32,7 +32,8 @@
         </appProperties>
     </application>
     
-    <logging traceSpecification="*=info:HEALTH=all"/>
+    <!-- Enable trace for debug purposes only.-->
+    <!--logging traceSpecification="*=info:HEALTH=all"/-->
 
     <!-- this sections mirrors permissions.xml to apply the permissions to the Kafka client jar in the shared library -->
     <variable name="kafkaCodebase" value="${server.config.dir}/kafkaLib/kafka-clients-3.5.1.jar"/>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/MultipleHealthCheck/server.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/MultipleHealthCheck/server.xml
@@ -9,7 +9,8 @@
         <feature>mpHealth-2.0</feature>
     </featureManager>
 	
-	<logging traceSpecification="*=info:HEALTH=all"/>
+	<!-- Enable trace for debug purposes only.-->
+	<!--logging traceSpecification="*=info:HEALTH=all"/-->
 
 	<application name="MultipleHealthCheckApp" type="war" location="MultipleHealthCheckApp.war" autoStart="true"></application>
 	


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #29856

- Disable MP Health 2.0 FAT traces, as they are not needed for now. It was generating at least 4 GB of traces, due to the amount of Repeats.