### PR TITLE
Make toString output consistent with Liberty trace

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceWithExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceWithExecutor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021,2022 IBM Corporation and others.
+ * Copyright (c) 2021,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -134,6 +134,21 @@ public class ContextServiceWithExecutor implements ContextService {
     public final int hashCode() {
         // This instance is unique per its managed executor, not per the shared context service.
         return managedExecutor.hashCode();
+    }
+
+    @Override
+    @Trivial
+    public String toString() {
+        // Both hashCode and identityHashCode are included so that we can correlate
+        // output in Liberty trace, which prints toString for values and method args
+        // but uses uses identityHashCode (id=...) when printing trace for a class
+        return new StringBuilder(48) //
+                        .append("ContextServiceWithExecutor@") //
+                        .append(Integer.toHexString(hashCode())) //
+                        .append("(id=") //
+                        .append(Integer.toHexString(System.identityHashCode(this))) //
+                        .append(')') //
+                        .toString();
     }
 
     public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> stage) {

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020,2021 IBM Corporation and others.
+ * Copyright (c) 2020,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -98,5 +98,20 @@ class ContextualDefaultExecutor implements Executor, WSManagedExecutorService {
     @Override
     public <I, T> CompletableFuture<T> newAsyncMethod(BiFunction<I, CompletableFuture<T>, CompletionStage<T>> invoker, I invocation) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Trivial
+    public String toString() {
+        // Both hashCode and identityHashCode are included so that we can correlate
+        // output in Liberty trace, which prints toString for values and method args
+        // but uses uses identityHashCode (id=...) when printing trace for a class
+        return new StringBuilder(47) //
+                        .append("ContextualDefaultExecutor@") //
+                        .append(Integer.toHexString(hashCode())) //
+                        .append("(id=") //
+                        .append(Integer.toHexString(System.identityHashCode(this))) //
+                        .append(')') //
+                        .toString();
     }
 }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ScheduledTask.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ScheduledTask.java
@@ -1097,5 +1097,20 @@ public class ScheduledTask<T> implements Callable<T>, ScheduledCustomExecutorTas
                     throw new IllegalStateException(status.type.toString());
             }
         }
+
+        @Override
+        @Trivial
+        public String toString() {
+            // Both hashCode and identityHashCode are included so that we can correlate
+            // output in Liberty trace, which prints toString for values and method args
+            // but uses uses identityHashCode (id=...) when printing trace for a class
+            return new StringBuilder(46) //
+                            .append("ScheduledTask.FutureImpl@") //
+                            .append(Integer.toHexString(hashCode())) //
+                            .append("(id=") //
+                            .append(Integer.toHexString(System.identityHashCode(this))) //
+                            .append(')') //
+                            .toString();
+        }
     }
 }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/UnusableExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/UnusableExecutor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018,2021 IBM Corporation and others.
+ * Copyright (c) 2018,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -67,5 +67,20 @@ class UnusableExecutor implements Executor, WSManagedExecutorService {
     @Override
     public <I, T> CompletableFuture<T> newAsyncMethod(BiFunction<I, CompletableFuture<T>, CompletionStage<T>> invoker, I invocation) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Trivial
+    public String toString() {
+        // Both hashCode and identityHashCode are included so that we can correlate
+        // output in Liberty trace, which prints toString for values and method args
+        // but uses uses identityHashCode (id=...) when printing trace for a class
+        return new StringBuilder(38) //
+                        .append("UnusableExecutor@") //
+                        .append(Integer.toHexString(hashCode())) //
+                        .append("(id=") //
+                        .append(Integer.toHexString(System.identityHashCode(this))) //
+                        .append(')') //
+                        .toString();
     }
 }

--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/EndpointActivationService.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/service/EndpointActivationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corporation and others.
+ * Copyright (c) 2012, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -207,6 +207,21 @@ public class EndpointActivationService implements XAResourceFactory, Application
         @Override
         public int hashCode() {
             return System.identityHashCode(activationSpec) + System.identityHashCode(messageEndpointFactory);
+        }
+
+        @Override
+        @Trivial
+        public String toString() {
+            // Both hashCode and identityHashCode are included so that we can correlate
+            // output in Liberty trace, which prints toString for values and method args
+            // but uses uses identityHashCode (id=...) when printing trace for a class
+            return new StringBuilder(38) //
+                            .append("ActivationParams@") //
+                            .append(Integer.toHexString(hashCode())) //
+                            .append("(id=") //
+                            .append(Integer.toHexString(System.identityHashCode(this))) //
+                            .append(')') //
+                            .toString();
         }
     }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/StatementCacheKey.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/StatementCacheKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corporation and others.
+ * Copyright (c) 2001, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -95,4 +95,17 @@ public abstract class StatementCacheKey {
         return x;
     }
 
+    @Override
+    public String toString() {
+        // Both hashCode and identityHashCode are included so that we can correlate
+        // output in Liberty trace, which prints toString for values and method args
+        // but uses uses identityHashCode (id=...) when printing trace for a class
+        return new StringBuilder(39) //
+                        .append("StatementCacheKey@") //
+                        .append(Integer.toHexString(hashCode())) //
+                        .append("(id=") //
+                        .append(Integer.toHexString(System.identityHashCode(this))) //
+                        .append(')') //
+                        .toString();
+    }
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -299,10 +299,16 @@ public class PolicyExecutorImpl implements PolicyExecutor {
         @Override
         @Trivial
         public String toString() {
+            // Both hashCode and identityHashCode are included so that we can correlate
+            // output in Liberty trace, which prints toString for values and method args
+            // but uses uses identityHashCode (id=...) when printing trace for a class
             String tf = threadFactory.toString();
-            return new StringBuilder(tf.length() + 31) //
-                            .append("VirtualThreadExecutor@").append(Integer.toHexString(hashCode())) //
-                            .append(' ').append(tf) //
+            return new StringBuilder(tf.length() + 44) //
+                            .append("VirtualThreadExecutor@") //
+                            .append(Integer.toHexString(hashCode())) //
+                            .append("(id=") //
+                            .append(Integer.toHexString(System.identityHashCode(this))) //
+                            .append(") ").append(tf) //
                             .toString();
         }
     }


### PR DESCRIPTION
Instances of classes that implement a custom hashCode are currently showing up in 2 different ways in Liberty trace.

When an instance of the class logs a trace point, Liberty trace prints id={System.identifyHashCode as hexadecimal}.
When the same instance of the class is shown in trace as a parameter of another trace point, Liberty trace prints the output of .toString(), which uses the .hashCode() hexadecimal by default.

This is an obstacle to debugging because the same class instance does not correlate between trace points. When there are multiple instances of the class you cannot tell which is which without possibly going back to the trace point that shows instance creation, but even that might have wrapped in the trace and not exist anymore.

To make it possible for trace points to correlate, this PR updates several places where our team wrote custom hashCode() methods to also define or update a toString() method to include id={System.identifyHashCode hexadecimal} into the output so that trace points can correlate.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
