### PR TITLE
MP OpenAPI: reduce FAT repeats on slow tests

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
@@ -52,4 +52,19 @@ public class FATSuite {
                                           MicroProfileActions.MP50, // mpOpenAPI-3.0, FULL
                                           MicroProfileActions.MP41);// mpOpenAPI-2.0, FULL
     }
+
+    /**
+     * A reduced set of repeats for slow tests where the implementation is common across all feature versions
+     * <p>
+     * Care should be taken when applying this repeat list to avoid having code paths go untested. If the code in common is not common across all versions of the feature, a more
+     * specific list of repeats may be more appropriate.
+     * 
+     * @param serverName the server which should have its features updated
+     * @return the repeat action
+     */
+    public static RepeatTests repeatReduced(String serverName) {
+        return MicroProfileActions.repeat(serverName,
+                                          MicroProfileActions.MP70_EE10, // mpOpenAPI-4.0, LITE
+                                          MicroProfileActions.MP61);// mpOpenAPI-3.1, FULL
+    }
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTest.java
@@ -50,7 +50,7 @@ public class CacheTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
+    public static RepeatTests r = FATSuite.repeatReduced(SERVER_NAME);
 
     @Test
     public void testCacheHit() throws Exception {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigBothTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigBothTest.java
@@ -53,7 +53,7 @@ public class MergeConfigBothTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
+    public static RepeatTests r = FATSuite.repeatReduced(SERVER_NAME);
 
     @After
     public void cleanup() throws Exception {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigTest.java
@@ -62,7 +62,7 @@ public class MergeConfigTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
+    public static RepeatTests r = FATSuite.repeatReduced(SERVER_NAME);
 
     @After
     public void cleanup() throws Exception {


### PR DESCRIPTION
Reduce the number of repeats that we do for tests which are slow and where the functionality under test is common across all versions and so the risk of missing a problem is low.

These tests are causing timeouts in our builds on some platforms.

For RTC 302481

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

