### PR TITLE
Prepare IntervalTask for checkpoint

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.common/src/io/openliberty/checkpoint/spi/CheckpointPhase.java
+++ b/dev/com.ibm.ws.kernel.boot.common/src/io/openliberty/checkpoint/spi/CheckpointPhase.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 
 /**
@@ -125,6 +126,35 @@ public enum CheckpointPhase {
             }
         }
         THE_PHASE = phase;
+        if (phase != INACTIVE) {
+            phase.addMultiThreadedHook(Integer.MIN_VALUE, new CheckpointHook() {
+                @Override
+                public void prepare() {
+                    debug(() -> "Locking checkpoint write lock for prepare");
+                    checkpointLock.writeLock().lock();
+                };
+
+                @Override
+                public void restore() {
+                    debug(() -> "Unlocking checkpoint write lock for restore");
+                    try {
+                        checkpointLock.writeLock().unlock();
+                    } catch (IllegalMonitorStateException e) {
+                        // ignore
+                    }
+                }
+
+                @Override
+                public void checkpointFailed() {
+                    debug(() -> "Unlocking checkpoint write lock for checkpointFailed");
+                    try {
+                        checkpointLock.writeLock().unlock();
+                    } catch (IllegalMonitorStateException e) {
+                        // ignore
+                    }
+                }
+            });
+        }
     }
 
     static CheckpointPhase THE_PHASE = CheckpointPhase.INACTIVE;
@@ -299,6 +329,22 @@ public enum CheckpointPhase {
     }
 
     /**
+     * A function to call with the checkpoint lock
+     *
+     * @param <T> Exception thrown by the call method
+     */
+    @FunctionalInterface
+    public static interface WithCheckpointLock<R, T extends Throwable> {
+        /**
+         * Called with the checkpoint lock to prevent the JVM from entering single-threaded
+         * mode.
+         *
+         * @throws T with checkpoint lock exception.
+         */
+        public R call() throws T;
+    }
+
+    /**
      * Runs the given function on restore if the runtime has been configured to perform
      * a checkpoint, the function is run after the JVM has re-entered multi-threaded mode;
      * otherwise the function is run immediately from the calling thread synchronously.
@@ -406,6 +452,34 @@ public enum CheckpointPhase {
 
     final synchronized void blockAddHooks() {
         this.blockAddHooks = true;
+    }
+
+    private static final ReentrantReadWriteLock checkpointLock = new ReentrantReadWriteLock();
+
+    /**
+     * Runs the given function while holding the checkpoint lock. This will prevent
+     * the JVM from entering single-thread mode when preparing for a checkpoint.
+     *
+     * @param <R>                The type of value returned by the function
+     * @param <T>                The type of throwable the function may throw
+     * @param withCheckpointLock The function to run
+     * @return The value returned by the function
+     * @throws T Any errors that occur while running the function
+     */
+    public <R, T extends Throwable> R runWithCheckpointLock(WithCheckpointLock<R, T> withCheckpointLock) throws T {
+        if (restored()) {
+            debug(() -> "Calling with no checkpoint lock: " + withCheckpointLock);
+            // call with no read lock on checkpoint
+            return withCheckpointLock.call();
+        }
+        // call with checkpoint lock to prevent the JVM from going into single-thread mode while running
+        debug(() -> "Calling with checkpoint lock: " + withCheckpointLock);
+        checkpointLock.readLock().lock();
+        try {
+            return withCheckpointLock.call();
+        } finally {
+            checkpointLock.readLock().unlock();
+        }
     }
 
     final class StaticCheckpointHook implements CheckpointHook {

--- a/dev/com.ibm.ws.kernel.boot.common/src/io/openliberty/checkpoint/spi/CheckpointPhase.java
+++ b/dev/com.ibm.ws.kernel.boot.common/src/io/openliberty/checkpoint/spi/CheckpointPhase.java
@@ -472,10 +472,10 @@ public enum CheckpointPhase {
             // call with no read lock on checkpoint
             return withCheckpointLock.call();
         }
-        // call with checkpoint lock to prevent the JVM from going into single-thread mode while running
-        debug(() -> "Calling with checkpoint lock: " + withCheckpointLock);
         checkpointLock.readLock().lock();
         try {
+            // call with checkpoint lock to prevent the JVM from going into single-thread mode while running
+            debug(() -> "Calling with checkpoint lock: " + withCheckpointLock);
             return withCheckpointLock.call();
         } finally {
             checkpointLock.readLock().unlock();

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -300,7 +300,7 @@ public class BaseTraceService implements TrService {
         systemErr = new SystemLogHolder(LoggingConstants.SYSTEM_ERR, System.err);
 
         earlyMessageTraceKiller_Timer.schedule(new EarlyMessageTraceCleaner(), 5 * MINUTE); // 5 minutes wait time
-        checkpointPhase.addMultiThreadedHook(new CheckpointHook() {
+        checkpointPhase.addMultiThreadedHook(Integer.MIN_VALUE, new CheckpointHook() {
             @Override
             public void prepare() {
                 // Get exclusive write lock for the thread preparing to checkpoint.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2023 IBM Corporation and others.
+ * Copyright (c) 2010, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -271,7 +271,7 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
         }
         threadPool = new ThreadPoolExecutor(coreThreads, maxThreads, 0, TimeUnit.MILLISECONDS, workQueue, threadFactory != null ? threadFactory : new ThreadFactoryImpl(poolName, threadGroupName), rejectedExecutionHandler);
 
-        threadPoolController = new ThreadPoolController(this, threadPool);
+        threadPoolController = new ThreadPoolController(threadPool);
 
         if (oldPool != null) {
             softShutdown(oldPool);

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointSPITestConfig.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/CheckpointSPITestConfig.java
@@ -56,6 +56,8 @@ public class CheckpointSPITestConfig {
 
     public final static String STATIC_ONRESTORE = "STATIC ONRESTORE - ";
 
+    public final static String WITH_LOCK = "WITH LOCK - ";
+
     private static final String USER_FEATURE_PATH = "usr/extension/lib/features/";
     private static final String USER_BUNDLE_PATH = "usr/extension/lib/";
     private static final String USER_FEATURE_USERTEST_MF = "features/test.checkpoint.config-1.0.mf";
@@ -91,6 +93,11 @@ public class CheckpointSPITestConfig {
         findLogMessage("Static rank prepare method", STATIC_MULTI_PREPARE_RANK + "-50 3 ", "SUCCESS", 500);
 
         findLogMessage("ProtectedString should be *****", "TESTING - ProtectedString prepare password: ", "*****", 500);
+
+        findLogMessage("runWithCheckpointLock", WITH_LOCK + "CALLED: ", "SUCCESS", 500);
+        findLogMessage("runWithCheckpointLock", WITH_LOCK + "NESTED IN READ: ", "SUCCESS", 500);
+        findLogMessage("runWithCheckpointLock", WITH_LOCK + "DELAYED: ", "SUCCESS", 500);
+        findLogMessage("runWithCheckpointLock", WITH_LOCK + "NESTED IN WRITE: ", "SUCCESS", 500);
     }
 
     @Before


### PR DESCRIPTION
Block work from IntervalTask once we have prepared for checkpoint This is to avoid deadlocks that can be possible once we go into single-thread mode for a checkpoint


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

