### PR TITLE
repository method sort parameters for pagination

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -884,3 +884,20 @@ CWWKD1086.named.params.unused.explanation=The Param annotation can only be used 
  when the query has named parameters.
 CWWKD1086.named.params.unused.useraction=Remove the Param annotation or switch \
  the query to use named parameters.
+
+CWWKD1087.null.param=CWWKD1087E: The {0} parameter of the {1} method of the \
+ {2} repository interface cannot be a null value.
+CWWKD1087.null.param.explanation=The value must not be null.
+CWWKD1087.null.param.useraction=Supply a non-null value.
+
+CWWKD1088.empty.sorts=CWWKD1088E: The sort criteria that is supplied via the \
+ {0} parameter of the {1} method of the {2} repository interface cannot be empty.
+CWWKD1088.empty.sorts.explanation=The sort criteria must not be empty.
+CWWKD1088.empty.sorts.useraction=Supply a value with non-empty sort criteria.
+
+CWWKD1089.unordered.pagination=CWWKD1089E: The {0} method of the {1} repository \
+ interface must specify sort criteria because the method returns a {2} value. \
+ Unordered data cannot be split into pages.
+CWWKD1089.unordered.pagination.explanation=Pagination requires ordered data.
+CWWKD1089.unordered.pagination.useraction=Use the OrderBy annotation to define \
+ sort criteria for the repository method.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -886,26 +886,25 @@ CWWKD1086.named.params.unused.useraction=Remove the Param annotation or switch \
  the query to use named parameters.
 
 CWWKD1087.null.param=CWWKD1087E: The {0} parameter of the {1} method of the \
- {2} repository interface cannot be a null value.
-CWWKD1087.null.param.explanation=The value must not be null.
-CWWKD1087.null.param.useraction=Supply a non-null value.
+ {2} repository interface is a null value. Specify a nonnull value.
+CWWKD1087.null.param.explanation=The parameter value must not be null.
+CWWKD1087.null.param.useraction=Specify a nonnull value to the parameter.
 
-CWWKD1088.empty.sorts=CWWKD1088E: The sort criteria that is supplied via the \
- {0} parameter of the {1} method of the {2} repository interface cannot be empty.
+CWWKD1088.empty.sorts=CWWKD1088E: The sort criteria that are specified by the \
+ {0} parameter of the {1} method of the {2} repository interface are empty.
 CWWKD1088.empty.sorts.explanation=The sort criteria must not be empty.
-CWWKD1088.empty.sorts.useraction=Supply a value with non-empty sort criteria.
+CWWKD1088.empty.sorts.useraction=Specify a value for the sort criteria.
 
 CWWKD1089.unordered.pagination=CWWKD1089E: The {0} method of the {1} repository \
- interface must specify sort criteria because the method returns a {2} value. \
+ interface must specify the sort criteria because the method returns a {2} value. \
  Unordered data cannot be split into pages.
 CWWKD1089.unordered.pagination.explanation=Pagination requires ordered data.
 CWWKD1089.unordered.pagination.useraction=Use the OrderBy annotation to define \
- sort criteria for the repository method.
+ the sort criteria for the repository method.
 
 CWWKD1090.orderby.conflict=CWWKD1090E: The {0} method of the {1} repository \
- interface cannot combine the OrderBy annotation and the OrderBy
- Query by Method Name keyword.
-CWWKD1090.orderby.conflict.explanation=The OrderBy keyword is not compatible \
- with the OrderBy annotation.
+ interface cannot combine the OrderBy annotation and the OrderBy keyword.
+CWWKD1090.orderby.conflict.explanation=The OrderBy annotation is not compatible \
+ with the OrderBy keyword.
 CWWKD1090.orderby.conflict.useraction=Use only the OrderBy annotation or the \
  OrderBy keyword.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -901,3 +901,11 @@ CWWKD1089.unordered.pagination=CWWKD1089E: The {0} method of the {1} repository 
 CWWKD1089.unordered.pagination.explanation=Pagination requires ordered data.
 CWWKD1089.unordered.pagination.useraction=Use the OrderBy annotation to define \
  sort criteria for the repository method.
+
+CWWKD1090.orderby.conflict=CWWKD1090E: The {0} method of the {1} repository \
+ interface cannot combine the OrderBy annotation and the OrderBy
+ Query by Method Name keyword.
+CWWKD1090.orderby.conflict.explanation=The OrderBy keyword is not compatible \
+ with the OrderBy annotation.
+CWWKD1090.orderby.conflict.useraction=Use only the OrderBy annotation or the \
+ OrderBy keyword.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2485,7 +2485,13 @@ public class QueryInfo {
                 for (int i = 0; i < orderBy.length; i++)
                     addSort(orderBy[i].ignoreCase(), orderBy[i].value(), orderBy[i].descending());
 
-                if (sortPositions.length == 0) {
+                if (sortPositions == NONE_STATIC_SORT_ONLY ||
+                    sortPositions.length > 0 && !sorts.isEmpty()) {
+                    throw exc(UnsupportedOperationException.class,
+                              "CWWKD1090.orderby.conflict",
+                              method.getName(),
+                              repositoryInterface.getName());
+                } else if (sortPositions.length == 0) {
                     sortPositions = NONE_STATIC_SORT_ONLY;
                     generateOrderBy(q);
                 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3495,17 +3495,32 @@ public class QueryInfo {
                     if (args[p] == null)
                         // BasicRepository.findAll(PageRequest, Order) requires
                         // NullPointerException when Order is null.
-                        throw new NullPointerException(paramTypes[p].getSimpleName() + ": null");
+                        throw exc(NullPointerException.class,
+                                  "CWWKD1087.null.param",
+                                  paramTypes[p].getName(),
+                                  method.getName(),
+                                  repositoryInterface.getName());
                     else
-                        throw new IllegalArgumentException(paramTypes[p].getSimpleName() + ": {}");
+                        throw exc(IllegalArgumentException.class,
+                                  "CWWKD1088.empty.sorts",
+                                  paramTypes[p].getName(),
+                                  method.getName(),
+                                  repositoryInterface.getName());
                 else if (Sort[].class.equals(paramTypes[p]))
-                    throw new IllegalArgumentException("Sort[]: {}");
-                // TODO NLS messages for any of the above?
+                    throw exc(IllegalArgumentException.class,
+                              "CWWKD1088.empty.sorts",
+                              Sort.class.getName() + "[]",
+                              method.getName(),
+                              repositoryInterface.getName());
             }
         }
 
         if (sortPositions == NONE)
-            throw new UnsupportedOperationException("unordered pagination"); // TODO NLS
+            throw exc(IllegalArgumentException.class,
+                      "CWWKD1089.unordered.pagination",
+                      method.getName(),
+                      repositoryInterface.getName(),
+                      method.getGenericReturnType().getTypeName());
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2470,8 +2470,13 @@ public class QueryInfo {
 
             // The @OrderBy annotation from Jakarta Data provides sort criteria statically
             if (orderBy.length > 0) {
-                //type = type == null ? Type.FIND : type;
-                sorts = sorts == null ? new ArrayList<>(orderBy.length + 2) : sorts;
+                if (sorts != null) // also has an OrderBy keyword
+                    throw exc(UnsupportedOperationException.class,
+                              "CWWKD1090.orderby.conflict",
+                              method.getName(),
+                              repositoryInterface.getName());
+
+                sorts = new ArrayList<>(orderBy.length);
                 if (q == null)
                     if (jpql == null) {
                         q = generateSelectClause();
@@ -2485,13 +2490,7 @@ public class QueryInfo {
                 for (int i = 0; i < orderBy.length; i++)
                     addSort(orderBy[i].ignoreCase(), orderBy[i].value(), orderBy[i].descending());
 
-                if (sortPositions == NONE_STATIC_SORT_ONLY ||
-                    sortPositions.length > 0 && !sorts.isEmpty()) {
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1090.orderby.conflict",
-                              method.getName(),
-                              repositoryInterface.getName());
-                } else if (sortPositions.length == 0) {
+                if (sortPositions.length == 0) {
                     sortPositions = NONE_STATIC_SORT_ONLY;
                     generateOrderBy(q);
                 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -87,6 +87,26 @@ public class QueryInfo {
     private static final Set<Class<?>> NON_ENTITY_RESULT_TYPES = new HashSet<>();
 
     /**
+     * Indicates the repository method has no Sort, Sort[], or Order parameters
+     * for dynamic sort criteria and also does not define any static sort criteria.
+     */
+    private static final int[] NONE = new int[0];
+
+    /**
+     * Indicates the repository method has no Sort, Sort[], or Order parameters
+     * for dynamic sort criteria, but has a Query annotation that might define
+     * static sort criteria.
+     */
+    private static final int[] NONE_QUERY_LANGUAGE_ONLY = new int[0];
+
+    /**
+     * Indicates the repository method has no Sort, Sort[], or Order parameters
+     * for dynamic sort criteria, but supplies static sort criteria via the
+     * OrderBy annotation or keyword.
+     */
+    private static final int[] NONE_STATIC_SORT_ONLY = new int[0];
+
+    /**
      * Primitive types for numeric values.
      */
     static final Set<Class<?>> PRIMITIVE_NUMERIC_TYPES = //
@@ -102,6 +122,12 @@ public class QueryInfo {
                            int.class, Integer.class,
                            long.class, Long.class,
                            Number.class);
+
+    /**
+     * Valid types for repository method parameters that specify sort criteria.
+     */
+    static final Set<Class<?>> SORT_PARAM_TYPES = //
+                    Set.of(Order.class, Sort.class, Sort[].class);
 
     /**
      * Valid types for repository method parameters after the query parameters.
@@ -270,6 +296,16 @@ public class QueryInfo {
      * For example, a single result of a query that returns List<MyEntity> is of the type MyEntity.
      */
     final Class<?> singleType;
+
+    /**
+     * Positions of Sort, Sort[], and Order parameters.
+     * When there are no parameters specifying sort criteria dynamically,
+     * then the value is one of:
+     * NONE
+     * NONE_QUERY_LANGUAGE_ONLY
+     * NONE_STATIC_SORT_ONLY
+     */
+    int[] sortPositions = NONE;
 
     /**
      * Ordered list of Sort criteria, which can be defined statically via the OrderBy annotation or keyword,
@@ -1766,6 +1802,10 @@ public class QueryInfo {
         if (countPages && type == Type.FIND)
             generateCount(numAttributeParams == 0 ? null : q.substring(startIndexForWhereClause));
 
+        if (type == Type.FIND ||
+            type == Type.FIND_AND_DELETE)
+            initDynamicSortPositions(paramTypes);
+
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "generateQueryByParameters", q);
         return q;
@@ -2314,26 +2354,6 @@ public class QueryInfo {
     }
 
     /**
-     * Identifies whether sort criteria can be dynamically supplied when invoking the query.
-     *
-     * @return true if it is possible to provide sort criteria dynamically, otherwise false.
-     */
-    @Trivial
-    boolean hasDynamicSortCriteria() {
-        boolean hasDynamicSort = false;
-        Class<?>[] paramTypes = method.getParameterTypes();
-        for (int i = paramCount; i < paramTypes.length && !hasDynamicSort; i++)
-            hasDynamicSort = PageRequest.class.equals(paramTypes[i])
-                             || Order.class.equals(paramTypes[i])
-                             || Sort[].class.equals(paramTypes[i])
-                             || Sort.class.equals(paramTypes[i]);
-
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(this, tc, "hasDynamicSortCriteria? " + hasDynamicSort);
-        return hasDynamicSort;
-    }
-
-    /**
      * Determine if the index of the text ignoring case if it is the next non-whitespace characters.
      *
      * @parma text the text to match.
@@ -2465,8 +2485,10 @@ public class QueryInfo {
                 for (int i = 0; i < orderBy.length; i++)
                     addSort(orderBy[i].ignoreCase(), orderBy[i].value(), orderBy[i].descending());
 
-                if (!hasDynamicSortCriteria())
+                if (sortPositions.length == 0) {
+                    sortPositions = NONE_STATIC_SORT_ONLY;
                     generateOrderBy(q);
+                }
             }
 
             jpql = q == null ? jpql : q.toString();
@@ -2490,6 +2512,41 @@ public class QueryInfo {
             throw x;
         }
 
+    }
+
+    /**
+     * Adds the specified 0-based index as a position where the repository method
+     * provides sort criteria.
+     *
+     * @param index 0-based position to add.
+     */
+    @Trivial
+    private void initDynamicSortPosition(int index) {
+        if (sortPositions.length == 0) {
+            sortPositions = new int[] { index };
+        } else {
+            // It is unusual, but supported, to have multiple parameters
+            // provide sort criteria
+            int[] previous = sortPositions;
+            sortPositions = new int[previous.length + 1];
+            System.arraycopy(previous, 0, sortPositions, 0, previous.length);
+            sortPositions[sortPositions.length - 1] = index;
+        }
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "found sort criteria position (1-based): " + (index + 1));
+    }
+
+    /**
+     * Records positions (0-based) of all sort criteria in the method parameters
+     * following the query parameters.
+     *
+     * @param paramTypes method parameter types.
+     */
+    @Trivial
+    private void initDynamicSortPositions(Class<?>[] paramTypes) {
+        for (int i = paramCount; i < paramTypes.length; i++)
+            if (SORT_PARAM_TYPES.contains(paramTypes[i]))
+                initDynamicSortPosition(i);
     }
 
     /**
@@ -3003,6 +3060,11 @@ public class QueryInfo {
             }
         }
 
+        sortPositions = NONE_QUERY_LANGUAGE_ONLY;
+        for (int i = paramCount; i < params.length; i++)
+            if (SORT_PARAM_TYPES.contains(params[i].getType()))
+                initDynamicSortPosition(i);
+
         int paramNamesCount = paramNames.size();
         if (hasExtraParam || qlParamNameCount != paramNamesCount) {
             // Does the method supply all named parameters that the query needs?
@@ -3054,8 +3116,11 @@ public class QueryInfo {
                 if (countPages)
                     generateCount(q.substring(where));
             }
+
+            initDynamicSortPositions(method.getParameterTypes());
             if (orderBy >= 0)
                 parseOrderBy(orderBy, q);
+
             type = Type.FIND;
         } else if (methodName.startsWith("delete") || methodName.startsWith("remove")) {
             int orderBy = -1;
@@ -3077,6 +3142,8 @@ public class QueryInfo {
 
             if (by > 0)
                 generateWhereClause(methodName, by + 2, orderBy > 0 ? orderBy : methodName.length(), q);
+
+            initDynamicSortPositions(method.getParameterTypes());
             if (orderBy > 0)
                 parseOrderBy(orderBy, q);
 
@@ -3384,8 +3451,49 @@ public class QueryInfo {
                 iNext += (iNext == desc ? 4 : 3);
         }
 
-        if (!hasDynamicSortCriteria())
+        if (sortPositions.length == 0) {
+            sortPositions = NONE_STATIC_SORT_ONLY;
             generateOrderBy(q);
+        }
+    }
+
+    /**
+     * Pagination is only possible if results are ordered.
+     *
+     * If the repository method has parameters to supply an order and these are
+     * empty or null, assume the user made a mistake and raise an error.
+     *
+     * If the repository method does not define an order or provide parameters
+     * for the user to supply an order, assume the intention is to default to
+     * the unique identifier in ascending order.
+     *
+     * @param args parameters to the repository method.
+     * @return sort criteria for the unique identifier in ascending order.
+     * @throws IllegalArgumentException if a Sort[] or Order parameter is empty.
+     * @throws NullPointerException     if a Sort or Order parameter is null.
+     */
+    @Trivial
+    List<Sort<Object>> requireOrderForPages(Object[] args) {
+        if (sortPositions.length > 0) {
+            Class<?>[] paramTypes = method.getParameterTypes();
+            for (int s = 0; s < sortPositions.length; s++) {
+                int p = sortPositions[s];
+                if (Order.class.equals(paramTypes[p]) ||
+                    Sort.class.equals(paramTypes[p]))
+                    if (args[p] == null)
+                        // BasicRepository.findAll(PageRequest, Order) requires
+                        // NullPointerException when Order is null.
+                        throw new NullPointerException(paramTypes[p].getSimpleName() + ": null");
+                    else
+                        throw new IllegalArgumentException(paramTypes[p].getSimpleName() + ": {}");
+                else if (Sort[].class.equals(paramTypes[p]))
+                    throw new IllegalArgumentException("Sort[]: {}");
+                // TODO NLS messages for any of the above?
+            }
+        }
+
+        // TODO can we default to Sorting on the ID?
+        return null;
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1065,26 +1065,14 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                       "Limit",
                                       "PageRequest");
 
-                        if (sortList == null && queryInfo.hasDynamicSortCriteria())
+                        if (sortList == null && queryInfo.sortPositions.length > 0)
                             sortList = queryInfo.sorts;
 
-                        if (sortList == null || sortList.isEmpty()) {
-                            if (pagination != null) {
-                                // BasicRepository.findAll(PageRequest, Order) requires NullPointerException when Order is null.
-                                if (queryInfo.paramCount == 0 && queryInfo.method.getParameterCount() == 2
-                                    && Order.class.equals(queryInfo.method.getParameterTypes()[1]))
-                                    throw new NullPointerException("Order: null");
-                                // TODO raise a helpful error to prevent some cases of attempted unordered pagination?
-                                //else if (!queryInfo.hasOrderBy)
-                                //    throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
-                                //                                            repositoryInterface.getName() +
-                                //                                            " repository has a PageRequest parameter without a way to " +
-                                //                                            " specify a deterministic ordering of results, which is required " +
-                                //                                            " when requesting pages. Use the OrderBy annotation or add a " +
-                                //                                            " parameter of type Order, Sort, or Sort... to specify an order" +
-                                //                                            " for results."); // TODO NLS
-                            }
-                        } else {
+                        if (pagination != null &&
+                            (sortList == null || sortList.isEmpty()))
+                            sortList = queryInfo.requireOrderForPages(args);
+
+                        if (sortList != null && !sortList.isEmpty()) {
                             boolean forward = pagination == null || pagination.mode() != PageRequest.Mode.CURSOR_PREVIOUS;
                             StringBuilder q = new StringBuilder(queryInfo.jpql);
                             StringBuilder order = null; // ORDER BY clause based on Sorts

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1051,8 +1051,11 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                     isSort |= queryInfo.sortPositions[s] == i;
                                 if (!isSort)
                                     // BasicRepository.findAll requires NullPointerException
-                                    throw new NullPointerException(method.getParameterTypes()[i].getSimpleName() +
-                                                                   ": null"); // TODO NLS
+                                    throw exc(NullPointerException.class,
+                                              "CWWKD1087.null.param",
+                                              method.getParameterTypes()[i].getName(),
+                                              method.getName(),
+                                              repositoryInterface.getName());
                             } else {
                                 throw exc(DataException.class,
                                           "CWWKD1023.extra.param",

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -744,6 +744,49 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Repository method that uses cursor-based pagination but does not specify
+     * any sort criteria, which should default to ascending by Id.
+     */
+    @Test
+    public void testCursoredPageRequestWithImplicitSort() {
+        PageRequest page1req = PageRequest.ofSize(4);
+        CursoredPage<Prime> page;
+        page = primes.findByRomanNumeralIgnoreCaseEndsWith("I", page1req);
+
+        assertEquals(List.of(2L, 3L, 7L, 11L),
+                     page.stream()
+                                     .map(p -> p.numberId)
+                                     .collect(Collectors.toList()));
+
+        PageRequest page2req = page.nextPageRequest();
+
+        page = primes.findByRomanNumeralIgnoreCaseEndsWith("i", page2req);
+
+        assertEquals(List.of(13L, 17L, 23L, 31L),
+                     page.stream()
+                                     .map(p -> p.numberId)
+                                     .collect(Collectors.toList()));
+
+        PageRequest page3req = page.nextPageRequest();
+
+        page = primes.findByRomanNumeralIgnoreCaseEndsWith("i", page3req);
+
+        assertEquals(List.of(37L, 41L, 43L, 47L),
+                     page.stream()
+                                     .map(p -> p.numberId)
+                                     .collect(Collectors.toList()));
+
+        page2req = page.previousPageRequest();
+
+        page = primes.findByRomanNumeralIgnoreCaseEndsWith("i", page2req);
+
+        assertEquals(List.of(13L, 17L, 23L, 31L),
+                     page.stream()
+                                     .map(p -> p.numberId)
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
      * Verify that cursor-based pagination can be used with an empty string Query,
      * which the spec allows as a valid query. It will need to generate a WHERE
      * clause when appending conditions for the cursor.
@@ -3687,32 +3730,6 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * BasicRepository.findAll(PageRequest, null) must raise NullPointerException.
-     */
-    @Test
-    public void testNullOrder() {
-        try {
-            Page<Package> page = packages.findAll(PageRequest.ofSize(15), null);
-            fail("BasicRepository.findAll(PageRequest, null) must raise NullPointerException. Instead: " + page);
-        } catch (NullPointerException x) {
-            // expected
-        }
-    }
-
-    /**
-     * BasicRepository.findAll(null, Order) must raise NullPointerException.
-     */
-    @Test
-    public void testNullPagination() {
-        try {
-            Page<Package> page = packages.findAll(null, Order.by(Sort.asc("id")));
-            fail("BasicRepository.findAll(null, Order) must raise NullPointerException. Instead: " + page);
-        } catch (NullPointerException x) {
-            // expected
-        }
-    }
-
-    /**
      * Test Null and NotNull on repository methods.
      */
     @Test
@@ -3856,6 +3873,31 @@ public class DataTestServlet extends FATServlet {
         } catch (NoSuchElementException x) {
             // expected
         }
+    }
+
+    /**
+     * Repository method that uses offset pagination but does not specify
+     * any sort criteria, which should default to ascending by Id.
+     */
+    @Test
+    public void testPageRequestWithImplicitSort() {
+        PageRequest page1req = PageRequest.ofSize(4);
+        Page<Prime> page;
+        page = primes.findByRomanNumeralIgnoreCaseStartsWith("X", page1req);
+
+        assertEquals(List.of(11L, 13L, 17L, 19L),
+                     page.stream()
+                                     .map(p -> p.numberId)
+                                     .collect(Collectors.toList()));
+
+        PageRequest page2req = page.nextPageRequest();
+
+        page = primes.findByRomanNumeralIgnoreCaseStartsWith("x", page2req);
+
+        assertEquals(List.of(23L, 29L, 31L, 37L),
+                     page.stream()
+                                     .map(p -> p.numberId)
+                                     .collect(Collectors.toList()));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -225,6 +225,12 @@ public interface Primes {
                                                               Order<Prime> order,
                                                               Sort<?>... orderBy);
 
+    CursoredPage<Prime> findByRomanNumeralIgnoreCaseEndsWith(String prefix,
+                                                             PageRequest pageReq);
+
+    Page<Prime> findByRomanNumeralIgnoreCaseStartsWith(String prefix,
+                                                       PageRequest pageReq);
+
     @OrderBy(value = "sumOfBits", descending = true)
     @OrderBy("name")
     Page<Prime> findByRomanNumeralStartsWithAndNumberIdLessThan(String prefix, long max, PageRequest pagination);

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -51,7 +51,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1084E.*bornIn", // Param annotation omitted
                                    "CWWKD1084E.*livingIn", // named parameter mismatch
                                    "CWWKD1085E.*livingOn", // extra Param annotations
-                                   "CWWKD1086E.*withAddressShorterThan" // Param used for positional parameter
+                                   "CWWKD1086E.*withAddressShorterThan", // Param used for positional parameter
+                                   "CWWKD1090E.*findByAddressOrderBy" // OrderBy anno/keyword conflict
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -15,7 +15,9 @@ package test.jakarta.data.errpaths.web;
 import java.time.Month;
 import java.util.List;
 
+import jakarta.data.Sort;
 import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
@@ -56,6 +58,20 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                        @Param("month") Month monthBorn,
                        @Param("month") int monthNum, // duplicate parameter name
                        @Param("day") int dayBorn);
+
+    /**
+     * This invalid method has a conflict between its OrderBy annotation and
+     * method name keyword.
+     */
+    @OrderBy("ssn")
+    List<Voter> findByAddressOrderByName(String address);
+
+    /**
+     * This invalid method has a conflict between its OrderBy annotation and
+     * method name keyword. It also has a dynamic sort parameter.
+     */
+    @OrderBy("name")
+    List<Voter> findByAddressOrderBySSN(int ssn, Sort<Voter> sort);
 
     /**
      * This invalid method has a mixture of positional and named parameters.


### PR DESCRIPTION
Consolidate and correct the code to identify repository method parameters that provide sort criteria. Use this information to properly detect and report errors. Also, allow an optimization where a repository method that uses pagination can be written without sort criteria and have it default to ascending by Id.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
