### PR TITLE
test: finish unit testing TCKResultInfo

### DIFF
--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -120,3 +120,6 @@ fat.test.container.images: testcontainers/ryuk:0.9.0, testcontainers/sshd:1.2.0,
     io.openliberty.org.bouncycastle.bcutil-jdk18on;version=latest,\
     io.openliberty.jakarta.concurrency.3.1;version=latest,\
     io.openliberty.jakarta.annotation.3.0;version=latest
+    
+-testpath: \
+    org.mockito:mockito-all;version=1.9.5

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -128,6 +128,10 @@ jar { // NOTE: this is called by fat.gradle:autoFVT
     finalizedBy assembleBinaryDependencies
 }
 
+test {
+   jvmArgs = ["--add-opens", "java.base/java.lang=ALL-UNNAMED"]
+}
+
 task publishArquillianSupportFeature(type:Copy) {
     dependsOn extractArquillianSupportFeature
     from('build/arquillian-feature-extract/extension')

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
@@ -235,6 +235,13 @@ public class TCKResultsInfo {
         }
     }
 
+    /**
+     * Returns url where the TCK can be downloaded.
+     * For Jakarta EE - https://download.eclipse.org/
+     * For Microprofile - https://repo1.maven.org
+     *
+     * @return
+     */
     public String getTCKURL() {
         switch (type) {
             case JAKARTA:
@@ -250,6 +257,12 @@ public class TCKResultsInfo {
         }
     }
 
+    /**
+     * Constructs and returns a unique file name for this run of the TCK in the from:
+     * <liberty-version>-<spec-name>-<spec-version>[-qualifiers]-java<java-major-version>-TCKResults.adoc
+     *
+     * @return
+     */
     public String getFilename() {
         String filename = getOpenLibertyVersion()
                           + "-" + getFullSpecName()
@@ -267,19 +280,27 @@ public class TCKResultsInfo {
         return filename;
     }
 
-    public String getReadableRepeatName() {
-        String readableRepeatName = getRepeat();
+    /**
+     * Constructs and returns a unique directory name for this run of the TCK in the form:
+     * TCK_Results_Certifications[<_repeat-action-id> | _remove_<feature-list>_add_<feature-list>]
+     *
+     * @return
+     */
+    public String getDirectoryName() {
+        String directory = "TCK_Results_Certifications";
 
-        if (readableRepeatName.contains("FeatureReplacementAction")) {
-            readableRepeatName = readableRepeatName.replaceAll("FeatureReplacementAction.*REMOVE ", "remove_")
+        if (getRepeat().contains("FeatureReplacementAction")) {
+            directory += getRepeat().replaceAll("FeatureReplacementAction.*REMOVE ", "remove_")
                             .replaceAll("\\[", "")
                             .replaceAll("\\]", "")
                             .replaceAll(" ADD ", "_add_")
                             .replaceAll(",", "-")
                             .replaceAll(" ", "");
+        } else {
+            directory += getRepeat();
         }
 
-        return readableRepeatName;
+        return directory;
     }
 
 }

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsInfo.java
@@ -54,6 +54,8 @@ public class TCKResultsInfo {
     private String platformVersion = "";
     private String[] qualifiers = new String[] {};
 
+    ///// Constructor /////
+
     public TCKResultsInfo(Type type, String specName, LibertyServer server, TCKJarInfo tckJarInfo) {
         this.type = type;
         this.specName = specName;
@@ -66,6 +68,8 @@ public class TCKResultsInfo {
         this.repeat = RepeatTestFilter.getRepeatActionsAsString();
     }
 
+    ///// Optional configuration /////
+
     public void withQualifiers(String[] qualifiers) {
         this.qualifiers = qualifiers;
     }
@@ -73,6 +77,8 @@ public class TCKResultsInfo {
     public void withPlatformVersion(String platformVersion) {
         this.platformVersion = platformVersion;
     }
+
+    ///// Getters /////
 
     /**
      * @return the javaMajorVersion
@@ -189,6 +195,8 @@ public class TCKResultsInfo {
         return this.qualifiers;
     }
 
+    ///// Utility methods /////
+
     /**
      * Returns a human readable full specification name such as "Jakarta Data 1.0"
      *
@@ -263,13 +271,12 @@ public class TCKResultsInfo {
         String readableRepeatName = getRepeat();
 
         if (readableRepeatName.contains("FeatureReplacementAction")) {
-            readableRepeatName = readableRepeatName.replaceAll("FeatureReplacementAction.*REMOVE", "remove")
+            readableRepeatName = readableRepeatName.replaceAll("FeatureReplacementAction.*REMOVE ", "remove_")
                             .replaceAll("\\[", "")
                             .replaceAll("\\]", "")
-                            .replaceAll("ADD", "add")
-                            .replaceAll("  ", " ")
+                            .replaceAll(" ADD ", "_add_")
                             .replaceAll(",", "-")
-                            .replaceAll(" ", "_");
+                            .replaceAll(" ", "");
         }
 
         return readableRepeatName;

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKResultsWriter.java
@@ -51,8 +51,8 @@ public class TCKResultsWriter {
             throw new RuntimeException(e);
         }
 
-        Path outputDirectory = Paths.get("results/" + "TCK_Results_Certifications" + resultInfo.getReadableRepeatName());
-        Path outputPath = Paths.get("results/" + "TCK_Results_Certifications" + resultInfo.getReadableRepeatName(), resultInfo.getFilename());
+        Path outputDirectory = Paths.get("results", resultInfo.getDirectoryName());
+        Path outputPath = outputDirectory.resolve(resultInfo.getFilename());
 
         File outputFile = outputPath.toFile();
         File outputDir = outputDirectory.toFile();
@@ -101,7 +101,7 @@ public class TCKResultsWriter {
         // Note that this copying *only* occurs in CI Orchestrator environments as the code wrapping FAT execution is responsible for performing the upload to LibFS.
         // The use case here is to make .adoc files available in the build directory without having to extract them from the FAT output zip every time.
         try {
-            Path extrasPath = Paths.get("extras/" + "TCK_Results_Certifications" + resultInfo.getReadableRepeatName(), resultInfo.getFilename());
+            Path extrasPath = Paths.get("extras", resultInfo.getDirectoryName(), resultInfo.getFilename());
             Files.createDirectories(extrasPath.getParent());
             Files.copy(outputPath, extrasPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {

--- a/dev/fattest.simplicity/test/componenttest/topology/utils/tck/TCKResultInfoTest.java
+++ b/dev/fattest.simplicity/test/componenttest/topology/utils/tck/TCKResultInfoTest.java
@@ -108,7 +108,7 @@ public class TCKResultInfoTest {
     }
 
     @Test
-    public void getReadableRepeatNameTest() {
+    public void getDirectoryNameTest() {
         // Ensure no repeat actions are active (left over from other unit tests)
         while (RepeatTestFilter.isAnyRepeatActionActive()) {
             RepeatTestFilter.deactivateRepeatAction();
@@ -119,20 +119,20 @@ public class TCKResultInfoTest {
         // No replacement action
         RepeatTestFilter.activateRepeatAction(FeatureReplacementAction.NO_REPLACEMENT());
         testResult = new TCKResultsInfo(Type.MICROPROFILE, "Fault Tolerance", null, VERSION_1_0_0);
-        assertEquals("", testResult.getReadableRepeatName());
+        assertEquals("TCK_Results_Certifications", testResult.getDirectoryName());
         RepeatTestFilter.deactivateRepeatAction();
 
         // Single replacement action
         RepeatTestFilter.activateRepeatAction(FeatureReplacementAction.EE11_FEATURES());
         testResult = new TCKResultsInfo(Type.MICROPROFILE, "Fault Tolerance", null, VERSION_1_0_0);
-        assertEquals("_EE11_FEATURES", testResult.getReadableRepeatName());
+        assertEquals("TCK_Results_Certifications_EE11_FEATURES", testResult.getDirectoryName());
         RepeatTestFilter.deactivateRepeatAction();
 
         // Multiple replacement actions
         RepeatTestFilter.activateRepeatAction(FeatureReplacementAction.EE10_FEATURES());
         RepeatTestFilter.activateRepeatAction(FeatureReplacementAction.BETA_OPTION());
         testResult = new TCKResultsInfo(Type.MICROPROFILE, "Fault Tolerance", null, VERSION_1_0_0);
-        assertEquals("_EE10_FEATURES_BETA_JVM_OPTIONS", testResult.getReadableRepeatName());
+        assertEquals("TCK_Results_Certifications_EE10_FEATURES_BETA_JVM_OPTIONS", testResult.getDirectoryName());
         RepeatTestFilter.deactivateRepeatAction();
         RepeatTestFilter.deactivateRepeatAction();
 
@@ -142,7 +142,7 @@ public class TCKResultInfoTest {
         action.addFeature("persistence-3.2");
         RepeatTestFilter.activateRepeatAction(action);
         testResult = new TCKResultsInfo(Type.MICROPROFILE, "Fault Tolerance", null, VERSION_1_0_0);
-        assertEquals("_remove_persistence-3.1-jpa-2.2-jpa-2.1-persistence-3.0_add_persistence-3.2", testResult.getReadableRepeatName());
+        assertEquals("TCK_Results_Certifications_remove_persistence-3.1-jpa-2.2-jpa-2.1-persistence-3.0_add_persistence-3.2", testResult.getDirectoryName());
         RepeatTestFilter.deactivateRepeatAction();
 
         // Ensure we cleaned up after ourselves


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Previous changes to TCKResultInfo were not fully unit tested because we had no method to mock a Liberty server.
- Introduced mockito to the fattest.simplicity unit tests
- Finished writing unit tests
- Modified to the readable repeat name method to avoid duplicate seperators
  - used to return: `_remove_persistence-3.1-_jpa-2.2-_jpa-2.1-_persistence-3.0_add_persistence-3.2`
  - will not return: `_remove_persistence-3.1-jpa-2.2-jpa-2.1-persistence-3.0_add_persistence-3.2`
