### PR TITLE
when server.xml is deleted throw an error

### DIFF
--- a/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
+++ b/dev/com.ibm.ws.config/resources/com/ibm/ws/config/internal/resources/ConfigMessages.nlsprops
@@ -494,5 +494,9 @@ schemagen.info.schema.file.created=CWWKG0109I: The schema was created in the [{0
 schemagen.info.schema.file.created.explanation=The command completed successfully.
 schemagen.info.schema.file.created.useraction=No action is required.
 
+error.config.root.deleted=CWWKG0110E: A configuration update was detected, but the server.xml does not exist. No configuration updates were made.
+error.config.root.deleted.explanation=The server.xml file was deleted. To cause no disruptions to running apps, no configuration changes are made.
+error.config.root.deleted.useraction=Add the server.xml file back to the server.
+
 # Non-TR message
 error.invalidOCDRef=ERROR: Metatype PID [{0}] specifies non-existent object class definition ID [{1}]

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigFileMonitor.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigFileMonitor.java
@@ -143,11 +143,11 @@ class ConfigFileMonitor implements com.ibm.ws.kernel.filemonitor.FileMonitor {
 
     @Override
     public void onChange(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles) {
-        configRefresher.refreshConfiguration();
+        configRefresher.refreshConfigurationIfServerXMLExists();
     }
 
     @Override
     public void onChange(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles, String filter) {
-        configRefresher.refreshConfiguration();
+        configRefresher.refreshConfigurationIfServerXMLExists();
     }
 }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigRefresher.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigRefresher.java
@@ -94,6 +94,20 @@ public class ConfigRefresher {
         runtimeUpdateManagerTracker.close();
     }
 
+    /*
+     * Called after configuration change is detected.
+     * If the server.xml does not exist, no config updates will be made.
+     * Otherwise, make config updates as normal.
+     */
+    public void refreshConfigurationIfServerXMLExists(){
+        if(!serverXMLConfig.hasConfigRoot() || !serverXMLConfig.configRootFile().exists()){
+            Tr.error(tc, "error.config.root.deleted");
+        }
+        else{
+            refreshConfiguration();
+        }
+    }
+
     public void refreshConfiguration() {
         doRefresh(null);
     }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerXMLConfiguration.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerXMLConfiguration.java
@@ -87,6 +87,10 @@ class ServerXMLConfiguration {
         return configRoot != null;
     }
 
+    File configRootFile() {
+        return configRoot.asFile();
+    }
+
     private static long getInitialConfigReadTime(BundleContext bundleContext) {
         if (bundleContext == null) {
             return 0;


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Add a check before updating config that checks if the server.xml exists. If no server.xml exists then no config updates will be made and an error will be thrown.

Add to the server xml removal test to
 - test that the server is still running after removing the server.xml
 - test that the server status command is working as intended with no server.xml in the server
 - test that when configDropins are added to the config that no config update is made
 - test that after the server.xml is added back to the server, the config updates are made

#28341 