### PR TITLE
JAX-WS: Servlet feature is added to prevent FeatureReplacementAction replacement issue

### DIFF
--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableDefaultValidationTestServer/global-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableDefaultValidationTestServer/global-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableDefaultValidationTestServer/server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableDefaultValidationTestServer/server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableDefaultValidationTestServer/servicename-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableDefaultValidationTestServer/servicename-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/global-false-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/global-false-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/global-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/global-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/incorrect-servicename-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/incorrect-servicename-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/servicename-false-global-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/servicename-false-global-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/servicename-false-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/servicename-false-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
      
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/servicename-true-global-false-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/servicename-true-global-false-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/servicename-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationTestServer/servicename-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/global-false-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/global-false-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/global-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/global-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/incorrect-portname-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/incorrect-portname-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/portname-false-global-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/portname-false-global-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/portname-false-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/portname-false-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/portname-true-global-false-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/portname-true-global-false-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/portname-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/portname-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/EnableSchemaValidationWebServiceTestServer/server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/GzipInterceptorsTestServer/server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/GzipInterceptorsTestServer/server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/global-false-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/global-false-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
    

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/global-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/global-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
    

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/incorrect-servicename-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/incorrect-servicename-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
    

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-false-global-false-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-false-global-false-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
    

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-false-global-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-false-global-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
    

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-false-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-false-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
    

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-true-global-false-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-true-global-false-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
    

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-true-global-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-true-global-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
    

--- a/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-true-server.xml
+++ b/dev/io.openliberty.jaxws.config_fat/publish/files/IgnoreUnexpectedElementConfigTestServer/servicename-true-server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
         <feature>jaxws-2.2</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
     
    


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes 
```
Expected: servlet-4.0, Actual: servlet-3.1.
This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly.
```