### PR TITLE
test for invalid entity

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -390,7 +390,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                 throw (DataException) exc(DataException.class,
                                           "CWWKD1080.datastore.general.err",
                                           getClassNames(repositoryInterfaces),
-                                          metadata.getName(),
+                                          metadata.getJ2EEName(),
                                           dataStore,
                                           x).initCause(x);
             }
@@ -459,7 +459,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         DataException x = exc(DataException.class,
                               "CWWKD1078.datastore.not.found",
                               getClassNames(repositoryInterfaces),
-                              metadata.getName(),
+                              metadata.getJ2EEName(),
                               dataStore,
                               dataSourceConfigExample,
                               databaseStoreConfigExample,
@@ -577,7 +577,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         DataException x = exc(DataException.class,
                               "CWWKD1079.jndi.not.found",
                               getClassNames(repositoryInterfaces),
-                              metadata.getName(),
+                              metadata.getJ2EEName(),
                               dataStore,
                               "@Resource(name=\"java:app/env/jdbc/dsRef\",lookup=\"jdbc/ds\")",
                               "jndiName=\"jdbc/ds\"",

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -46,6 +46,7 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1078E.*test.jakarta.data.errpaths.web.InvalidNonJNDIRepo",
                                    "CWWKD1079E.*test.jakarta.data.errpaths.web.InvalidJNDIRepo",
                                    "CWWKD1080E.*test.jakarta.data.errpaths.web.InvalidDatabaseRepo",
+                                   "CWWKD1080E.*test.jakarta.data.errpaths.web.Inventions", // has invalid entity class
                                    "CWWKD1082E.*test.jakarta.data.errpaths.web.WrongPersistenceUnitRefRepo",
                                    "CWWKD1083E.*bornOn", // duplicate Param annotations
                                    "CWWKD1084E.*bornIn", // Param annotation omitted

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -436,7 +436,7 @@ public class DataErrPathsTestServlet extends FATServlet {
 
     /**
      * Tests an error path where the repository specifies an entity that is not a
-     * valid JPA entity because it has 2 Id attributes without using IdClass.
+     * valid JPA entity because it has no Id attribute.
      */
     @Test
     public void testRepositoryWithInvalidEntity() {
@@ -444,8 +444,7 @@ public class DataErrPathsTestServlet extends FATServlet {
             Invention i = errInvalidEntityRepo //
                             .save(new Invention(1, 2, "Perpetual Motion Machine"));
             fail("Should not be able to use a repository operation for an entity" +
-                 " that is not valid because it has 2 Id attributes without" +
-                 " IdClass. Saved: " + i);
+                 " that is not valid because it has no Id attribute. Saved: " + i);
         } catch (CompletionException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1080E:") ||

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -436,7 +436,7 @@ public class DataErrPathsTestServlet extends FATServlet {
 
     /**
      * Tests an error path where the repository specifies an entity that is not a
-     * valid JPA entity because it has 2 Id attributes without using IdClsas.
+     * valid JPA entity because it has 2 Id attributes without using IdClass.
      */
     @Test
     public void testRepositoryWithInvalidEntity() {

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -84,6 +84,9 @@ public class DataErrPathsTestServlet extends FATServlet {
     InvalidJNDIRepo errIncorrectJNDIName;
 
     @Inject
+    Inventions errInvalidEntityRepo;
+
+    @Inject
     WrongPersistenceUnitRefRepo errWrongPersistenceUnitRef;
 
     @Resource
@@ -427,6 +430,26 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1080E:") ||
                 !x.getMessage().contains(InvalidDatabaseRepo.class.getName()))
+                throw x;
+        }
+    }
+
+    /**
+     * Tests an error path where the repository specifies an entity that is not a
+     * valid JPA entity because it has 2 Id attributes without using IdClsas.
+     */
+    @Test
+    public void testRepositoryWithInvalidEntity() {
+        try {
+            Invention i = errInvalidEntityRepo //
+                            .save(new Invention(1, 2, "Perpetual Motion Machine"));
+            fail("Should not be able to use a repository operation for an entity" +
+                 " that is not valid because it has 2 Id attributes without" +
+                 " IdClass. Saved: " + i);
+        } catch (CompletionException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1080E:") ||
+                !x.getMessage().contains(Invention.class.getName()))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Invention.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Invention.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+
+/**
+ * An invalid entity - because it lacks an Id attribute.
+ */
+@Entity
+public class Invention {
+
+    @Column(nullable = false)
+    public int disclosureNum;
+
+    public int patentNum;
+
+    @Column(nullable = false)
+    public String title;
+
+    public Invention() {
+    }
+
+    public Invention(int disclosureNum, int patentNum, String title) {
+        this.disclosureNum = disclosureNum;
+        this.patentNum = patentNum;
+        this.title = title;
+    }
+
+    @Override
+    public String toString() {
+        return "Invention#" + disclosureNum + "(" + patentNum + "): " + title;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Inventions.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Inventions.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for an invalid entity type that lacks an Id attribute.
+ */
+@Repository(dataStore = "java:module/jdbc/DataSourceForInvalidEntity")
+public interface Inventions extends BasicRepository<Invention, Integer> {
+
+}


### PR DESCRIPTION
Write an automated test case for the scenario where a repository defines operations on an entity class that is not valid. Ensure that a meaningful error is raised to the user.  This also includes corrections to the application artifact name value that is supplied to error messages.  The metadata.getName is returning null. Use getJ2EEName instead because it contains the correct value.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
