### PR TITLE
cancelled: 28009 delivery delay fat rework

### DIFF
--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/DelayFullTest.java
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/DelayFullTest.java
@@ -199,10 +199,19 @@ public class DelayFullTest {
         return TestUtils.runInServlet(clientHost, clientPort, ddContextRoot, test); // throws IOException
     }
 
+    /**
+     * Tests using different delivery delay values when sending messages to a Queue destination.
+     * Runs tests with both simplified and domain-specific APIs
+     * 
+     * @throws Exception
+     */
     @Test
     public void testDeliveryDelayForDifferentDelays_B() throws Exception {
+    	
+    	// Configure server to use MDB receiving from "local" Queue
         restartClient(MDB_CONFIG_QUEUE_BINDINGS);
 
+        // Run test using simplified API
         runInServlet("testDeliveryDelayForDifferentDelays");
 
         String msg = clientServer.waitForStringInLogUsingLastOffset("Message received on mdb : QueueBindingsMessage2");
@@ -210,8 +219,22 @@ public class DelayFullTest {
         msg = clientServer.waitForStringInLogUsingLastOffset("Message received on mdb : QueueBindingsMessage1");
         assertNotNull("Could not find the upload message in the trace.log", msg);
 
+
+        // Run the test using domain-specific API
+        runInServlet("testDeliveryDelayForDifferentDelaysClassicApi");
+
+        msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : QueueBindingsMessage2-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+        msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : QueueBindingsMessage1-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+        
+        
+    	// Configure server to use MDB receiving from "remote" Queue
         restartServers(MDB_CONFIG_QUEUE_TCP);
 
+        // Run test using simplified API
         runInServlet("testDeliveryDelayForDifferentDelays_Tcp");
 
         msg = clientServer.waitForStringInLogUsingLastOffset("Message received on mdb : QueueTCPMessage2");
@@ -219,24 +242,7 @@ public class DelayFullTest {
         msg = clientServer.waitForStringInLogUsingLastOffset("Message received on mdb : QueueTCPMessage1");
         assertNotNull("Could not find the upload message in the trace.log", msg);
 
-        restartServers();
-    }
-
-    @Test
-    public void testDeliveryDelayForDifferentDelaysClassicApi() throws Exception {
-        restartClient(MDB_CONFIG_QUEUE_BINDINGS);
-
-        runInServlet("testDeliveryDelayForDifferentDelaysClassicApi");
-
-        String msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : QueueBindingsMessage2-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-        msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : QueueBindingsMessage1-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-
-        restartServers(MDB_CONFIG_QUEUE_TCP);
-
+        // Run test using domain-specific API
         runInServlet("testDeliveryDelayForDifferentDelaysClassicApi_Tcp");
 
         msg = clientServer.waitForStringInLogUsingLastOffset(
@@ -245,14 +251,25 @@ public class DelayFullTest {
         msg = clientServer.waitForStringInLogUsingLastOffset(
             "Message received on mdb : QueueTCPMessage1-ClassicApi");
         assertNotNull("Could not find the upload message in the trace.log", msg);
-
+        
+        
         restartServers();
     }
 
+
+    /**
+     * Tests using different delivery delay values when sending messages to a Topic destination.
+     * Runs tests with both simplified and domain-specific APIs
+     * 
+     * @throws Exception
+     */
     @Test
     public void testDeliveryDelayForDifferentDelaysTopic_B() throws Exception {
-        restartClient(MDB_CONFIG_TOPIC_BINDINGS);
 
+    	// Configure server to use MDB receiving from "local" Topic
+    	restartClient(MDB_CONFIG_TOPIC_BINDINGS);
+
+    	// Run test using simplified API
         runInServlet("testDeliveryDelayForDifferentDelaysTopic");
 
         String msg = clientServer.waitForStringInLogUsingLastOffset("Message received on mdb : TopicBindingsMessage2");
@@ -260,8 +277,20 @@ public class DelayFullTest {
         msg = clientServer.waitForStringInLogUsingLastOffset("Message received on mdb : TopicBindingsMessage1");
         assertNotNull("Could not find the upload message in the trace.log", msg);
 
+        // Run test using domain-specific API
+        runInServlet("testDeliveryDelayForDifferentDelaysTopicClassicApi");
+
+        msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : TopicBindingsMessage2-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+        msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : TopicBindingsMessage1-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+        
+    	// Configure server to use MDB receiving from "remote" Topic
         restartServers(MDB_CONFIG_TOPIC_TCP);
 
+        // Run test using simplified API
         runInServlet("testDeliveryDelayForDifferentDelaysTopic_Tcp");
 
         msg = clientServer.waitForStringInLogUsingLastOffset("Message received on mdb : TopicTCPMessage2");
@@ -269,24 +298,7 @@ public class DelayFullTest {
         msg = clientServer.waitForStringInLogUsingLastOffset("Message received on mdb : TopicTCPMessage1");
         assertNotNull("Could not find the upload message in the trace.log", msg);
 
-        restartServers();
-    }
-    
-    @Test
-    public void testDeliveryDelayForDifferentDelaysTopicClassicApi()throws Exception {
-        restartClient(MDB_CONFIG_TOPIC_BINDINGS);
-
-        runInServlet("testDeliveryDelayForDifferentDelaysTopicClassicApi");
-
-        String msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : TopicBindingsMessage2-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-        msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : TopicBindingsMessage1-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-
-        restartServers(MDB_CONFIG_TOPIC_TCP);
-
+        // Run test using domain-specific API
         runInServlet("testDeliveryDelayForDifferentDelaysTopicClassicApi_Tcp");
         msg = clientServer.waitForStringInLogUsingLastOffset(
             "Message received on mdb : TopicTCPMessage2-ClassicApi");
@@ -297,7 +309,6 @@ public class DelayFullTest {
 
         restartServers();
     }
-    
 
     @Test
     public void testPersistentMessageStore_B() throws Exception {

--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/DelayFullTest.java
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/DelayFullTest.java
@@ -206,7 +206,7 @@ public class DelayFullTest {
      * @throws Exception
      */
     @Test
-    public void testDeliveryDelayForDifferentDelays_B() throws Exception {
+    public void testDeliveryDelayForDifferentDelays_Queue() throws Exception {
     	
     	// Configure server to use MDB receiving from "local" Queue
         restartClient(MDB_CONFIG_QUEUE_BINDINGS);
@@ -264,7 +264,7 @@ public class DelayFullTest {
      * @throws Exception
      */
     @Test
-    public void testDeliveryDelayForDifferentDelaysTopic_B() throws Exception {
+    public void testDeliveryDelayForDifferentDelays_Topic() throws Exception {
 
     	// Configure server to use MDB receiving from "local" Topic
     	restartClient(MDB_CONFIG_TOPIC_BINDINGS);

--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/DelayFullTest.java
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/DelayFullTest.java
@@ -223,6 +223,33 @@ public class DelayFullTest {
     }
 
     @Test
+    public void testDeliveryDelayForDifferentDelaysClassicApi() throws Exception {
+        restartClient(MDB_CONFIG_QUEUE_BINDINGS);
+
+        runInServlet("testDeliveryDelayForDifferentDelaysClassicApi");
+
+        String msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : QueueBindingsMessage2-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+        msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : QueueBindingsMessage1-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+
+        restartServers(MDB_CONFIG_QUEUE_TCP);
+
+        runInServlet("testDeliveryDelayForDifferentDelaysClassicApi_Tcp");
+
+        msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : QueueTCPMessage2-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+        msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : QueueTCPMessage1-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+
+        restartServers();
+    }
+
+    @Test
     public void testDeliveryDelayForDifferentDelaysTopic_B() throws Exception {
         restartClient(MDB_CONFIG_TOPIC_BINDINGS);
 
@@ -244,6 +271,33 @@ public class DelayFullTest {
 
         restartServers();
     }
+    
+    @Test
+    public void testDeliveryDelayForDifferentDelaysTopicClassicApi()throws Exception {
+        restartClient(MDB_CONFIG_TOPIC_BINDINGS);
+
+        runInServlet("testDeliveryDelayForDifferentDelaysTopicClassicApi");
+
+        String msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : TopicBindingsMessage2-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+        msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : TopicBindingsMessage1-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+
+        restartServers(MDB_CONFIG_TOPIC_TCP);
+
+        runInServlet("testDeliveryDelayForDifferentDelaysTopicClassicApi_Tcp");
+        msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : TopicTCPMessage2-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+        msg = clientServer.waitForStringInLogUsingLastOffset(
+            "Message received on mdb : TopicTCPMessage1-ClassicApi");
+        assertNotNull("Could not find the upload message in the trace.log", msg);
+
+        restartServers();
+    }
+    
 
     @Test
     public void testPersistentMessageStore_B() throws Exception {
@@ -285,58 +339,6 @@ public class DelayFullTest {
         assertTrue("testPersistentMessageStoreTopic_B failed", testResult);
     }
 
-    @Test
-    public void testDeliveryDelayForDifferentDelaysClassicApi() throws Exception {
-        restartClient(MDB_CONFIG_QUEUE_BINDINGS);
-
-        runInServlet("testDeliveryDelayForDifferentDelaysClassicApi");
-
-        String msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : QueueBindingsMessage2-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-        msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : QueueBindingsMessage1-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-
-        restartServers(MDB_CONFIG_QUEUE_TCP);
-
-        runInServlet("testDeliveryDelayForDifferentDelaysClassicApi_Tcp");
-
-        msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : QueueTCPMessage2-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-        msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : QueueTCPMessage1-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-
-        restartServers();
-    }
-
-    @Test
-    public void testDeliveryDelayForDifferentDelaysTopicClassicApi()throws Exception {
-        restartClient(MDB_CONFIG_TOPIC_BINDINGS);
-
-        runInServlet("testDeliveryDelayForDifferentDelaysTopicClassicApi");
-
-        String msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : TopicBindingsMessage2-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-        msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : TopicBindingsMessage1-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-
-        restartServers(MDB_CONFIG_TOPIC_TCP);
-
-        runInServlet("testDeliveryDelayForDifferentDelaysTopicClassicApi_Tcp");
-        msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : TopicTCPMessage2-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-        msg = clientServer.waitForStringInLogUsingLastOffset(
-            "Message received on mdb : TopicTCPMessage1-ClassicApi");
-        assertNotNull("Could not find the upload message in the trace.log", msg);
-
-        restartServers();
-    }
 
     @Test
     public void testPersistentMessageStoreClassicApi_B() throws Exception {


### PR DESCRIPTION
- [ x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


These changes merge some of the tests that test different deliveryDelay values. There are 4 tests covering variants of destination (Queue/Topic) and API (simplified/domain-specific). Each test starts the liberty servers, runs a test using a "local"destination, restarts that server with a configuration for a "remote" destination and re-runs the tests. This means there are 8 server restarts.
By combining the different API tests that use the same configurations, the number of server restarts can effectively be halved, which should reduce the resource cost and time takes when running the tests.