### PR TITLE
Replace @-char in cached lib container path

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/library/internal/LibraryGeneration.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/library/internal/LibraryGeneration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -113,7 +113,7 @@ final class LibraryGeneration {
     }
 
     void addContainerFromFile(File f, Collection<ArtifactContainer> containers) {
-        String filename = String.format("%s/%s_%s@%s", SharedLibraryFactory.CONT_CACHE, libraryId, genId, f.getName());
+        String filename = String.format("%s/%s_%s_%s", SharedLibraryFactory.CONT_CACHE, libraryId, genId, f.getName());
         File wc = library.ctx.getBundle().getDataFile(filename);
         boolean ok = wc.mkdir();
         if (!ok) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Replace the `@`-char in cached library container paths to obviate any question of security vulnerability.