### PR TITLE
Fix Class path for com.ibm.ws.security.oidc.client_fat.spnego

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/bnd.bnd
@@ -30,4 +30,10 @@ fat.project: true
     com.ibm.ws.security.spnego_fat;version=latest,\
     com.ibm.ws.security.spnego.fat.common;version=latest,\
     com.ibm.ws.security.token.s4u2;version=latest,\
-    net.sourceforge.htmlunit:htmlunit;version=2.44.0
+    org.apache.httpcomponents:httpclient;version=4.1.2,\
+    org.apache.httpcomponents:httpcore;version=4.1.2,\
+    net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
+    net.sourceforge.htmlunit:htmlunit-cssparser;version=1.6.0,\
+	net.sourceforge.htmlunit:webdriver;version=2.6,\
+    xalan:xalan;version=2.7.2, \
+    org.brotli:dec;version=0.1.2

--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021,2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/build.gradle
@@ -20,8 +20,12 @@ dependencies {
                'org.apache.sshd:sshd-core:2.9.2',
                'org.apache.sshd:sshd-scp:2.9.2',
                'net.sourceforge.htmlunit:htmlunit:2.44.0',
+               'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
                'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
                'rhino:js:1.6R5',
+               'xalan:xalan:2.7.2',
+               'org.brotli:dec:0.1.2',
+               project(':io.openliberty.org.apache.xercesImpl'),
                project(':io.openliberty.org.apache.commons.codec'), // 1.15 (was 1.4)
                'org.apache.httpcomponents:httpclient:4.1.2',
                'org.apache.httpcomponents:httpcore:4.1.2',


### PR DESCRIPTION
We are seeing the following failure:
```java
test_SPNEGO_OIDC_Client_GetMainPath_NotContain_no_Config:java.lang.NoClassDefFoundError: 2024-08-02-11:44:00:518 org.brotli.dec.BrotliInputStream at com.gargoylesoftware.htmlunit.WebClient.<clinit>(WebClient.java:161) at com.ibm.ws.security.fat.common.TestHelpers.getWebClient(TestHelpers.java:496) at com.ibm.ws.security.fat.common.CommonTest.getAndSaveWebClient(CommonTest.java:178) at com.ibm.ws.security.openidconnect.client_fat.spnego.config.SpnegoGenericOidcClientConsent_ConfigTests.test_SPNEGO_OIDC_Client_GetMainPath_NotContain_no_Config(SpnegoGenericOidcClientConsent_ConfigTests.java:74) at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:204) at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:364) at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:178)
```

This is because the classpath for `com.ibm.ws.security.oidc.client_fat.spnego` is missing some bundles. 


- [ X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
