### PR TITLE
Cleanup from recent merges

### DIFF
--- a/dev/com.ibm.ws.classloading_classpath_fat/bnd.bnd
+++ b/dev/com.ibm.ws.classloading_classpath_fat/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -51,4 +51,5 @@ tested.features:
 	com.ibm.websphere.javaee.ejb.3.2, \
 	fattest.simplicity, \
 	com.ibm.ws.componenttest,\
-	com.ibm.websphere.javaee.connector.1.7
+	com.ibm.websphere.javaee.connector.1.7,\
+	com.ibm.websphere.javaee.annotation.1.3

--- a/dev/io.openliberty.io.smallrye.openapi4.model/.classpath
+++ b/dev/io.openliberty.io.smallrye.openapi4.model/.classpath
@@ -6,6 +6,5 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="src" output="bin" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.io.smallrye.openapi4.model/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.io.smallrye.openapi4.model/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal.services/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal.services/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
@@ -37,7 +37,8 @@ WS-TraceGroup: MPOPENAPI
     com.ibm.websphere.org.osgi.core;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-    com.ibm.ws.org.osgi.annotation.versioning;version=latest
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    com.ibm.ws.container.service;version=latest
 
 -testpath: \
     org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal.services/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal.services/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -45,7 +45,8 @@ WS-TraceGroup: MPOPENAPI
     com.ibm.websphere.org.osgi.core;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-    com.ibm.ws.org.osgi.annotation.versioning;version=latest
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    com.ibm.ws.container.service;version=latest
 
 -testpath: \
     org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/io.openliberty.microprofile.openapi.4.0.internal.services/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.4.0.internal.services/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -49,7 +49,8 @@ WS-TraceGroup: MPOPENAPI
     com.ibm.websphere.org.osgi.core;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-    com.ibm.ws.org.osgi.annotation.versioning;version=latest
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    com.ibm.ws.container.service;version=latest
 
 -testpath: \
     org.hamcrest:hamcrest-all;version=1.3, \


### PR DESCRIPTION
- Remove non-existent source directory from .classpath file
- Add com.ibm.ws.container.service to bnd buildpath for indirect reference errors in eclipse
- Add missing bndtools.core.prefs file
- Add annotations 1.3 java ee API jar to buildpath for when building with Java 17 where it isn't in the JDK any longer

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
