### PR TITLE
(LibertyOP Test) Removing case sensitivity from cookie attribute

### DIFF
--- a/dev/com.ibm.ws.security.social_fat.LibertyOP.1/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_CookieVerificationTests.java
+++ b/dev/com.ibm.ws.security.social_fat.LibertyOP.1/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_CookieVerificationTests.java
@@ -105,8 +105,8 @@ public class LibertyOP_CookieVerificationTests extends SocialCommonTest {
                 Constants.RESPONSE_COOKIE, Constants.STRING_MATCHES,
                 "Should have found a WASOidcNonce cookie but didn't.", null,
                 "WASOidcNonce[pn][0-9]+=[^" + CommonValidationTools.COOKIE_DELIMITER + "]+");
-        String expirationCookieFormat = JakartaEEAction.isEE10OrLaterActive() ? "; max-age=0"
-                : "; Expires=Thu, 01 Dec 1994";
+        String expirationCookieFormat = JakartaEEAction.isEE10OrLaterActive() ? ";(?i) max-age=0"
+                : ";(?i) Expires=Thu, 01 Dec 1994";
         expectations = vData.addExpectation(expectations, SocialConstants.LIBERTYOP_PERFORM_SOCIAL_LOGIN,
                 Constants.RESPONSE_HEADER, Constants.STRING_MATCHES,
                 "Should have found a Set-Cookie header to clear the WASOidcState cookie but didn't.", null,


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This pull request fixes a test failure caused by changes in casing for cookie attributes. This test was written expecting the casing `max-age` or `Expires`. 

This presents an issue if the response is provided with a `Set-Cookie` header that contains different casing for the attributes. For example, `Max-Age`. The `(?i)` inline flag is now used in the regular expression to allow either casing version to be accepted. 

This change aligns with [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.2), which specifies cookie attribute names are case insensitive.
