### PR TITLE
Update WSX509KeyManager.chooseEngineClientAlias to match JDK 17.0.0.11

### DIFF
--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
@@ -319,7 +319,9 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
     public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine engine) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.entry(tc, "chooseEngineServerAlias", new Object[] { keyType, issuers, engine });
-
+            System.out.println("WRG+++Major: "+JavaInfo.majorVersion());
+            System.out.println("WRG+++Minor: "+JavaInfo.minorVersion());    
+            System.out.println("WRG+++Micro: "+JavaInfo.microVersion()); 
         String rc = null;
         if (null != customKM && customKM instanceof X509ExtendedKeyManager) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
@@ -342,18 +344,18 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
     @Override
     public String chooseEngineClientAlias(String[] keyType, Principal[] issuers, SSLEngine engine) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-            Tr.entry(tc, "chooseEngineClientAlias", new Object[] { keyType, issuers, engine });
-
+            Tr.entry(tc, "chooseEngineClientAlias", new Object[] { keyType, issuers, engine }); 
+            System.out.println("WRG+++Major: "+JavaInfo.majorVersion());
+            System.out.println("WRG+++Minor: "+JavaInfo.minorVersion());    
+            System.out.println("WRG+++Micro: "+JavaInfo.microVersion()); 
+            
         String rc = null;
         if (null != customKM && customKM instanceof X509ExtendedKeyManager) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(tc, "chooseEngineClientAlias, using customKM -> " + customKM.getClass().getName());
             rc = ((X509ExtendedKeyManager) customKM).chooseEngineClientAlias(keyType, issuers, engine);
-        } else {
-            System.out.println("WRG+++Major: "+JavaInfo.majorVersion());
-            System.out.println("WRG+++Minor: "+JavaInfo.minorVersion());    
-            System.out.println("WRG+++Micro: "+JavaInfo.microVersion());            
-            if(JavaInfo.majorVersion() >=17 && JavaInfo.minorVersion() >=11)
+        } else {          
+            if(JavaInfo.majorVersion() >=17 && JavaInfo.microVersion() >=11)
             rc = chooseClientAlias(keyType, issuers, null);
             else{
             rc = chooseClientAlias(keyType[0], issuers);

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
@@ -319,9 +319,6 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
     public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine engine) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.entry(tc, "chooseEngineServerAlias", new Object[] { keyType, issuers, engine });
-            System.out.println("WRG+++Major: "+JavaInfo.majorVersion());
-            System.out.println("WRG+++Minor: "+JavaInfo.minorVersion());    
-            System.out.println("WRG+++Micro: "+JavaInfo.microVersion()); 
         String rc = null;
         if (null != customKM && customKM instanceof X509ExtendedKeyManager) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
@@ -354,12 +351,13 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(tc, "chooseEngineClientAlias, using customKM -> " + customKM.getClass().getName());
             rc = ((X509ExtendedKeyManager) customKM).chooseEngineClientAlias(keyType, issuers, engine);
-        } else {          
-            if(JavaInfo.majorVersion() >=17 && JavaInfo.microVersion() >=11)
-            rc = chooseClientAlias(keyType, issuers, null);
-            else{
-            rc = chooseClientAlias(keyType[0], issuers);
-            }
+        } else {        
+            System.out.println("WRG++++Broken");
+            // if(JavaInfo.majorVersion() >=17 && JavaInfo.microVersion() >=11)
+            //rc = chooseClientAlias(keyType, issuers, null);
+            // else{
+            // rc = chooseClientAlias(keyType[0], issuers);
+            // }
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
@@ -352,9 +352,9 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
                 Tr.debug(tc, "chooseEngineClientAlias, using customKM -> " + customKM.getClass().getName());
             rc = ((X509ExtendedKeyManager) customKM).chooseEngineClientAlias(keyType, issuers, engine);
         } else {        
-            System.out.println("WRG++++Broken");
             // if(JavaInfo.majorVersion() >=17 && JavaInfo.microVersion() >=11)
-            //rc = chooseClientAlias(keyType, issuers, null);
+            System.out.println("WRG++++This is a bug fix")
+            rc = chooseClientAlias(keyType, issuers, null);
             // else{
             // rc = chooseClientAlias(keyType[0], issuers);
             // }

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.ssl.Constants;
 import com.ibm.websphere.ssl.JSSEHelper;
 import com.ibm.websphere.ssl.SSLConfig;
 import com.ibm.ws.ffdc.FFDCFilter;
+import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.ws.ssl.config.KeyStoreManager;
 import com.ibm.ws.ssl.config.SSLConfigManager;
 import com.ibm.ws.ssl.config.WSKeyStore;
@@ -349,7 +350,14 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
                 Tr.debug(tc, "chooseEngineClientAlias, using customKM -> " + customKM.getClass().getName());
             rc = ((X509ExtendedKeyManager) customKM).chooseEngineClientAlias(keyType, issuers, engine);
         } else {
+            System.out.println("WRG+++Major: "+JavaInfo.majorVersion());
+            System.out.println("WRG+++Minor: "+JavaInfo.minorVersion());    
+            System.out.println("WRG+++Micro: "+JavaInfo.microVersion());            
+            if(JavaInfo.majorVersion() >=17 && JavaInfo.minorVersion() >=11)
+            rc = chooseClientAlias(keyType, issuers, null);
+            else{
             rc = chooseClientAlias(keyType[0], issuers);
+            }
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())


### PR DESCRIPTION
In JDK 17.0.0.11 the WSX509KeyManager.chooseEngineClientAlias was updated to expect the full list of `keytype` instead of the first one in the array. This Pull Request is going to make our code compatible with that change.


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
