### PR TITLE
error detection for query language parameters

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -217,15 +217,16 @@ CWWKD1018.confl.special.param.useraction=Update the repository to not use \
  both of the Jakarta Data special parameter types in the same method signature.
 
 CWWKD1019.mixed.positional.named=CWWKD1019E: The {0} method of the {1} repository \
- interface defines a mixture of {2} positional parameters and \
- {3} named parameters ({4}) for the Query annotation value: {5}. A query with \
+ interface cannot have a query that mixes positional and named parameters. \
+ The interface defines a mix of {2} positional parameters and
+ {3} named parameters {4} for the Query annotation value: {5}. A query with \
  positional parameters must reference each parameter by its ordinal value, \
  starting with ?1, and the method parameters must not have the Param annotation. \
- A query with named parameters must reference each parameter by its name, \
+ In a query with named parameters, each parameter must be referenced by its name, \
  such as {6}, and the method parameters must have the Param annotation, \
- such as {7}. Alternatively, if you enable the -parameters compile option, \
- the method parameters can indicate the named parameter by having the same name \
- as the named parameter. For example, {8}.
+ such as {7}. Alternatively, enabling the -parameters compile option allows \
+ method parameters to indicate the named parameter by matching its name, \
+ for example, {8}.
 CWWKD1019.mixed.positional.named.explanation=Queries with parameters must use all \
  named parameters or all positional parameters, not a combination.
 CWWKD1019.mixed.positional.named.useraction=Update the repository method to use \
@@ -838,11 +839,11 @@ CWWKD1082.entity.classes.missing.explanation=Repositories use entity classes \
 CWWKD1082.entity.classes.missing.useraction=Include all entity classes \
  in the persistence unit.
 
-CWWKD1083.dup.method.param=CWWKD1083E: Multiple parameters of the {0} method \
+CWWKD1083.dup.method.param=CWWKD1083E: Multiple parameters in the {0} method \
  of the {1} repository interface correspond to the named parameter: {2}. \
  You can annotate one method parameter with {3} to specify the query language \
  named parameter. Alternatively, you can enable the -parameters compile option \
- and define one method parameter of the form, {4}, which does not require the \
+ and define one method parameter in the form, {4}, which does not require the \
  Param annotation.
 CWWKD1083.dup.method.param.explanation=Each method parameter must correspond \
  to exactly one query parameter.
@@ -864,7 +865,7 @@ CWWKD1084.missing.named.params.useraction=Add parameters to the repository metho
  to specify the missing named parameters.
 
 CWWKD1085.extra.method.params=CWWKD1085E: The parameters of the {0} method \
- of the {1} repository interface define query parameters ({2}) that do not \
+ of the {1} repository interface define query parameters ({2}), which do not \
  match any of the named parameters ({3}) that are used by the Query annotation \
  value: {4}.
 CWWKD1085.extra.method.params.explanation=All the method parameters must be \
@@ -872,12 +873,12 @@ CWWKD1085.extra.method.params.explanation=All the method parameters must be \
 CWWKD1085.extra.method.params.useraction=Remove the extra method parameters.
 
 CWWKD1086.named.params.unused=CWWKD1086E: The parameters of the {0} method \
- of the {1} repository interface define named parameters ({2}) that are not \
+ of the {1} repository interface define named parameters ({2}), which are not \
  used in the Query annotation value: {3}. You can refer to named parameters \
  in a query by using the : character followed by the parameter name. \
- For example, {4}. You can refer to positional parameters in a query by using \
- the ? character followed by the ordinal value, starting with ?1. Do not \
- annotated method parameters to have the Param annotation when the query \
+ For example, {4}. Positional parameters in a query can be referenced by using \
+ the ? character followed by an ordinal value, starting with ?1. Avoid \
+ annotating method parameters with the Param annotation when the query \
  uses positional parameters or has no parameters.
 CWWKD1086.named.params.unused.explanation=The Param annotation can only be used \
  when the query has named parameters.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -847,8 +847,7 @@ CWWKD1083.dup.method.param=CWWKD1083E: Multiple parameters of the {0} method \
 CWWKD1083.dup.method.param.explanation=Each method parameter must correspond \
  to exactly one query parameter.
 CWWKD1083.dup.method.param.useraction=Check if each of the method parameters \
- specifies the correct named parameter. Remove method parameters that are \
- duplicates.
+ specifies the correct named parameter. Remove duplicate method parameters. \
 
 CWWKD1084.missing.named.params=CWWKD1084E: The parameters of the {0} method \
  of the {1} repository interface do not define the named parameters ({2}) \
@@ -868,7 +867,7 @@ CWWKD1085.extra.method.params=CWWKD1085E: The parameters of the {0} method \
  of the {1} repository interface define query parameters ({2}) that do not \
  match any of the named parameters ({3}) that are used by the Query annotation \
  value: {4}.
-CWWKD1085.extra.method.params.explanation=All of the method parameters must be \
+CWWKD1085.extra.method.params.explanation=All the method parameters must be \
  used by the query or be Jakarta Data defined parameter types.
 CWWKD1085.extra.method.params.useraction=Remove the extra method parameters.
 

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -217,8 +217,15 @@ CWWKD1018.confl.special.param.useraction=Update the repository to not use \
  both of the Jakarta Data special parameter types in the same method signature.
 
 CWWKD1019.mixed.positional.named=CWWKD1019E: The {0} method of the {1} repository \
- interface cannot have a query with a mixture of positional parameters and named \
- parameters.
+ interface defines a mixture of {2} positional parameters and \
+ {3} named parameters ({4}) for the Query annotation value: {5}. A query with \
+ positional parameters must reference each parameter by its ordinal value, \
+ starting with ?1, and the method parameters must not have the Param annotation. \
+ A query with named parameters must reference each parameter by its name, \
+ such as {6}, and the method parameters must have the Param annotation, \
+ such as {7}. Alternatively, if you enable the -parameters compile option, \
+ the method parameters can indicate the named parameter by having the same name \
+ as the named parameter. For example, {8}.
 CWWKD1019.mixed.positional.named.explanation=Queries with parameters must use all \
  named parameters or all positional parameters, not a combination.
 CWWKD1019.mixed.positional.named.useraction=Update the repository method to use \
@@ -830,3 +837,37 @@ CWWKD1082.entity.classes.missing.explanation=Repositories use entity classes \
  that must be defined in the persistence unit.
 CWWKD1082.entity.classes.missing.useraction=Include all entity classes \
  in the persistence unit.
+
+CWWKD1083.dup.method.param=CWWKD1083E: Multiple parameters of the {0} method \
+ of the {1} repository interface correspond to the named parameter: {2}. \
+ You can annotate one method parameter with {3} to specify the query language \
+ named parameter. Alternatively, you can enable the -parameters compile option \
+ and define one method parameter of the form, {4}, which does not require the \
+ Param annotation.
+CWWKD1083.dup.method.param.explanation=Each method parameter must correspond \
+ to exactly one query parameter.
+CWWKD1083.dup.method.param.useraction=Check if each of the method parameters \
+ specifies the correct named parameter. Remove method parameters that are \
+ duplicates.
+
+CWWKD1084.missing.named.params=CWWKD1084E: The parameters of the {0} method \
+ of the {1} repository interface do not define the named parameters ({2}) \
+ that are required by the Query annotation value: {3}. You can define a \
+ named parameter for the query by placing the Param annotation on a \
+ corresponding method parameter. For example, {4}. Alternatively, if you \
+ enable the -parameters compile option, you can omit the Param annotation \
+ if you name the method parameter to have the same name as the named parameter. \
+ For example, if String is the named parameter type, the method parameter \
+ can be {5}, which does not require the Param annotation.
+CWWKD1084.missing.named.params.explanation=The Query annotation value requires \
+ one or more named parameters that are not supplied by the repository method.
+CWWKD1084.missing.named.params.useraction=Add parameters to the repository method \
+ to specify the missing named parameters.
+
+CWWKD1085.extra.method.params=CWWKD1085E: The parameters of the {0} method \
+ of the {1} repository interface define query parameters ({2}) that do not \
+ match any of the named parameters ({3}) that are used by the Query annotation \
+ value: {4}.
+CWWKD1085.extra.method.params.explanation=All of the method parameters must be \
+ used by the query or be Jakarta Data defined parameter types.
+CWWKD1085.extra.method.params.useraction=Remove the extra method parameters.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -871,3 +871,16 @@ CWWKD1085.extra.method.params=CWWKD1085E: The parameters of the {0} method \
 CWWKD1085.extra.method.params.explanation=All of the method parameters must be \
  used by the query or be Jakarta Data defined parameter types.
 CWWKD1085.extra.method.params.useraction=Remove the extra method parameters.
+
+CWWKD1086.named.params.unused=CWWKD1086E: The parameters of the {0} method \
+ of the {1} repository interface define named parameters ({2}) that are not \
+ used in the Query annotation value: {3}. You can refer to named parameters \
+ in a query by using the : character followed by the parameter name. \
+ For example, {4}. You can refer to positional parameters in a query by using \
+ the ? character followed by the ordinal value, starting with ?1. Do not \
+ annotated method parameters to have the Param annotation when the query \
+ uses positional parameters or has no parameters.
+CWWKD1086.named.params.unused.explanation=The Param annotation can only be used \
+ when the query has named parameters.
+CWWKD1086.named.params.unused.useraction=Remove the Param annotation or switch \
+ the query to use named parameters.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -165,7 +165,7 @@ public class PageImpl<T> implements Page<T> {
     @Override
     public PageRequest previousPageRequest() {
         if (pageRequest.page() > 1)
-            return PageRequest.ofPage(pageRequest.page() - 2, pageRequest.size(), pageRequest.requestTotal());
+            return PageRequest.ofPage(pageRequest.page() - 1, pageRequest.size(), pageRequest.requestTotal());
         else
             throw exc(NoSuchElementException.class,
                       "CWWKD1038.no.prev.offset.page",

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1014,7 +1014,7 @@ public class QueryInfo {
     @Trivial
     private UnsupportedOperationException excMixedQLParamTypes(int methodNPCount) {
         String firstNamedParam = null;
-        StringBuilder allNamedParams = new StringBuilder();
+        StringBuilder allNamedParams = new StringBuilder().append('(');
         for (String name : paramNames) {
             if (firstNamedParam == null)
                 firstNamedParam = name;
@@ -1022,6 +1022,7 @@ public class QueryInfo {
                 allNamedParams.append(", ");
             allNamedParams.append(':').append(name);
         }
+        allNamedParams.append(')');
 
         Class<?> firstNamedParamType = String.class;
         for (Parameter p : method.getParameters()) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -939,31 +939,41 @@ public class QueryInfo {
     @Trivial
     private MappingException excExtraMethodArgNamedParams(Set<String> extras,
                                                           Set<String> qlRequired) {
-        boolean first = true;
+        String firstExtraParam = null;
         StringBuilder extraParamNames = new StringBuilder();
         for (String name : extras) {
-            if (!first)
+            if (firstExtraParam == null)
+                firstExtraParam = name;
+            else
                 extraParamNames.append(", ");
             extraParamNames.append(name);
-            first = false;
         }
 
-        first = true;
+        boolean isFirst = true;
         StringBuilder qlParamNames = new StringBuilder();
         for (String name : qlRequired) {
-            if (!first)
+            if (!isFirst)
                 qlParamNames.append(", ");
             qlParamNames.append(':').append(name);
-            first = false;
+            isFirst = false;
         }
 
-        return exc(MappingException.class,
-                   "CWWKD1085.extra.method.params",
-                   method.getName(),
-                   repositoryInterface.getName(),
-                   extraParamNames,
-                   qlParamNames,
-                   method.getAnnotation(Query.class).value());
+        if (qlRequired.isEmpty())
+            return exc(MappingException.class,
+                       "CWWKD1086.named.params.unused",
+                       method.getName(),
+                       repositoryInterface.getName(),
+                       extraParamNames,
+                       method.getAnnotation(Query.class).value(),
+                       ':' + firstExtraParam);
+        else
+            return exc(MappingException.class,
+                       "CWWKD1085.extra.method.params",
+                       method.getName(),
+                       repositoryInterface.getName(),
+                       extraParamNames,
+                       qlParamNames,
+                       method.getAnnotation(Query.class).value());
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1828,9 +1828,6 @@ public class QueryInfo {
                 // Look for single entity attribute with the desired type:
                 String singleAttributeName = null;
                 for (Map.Entry<String, Class<?>> entry : entityInfo.attributeTypes.entrySet()) {
-                    // TODO include type variable for collection element in comparison?
-                    // JPA metamodel might not be including this information
-                    Class<?> collectionElementType = entityInfo.collectionElementTypes.get(entry.getKey());
                     Class<?> attributeType = entry.getValue();
                     if (attributeType.isPrimitive())
                         attributeType = wrapperClassIfPrimitive(attributeType);
@@ -1873,7 +1870,6 @@ public class QueryInfo {
                                 first = false;
                             }
                         else
-                            // TODO include/exclude Page/CursoredPage based on whether PageRequest is supplied?
                             throw exc(MappingException.class,
                                       "CWWKD1005.find.rtrn.err",
                                       method.getName(),
@@ -2295,20 +2291,6 @@ public class QueryInfo {
                 throw new DataException(x instanceof InvocationTargetException ? x.getCause() : x);
             }
         return cursorValues.toArray();
-    }
-
-    /**
-     * Identifies possible positions of named parameters within the JPQL.
-     *
-     * @param jpql JPQL
-     * @return possible positions of named parameters within the JPQL.
-     */
-    @Trivial
-    private static List<Integer> getParameterPositions(String jpql) { // TODO move this to where we are already stepping through the QL
-        List<Integer> positions = new ArrayList<>();
-        for (int index = 0; (index = jpql.indexOf(':', index)) >= 0;)
-            positions.add(++index);
-        return positions;
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2066,6 +2066,32 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Verify a repository method can use JPQL query language that supplies
+     * id(this) as an argument to another function.
+     */
+    @Test
+    public void testFunctionWithIdThisArg() {
+        vehicles.delete();
+
+        Vehicle v1 = new Vehicle();
+        v1.make = "Chevrolet";
+        v1.model = "Silverado";
+        v1.numSeats = 3;
+        v1.price = 38000f;
+        v1.vinId = "CS102030405060708";
+        vehicles.save(List.of(v1));
+
+        v1 = vehicles.withVINLowerCase("cs102030405060708").orElseThrow();
+        assertEquals("Chevrolet", v1.make);
+        assertEquals("Silverado", v1.model);
+        assertEquals(3, v1.numSeats);
+        assertEquals(38000f, v1.price, 0.001f);
+        assertEquals("CS102030405060708", v1.vinId);
+
+        assertEquals(1L, vehicles.delete());
+    }
+
+    /**
      * Verify that ORDER BY can be generated, taking into account the entity variable name of a custom query.
      * The custom query in this case has no WHERE clause.
      * Other tests cover similar scenarios in which a WHERE clause is present.
@@ -3610,19 +3636,6 @@ public class DataTestServlet extends FATServlet {
     public void testNamedParametersFromMethodParameterNames() {
         assertArrayEquals(new long[] { 19, 29, 43, 47 },
                           primes.matchAny(19, "XLVII", "2B", "twenty-nine"));
-    }
-
-    /**
-     * Use a repository query with both named parameters and positional parameters. Expect this to be rejected.
-     */
-    @Test
-    public void testNamedParametersMixedWithPositionalParameters() {
-        try {
-            Collection<Long> found = primes.matchAnyWithMixedUsageOfPositionalAndNamed("three", 23);
-            fail("Should not be able to mix positional and named parameters. Found: " + found);
-        } catch (MappingException x) {
-            // expected
-        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -480,6 +480,41 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Asynchronous repository method that returns a CompletableFuture of Page.
+     */
+    @Test
+    public void testCompletableFutureOfPage() throws ExecutionException, //
+                    InterruptedException, TimeoutException {
+        PageRequest page1req = PageRequest.ofPage(1).size(4);
+        PageRequest page3req = PageRequest.ofPage(3).size(4);
+
+        Order<Prime> asc = Order.by(Sort.asc(ID));
+
+        CompletableFuture<Page<Long>> cf1 = //
+                        primes.divisibleByTwo(false, page1req, asc);
+
+        CompletableFuture<Page<Long>> cf3 = //
+                        primes.divisibleByTwo(false, page3req, asc);
+
+        Page<Long> page1 = cf1.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+        Page<Long> page3 = cf3.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+
+        assertEquals(List.of(3L, 5L, 7L, 11L),
+                     page1.content());
+
+        assertEquals(List.of(29L, 31L, 37L, 41L),
+                     page3.content());
+
+        PageRequest page2req = page3.previousPageRequest();
+        assertEquals(page2req, page1.nextPageRequest());
+
+        assertEquals(List.of(13L, 17L, 19L, 23L),
+                     primes.divisibleByTwo(false, page2req, asc)
+                                     .thenApply(Page::content)
+                                     .get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
+    }
+
+    /**
      * Asynchronous repository method that returns a CompletionStage of CursoredPage.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -279,9 +279,6 @@ public interface Primes {
                                                          String numeral,
                                                          @Param("hexadecimal") String hex);
 
-    @Query("SELECT o.numberId FROM Prime o WHERE (o.name = ?1 OR o.numberId=:num)")
-    Collection<Long> matchAnyWithMixedUsageOfPositionalAndNamed(String name, long num);
-
     @Query("SELECT name WHERE numberId < 50 AND LEFT(name, LENGTH(:s)) = :s")
     @OrderBy("name")
     List<String> matchLeftSideOfName(@Param("s") String searchFor);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -104,6 +104,12 @@ public interface Primes {
     @Asynchronous
     CompletableFuture<Short> countByNumberIdBetweenAndEvenNot(long first, long last, boolean isOdd);
 
+    @Asynchronous
+    @Find
+    CompletableFuture<Page<Long>> divisibleByTwo(boolean even,
+                                                 PageRequest req,
+                                                 Order<Prime> order);
+
     @Find
     Stream<Prime> find(boolean even, int sumOfBits, Limit limit, Sort<?>... sorts);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 
 import jakarta.data.Limit;
 import jakarta.data.repository.Delete;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 
@@ -64,4 +65,9 @@ public interface Vehicles {
     Iterable<Vehicle> save(Iterable<Vehicle> v);
 
     boolean updateByVinIdAddPrice(String vin, float priceIncrease);
+
+    // TODO switch to the following once #29893 is fixed
+    //@Query("WHERE LOWER(ID(THIS)) = ?1")
+    @Query("WHERE LOWER(vinId) = ?1")
+    Optional<Vehicle> withVINLowerCase(String lowerCaseVIN);
 }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -39,12 +39,18 @@ public class DataErrPathsTest extends FATServletClient {
      */
     private static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
+                                   "CWWJP9991W.*4002", // 2 persistence units attempt to autocreate same table
+                                   "CWWKD1019E.*livingAt", // mix of named/positional parameters
+                                   "CWWKD1019E.*residingAt", // unused parameters
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",
                                    "CWWKD1078E.*test.jakarta.data.errpaths.web.InvalidNonJNDIRepo",
                                    "CWWKD1079E.*test.jakarta.data.errpaths.web.InvalidJNDIRepo",
                                    "CWWKD1080E.*test.jakarta.data.errpaths.web.InvalidDatabaseRepo",
                                    "CWWKD1082E.*test.jakarta.data.errpaths.web.WrongPersistenceUnitRefRepo",
-                                   "CWWJP9991W.*4002" // 2 persistence units attempt to autocreate same table
+                                   "CWWKD1083E.*bornOn", // duplicate Param annotations
+                                   "CWWKD1084E.*bornIn", // Param annotation omitted
+                                   "CWWKD1084E.*livingIn", // named parameter mismatch
+                                   "CWWKD1085E.*livingOn" // extra Param annotations
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -50,7 +50,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1083E.*bornOn", // duplicate Param annotations
                                    "CWWKD1084E.*bornIn", // Param annotation omitted
                                    "CWWKD1084E.*livingIn", // named parameter mismatch
-                                   "CWWKD1085E.*livingOn" // extra Param annotations
+                                   "CWWKD1085E.*livingOn", // extra Param annotations
+                                   "CWWKD1086E.*withAddressShorterThan" // Param used for positional parameter
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -214,6 +214,24 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Verify an error is raised for a repository method with a query that
+     * requires 1 positional parameter, but the method supplies 3 parameters.
+     */
+    @Test
+    public void testExtraPositionalParameters() {
+        try {
+            List<Voter> found = voters.withAddressLongerThan(20, 25, 30);
+            fail("Method with extra positional parameters ought to raise an" +
+                 " error. Instead found: " + found);
+        } catch (IllegalArgumentException x) {
+            // Error is detected by EclipseLink
+            if (x.getMessage() == null ||
+                !x.getMessage().contains("WHERE LENGTH(address) > ?1"))
+                throw x;
+        }
+    }
+
+    /**
      * Verify an error is raised for a repository method that has a Param annotation
      * that specifies a name value that does not match the name of a named parameter
      * from the query.
@@ -248,6 +266,25 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1084E:") ||
                 !x.getMessage().contains("bornIn"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that attempts to use
+     * the Param annotation (which is for named parameters only) to supply its
+     * single positional parameter.
+     */
+    @Test
+    public void testParamUsedForPositionalParameter() {
+        try {
+            List<Voter> found = voters.withAddressShorterThan(100);
+            fail("Method that tries to use Param for a positional parameter" +
+                 " ought to raise an error. Instead found: " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1086E:") ||
+                !x.getMessage().contains("(maxLength)"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -25,6 +25,7 @@ import jakarta.annotation.sql.DataSourceDefinition;
 import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.exceptions.DataException;
+import jakarta.data.exceptions.MappingException;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.inject.Inject;
@@ -130,6 +131,124 @@ public class DataErrPathsTestServlet extends FATServlet {
             }
         } catch (Exception x) {
             throw new ServletException(x);
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that attempts to use
+     * both named parameters and positional parameters in the same query.
+     */
+    @Test
+    public void testBothNamedAndPositionalParameters() {
+        try {
+            List<Voter> found = voters.livingAt(701,
+                                                "Silver Creek Rd NE",
+                                                "Rochester",
+                                                "MN",
+                                                55906);
+            fail("Method that mixes named parameters with positional parameters" +
+                 " ought to raise an appropriate error. Instead found: " + found);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1019E:") ||
+                !x.getMessage().contains("livingAt"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that defines two method
+     * parameters (Param annotation) for the same named parameter.
+     */
+    @Test
+    public void testDuplicateNamedParam() {
+        try {
+            List<Voter> found = voters.bornOn(1977, Month.SEPTEMBER, 9, 26);
+            fail("Method with two Param annotations for the same named parameter" +
+                 " ought to raise an appropriate error. Instead found: " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1083E:") ||
+                !x.getMessage().contains("bornOn"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that has extra Param
+     * annotations that do not correspond to any named parameters in the query.
+     */
+    @Test
+    public void testExtraParamAnnos() {
+        try {
+            List<Voter> found = voters.livingOn("E River Rd NE", "Rochester", "MN");
+            fail("Method with extra Param annotations ought to raise an error." +
+                 " Instead found: " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1085E:") ||
+                !x.getMessage().contains("livingOn"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that has extra method
+     * parameters that do not correspond to any parameters in the query.
+     */
+    @Test
+    public void testExtraParameters() {
+        try {
+            List<Voter> found = voters.residingAt(701,
+                                                  "Silver Creek Rd NE",
+                                                  "Rochester",
+                                                  "MN");
+            fail("Method with extra method parameters ought to raise an error." +
+                 " Instead found: " + found);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1019E:") ||
+                !x.getMessage().contains("residingAt"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that has a Param annotation
+     * that specifies a name value that does not match the name of a named parameter
+     * from the query.
+     */
+    @Test
+    public void testMismatchedParameterNames() {
+        try {
+            List<Voter> found = voters.livingIn("Rochester", "MN");
+            fail("Method where the Param annotation specifies a name that does" +
+                 " not match a named parameter in the query ought to raise an. " +
+                 " error. Instead found: " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1084E:") ||
+                !x.getMessage().contains("livingIn"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that defines two method
+     * parameters (Param annotation) for the same named parameter.
+     */
+    @Test
+    public void testMissingParamAnno() {
+        try {
+            List<Voter> found = voters.bornIn(1951);
+            fail("Method that lacks a Param annotation and runs without the" +
+                 " -parameters compile option ought to raise an error. " +
+                 " Instead found: " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1084E:") ||
+                !x.getMessage().contains("bornIn"))
+                throw x;
         }
     }
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -12,13 +12,103 @@
  *******************************************************************************/
 package test.jakarta.data.errpaths.web;
 
+import java.time.Month;
+import java.util.List;
+
 import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Param;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
 /**
  * Repository with a valid entity.
+ * Some methods are valid.
+ * Others have errors, as indicated.
  */
 @Repository(dataStore = "java:app/jdbc/DerbyDataSource")
 public interface Voters extends BasicRepository<Voter, Integer> {
 
+    /**
+     * This invalid method neglects to include the Param annotation for a
+     * named parameter and is not running with -parameters enabled.
+     */
+    @Query("""
+                    WHERE EXTRACT(YEAR FROM birthday) = :year
+                    ORDER BY EXTRACT(MONTH FROM birthday) ASC,
+                             EXTRACT(DAY FROM birthday) ASC,
+                             ssn ASC
+                    """)
+    List<Voter> bornIn(int year); // missing @Param and -parameters not used
+
+    /**
+     * This invalid method has two Param annotations for the "month" named parameter.
+     */
+    @Query("""
+                    WHERE EXTRACT(YEAR FROM birthday) = :year
+                      AND EXTRACT(MONTH FROM birthday) = :month
+                      AND EXTRACT(DAY FROM birthday) = :day
+                    ORDER BY EXTRACT(YEAR FROM birthday) DESC,
+                             EXTRACT(MONTH FROM birthday) ASC,
+                             EXTRACT(DAY FROM birthday) ASC,
+                             ssn ASC
+                    """)
+    List<Voter> bornOn(@Param("year") int yearBorn,
+                       @Param("month") Month monthBorn,
+                       @Param("month") int monthNum, // duplicate parameter name
+                       @Param("day") int dayBorn);
+
+    /**
+     * This invalid method has a mixture of positional and named parameters.
+     */
+    @Query("""
+                    WHERE LOWER(address) = LOWER(CONCAT(?1, ?2, :city, ?4, :zip))
+                    ORDER BY LOWER(address) ASC,
+                             ssn ASC
+                    """)
+    List<Voter> livingAt(int houseNum,
+                         String streetName,
+                         @Param("city") String city,
+                         String stateCode,
+                         @Param("zip") int zip);
+
+    /**
+     * This invalid method has a mismatch between one of the named parameter names
+     * (:stateCode) and the Param annotation (state).
+     */
+    @Query("""
+                    WHERE UPPER(address) LIKE CONCAT('% ', UPPER(:city), ', %')
+                      AND UPPER(address) LIKE CONCAT('%, ', UPPER(:stateCode), ' %')
+                    ORDER BY UPPER(address) ASC,
+                             ssn ASC
+                    """)
+    List<Voter> livingIn(@Param("city") String city,
+                         @Param("state") String stateCode); // Param does not match
+
+    /**
+     * This invalid method has extra Param annotations (city, state) that are not
+     * used in the query.
+     */
+    @Query("""
+                    WHERE UPPER(address) LIKE CONCAT('% ', UPPER(:street), ', %')
+                    ORDER BY UPPER(address) ASC,
+                             ssn ASC
+                    """)
+    List<Voter> livingOn(@Param("street") String street,
+                         @Param("city") String city, // extra, unused Param
+                         @Param("state") String stateCode); // extra, unused Param
+
+    /**
+     * This invalid method has matching named parameters and Param annotation,
+     * but also has extra parameters (city, stateCode) that are not used in the
+     * query.
+     */
+    @Query("""
+                    WHERE address LIKE CONCAT(:houseNum, ' ', :street, ', %')
+                    ORDER BY address ASC,
+                             ssn ASC
+                    """)
+    List<Voter> residingAt(@Param("houseNum") int houseNum,
+                           @Param("street") String street,
+                           String city, // extra, unused parameter
+                           String stateCode); // extra, unused parameter
 }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -111,4 +111,19 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                            @Param("street") String street,
                            String city, // extra, unused parameter
                            String stateCode); // extra, unused parameter
+
+    /**
+     * This invalid method has a query that requires a single positional parameter,
+     * but the method supplies 3 parameters.
+     */
+    @Query("WHERE LENGTH(address) > ?1 ORDER BY ssn ASC")
+    List<Voter> withAddressLongerThan(int min1, int min2, int min3);
+
+    /**
+     * This invalid method has a query that requires a positional parameter,
+     * but the method uses the Param annotation to defined a named parameter
+     * instead.
+     */
+    @Query("WHERE LENGTH(address) < ?1 ORDER BY ssn ASC")
+    List<Voter> withAddressShorterThan(@Param("maxLength") int maxAddressLength);
 }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/_Voter.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/_Voter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import jakarta.data.metamodel.SortableAttribute;
+import jakarta.data.metamodel.StaticMetamodel;
+import jakarta.data.metamodel.TextAttribute;
+import jakarta.data.metamodel.impl.SortableAttributeRecord;
+import jakarta.data.metamodel.impl.TextAttributeRecord;
+
+/**
+ * Static metamodel for the Voter entity.
+ */
+@StaticMetamodel(Voter.class)
+public interface _Voter {
+    String ADDRESS = "address";
+    String BIRTHDAY = "birthday";
+    String NAME = "name";
+    String PHONE_NUMBER = "phoneNumber"; // not an attribute of the entity
+    String SSN = "ssn";
+
+    TextAttribute<Voter> address = new TextAttributeRecord<>(ADDRESS);
+
+    SortableAttribute<Voter> birthday = new SortableAttributeRecord<>(BIRTHDAY);
+
+    TextAttribute<Voter> name = new TextAttributeRecord<>(NAME);
+
+    // not an attribute of the entity
+    SortableAttribute<Voter> phoneNumber = new SortableAttributeRecord<>(PHONE_NUMBER);
+
+    SortableAttribute<Voter> ssn = new SortableAttributeRecord<>(SSN);
+}

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -526,7 +526,7 @@ public class DataExperimentalServlet extends FATServlet {
      * Repository method performing a parameter-based query on a compound entity Id which is an IdClass,
      * where the method parameter is annotated with By.
      */
-    // TODO enable once ? is fixed. EclipseLink rejects LOWER(id(o)) with:
+    // TODO enable once #29893 is fixed. EclipseLink rejects LOWER(id(o)) with:
     // The encapsulated expression is not a valid expression.
     //@Test
     public void testIdClassFindByAnnotatedParameter() {


### PR DESCRIPTION
Test various error paths where the user incorrectly specifies named and positional parameters on repository methods.
This includes scenarios such as mixing the two types, having too many or too few parameters, having duplicate definitions of a named parameter, and so forth.  NLS messages are added (or in one case, updated) for these error paths, including detailed information that will be important to users for figuring out how to correct the problem.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
