### PR TITLE
Don't import jsonsupport

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.server.rest/bnd.bnd
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/bnd.bnd
@@ -31,7 +31,6 @@ Private-Package: \
   com.ibm.ws.jmx.connector.server.internal.resources.*
 
 Import-Package: \
-  com.ibm.websphere.jsonsupport;version='[1.0,2.0)', \
   *
 
 Export-Package: \
@@ -95,7 +94,6 @@ instrument.classesExcludes: com/ibm/ws/jmx/connector/server/internal/resources/*
 	com.ibm.ws.jmx.request;version=latest,\
 	com.ibm.websphere.rest.handler;version=latest,\
 	com.ibm.ws.rest.handler;version=latest,\
-	io.openliberty.jsonsupport.internal;version=latest,\
 	com.ibm.ws.webcontainer;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 


### PR DESCRIPTION
This is an unused dependcy

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).

##################################

The com.ibm.ws.jmx.connector.server.rest bundle imports the com.ibm.websphere.jsonsupport package, but doesn't appear to make any use of it, so the dependency should probably be removed.