### PR TITLE
refactoring to QueryInfo

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1096,6 +1096,7 @@ public class QueryInfo {
     @Trivial
     NonUniqueResultException excNonUniqueResult(int numResults) {
         throw exc(NonUniqueResultException.class,
+                  "CWWKD1054.non.unique.result",
                   method.getName(),
                   repositoryInterface.getName(),
                   method.getGenericReturnType().getTypeName(),

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1010,7 +1010,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                         // The first method parameters are used as query parameters.
                         // Beyond that, they can have other purposes such as
                         // pagination and sorting.
-                        for (int i = queryInfo.paramCount; //
+                        for (int i = queryInfo.jpqlParamCount; //
                                         i < (args == null ? 0 : args.length); //
                                         i++) {
                             Object param = args[i];
@@ -1061,7 +1061,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                           "CWWKD1023.extra.param",
                                           method.getName(),
                                           repositoryInterface.getName(),
-                                          queryInfo.paramCount,
+                                          queryInfo.jpqlParamCount,
                                           method.getParameterTypes()[i].getName(),
                                           queryInfo.jpql);
                             }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.data.internal.persistence;
+
+import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+import jakarta.data.Limit;
+import jakarta.data.Order;
+import jakarta.data.Sort;
+import jakarta.data.page.PageRequest;
+
+/**
+ * A location for helper methods that do not require any state.
+ */
+public class Util {
+    /**
+     * Commonly used result types that are not entities.
+     */
+    static final Set<Class<?>> NON_ENTITY_RESULT_TYPES = new HashSet<>();
+
+    /**
+     * Primitive types for numeric values.
+     */
+    static final Set<Class<?>> PRIMITIVE_NUMERIC_TYPES = //
+                    Set.of(long.class, int.class, short.class, byte.class,
+                           double.class, float.class);
+
+    /**
+     * Return types for deleteBy that distinguish delete-only from find-and-delete.
+     */
+    static final Set<Class<?>> RETURN_TYPES_FOR_DELETE_ONLY = //
+                    Set.of(void.class, Void.class,
+                           boolean.class, Boolean.class,
+                           int.class, Integer.class,
+                           long.class, Long.class,
+                           Number.class);
+
+    /**
+     * Valid types for repository method parameters that specify sort criteria.
+     */
+    static final Set<Class<?>> SORT_PARAM_TYPES = //
+                    Set.of(Order.class, Sort.class, Sort[].class);
+
+    /**
+     * Valid types for repository method parameters after the query parameters.
+     */
+    static final Set<Class<?>> SPECIAL_PARAM_TYPES = //
+                    Set.of(Limit.class, Order.class, PageRequest.class,
+                           Sort.class, Sort[].class);
+
+    /**
+     * Valid types for when a repository method computes an update count
+     */
+    static final Set<Class<?>> UPDATE_COUNT_TYPES = //
+                    Set.of(boolean.class, Boolean.class,
+                           int.class, Integer.class,
+                           long.class, Long.class,
+                           void.class, Void.class,
+                           Number.class);
+
+    /**
+     * Valid types for jakarta.persistence.Version, except for
+     * java.sql.Timestamp, which is not a valid type in Jakarta Data.
+     */
+    public static final Set<Class<?>> VERSION_TYPES = //
+                    Set.of(Instant.class,
+                           int.class, Integer.class,
+                           LocalDateTime.class,
+                           long.class, Long.class,
+                           short.class, Short.class);
+
+    /**
+     * Mapping of Java primitive class to wrapper class.
+     */
+    private static final Map<Class<?>, Class<?>> WRAPPER_CLASSES = //
+                    Map.of(boolean.class, Boolean.class,
+                           byte.class, Byte.class,
+                           char.class, Character.class,
+                           double.class, Double.class,
+                           float.class, Float.class,
+                           int.class, Integer.class,
+                           long.class, Long.class,
+                           short.class, Short.class,
+                           void.class, Void.class);
+
+    /**
+     * Returns true if it is certain the class cannot be an entity
+     * because it is one of the common non-entity result types
+     * or it is an enumeration, interface, or abstract class.
+     * Otherwise, returns false.
+     *
+     * @param c class of result.
+     * @return true if a result of the type might be an entity, otherwise false.
+     */
+    @Trivial
+    public static boolean cannotBeEntity(Class<?> c) {
+        int modifiers;
+        return NON_ENTITY_RESULT_TYPES.contains(c) ||
+               c.isEnum() ||
+               Modifier.isInterface(modifiers = c.getModifiers()) ||
+               Modifier.isAbstract(modifiers);
+    }
+
+    /**
+     * Indicates if the specified class is a wrapper for the primitive class.
+     *
+     * @param primitive primitive class.
+     * @param cl        another class that might be a wrapper class for the primitive class.
+     * @return true if the class is the wrapper class for the primitive class, otherwise false.
+     */
+    static final boolean isWrapperClassFor(Class<?> primitive, Class<?> cl) {
+        return primitive == long.class && cl == Long.class ||
+               primitive == int.class && cl == Integer.class ||
+               primitive == float.class && cl == Float.class ||
+               primitive == double.class && cl == Double.class ||
+               primitive == char.class && cl == Character.class ||
+               primitive == byte.class && cl == Byte.class ||
+               primitive == boolean.class && cl == Boolean.class ||
+               primitive == short.class && cl == Short.class;
+    }
+
+    static {
+        for (Entry<Class<?>, Class<?>> e : WRAPPER_CLASSES.entrySet()) {
+            NON_ENTITY_RESULT_TYPES.add(e.getKey()); // primitive classes
+            NON_ENTITY_RESULT_TYPES.add(e.getValue()); // wrapper classes
+        }
+        NON_ENTITY_RESULT_TYPES.add(BigDecimal.class);
+        NON_ENTITY_RESULT_TYPES.add(BigInteger.class);
+        NON_ENTITY_RESULT_TYPES.add(Object.class);
+        NON_ENTITY_RESULT_TYPES.add(String.class);
+    }
+
+    /**
+     * Returns some of the more commonly used return types that are valid
+     * for a life cycle method.
+     *
+     * @param singularClassName        simple class name of the entity
+     * @param hasSingularEntityParam   if the life cycle method entity parameter is
+     *                                     singular (not an Iterable or array)
+     * @param includeBooleanAndNumeric whether to include boolean and numeric types
+     *                                     as valid.
+     * @return some of the more commonly used return types that are valid for a
+     *         life cycle method.
+     */
+    static List<String> lifeCycleReturnTypes(String singularClassName,
+                                             boolean hasSingularEntityParam,
+                                             boolean includeBooleanAndNumeric) {
+        List<String> validReturnTypes = new ArrayList<>();
+        if (includeBooleanAndNumeric) {
+            validReturnTypes.add("boolean");
+            validReturnTypes.add("int");
+            validReturnTypes.add("long");
+        }
+
+        validReturnTypes.add("void");
+
+        if (hasSingularEntityParam) {
+            validReturnTypes.add(singularClassName);
+        } else {
+            validReturnTypes.add(singularClassName + "[]");
+            validReturnTypes.add("List<" + singularClassName + ">");
+        }
+
+        return validReturnTypes;
+    }
+
+    /**
+     * Returns the wrapper class if a primitive class, otherwise the same class.
+     *
+     * @param c class that is possibly a primitive class.
+     * @return wrapper class for a primitive, otherwise the same class that was supplied as a parameter.
+     */
+    @Trivial
+    static final Class<?> wrapperClassIfPrimitive(Class<?> c) {
+        Class<?> w = WRAPPER_CLASSES.get(c);
+        return w == null ? c : w;
+    }
+}

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -48,6 +48,7 @@ import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.QueryInfo;
+import io.openliberty.data.internal.persistence.Util;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.EmptyResultException;
 import jakarta.data.exceptions.EntityExistsException;
@@ -334,7 +335,7 @@ public class DataExtension implements Extension {
 
             // For efficiency, detect some obvious non-entity types.
             // Other non-entity types will be detected later.
-            if (QueryInfo.cannotBeEntity(entityClass)) {
+            if (Util.cannotBeEntity(entityClass)) {
                 queries = hasQueryAnno //
                                 ? queriesWithQueryAnno //
                                 : additionalQueriesForPrimaryEntity;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -69,7 +69,7 @@ import com.ibm.wsspi.resource.ResourceFactory;
 import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.EntityInfo;
 import io.openliberty.data.internal.persistence.EntityManagerBuilder;
-import io.openliberty.data.internal.persistence.QueryInfo;
+import io.openliberty.data.internal.persistence.Util;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.MappingException;
 import jakarta.persistence.Convert;
@@ -546,13 +546,13 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
 
             if (vPrecedence > 1 &&
                 len == 7 &&
-                QueryInfo.VERSION_TYPES.contains(type) &&
+                Util.VERSION_TYPES.contains(type) &&
                 "version".equalsIgnoreCase(name)) {
                 versionAttrName = name;
                 vPrecedence = 1;
             } else if (vPrecedence > 2 &&
                        len == 8 &&
-                       QueryInfo.VERSION_TYPES.contains(type) &&
+                       Util.VERSION_TYPES.contains(type) &&
                        "_version".equalsIgnoreCase(name)) {
                 versionAttrName = name;
                 vPrecedence = 2;

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -58,6 +58,10 @@ public class DataTest extends FATServletClient {
                                    "CWWKD1046E.*singleHexDigit",
                                    "CWWKD1047E.*numberAsByte",
                                    "CWWKD1049E.*countAsBooleanByNumberIdLessThan",
+                                   "CWWKD1054E.*deleteByDescription",
+                                   "CWWKD1054E.*deleteFirst",
+                                   "CWWKD1054E.*findAsLongBetween",
+                                   "CWWKD1054E.*findByNumberIdBetween",
                                    "CWWKD1075E.*Apartment2",
                                    "CWWKD1075E.*Apartment3"
                     };

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -42,6 +42,7 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWJP9991W.*4002", // 2 persistence units attempt to autocreate same table
                                    "CWWKD1019E.*livingAt", // mix of named/positional parameters
                                    "CWWKD1019E.*residingAt", // unused parameters
+                                   "CWWKD1046E.*register", // incompatible return type
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",
                                    "CWWKD1078E.*test.jakarta.data.errpaths.web.InvalidNonJNDIRepo",
                                    "CWWKD1079E.*test.jakarta.data.errpaths.web.InvalidJNDIRepo",

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -235,6 +235,31 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Verify an error is raised for a repository insert method with a parameter
+     * that can insert multiple entities and a return type that can only return
+     * one inserted entity.
+     */
+    @Test
+    public void testInsertMultipleEntitiesButOnlyReturnOne() {
+        Voter v1 = new Voter(100200300, "Valerie", //
+                        LocalDate.of(1947, Month.NOVEMBER, 7), //
+                        "88 23rd Ave SW, Rochester, MN 55902");
+        Voter v2 = new Voter(400500600, "Vinny", //
+                        LocalDate.of(1988, Month.NOVEMBER, 8), //
+                        "2016 45th St SE, Rochester, MN 55904");
+        try {
+            Voter inserted = voters.register(v1, v2);
+            fail("Insert method with singular return type should not be able to " +
+                 "insert two entities. Instead returned: " + inserted);
+        } catch (ClassCastException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1046E:") ||
+                !x.getMessage().contains("register"))
+                throw x;
+        }
+    }
+
+    /**
      * Verify an error is raised for a repository method that has a Param annotation
      * that specifies a name value that does not match the name of a named parameter
      * from the query.

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import jakarta.data.Sort;
 import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
@@ -112,6 +113,13 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     List<Voter> livingOn(@Param("street") String street,
                          @Param("city") String city, // extra, unused Param
                          @Param("state") String stateCode); // extra, unused Param
+
+    /**
+     * For testing an error where the method parameter allows multiple entities,
+     * but the return type only allows one.
+     */
+    @Insert
+    Voter register(Voter... v);
 
     /**
      * This invalid method has matching named parameters and Param annotation,

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
@@ -53,6 +53,7 @@ public class DataJPATest extends FATServletClient {
                                    "CWWKD1046E.*numFullTimeWorkersAsDouble",
                                    "CWWKD1046E.*numFullTimeWorkersAsFloat",
                                    "CWWKD1046E.*numFullTimeWorkersAsShort",
+                                   "CWWKD1054E.*findByIsControlTrueAndNumericValueBetween",
                                    "CWWKD1075E.*Apartment2",
                                    "CWWKD1075E.*Apartment3"
                     };

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
@@ -43,6 +43,7 @@ public class DataCoreTckLauncher {
     @After
     public void tearDown() throws Exception {
         String[] ignoredMessages = new String[] {
+                                                  "CWWKD1054E", // tested error path
                                                   "CWWKE0955E" //websphere.java.security java 18+
         };
         if (persistenceServer.isStarted()) {

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataFullTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataFullTckLauncher.java
@@ -50,6 +50,7 @@ public class DataFullTckLauncher {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer(
+                          "CWWKD1054E", // tested error path
                           "CWWKE0955E" //websphere.java.security java 18+
         );
     }

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
@@ -48,6 +48,7 @@ public class DataWebTckLauncher {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer(
+                          "CWWKD1054E", // tested error path
                           "CWWKE0955E" //websphere.java.security java 18+
         );
     }


### PR DESCRIPTION
Refactoring mainly to QueryInfo and RepositoryImpl that involves renaming a misleading field, moving methods to where they make more sense, and moving some constants and utility methods to a utility class. While doing this, I spotted an exception that was being raised with its NLS message id missing, which would cause its message to appear wrongly in the exception and for its message not to be logged. After fixing that, we also needed excludes of those messagse for tests that were causing the error on purpose to test it.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
