### PR TITLE
Enable database rotation for Jakarta Data DDLGen testing

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/DDLGenScriptHelper.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/DDLGenScriptHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import componenttest.topology.impl.LibertyServer;
 /**
  * Helps us build and run the command that generates DDL.
  */
+@Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
 public class DDLGenScriptHelper {
 
     private final String scriptName;

--- a/dev/com.ibm.ws.jbatch.fat.common/src/com/ibm/ws/jbatch/test/BatchRestUtils.java
+++ b/dev/com.ibm.ws.jbatch.fat.common/src/com/ibm/ws/jbatch/test/BatchRestUtils.java
@@ -1548,6 +1548,7 @@ public class BatchRestUtils {
     /**
      * Inner class that holds the output from a process.
      */
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     private static class ProcessOutput {
         private final List<String> sysout;
         private final List<String> syserr;
@@ -1600,7 +1601,7 @@ public class BatchRestUtils {
         }
     }
     
-
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     private ProcessBuilder getProcessBuilder(LibertyServer server) throws Exception {
         String scriptName;
         String serverName = server.getServerName();
@@ -1616,6 +1617,7 @@ public class BatchRestUtils {
         return new ProcessBuilder(scriptName, "generate", serverName).directory(new File(installRoot));
     }
 
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     public String getBatchDDL(LibertyServer server) throws Exception {
 
         ProcessBuilder processBuilder = getProcessBuilder(server);

--- a/dev/com.ibm.ws.jbatch.open.bonuspayout_fat/fat/src/batch/fat/util/BatchFATHelper.java
+++ b/dev/com.ibm.ws.jbatch.open.bonuspayout_fat/fat/src/batch/fat/util/BatchFATHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -279,6 +279,7 @@ public abstract class BatchFATHelper {
     /**
      * Inner class that holds the output from a process.
      */
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     private static class ProcessOutput {
         private final List<String> sysout;
         private final List<String> syserr;
@@ -331,6 +332,7 @@ public abstract class BatchFATHelper {
         }
     }
 
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     private ProcessBuilder getProcessBuilder(LibertyServer server) throws Exception {
         String scriptName;
         String serverName = server.getServerName();
@@ -346,6 +348,7 @@ public abstract class BatchFATHelper {
         return new ProcessBuilder(scriptName, "generate", serverName).directory(new File(installRoot));
     }
 
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     public String getBatchDDL(LibertyServer server) throws Exception {
 
         String methodName = "getBatchDDL";

--- a/dev/com.ibm.ws.jbatch.open.partition_fat/fat/src/batch/fat/util/BatchFATHelper.java
+++ b/dev/com.ibm.ws.jbatch.open.partition_fat/fat/src/batch/fat/util/BatchFATHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -279,6 +279,7 @@ public abstract class BatchFATHelper {
     /**
      * Inner class that holds the output from a process.
      */
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     private static class ProcessOutput {
         private final List<String> sysout;
         private final List<String> syserr;
@@ -331,6 +332,7 @@ public abstract class BatchFATHelper {
         }
     }
 
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     private ProcessBuilder getProcessBuilder(LibertyServer server) throws Exception {
         String scriptName;
         String serverName = server.getServerName();
@@ -346,6 +348,7 @@ public abstract class BatchFATHelper {
         return new ProcessBuilder(scriptName, "generate", serverName).directory(new File(installRoot));
     }
 
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     public String getBatchDDL(LibertyServer server) throws Exception {
 
         String methodName = "getBatchDDL";

--- a/dev/com.ibm.ws.jbatch.open.security_fat/fat/src/batch/fat/util/BatchFATHelper.java
+++ b/dev/com.ibm.ws.jbatch.open.security_fat/fat/src/batch/fat/util/BatchFATHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -279,6 +279,7 @@ public abstract class BatchFATHelper {
     /**
      * Inner class that holds the output from a process.
      */
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     private static class ProcessOutput {
         private final List<String> sysout;
         private final List<String> syserr;
@@ -331,6 +332,7 @@ public abstract class BatchFATHelper {
         }
     }
 
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     private ProcessBuilder getProcessBuilder(LibertyServer server) throws Exception {
         String scriptName;
         String serverName = server.getServerName();
@@ -346,6 +348,7 @@ public abstract class BatchFATHelper {
         return new ProcessBuilder(scriptName, "generate", serverName).directory(new File(installRoot));
     }
 
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     public String getBatchDDL(LibertyServer server) throws Exception {
 
         String methodName = "getBatchDDL";

--- a/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/util/BatchFATHelper.java
+++ b/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/util/BatchFATHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -271,6 +271,7 @@ public abstract class BatchFATHelper {
     /**
      * Inner class that holds the output from a process.
      */
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     private static class ProcessOutput {
         private final List<String> sysout;
         private final List<String> syserr;
@@ -323,6 +324,7 @@ public abstract class BatchFATHelper {
         }
     }
 
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     private ProcessBuilder getProcessBuilder(LibertyServer server) throws Exception {
         String scriptName;
         String serverName = server.getServerName();
@@ -338,6 +340,7 @@ public abstract class BatchFATHelper {
         return new ProcessBuilder(scriptName, "generate", serverName).directory(new File(installRoot));
     }
 
+    @Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
     public String getBatchDDL(LibertyServer server) throws Exception {
 
         String methodName = "getBatchDDL";

--- a/dev/fattest.simplicity/src/componenttest/containers/TestContainerSuite.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/TestContainerSuite.java
@@ -109,7 +109,7 @@ public class TestContainerSuite {
 
             // Output pattern
             System.setProperty("org.slf4j.simpleLogger.showDateTime", "true");
-            System.setProperty("org.slf4j.simpleLogger.dateTimeFormat", "[mm/dd/YYY HH:mm:ss:SSS z]");
+            System.setProperty("org.slf4j.simpleLogger.dateTimeFormat", "[MM/dd/yyyy HH:mm:ss:SSS z]");
         } else {
             Log.info(c, m, "The SLF4J simpleLogger was already configured with a logFile of " +
                            System.getProperty("org.slf4j.simpleLogger.logFile") +
@@ -118,7 +118,7 @@ public class TestContainerSuite {
 
         // Levels
         System.setProperty("org.slf4j.simpleLogger.log.org.testcontainers", "debug");
-        System.setProperty("org.slf4j.simpleLogger.log.tc", "info");
+        System.setProperty("org.slf4j.simpleLogger.log.tc", "debug");
         System.setProperty("org.slf4j.simpleLogger.log.com.github.dockerjava", "warn");
         System.setProperty("org.slf4j.simpleLogger.log.com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire", "off");
 

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/DDLGenScript.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/DDLGenScript.java
@@ -265,7 +265,10 @@ public class DDLGenScript {
          * @return                   this
          */
         public DDLGenScriptResult assertDDLFiles(List<String> expectedFileNames) {
-            assertEquals("Expected number of ddl files did not match actual number of files", expectedFileNames.size(), getFileNames());
+            List<String> observedFileNames = getFileNames();
+            assertEquals("Expected number of ddl files did not match actual number of files " + observedFileNames,
+                         expectedFileNames.size(),
+                         observedFileNames.size());
 
             for (String expectedFile : expectedFileNames) {
                 assertTrue("The expected file " + expectedFile + " was not in " + ddlDir.getAbsolutePath(), getFileNames().contains(expectedFile));

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/DDLGenScript.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/DDLGenScript.java
@@ -1,0 +1,313 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package componenttest.topology.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.ibm.websphere.simplicity.Machine;
+import com.ibm.websphere.simplicity.OperatingSystem;
+import com.ibm.websphere.simplicity.ProgramOutput;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Utility class for DDL Generation
+ */
+public class DDLGenScript {
+
+    // Known locations of scripts
+    private final String script;
+    private final String debugScript;
+
+    // The server
+    private final LibertyServer server;
+
+    // Generated processes
+    private final Deque<ProgramOutput> outputs;
+
+    // Configuration fields
+    private boolean isDebug = false;
+
+    ///// Builder /////
+
+    /**
+     * Start to build an execution of the DDLGen Script for the provided server.
+     *
+     * @param  server The server on which the script will run.
+     * @return        this
+     */
+    public static DDLGenScript build(LibertyServer server) {
+        Objects.requireNonNull(server);
+
+        if (!server.isStarted()) {
+            throw new RuntimeException("Server must be started prior to DDLGenScript.build()");
+        }
+
+        return new DDLGenScript(server);
+    }
+
+    ///// Constructor /////
+
+    private DDLGenScript(LibertyServer server) {
+        this.server = server;
+
+        Machine m = server.getMachine();
+
+        OperatingSystem os;
+        try {
+            os = m.getOperatingSystem();
+        } catch (Exception e) {
+            throw new RuntimeException("Unknown operation system", e);
+        }
+
+        if (os == OperatingSystem.WINDOWS) {
+            script = server.getInstallRoot() + File.separator + "bin" + File.separator + "ddlGen.bat";
+            debugScript = null;
+        } else {
+            script = server.getInstallRoot() + File.separator + "bin" + File.separator + "ddlGen";
+            debugScript = server.getInstallRoot() + File.separator + "bin" + File.separator + "ddlGenDebug";
+        }
+
+        outputs = new LinkedList<>();
+    }
+
+    ///// Actions /////
+
+    /**
+     * Will run the DDLGen debug script if it is available for the OS.
+     * Will also collect additional debug information from the OS prior to executing the DDLGen [debug] script.
+     *
+     * @return this
+     */
+    public DDLGenScript withDebug() {
+        if (!Objects.nonNull(debugScript)) {
+            Log.info(DDLGenScript.class, "withDebug", "Operating system does not support debug script, will run with traditional script.");
+            isDebug = true;
+        }
+
+        Properties env = new Properties();
+        try {
+            outputs.add(server.getMachine().execute("uname", new String[] {}, server.getInstallRoot(), env));
+            outputs.add(server.getMachine().execute("dirname", new String[] { "`pwd`" }, server.getInstallRoot(), env));
+            outputs.add(server.getMachine().execute("env", new String[] {}, server.getInstallRoot(), env));
+            outputs.add(server.getMachine().execute("cat", new String[] { script }, server.getInstallRoot(), env));
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to execute debug scripts: " + e);
+        }
+
+        return this;
+    }
+
+    ///// Termination /////
+
+    public DDLGenScriptResult execute() {
+        String[] opts = new String[] { "generate", server.getServerName() };
+        Properties env = new Properties();
+
+        try {
+            if (isDebug) {
+                outputs.addFirst(server.getMachine().execute(debugScript, opts, server.getInstallRoot(), env));
+            } else {
+                outputs.addFirst(server.getMachine().execute(script, opts, server.getInstallRoot(), env));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to execute ddlGen op ddlGenDebug script", e);
+        }
+
+        return DDLGenScriptResult.process(this);
+    }
+
+    ///// Getters /////
+
+    public LibertyServer getServer() {
+        return server;
+    }
+
+    public Deque<ProgramOutput> getOutputs() {
+        return outputs;
+    }
+
+    ///// Result nested class ////
+    public static class DDLGenScriptResult {
+
+        private static final String SUCCESS_MESSAGE = "CWWKD0107I";
+
+        // Obtained from https://www.ibm.com/docs/en/was-liberty/nd?topic=line-generating-data-definition-language#tasktwlp_ddlgen__result__1
+        private static final Map<Integer, String> RESULT_CODE_MAP = new HashMap<>();
+        static {
+            RESULT_CODE_MAP.put(0, "Success");
+            RESULT_CODE_MAP.put(20, "The action provided is not valid");
+            RESULT_CODE_MAP.put(21, "The server was not found.");
+            RESULT_CODE_MAP.put(22, "The localConnector feature is not present in the server configuration"
+                                    + " or the server was not started.");
+            RESULT_CODE_MAP.put(23, "The MBean that generates DDL was not found.");
+            RESULT_CODE_MAP.put(24, "The MBean that generates DDL reported an error.");
+            RESULT_CODE_MAP.put(25, "The server output directory was not found.");
+            RESULT_CODE_MAP.put(255, "An unexpected error occurred.");
+        }
+
+        private final DDLGenScript script;
+
+        private final List<String> sysout;
+
+        private final File ddlDir;
+
+        ///// Builder /////
+
+        protected static DDLGenScriptResult process(DDLGenScript script) {
+            Objects.requireNonNull(script);
+
+            return new DDLGenScriptResult(script);
+        }
+
+        ///// Constructor /////
+
+        private DDLGenScriptResult(DDLGenScript script) {
+            this.script = script;
+
+            sysout = new ArrayList<String>();
+
+            final Iterator<ProgramOutput> i = Objects.requireNonNull(script.getOutputs()).iterator();
+            while (i.hasNext()) {
+                ProgramOutput output = i.next();
+
+                sysout.addAll(Arrays.asList(output.getStdout().split(System.lineSeparator())));
+
+                Log.info(DDLGenScriptResult.class, "<init>", "Executed command:" + output.getCommand());
+                Log.info(DDLGenScriptResult.class, "<init>", "stdout:" + output.getStdout());
+                Log.info(DDLGenScriptResult.class, "<init>", "stderr:" + output.getStderr());
+                Log.info(DDLGenScriptResult.class, "<init>", "rc:" + output.getReturnCode());
+                Log.info(DDLGenScriptResult.class, "<init>", "serverRoot:" + script.getServer().getServerRoot());
+            }
+
+            String userDir = script.getServer().getUserDir();
+            String serverName = script.getServer().getServerName();
+
+            String _ddlDir;
+            if (userDir.length() >= 1 && userDir.endsWith(File.separator)) {
+                _ddlDir = userDir + "servers" + File.separator + serverName + File.separator + "ddl";
+            } else {
+                _ddlDir = userDir + File.separator + "servers" + File.separator + serverName + File.separator + "ddl";
+            }
+
+            ddlDir = new File(_ddlDir);
+
+        }
+
+        ///// Assertions /////
+
+        /**
+         * Asserts that the script(s) all ran successfully, that the expected success message was output,
+         * and that the directory where the DDL files should have been placed exists.
+         *
+         * @return this
+         */
+        public DDLGenScriptResult assertSuccessful() {
+            Deque<ProgramOutput> outputs = Objects.requireNonNull(script.getOutputs());
+
+            assertEquals("DDLGen script failed with result: " + RESULT_CODE_MAP.get(outputs.getFirst().getReturnCode()), 0, outputs.getFirst().getReturnCode());
+
+            Iterator<ProgramOutput> i = outputs.iterator();
+            while (i.hasNext()) {
+                ProgramOutput output = i.next();
+                assertEquals("Debug script failed with result: " + output.getReturnCode(), 0, output.getReturnCode());
+            }
+
+            sysout.stream()
+                            .filter(line -> line.contains(SUCCESS_MESSAGE))
+                            .findFirst()
+                            .orElseThrow(() -> new AssertionError("Output did not contain " + SUCCESS_MESSAGE));
+
+            assertTrue("The output directory did not exist: " + ddlDir.getAbsolutePath(), ddlDir.exists());
+            assertTrue("The output directory was not a directory: " + ddlDir.getAbsolutePath(), ddlDir.isDirectory());
+
+            return this;
+        }
+
+        /**
+         * Asserts that an expected DDL file exists in the DDL directory
+         *
+         * @param  expectedFileName the expected file name with .ddl extension
+         * @return                  this
+         */
+        public DDLGenScriptResult assertDDLFile(String expectedFileName) {
+            assertTrue("Expected file " + expectedFileName + " did not exist in " + ddlDir.getAbsolutePath(), getFileNames().contains(expectedFileName));
+            return this;
+        }
+
+        /**
+         * Asserts that all the expected DDL files exists in the DDL directory
+         *
+         * @param  expectedFileNames the list of expected file names with .ddl extensions
+         * @return                   this
+         */
+        public DDLGenScriptResult assertDDLFiles(List<String> expectedFileNames) {
+            assertEquals("Expected number of ddl files did not match actual number of files", expectedFileNames.size(), getFileNames());
+
+            for (String expectedFile : expectedFileNames) {
+                assertTrue("The expected file " + expectedFile + " was not in " + ddlDir.getAbsolutePath(), getFileNames().contains(expectedFile));
+            }
+
+            return this;
+        }
+
+        ///// Terminations /////
+
+        /**
+         * Return a line from system.out that contains an expected substring for further analysis.
+         *
+         * @param  expected an expected substring to find
+         * @return          the line from system.out or null if no line was found
+         */
+        public String getLineInSysoutContaining(String expected) {
+            for (String line : sysout) {
+                if (line.contains(expected)) {
+                    return line;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Get all DDL file names from the DDL directory.
+         *
+         * @return all generated DDL file names
+         */
+        public List<String> getFileNames() {
+            return Arrays.asList(ddlDir.list());
+        }
+
+        /**
+         * Get all DDL file paths in the DDL directory.
+         *
+         * @return all generated DDL file paths
+         */
+        public List<String> getFileLocations() {
+            return Stream.of(ddlDir.list()).map(fileName -> ddlDir.getAbsolutePath() + File.separator + fileName).collect(Collectors.toList());
+        }
+
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_datastore/fat/src/test/jakarta/data/datastore/DDLGenScriptHelper.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/fat/src/test/jakarta/data/datastore/DDLGenScriptHelper.java
@@ -36,6 +36,7 @@ import componenttest.topology.impl.LibertyServer;
 /**
  *
  */
+@Deprecated // TODO switch to use the DDLGenScriptHelper from fattest.simplicity
 public abstract class DDLGenScriptHelper {
 
     /**

--- a/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/DDLGenTest.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/DDLGenTest.java
@@ -15,9 +15,7 @@ package test.jakarta.data.ddlgen;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
@@ -25,7 +23,6 @@ import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
@@ -35,9 +32,6 @@ import test.jakarta.data.ddlgen.web.DDLGenTestServlet;
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
 public class DDLGenTest extends FATServletClient {
-    // TODO enable testcontainers code once ddlgen is used
-    //@ClassRule
-    //public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 
     @Server("io.openliberty.data.internal.fat.ddlgen")
     @TestServlet(servlet = DDLGenTestServlet.class, contextRoot = "DDLGenTestApp")
@@ -46,11 +40,11 @@ public class DDLGenTest extends FATServletClient {
     @BeforeClass
     public static void setUp() throws Exception {
         // Get driver type
-        //DatabaseContainerType type = DatabaseContainerType.valueOf(testContainer);
-        //server.addEnvVar("DB_DRIVER", type.getDriverName());
+        DatabaseContainerType type = DatabaseContainerType.valueOf(FATSuite.testContainer);
+        server.addEnvVar("DB_DRIVER", type.getDriverName());
 
         // Set up server DataSource properties
-        //DatabaseContainerUtil.setupDataSourceDatabaseProperties(server, testContainer);
+        DatabaseContainerUtil.setupDataSourceDatabaseProperties(server, FATSuite.testContainer);
 
         WebArchive war = ShrinkHelper.buildDefaultApp("DDLGenTestApp", "test.jakarta.data.ddlgen.web");
         ShrinkHelper.exportAppToServer(server, war);

--- a/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/DDLGenTest.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/DDLGenTest.java
@@ -12,12 +12,22 @@
  *******************************************************************************/
 package test.jakarta.data.ddlgen;
 
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
+import org.testcontainers.containers.Container.ExecResult;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
@@ -41,6 +51,9 @@ public class DDLGenTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        // Create an additional user and schema on database (matches authData id="dbuser")
+        createUserAndSchema(FATSuite.testContainer, "dbuser", "DBuserPassw0rd");
+
         // Get driver type
         DatabaseContainerType type = DatabaseContainerType.valueOf(FATSuite.testContainer);
         server.addEnvVar("DB_DRIVER", type.getDriverName());
@@ -60,12 +73,93 @@ public class DDLGenTest extends FATServletClient {
 
         runTest(server, "DDLGenTestApp/DDLGenTestServlet", "executeDDL" +
                                                            "&scripts=" + String.join(",", result.getFileLocations()) +
-                                                           "&withDataStore=TestDataStore" +
-                                                           "&forDataSource=java:app/env/adminDataSourceRef");
+                                                           "&withDatabaseStore=TestDataStore" +
+                                                           "&usingDataSource=java:app/env/adminDataSourceRef");
+
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer();
+    }
+
+    /**
+     * TODO if we end up writing more tests that require a separate user/schema
+     * consider moving this method to DatabaseContainerUtil {@link DatabaseContainerUtil}
+     *
+     * @param testContainer the container
+     * @param user          the user/schema to create (the schema will be named after the user)
+     * @param pass          the password for the user
+     * @throws Exception if any database connection or query executions occur
+     */
+    private static void createUserAndSchema(JdbcDatabaseContainer<?> testContainer, String user, String pass) throws Exception {
+        final DatabaseContainerType type = DatabaseContainerType.valueOf(testContainer);
+
+        Log.entering(FATSuite.class, "createUserAndSchema", new Object[] { type, user, pass });
+        try {
+            switch (type) {
+                case DB2: //working
+                    final List<ExecResult> results = new ArrayList<>();
+                    final String connectDBPrefix = "db2 connect to " + testContainer.getDatabaseName() + "; ";
+
+                    // On DB2 database users and OS users are one and the same, so need to create a user using OS commands.
+                    results.add(testContainer.execInContainer("sh", "-c", "useradd -s /bin/bash " + user));
+                    results.add(testContainer.execInContainer("sh", "-c", "echo '" + user + ":" + pass + "' | chpasswd"));
+                    results.add(testContainer.execInContainer("su", "-", testContainer.getUsername(), "-c",
+                                                              connectDBPrefix + "db2 grant createtab, connect on database to user " + user + ";"));
+                    results.add(testContainer.execInContainer("su", "-", testContainer.getUsername(), "-c",
+                                                              connectDBPrefix + "db2 create schema authorization " + user + ";"));
+                    results.add(testContainer.execInContainer("su", "-", testContainer.getUsername(), "-c",
+                                                              connectDBPrefix + "db2 grant all privileges on schema " + user + " to user " + user + ";"));
+
+                    for (ExecResult result : results) {
+                        assertEquals("Unexpected result from command on DB2 container, std.err: " + result.getStderr(), 0, result.getExitCode());
+                    }
+                    break;
+                case Derby:
+                    // Unnecessary
+                    break;
+                case DerbyClient:
+                    // Unnecessary
+                    break;
+                case Oracle: //working
+                    // On oracle a user and a schema are one and the same, so just create a user
+                    try (Connection con = testContainer.createConnection(""); Statement stmt = con.createStatement()) {
+                        stmt.executeUpdate("alter session set \"_ORACLE_SCRIPT\"=true");
+                        stmt.executeUpdate("alter user " + testContainer.getUsername() + " quota unlimited on users");
+                        stmt.executeUpdate("create user " + user + " identified by " + pass);
+                        stmt.executeUpdate("grant connect, create session to " + user);
+                        stmt.executeUpdate("grant unlimited tablespace to " + user);
+                    }
+                    break;
+                case Postgres: //working
+                    try (Connection con = testContainer.createConnection(""); Statement stmt = con.createStatement()) {
+                        stmt.executeUpdate("create user " + user + " with password '" + pass + "'");
+                        stmt.executeUpdate("grant connect on database " + testContainer.getDatabaseName() + " to " + user + " with grant option");
+                        stmt.executeUpdate("create schema " + user);
+                        stmt.executeUpdate("alter default privileges in schema " + user +
+                                           " grant all privileges on tables to " + user);
+                        stmt.executeUpdate("grant usage on schema " + user + " to " + user);
+                    }
+                    break;
+                case SQLServer: //working
+                    //TODO remove once bug is fixed: https://github.com/testcontainers/testcontainers-java/pull/9463
+                    //replace with: testContainer.createConnection(";databaseName=TEST")
+                    testContainer.withUrlParam("databaseName", "TEST");
+
+                    try (Connection con = testContainer.createConnection(""); Statement stmt = con.createStatement()) {
+                        stmt.executeUpdate("create login " + user + " with password = '" + pass + "'");
+                        stmt.executeUpdate("create user " + user + " from login " + user);
+                        stmt.executeUpdate("grant connect to " + user);
+                        stmt.executeUpdate("create schema " + user);
+                        stmt.executeUpdate("grant control on schema :: " + user + " to " + user);
+                    }
+                    break;
+                default:
+                    throw new RuntimeException("Unknown database container type");
+            }
+        } finally {
+            Log.exiting(FATSuite.class, "createUserAndSchema");
+        }
     }
 }

--- a/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/FATSuite.java
@@ -12,18 +12,23 @@
  *******************************************************************************/
 package test.jakarta.data.ddlgen;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
                 AlwaysPassesTest.class,
                 DDLGenTest.class
 })
-// TODO uncomment once ddlgen is used
-public class FATSuite { //extends TestContainerSuite {
+public class FATSuite extends TestContainerSuite {
+
+    @ClassRule
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 }

--- a/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/FATSuite.java
@@ -28,7 +28,6 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 DDLGenTest.class
 })
 public class FATSuite extends TestContainerSuite {
-
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 }

--- a/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/bootstrap.properties
@@ -12,5 +12,4 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all
-# TODO can remove the following once this test bucket requires Java 21 where Java 2 security is disabled
 websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/server.xml
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/server.xml
@@ -13,9 +13,15 @@
 <server>
 
   <featureManager>
-    <feature>componenttest-2.0</feature>
+    <!-- Tested features -->
     <feature>data-1.0</feature>
     <feature>persistence-3.2</feature>
+    
+    <!-- Necessary for ddlGen script -->
+    <feature>localConnector-1.0</feature>
+    
+    <!-- Necessary for test infrastructure -->
+    <feature>componenttest-2.0</feature>
     <feature>servlet-6.1</feature>
   </featureManager>
 

--- a/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/server.xml
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/server.xml
@@ -31,9 +31,8 @@
     <logValues>test.jakarta.data.ddlgen.web</logValues>
   </data>
 
-  <!-- TODO when using a production database only one user is created -->
   <authData id="dbadmin" user="dbadmin" password="adminpwd" fat.modify="true"/>
-  <authData id="dbuser" user="dbuser" password="dbpwd" fat.modify="true"/>
+  <authData id="dbuser" user="dbuser" password="DBuserPassw0rd"/>
 
   <application location="DDLGenTestApp.war"/>
 

--- a/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/server.xml
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/server.xml
@@ -25,8 +25,9 @@
     <logValues>test.jakarta.data.ddlgen.web</logValues>
   </data>
 
-  <authData id="dbadmin" user="dbadmin" password="adminpwd"/>
-  <authData id="dbuser" user="dbuser" password="dbpwd"/>
+  <!-- TODO when using a production database only one user is created -->
+  <authData id="dbadmin" user="dbadmin" password="adminpwd" fat.modify="true"/>
+  <authData id="dbuser" user="dbuser" password="dbpwd" fat.modify="true"/>
 
   <application location="DDLGenTestApp.war"/>
 
@@ -44,10 +45,8 @@
 
   <library id="JDBCLibrary">
     <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
-    <file name="${shared.resource.dir}/derby/derby.jar"/> <!-- TODO remove -->
   </library>
 
-  <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
   <javaPermission codeBase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
 
 </server>

--- a/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/DDLGenTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/DDLGenTestServlet.java
@@ -55,19 +55,22 @@ public class DDLGenTestServlet extends FATServlet {
     // TODO consider moving this to a shared location
     public void executeDDL(HttpServletRequest request, HttpServletResponse response) throws Exception {
         List<String> files = Arrays.asList(Objects.requireNonNull(request.getParameter("scripts")).split(","));
-        String withDataStore = Objects.requireNonNull(request.getParameter("withDataStore"));
-        String forDataSource = Objects.requireNonNull(request.getParameter("forDataSource"));
+        String withDatabaseStore = Objects.requireNonNull(request.getParameter("withDatabaseStore"));
+        String usingDataSource = Objects.requireNonNull(request.getParameter("usingDataSource"));
 
-        DataSource ds = InitialContext.doLookup(forDataSource);
+        DataSource ds = InitialContext.doLookup(usingDataSource);
 
         for (String file : files) {
-            if (!file.contains(withDataStore)) {
+            if (!file.contains(withDatabaseStore))
                 continue;
-            }
+
             try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
                 System.out.println("Execute DDL file: " + file);
                 String line;
                 while ((line = reader.readLine()) != null) {
+                    if (line.isBlank() || line.equals("EXIT;"))
+                        continue;
+
                     System.out.println("  Execute SQL Statement: " + line);
                     try (Connection con = ds.getConnection(); Statement stmt = con.createStatement()) {
                         stmt.execute(line);

--- a/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/DDLGenTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/DDLGenTestServlet.java
@@ -52,7 +52,6 @@ public class DDLGenTestServlet extends FATServlet {
      * The test bucket must arrange for it to run before other test
      * as part of setup.
      */
-    // TODO consider moving this to a shared location
     public void executeDDL(HttpServletRequest request, HttpServletResponse response) throws Exception {
         List<String> files = Arrays.asList(Objects.requireNonNull(request.getParameter("scripts")).split(","));
         String withDatabaseStore = Objects.requireNonNull(request.getParameter("withDatabaseStore"));

--- a/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/Part.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/Part.java
@@ -14,6 +14,8 @@ package test.jakarta.data.ddlgen.web;
 
 import java.util.Objects;
 
+import test.jakarta.data.ddlgen.web.Part.Identifier;
+
 /**
  * A record entity with a composite id.
  */
@@ -28,7 +30,7 @@ public record Part(Identifier id, String name, float price, int version) {
 
     /**
      * Composite id for the Part entity.
-     * TODO switch to a record once #29460 is fixed
+     * TODO switch to a record once issue is resolved: https://github.com/OpenLiberty/open-liberty/issues/29460
      */
     public static class Identifier {
         public String partNum;

--- a/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/Parts.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/Parts.java
@@ -16,8 +16,7 @@ import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Repository;
 
 /**
- * Repository for a record entity that has a composite primary key that
- * TODO will be a record.
+ * Repository for a record entity that has a composite primary key that is a record.
  */
 @Repository(dataStore = "TestDataStore")
 public interface Parts extends BasicRepository<Part, Part.Identifier> {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Enable DatabaseRotation for DDL Gen testing
- Create a common DDL Generation helper class
- Execute DDL file on servlet
- Create a database user and schema on databases for testing
