### PR TITLE
(OIDC Test) Adjusting case sensitivity on cookie attribute regex

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientCookieVerificationTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.1/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientCookieVerificationTests.java
@@ -91,7 +91,7 @@ public class OidcClientCookieVerificationTests extends CommonTest {
         expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.RESPONSE_COOKIE, Constants.STRING_MATCHES, "Should have found a WASOidcState cookie but didn't.", null, "WASOidcState[pn][0-9]+=[^" + CommonValidationTools.COOKIE_DELIMITER + "]+");
         expectations = vData.addExpectation(expectations, Constants.GET_LOGIN_PAGE, Constants.RESPONSE_COOKIE, Constants.STRING_MATCHES, "Should have found a WASOidcNonce cookie but didn't.", null, "WASOidcNonce[pn][0-9]+=[^" + CommonValidationTools.COOKIE_DELIMITER + "]+");
         expectations = getSuccessfulAccessExpectations(updatedTestSettings, expectations);
-        String expirationCookieFormat = JakartaEEAction.isEE10OrLaterActive() ? "; max-age=0" : "; Expires=Thu, 01 Dec 1994";
+        String expirationCookieFormat = JakartaEEAction.isEE10OrLaterActive() ? ";(?i) max-age=0" : ";(?i) Expires=Thu, 01 Dec 1994";
         expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcState cookie but didn't.", null, "WASOidcState[pn][0-9]+=\"\"" + expirationCookieFormat);
         expectations = vData.addExpectation(expectations, Constants.LOGIN_USER, Constants.RESPONSE_HEADER, Constants.STRING_MATCHES, "Should have found a Set-Cookie header to clear the WASOidcNonce cookie but didn't.", null, "WASOidcNonce[pn][0-9]+=\"\"" + expirationCookieFormat);
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


This pull request fixes a test failure caused by changes in casing for cookie attributes. This test was written expecting the casing `max-age` or `Expires`. 

This presents an issue if the response is provided with a `Set-Cookie` header that contains different casing for the attributes. For example, `Max-Age`. The `(?i)` inline flag is now used in the regular expression to allow either casing version to be accepted. 

This change aligns with [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.2), which specifies cookie attribute names are case insensitive.