### PR TITLE
Fix test_SPNEGO_OIDC_CreateClientWithEveryParamVariation1

### DIFF
--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/bnd.bnd
@@ -20,6 +20,7 @@ fat.project: true
 
 -buildpath: \
     com.ibm.json4j;version=latest,\
+    org.apache.httpcomponents:httpcore;version=4.4.13, \
     com.ibm.ws.com.meterware.httpunit.1.7;version=latest,\
     com.ibm.ws.security.fat.common;version=latest,\
     com.ibm.ws.security.oauth.2.0;version=latest,\

--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
Failure is seeing that looks like this:
test_SPNEGO_OIDC_CreateClientWithEveryParamVariation1:java.lang.NoSuchFieldError: 2024-08-16-09:07:21:909 INSTANCE     at org.apache.http.impl.io.DefaultHttpRequestWriterFactory.<init>(DefaultHttpRequestWriterFactory.java:53)     at org.apache.http.impl.io.DefaultHttpRequestWriterFactory.<init>(DefaultHttpRequestWriterFactory.java:57)     at org.apache.http.impl.io.DefaultHttpRequestWriterFactory.<clinit>(DefaultHttpRequestWriterFactory.java:47)     at org.apache.http.impl.conn.ManagedHttpClientConnectionFactory.<init>(ManagedHttpClientConnectionFactory.java:83)     at org.apache.http.impl.conn.ManagedHttpClientConnectionFactory.<init>(ManagedHttpClientConnectionFactory.java:96)     at org.apache.http.impl.conn.ManagedHttpClientConnectionFactory.<init>(ManagedHttpClientConnectionFactory.java:105)     at org.apache.http.impl.conn.ManagedHttpClientConnectionFactory.<clinit>(ManagedHttpClientConnectionFactory.java:63)     at org.apache.http.impl.conn.PoolingHttpClientConnectionManager$InternalConnectionFactory.<init>(PoolingHttpClientConnectionManager.java:620)     at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.<init>(PoolingHttpClientConnectionManager.java:181)     at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.<init>(PoolingHttpClientConnectionManager.java:165)     at com.gargoylesoftware.htmlunit.HttpWebConnection.createConnectionManager(HttpWebConnection.java:1183)     at com.gargoylesoftware.htmlunit.HttpWebConnection.reconfigureHttpClientIfNeeded(HttpWebConnection.java:652)     at com.gargoylesoftware.htmlunit.HttpWebConnection.getResponse(HttpWebConnection.java:172)     at com.gargoylesoftware.htmlunit.WebClient.loadWebResponseFromWebConnection(WebClient.java:1536)     at com.gargoylesoftware.htmlunit.WebClient.loadWebResponse(WebClient.java:1459)     at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:447)     at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:368)     at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:536)

The root cause of the above stack trace is 
```Caused by: java.lang.NoSuchFieldError: INSTANCE```

This is because we are pulling two versions of the httpcore bundle. This change fixes that


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
