### PR TITLE
Remove mention of z/OS related to attach

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -462,7 +462,7 @@ serverEnvDefaults()
 
   # Add -Xquickstart -Xshareclasses:none for client JVMs only.  We don't want 
   # shared classes cache created for client operations.
-  # Add -Dcom.ibm.tools.attach.enable=yes to allow self-attach on z/OS
+  # Add -Dcom.ibm.tools.attach.enable=yes to allow self-attach
   
   IBM_JAVA_OPTIONS="-Xquickstart -Dcom.ibm.tools.attach.enable=yes ${SPECIFIED_JAVA_OPTIONS} -Xshareclasses:none"
   export IBM_JAVA_OPTIONS


### PR DESCRIPTION
There is a comment on line 446 that says com.ibm.tools.attach.enable system property should be set to yes for z/OS. There is a bug #30045 that says this should say it is set for platforms other than z/OS. In either case Open Liberty doesn't support z/OS so it shouldn't really mention z/OS. There are other mentions of z/OS but this will just removed the requested reference.

Fixes #30045

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).

