### PR TITLE
Remove incorrect comment from server help package output.

### DIFF
--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherOptions.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherOptions.nlsprops
@@ -255,7 +255,7 @@ option-desc.no-password=\
 option-key.server-root=\
 \ \ \ \ --server-root="root server folder in archive"
 option-desc.package.server-root=\
-\tSpecifies the root server folder name in the archive file.           \n\
+\tSpecifies the root server folder name in the archive file. 
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
 option-key.force=\
 \ \ \ \ --force


### PR DESCRIPTION
When running server help package the following is output at the end:

```
 at 72 chars -- leading tab-----------
```

this comment goes in the nls file to ensure that the width of options in the help output is no more than 72 characters. However the proceeding line was incorrectly terminated with \n\ which say print new line and then turn off the next new line character. This means the # that indicates the start of a comment is treated as part of the prior key and results in a comment appearing in the output. This has been in Liberty for at least 5 years.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


