### PR TITLE
29876 app naming

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/ModuleSelectionConfigImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/ModuleSelectionConfigImpl.java
@@ -310,7 +310,11 @@ public class ModuleSelectionConfigImpl implements ModuleSelectionConfig, OpenAPI
         }
     }
 
-    private static final Pattern CONFIG_VALUE_NAME_REFERENCE = Pattern.compile("(.+?)(/(.+))?");
+    /*
+     * At least one character that is not a '/', non-greedy.
+     * Then optionally: Exactly one '/' followed by at least one character.
+     */
+    private static final Pattern CONFIG_VALUE_NAME_REFERENCE = Pattern.compile("([^/]+?)(/(.+))?");
 
     /**
      * Parses a comma separated list of app and module names into a list of {@code ModuleName}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
@@ -43,6 +43,8 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
@@ -625,6 +627,35 @@ public class MergeConfigServerXMLTest {
         OpenAPITestUtil.checkPaths(openapiNode, 2, "/test1/test", "/test2/test");
         OpenAPITestUtil.checkInfo(openapiNode, "Generated API", "1.0");
         OpenAPITestUtil.checkServersForContextRoot(openapiNode, "");
+    }
+
+    @Test
+    @Mode(TestMode.FULL)
+    public void testInvalidServerXMLEmptyNames() throws Exception {
+        server.setMarkToEndOfLog();
+        MpOpenAPIElement.MpOpenAPIElementBuilder.cloneBuilderFromServerResetAppsAndModules(server)
+                                                .addIncludedApplicaiton("") //Empty app names
+                                                .addExcludedModule("testEar/") //And apps with empty module names are both invalid
+                                                .buildAndPushToServer();
+
+        List<String> list = new ArrayList<>(Arrays.asList("CWWKO1678W", "CWWKO1679W")); //Expect both an invalid app and invalid module warning.
+        server.waitForStringsInLogUsingMark(list);
+
+    }
+
+    @Test
+    @Mode(TestMode.FULL)
+    public void testInvalidServerXMLJustSlash() throws Exception {
+        server.setMarkToEndOfLog();
+
+        MpOpenAPIElement.MpOpenAPIElementBuilder.cloneBuilderFromServerResetAppsAndModules(server)
+                                                .addIncludedApplicaiton("/") //An app 
+                                                .addExcludedModule("/") //or module name that's just a slash is invalid
+                                                .buildAndPushToServer();
+
+        List<String> list = new ArrayList<>(Arrays.asList("CWWKO1678W", "CWWKO1679W")); //Expect both an invalid app and invalid module warning.
+        server.waitForStringsInLogUsingMark(list);
+
     }
 
     private void setMergeConfig(List<String> included, List<String> excluded, MpOpenAPIInfoElement info) throws Exception {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigTest.java
@@ -453,6 +453,18 @@ public class MergeConfigTest {
                                                                         // deployed
     }
 
+    @Test
+    public void testInvalidAppNameJustSlash() throws Exception {
+        setMergeConfig("/", "", null);
+        server.startServer();
+
+        //CWWKO1666W: Invalid name in the applications we're trying to merge
+        assertThat(server.findStringsInTrace("CWWKO1666W"), hasSize(1));
+
+        // Expect this warning because we're testing an invalid name
+        server.stopServer("CWWKO1666W");
+    }
+
     private void setMergeConfig(String included,
                                 String excluded,
                                 String info) {

--- a/dev/io.openliberty.microprofile.openapi.internal.common/resources/io/openliberty/microprofile/openapi/internal/resources/OpenAPI.nlsprops
+++ b/dev/io.openliberty.microprofile.openapi.internal.common/resources/io/openliberty/microprofile/openapi/internal/resources/OpenAPI.nlsprops
@@ -132,13 +132,13 @@ OPEN_API_PATH_SEGMENT_INVALID_CWWKO1677E.explanation=OpenAPI path segment "/." o
 OPEN_API_PATH_SEGMENT_INVALID_CWWKO1677E.useraction=Remove any path "/." or "/.." segment from the path.
 
 # {1} - the server.xml element name, either includeApplication or excludeApplication
-OPEN_API_SLASH_IN_APPLICATION_CWWKO1678W=CWWKO1678W: The configured {0} application name in the {1} element is not valid because it contains the "/" character.
+OPEN_API_SLASH_IN_APPLICATION_CWWKO1678W=CWWKO1678W: The configured {0} application name in the {1} element is not valid because it contains the "/" character or was empty.
 OPEN_API_SLASH_IN_APPLICATION_CWWKO1678W.explanation=An application cannot name cannot include a "/" as the "/" is used to separate the application from its component modules.
 OPEN_API_SLASH_IN_APPLICATION_CWWKO1678W.useraction=Remove the "/" from the includeApplication or excludeApplication element in your server.xml file, or convert that element to includeModule or excludeModule to reference a single module.
 
 # {1} - the server.xml element name, either includeModule or excludeModule
 OPEN_API_SLASH_IN_MODULE_CWWKO1679W=CWWKO1679W: The configured {0} module name in the {1} element is not valid as it is not in the format "<application-name>/<module-name>".
-OPEN_API_SLASH_IN_MODULE_CWWKO1679W.explanation=A module must be in the format "<application-name>/<module-name>"; therefore, a module name without a "/" is not valid.
+OPEN_API_SLASH_IN_MODULE_CWWKO1679W.explanation=A module must be in the format "<application-name>/<module-name>"; therefore, a module name without a "/" or an empty application name or module name is not valid.
 OPEN_API_SLASH_IN_MODULE_CWWKO1679W.useraction=Correct the includeModule or excludeModule element in your server.xml file, or convert that element to includeApplication or excludeApplication to reference an entire application.
 
 OPENAPI_USING_WRONG_NAME_SOURCE_CWWKO1680W=CWWKO1680W: The {1} application name in the {0} configuration element does not match the name of any deployed application, but it matches either the name from the deployment descriptor or the archive name of the {2} application. The application name that is used here must be the one specified in the server.xml file, or if no name is specified, the archive file name without the extension.

--- a/dev/io.openliberty.microprofile.openapi.internal.common/resources/io/openliberty/microprofile/openapi/internal/resources/OpenAPI.nlsprops
+++ b/dev/io.openliberty.microprofile.openapi.internal.common/resources/io/openliberty/microprofile/openapi/internal/resources/OpenAPI.nlsprops
@@ -132,13 +132,13 @@ OPEN_API_PATH_SEGMENT_INVALID_CWWKO1677E.explanation=OpenAPI path segment "/." o
 OPEN_API_PATH_SEGMENT_INVALID_CWWKO1677E.useraction=Remove any path "/." or "/.." segment from the path.
 
 # {1} - the server.xml element name, either includeApplication or excludeApplication
-OPEN_API_SLASH_IN_APPLICATION_CWWKO1678W=CWWKO1678W: The configured {0} application name in the {1} element is not valid because it contains the "/" character or was empty.
+OPEN_API_SLASH_IN_APPLICATION_CWWKO1678W=CWWKO1678W: The configured {0} application name in the {1} element is not valid because it contains the "/" character or is empty.
 OPEN_API_SLASH_IN_APPLICATION_CWWKO1678W.explanation=An application cannot name cannot include a "/" as the "/" is used to separate the application from its component modules.
 OPEN_API_SLASH_IN_APPLICATION_CWWKO1678W.useraction=Remove the "/" from the includeApplication or excludeApplication element in your server.xml file, or convert that element to includeModule or excludeModule to reference a single module.
 
 # {1} - the server.xml element name, either includeModule or excludeModule
 OPEN_API_SLASH_IN_MODULE_CWWKO1679W=CWWKO1679W: The configured {0} module name in the {1} element is not valid as it is not in the format "<application-name>/<module-name>".
-OPEN_API_SLASH_IN_MODULE_CWWKO1679W.explanation=A module must be in the format "<application-name>/<module-name>"; therefore, a module name without a "/" or an empty application name or module name is not valid.
+OPEN_API_SLASH_IN_MODULE_CWWKO1679W.explanation=A module must be in the format "<application-name>/<module-name>"; therefore, a module name without a forward slash ("/") , or an empty application name or module name, is not valid.
 OPEN_API_SLASH_IN_MODULE_CWWKO1679W.useraction=Correct the includeModule or excludeModule element in your server.xml file, or convert that element to includeApplication or excludeApplication to reference an entire application.
 
 OPENAPI_USING_WRONG_NAME_SOURCE_CWWKO1680W=CWWKO1680W: The {1} application name in the {0} configuration element does not match the name of any deployed application, but it matches either the name from the deployment descriptor or the archive name of the {2} application. The application name that is used here must be the one specified in the server.xml file, or if no name is specified, the archive file name without the extension.

--- a/dev/io.openliberty.microprofile.openapi.internal.common/src/io/openliberty/microprofile/openapi/internal/common/OpenAPIAppConfigProviderImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.internal.common/src/io/openliberty/microprofile/openapi/internal/common/OpenAPIAppConfigProviderImpl.java
@@ -130,7 +130,14 @@ public class OpenAPIAppConfigProviderImpl implements OpenAPIAppConfigProvider {
     }
 
     private static boolean isNotValidModuleName(String elementName) {
-        if (elementName.indexOf('/') <= 0) {
+        //Check it contains at least one '/' and at least one character
+        //before and after the first '/'
+
+        //The looseness of this rule is intentional. If the name is not valid
+        //under liberty rules we'll emit a different error message when we can't
+        //link this name to an actual module
+        if (elementName.indexOf('/') < 0
+            || elementName.indexOf('/') == elementName.length() - 1) {
             Tr.warning(tc, INVALID_MODULE_WARNING, elementName, elementName);
             return true;
         }
@@ -138,7 +145,8 @@ public class OpenAPIAppConfigProviderImpl implements OpenAPIAppConfigProvider {
     }
 
     private static boolean isNotValidAppName(String elementName) {
-        if (elementName.indexOf('/') > 0) {
+        if (elementName.indexOf('/') >= 0
+            || elementName.length() == 0) {
             Tr.warning(tc, INVALID_APP_WARNING, elementName, elementName);
             return true;
         }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Resolves #29876

################################################################################################

This PR does the following

1. Fixes an old bug in ModuleSelectionConfigImpl where the regex verifying modules would match anything but the empty string. What to do about this was discussed in slack and we decided to avoid the risk of breaking something that worked before.
2. After finding that problem I also went to OpenAPIAppConfigProviderImpl and double checked the logic there, and added a little more to keep it in sync, which ensures we don't get a CWWKO1666W when something is configured in server.xml
3. Added some tests to cover the new checks