### PR TITLE
interrupt virtual threads when application component stops

### DIFF
--- a/dev/com.ibm.ws.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent/bnd.bnd
@@ -45,20 +45,10 @@ Include-Resource:\
   com.ibm.ws.concurrent.internal.ContextServiceImpl,\
   com.ibm.ws.concurrent.internal.ManagedExecutorServiceImpl,\
   com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl,\
-  com.ibm.ws.concurrent.internal.ManagedThreadFactoryService
+  com.ibm.ws.concurrent.internal.ManagedThreadFactoryService,\
+  com.ibm.ws.concurrent.internal.ThreadGroupTracker
 
 -dsannotations-inherit: true
-
-Service-Component:\
-  com.ibm.ws.concurrent.tracker;\
-      provide:='\
-        com.ibm.ws.container.service.metadata.ComponentMetaDataListener,\
-        com.ibm.ws.concurrent.internal.ThreadGroupTracker';\
-    implementation:=com.ibm.ws.concurrent.internal.ThreadGroupTracker;\
-    configuration-policy:=ignore;\
-    immediate:=true;\
-    deferrableScheduledExecutor='java.util.concurrent.ScheduledExecutorService(deferrable=true)';\
-    metadataIdentifierService=com.ibm.ws.container.service.metadata.extended.MetaDataIdentifierService
 
 instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 


### PR DESCRIPTION
The Concurrency spec requires managed threads to be interrupted when the application artifact that created them stops. This is already being done for managed platform threads, but needs to be done for managed virtual threads as well, which is covered in this PR.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
