### PR TITLE
mpOpenAPI: server.xml message for missing include

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/ModuleSelectionConfigImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/ModuleSelectionConfigImpl.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package io.openliberty.microprofile.openapi20.internal;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -193,8 +191,13 @@ public class ModuleSelectionConfigImpl implements ModuleSelectionConfig, OpenAPI
             }
         }
 
-        for (String unmatchedInclude : includedNotYetSeen.stream().map(ModuleName::toString).collect(toList())) {
-            Tr.warning(tc, MessageConstants.OPENAPI_MERGE_UNUSED_INCLUDE_CWWKO1667W, Constants.MERGE_INCLUDE_CONFIG, unmatchedInclude);
+        for (ModuleName unmatchedInclude : includedNotYetSeen) {
+            if (config.serverxmlmode && ProductInfo.getBetaEdition()) {
+                String elementName = unmatchedInclude.moduleName == null ? "includeApplication" : "includeModule";
+                Tr.warning(tc, MessageConstants.OPENAPI_MERGE_UNUSED_INCLUDE_SERVERXML_CWWKO1684W, elementName, unmatchedInclude);
+            } else {
+                Tr.warning(tc, MessageConstants.OPENAPI_MERGE_UNUSED_INCLUDE_CWWKO1667W, Constants.MERGE_INCLUDE_CONFIG, unmatchedInclude);
+            }
         }
 
         //Now we repeat the process for excluded applications and modules, however this time we only throw a warning message if we get a match on the deployment descriptor's name

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/MessageConstants.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/MessageConstants.java
@@ -38,6 +38,7 @@ public class MessageConstants {
     public static final String OPENAPI_VERSION_INVALID_CWWK06181W = "OPENAPI_VERSION_INVALID_CWWK06181W";
     public static final String OPENAPI_VERSION_NOT_SUPPORTED_CWWK06182W = "OPENAPI_VERSION_NOT_SUPPORTED_CWWK06182W";
     public static final String OPENAPI_INFO_INVALID_SERVERXML_CWWKO1683W = "OPENAPI_INFO_INVALID_SERVERXML_CWWKO1683W";
+    public static final String OPENAPI_MERGE_UNUSED_INCLUDE_SERVERXML_CWWKO1684W = "OPENAPI_MERGE_UNUSED_INCLUDE_SERVERXML_CWWKO1684W";
 
     private MessageConstants() {
         // This class is not meant to be instantiated.

--- a/dev/io.openliberty.microprofile.openapi.internal.common/resources/io/openliberty/microprofile/openapi/internal/resources/OpenAPI.nlsprops
+++ b/dev/io.openliberty.microprofile.openapi.internal.common/resources/io/openliberty/microprofile/openapi/internal/resources/OpenAPI.nlsprops
@@ -157,3 +157,7 @@ OPENAPI_VERSION_NOT_SUPPORTED_CWWK06182W.useraction=Update the openAPIVersion at
 OPENAPI_INFO_INVALID_SERVERXML_CWWKO1683W=CWWKO1683W: The mpOpenAPI info configuration element in the server.xml file is invalid. Both the title and version attributes must be set. The info element will be ignored.
 OPENAPI_INFO_INVALID_SERVERXML_CWWKO1683W.explanation=The title and version fields are required properties in the info object of an OpenAPI document. When configuring the info object, a value must be provided for the title and version attributes.
 OPENAPI_INFO_INVALID_SERVERXML_CWWKO1683W.useraction=Ensure that the title and version attributes are set to valid values in the mpOpenAPI info element.
+
+OPENAPI_MERGE_UNUSED_INCLUDE_SERVERXML_CWWKO1684W=CWWKO1684W: The {0} configuration element includes "{1}" but that does not match any deployed application or web module.
+OPENAPI_MERGE_UNUSED_INCLUDE_SERVERXML_CWWKO1684W.explanation=The server is configured to create OpenAPI documentation for the application or module name, but no application or web module with that name was deployed.
+OPENAPI_MERGE_UNUSED_INCLUDE_SERVERXML_CWWKO1684W.useraction=Check that all applications started correctly and that the names in the configuration are specified correctly.


### PR DESCRIPTION
Add a message for when an application or module is configured to be included in the OpenAPI documentation but isn't found.

With this change, the message is
```
[WARNING ] CWWKO1684W: The includeApplication configuration element includes "marketting" but that does not match any deployed application or web module.
```

Fixes #30040

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
