### PR TITLE
Add debug from OpenTelemetry Collector and increase metric export interval for `io.openliberty.http.monitor_fat`

### DIFF
--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSFApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSFApplicationTest.java
@@ -107,7 +107,7 @@ public class ContainerJSFApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
 
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
                                            requestMethod));
     }
@@ -147,7 +147,7 @@ public class ContainerJSFApplicationTest extends BaseTestClass {
         String urlXHTML = "http://" + server.getHostname() + ":"
                           + server.getHttpDefaultPort() + routeXHTML;
         HtmlPage page = (HtmlPage) webClient1.getPage(urlXHTML);
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
 
         //Expected count 3 : 1 xhtml, 2 resource
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteXHTML, responseStatus, requestMethod, null, ">2", null));
@@ -159,7 +159,7 @@ public class ContainerJSFApplicationTest extends BaseTestClass {
         String urlJSF = "http://" + server.getHostname() + ":"
                         + server.getHttpDefaultPort() + routeJSF;
         page = (HtmlPage) webClient2.getPage(urlJSF);
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
 
         //Expected count 5 : + 2 resource loading (since xhtml loaded resources first, they continue to load form the /[jakarta.javax].faces.resource/*.xhtml path
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteXHTML, responseStatus, requestMethod, null, ">4", null));
@@ -173,7 +173,7 @@ public class ContainerJSFApplicationTest extends BaseTestClass {
         String urlFaces = "http://" + server.getHostname() + ":"
                           + server.getHttpDefaultPort() + routeFaces;
         page = (HtmlPage) webClient3.getPage(urlFaces);
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
 
         //Expected count 7 : + 2 resource loading (since xhtml loaded resources first, they continue to load form the /[jakarta.javax].faces.resource/*.xhtml path
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteXHTML, responseStatus, requestMethod, null, ">6", null));
@@ -187,7 +187,7 @@ public class ContainerJSFApplicationTest extends BaseTestClass {
         String urlFacesNode = "http://" + server.getHostname() + ":"
                               + server.getHttpDefaultPort() + routeFacesNode;
         page = (HtmlPage) webClient4.getPage(urlFacesNode);
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
 
         //Expected count 9 : + 2 resource loading (since xhtml loaded resources first, they continue to load form the /[jakarta.javax].faces.resource/*.xhtml path
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRouteXHTML, responseStatus, requestMethod, null, ">8", null));

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSPApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSPApplicationTest.java
@@ -103,7 +103,7 @@ public class ContainerJSPApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
                                            requestMethod));
 
@@ -120,7 +120,7 @@ public class ContainerJSPApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod));
 
     }
@@ -137,7 +137,7 @@ public class ContainerJSPApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
                                            requestMethod));
 
@@ -148,7 +148,7 @@ public class ContainerJSPApplicationTest extends BaseTestClass {
 
         res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
                                            requestMethod));
     }

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerNoAppTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerNoAppTest.java
@@ -86,7 +86,7 @@ public class ContainerNoAppTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(Constants.OTEL_SERVICE_NOT_SET, getContainerCollectorMetrics(container), route, responseStatus, requestMethod));
 
     }

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerRestApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerRestApplicationTest.java
@@ -107,7 +107,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod));
 
     }
@@ -122,7 +122,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod));
 
     }
@@ -138,7 +138,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod));
 
     }
@@ -154,7 +154,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod));
 
     }
@@ -170,7 +170,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod));
 
     }
@@ -186,7 +186,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod));
     }
 
@@ -203,7 +203,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod,
                                            errorType));
 
@@ -221,7 +221,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), resolvedRoute, responseStatus,
                                            requestMethod));
 
@@ -240,7 +240,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod,
                                            errorType));
 
@@ -259,7 +259,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod,
                                            errorType));
 
@@ -278,7 +278,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
                                            requestMethod));
 
@@ -297,7 +297,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
                                            requestMethod));
 
@@ -316,7 +316,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
                                            requestMethod));
 
@@ -341,7 +341,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         Log.info(c, " cr1_params_query", "the response is " + res);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
                                            requestMethod));
 
@@ -364,7 +364,7 @@ public class ContainerRestApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
                                            requestMethod));
 

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerServletApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerServletApplicationTest.java
@@ -105,7 +105,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
         String res = requestHttpServlet(route, server, requestMethod);
 
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
 
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus,
                                            requestMethod));
@@ -123,7 +123,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
         String res = requestHttpServlet(route, server, requestMethod);
 
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
 
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus,
                                            requestMethod));
@@ -142,7 +142,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
         String res = requestHttpServlet(route, server, requestMethod);
 
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
 
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus,
                                            requestMethod));
@@ -160,7 +160,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus,
                                            requestMethod));
 
@@ -177,7 +177,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus,
                                            requestMethod));
 
@@ -194,7 +194,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus,
                                            requestMethod));
 
@@ -213,7 +213,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod, "failMode=zero");
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod,
                                            errorType));
 
@@ -232,7 +232,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
                                            requestMethod));
 
@@ -249,7 +249,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod, "failMode=custom");
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus,
                                            requestMethod));
 
@@ -268,7 +268,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod, "failMode=io");
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod,
                                            errorType));
 
@@ -287,7 +287,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod, "failMode=iae");
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(SERVICE_NAME, getContainerCollectorMetrics(container), route, responseStatus, requestMethod,
                                            errorType));
 
@@ -306,7 +306,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(WILDCARD_SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus, requestMethod));
 
     }
@@ -324,7 +324,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(WILDCARD_SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus, requestMethod));
 
     }
@@ -342,7 +342,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
-        TimeUnit.SECONDS.sleep(4);
+        TimeUnit.SECONDS.sleep(5);
         assertTrue(validateMpTelemetryHttp(WILDCARD_SERVICE_NAME, getContainerCollectorMetrics(container), expectedRoute, responseStatus, requestMethod));
 
     }

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/FATSuite.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/FATSuite.java
@@ -76,7 +76,7 @@ public class FATSuite extends TestContainerSuite {
             server.addEnvVar("OTEL_SDK_DISABLED", "false");
             server.addEnvVar("OTEL_TRACES_EXPORTER", "none");
             server.addEnvVar("OTEL_LOGS_EXPORTER", "none");
-            server.addEnvVar("OTEL_METRIC_EXPORT_INTERVAL", "200");
+            server.addEnvVar("OTEL_METRIC_EXPORT_INTERVAL", "1000");
             return archive;
         }
     }

--- a/dev/io.openliberty.http.monitor_fat/publish/files/config.yaml
+++ b/dev/io.openliberty.http.monitor_fat/publish/files/config.yaml
@@ -6,6 +6,8 @@ receivers:
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
+  debug:
+    verbosity: normal
 
 processors:
   batch:
@@ -15,4 +17,4 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [prometheus]
+      exporters: [prometheus, debug]


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

It could be that the short export interval (i.e., 200ms) was causing throughput issues with the exporter.