### PR TITLE
Correct casing for mpOpenAPI.info element name

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.internal.common/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/io.openliberty.microprofile.openapi.internal.common/resources/OSGI-INF/l10n/metatype.properties
@@ -40,7 +40,7 @@ excludeModule.desc=Module names, one per element, that are to be excluded from t
 openAPIVersion=OpenAPI specification version
 openAPIVersion.desc=The version of the OpenAPI specification that should be used for the OpenAPI document. mpOpenAPI-4.0 defaults to "3.1" and also supports "3.0". Earlier versions only support "3.0".
 
-info=OpenAPI document info
+info=OpenAPI Document Info
 info.desc=Sets the info section of the OpenAPI document, overriding any info section provided in the application.
 
 title=API title


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

The labels of elements should use Title Case. For some reason, this check only gets run when the metatype elements are non-beta, so we didn't notice until we were preparing #29961