### PR TITLE
(OIDC Test) Removing case sensitive check on cookie attributes

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/CommonTests/CookieNameOidcClientTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/CommonTests/CookieNameOidcClientTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -131,8 +132,9 @@ public class CookieNameOidcClientTests extends CommonTest {
         }
         boolean foundExpiredCookie = false;
         if (cookieLine != null) {
-            foundExpiredCookie = JakartaEEAction.isEE10OrLaterActive() ? cookieLine.contains("max-age=0") : 
-                (cookieLine.contains("Expires=") && cookieLine.contains("16:00"));
+            String lowerCookieLine = cookieLine.toLowerCase(Locale.ENGLISH);
+            foundExpiredCookie = JakartaEEAction.isEE10OrLaterActive() ? lowerCookieLine.contains("max-age=0") : 
+                (lowerCookieLine.contains("expires=") && cookieLine.contains("16:00"));
         }
         Assert.assertTrue("did not find expected expired cookie", foundExpiredCookie);
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Cookie attributes are defined to be case-insensitive according to the HTTP specification. However, our test code was performing case-sensitive checks on cookie attributes. This caused tests to fail when cookie attributes had different casing (e.g., `Max-Age=0` vs `max-age=0`).

This PR updates the test code to perform case-insensitive checks on cookie attributes. This change is in accordance to [RFC 6265 Section 4.1:](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1) "Attribute names are case-insensitive."
