### PR TITLE
Reduced logs in testMessageLogs in mpTelemetry Logs container FAT

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingServletTest.java
@@ -50,6 +50,8 @@ public class LoggingServletTest {
 
     private static final String[] EXPECTED_FAILURES = { "CWMOT5005W", "SRVE0315E", "SRVE0777E" };
 
+    public static final int WAIT_TIMEOUT = 5; // 5 seconds
+
     @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
                     .withDockerfileFromBuilder(builder -> builder.from(TestUtils.IMAGE_NAME)
@@ -96,7 +98,7 @@ public class LoggingServletTest {
         TestUtils.runApp(server, "logs");
 
         //Allow time for the collector to receive and bridge logs.
-        TimeUnit.SECONDS.sleep(5);
+        TimeUnit.SECONDS.sleep(WAIT_TIMEOUT);
 
         final String logs = container.getLogs();
 
@@ -128,7 +130,7 @@ public class LoggingServletTest {
         TestUtils.runApp(server, "logs");
 
         //Allow time for the collector to receive and bridge logs.
-        TimeUnit.SECONDS.sleep(5);
+        TimeUnit.SECONDS.sleep(WAIT_TIMEOUT);
 
         final String logs = container.getLogs();
 
@@ -161,7 +163,7 @@ public class LoggingServletTest {
         TestUtils.runApp(server, "ffdc1");
 
         //Allow time for the collector to receive and bridge logs.
-        TimeUnit.SECONDS.sleep(5);
+        TimeUnit.SECONDS.sleep(WAIT_TIMEOUT);
 
         final String logs = container.getLogs();
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingServletTest.java
@@ -44,7 +44,7 @@ public class LoggingServletTest {
     @Server("TelemetryLogsServer")
     public static LibertyServer server;
 
-    public static final String SERVER_XML_ALL_SOURCES = "allSourcesServer.xml";
+    public static final String SERVER_XML_MSG_SOURCES = "msgSourceServer.xml";
     public static final String SERVER_XML_TRACE_SOURCE = "traceSourceServer.xml";
     public static final String SERVER_XML_FFDC_SOURCE = "FFDCSourceServer.xml";
 
@@ -91,7 +91,7 @@ public class LoggingServletTest {
         TestUtils.isContainerStarted("LogsExporter", container);
 
         RemoteFile messageLogFile = server.getDefaultLogFile();
-        setConfig(SERVER_XML_ALL_SOURCES, messageLogFile, server);
+        setConfig(SERVER_XML_MSG_SOURCES, messageLogFile, server);
 
         TestUtils.runApp(server, "logs");
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/publish/files/msgSourceServer.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/publish/files/msgSourceServer.xml
@@ -1,0 +1,29 @@
+
+<server>
+    <featureManager>
+        <feature>servlet-6.0</feature>
+    	<feature>mpTelemetry-2.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml" />
+
+    <keyStore id="defaultKeyStore" password="Liberty"/>
+
+    <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="${bvt.prop.HTTP_default}"
+                  httpsPort="${bvt.prop.HTTP_default.secure}" />
+
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
+    <applicationMonitor updateTrigger="mbean"/>
+
+    <!--Java2 security-->
+    <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
+    
+   	<mpTelemetry source="message"/>
+
+
+
+
+</server>

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/publish/files/msgSourceServer.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/publish/files/msgSourceServer.xml
@@ -21,9 +21,6 @@
     <!--Java2 security-->
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
     
-   	<mpTelemetry source="message"/>
-
-
-
+    <mpTelemetry source="message"/>
 
 </server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #30024 

- All the sources were enabled, hence there were a lot of logs being sent to OTLP, causing a slowness, when the test looked for a particular message, it could not find it, since the message did not get logged yet. Reduced the number of logs sent to otlp, by only specifying "messages" in the source attribute.
- Refactored the code for easy readability.

