### PR TITLE
Added additional debug and retry to RequestTiming FAT

### DIFF
--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -477,6 +477,7 @@ public class SlowRequestTiming {
 
         List<String> lines = server.findStringsInFileInLibertyServerRoot("ms", MESSAGE_LOG);
         for (String line : lines) {
+            CommonTasks.writeLogMsg(Level.INFO, "Checking the following line : " + line);
             assertFalse("contextInfo found when it was disabled..", line.contains("|"));
         }
 
@@ -496,6 +497,7 @@ public class SlowRequestTiming {
 
         for (String line : lines) {
             if (!line.contains("TRAS0112W") && !line.contains("TRAS0113I") && !line.contains("CWWKG0028A")) {
+                CommonTasks.writeLogMsg(Level.INFO, "Checking the following line : " + line);
                 assertTrue("contextInfo is missing...", line.contains("|"));
             }
         }
@@ -564,6 +566,7 @@ public class SlowRequestTiming {
         List<String> lines = server.findStringsInFileInLibertyServerRoot("ms", MESSAGE_LOG);
 
         for (String line : lines) {
+            CommonTasks.writeLogMsg(Level.INFO, "Checking the following line : " + line);
             assertFalse("Pattern found when it is disabled..", (line.contains("|")));
         }
         CommonTasks.writeLogMsg(Level.INFO, "******** As Expected : Pattern disabled ******* ");

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -582,6 +582,7 @@ public class SlowRequestTiming {
 
         for (String line : lines) {
             if (!line.contains("TRAS0112W") && !line.contains("TRAS0113I") && !line.contains("CWWKG0028A")) {
+                CommonTasks.writeLogMsg(Level.INFO, "Checking the following line : " + line);
                 assertTrue("Pattern NOT found when it is enabled..", (line.contains("|")));
             }
         }

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -449,7 +449,6 @@ public class SlowRequestTiming {
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i);
             CommonTasks.writeLogMsg(Level.INFO, "-------->  " + line);
-
             assertFalse("contextInfo found!", line.contains("|"));
 
         }
@@ -745,6 +744,15 @@ public class SlowRequestTiming {
 
         server.waitForStringInLog("TRAS0112W", 20000);
         int slowCount = fetchNoOfslowRequestWarnings();
+
+        //Retry the request again
+        if (slowCount == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequest("?sleepTime=4000");
+            createRequest("?sleepTime=4000");
+            server.waitForStringInLog("TRAS0112W", 20000);
+            slowCount = fetchNoOfslowRequestWarnings();
+        }
 
         assertTrue("No slow warning found for sampleRate 2!", (slowCount > 0));
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Adds additional debug to some tests in the RequestTiming FAT, to check what line is getting processed
- Added a retry to `testSlowReqSampleRateDynamicUpdate`, due to fast environments, the slow request may not get detected.