### PR TITLE
fix: ensure z/OS uses supported encoding for JSON TCKs

### DIFF
--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/fat/src/io/openliberty/jakarta/jsonb/tck/JsonbTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/fat/src/io/openliberty/jakarta/jsonb/tck/JsonbTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/fat/src/io/openliberty/jakarta/jsonb/tck/JsonbTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/fat/src/io/openliberty/jakarta/jsonb/tck/JsonbTckLauncher.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.jakarta.jsonb.tck;
 
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,6 +27,7 @@ import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
@@ -41,6 +44,15 @@ import componenttest.topology.utils.tck.TCKRunner;
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 11)
 @MaximumJavaLevel(javaLevel = 21) //Fails on Java 23 due to updates to CLDR https://jdk.java.net/23/release-notes#JDK-8319990
+/*
+ * Tests run on client JVM and each test requires a new JVM fork because the TCK itself has a provider
+ * which needs to be discovered in some tests, and ignored in other tests. When this fork is created on
+ * z/OS the maven-surefire-plugin fails with:
+ * - Corrupted channel by directly writing to native stream in forked JVM 1.
+ * - The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
+ * This seems to be a bug in the maven-surefire-plugin, which will hopefully be fixed in a future release
+ */
+@SkipIfSysProp(OS_ZOS)
 public class JsonbTckLauncher {
 
     final static Map<String, String> additionalProps = new HashMap<>();

--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2022, 2024 IBM Corporation and others. All rights reserved. 
+<!-- Copyright (c) 2022, 2025 IBM Corporation and others. All rights reserved. 
 	This program and the accompanying materials are made available under the 
 	terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	and is available at http://www.eclipse.org/legal/epl-2.0/ Contributors: 
@@ -173,7 +173,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.1.2</version>
 				<configuration>
-					<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). -->
+					<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBytes(). -->
 					<trimStackTrace>false</trimStackTrace>
 					<failIfNoTests>true</failIfNoTests>
 					<dependenciesToScan>${jakarta.jsonb.tck.groupId}:jakarta.json.bind-tck</dependenciesToScan>

--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -177,7 +177,6 @@
 					<trimStackTrace>false</trimStackTrace>
 					<failIfNoTests>true</failIfNoTests>
 					<dependenciesToScan>${jakarta.jsonb.tck.groupId}:jakarta.json.bind-tck</dependenciesToScan>
-					<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
 					<systemPropertyVariables>
 						<jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
 						<signature.sigTestClasspath>${project.build.directory}/signaturedirectory/jakarta.json.bind-api.jar:${project.build.directory}/jdk11-bundle/java.base:${project.build.directory}/jdk11-bundle/java.rmi:${project.build.directory}/jdk11-bundle/java.sql:${project.build.directory}/jdk11-bundle/java.naming</signature.sigTestClasspath>

--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -171,8 +171,9 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M5</version>
+				<version>3.1.2</version>
 				<configuration>
+					<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). -->
 					<trimStackTrace>false</trimStackTrace>
 					<failIfNoTests>true</failIfNoTests>
 					<dependenciesToScan>${jakarta.jsonb.tck.groupId}:jakarta.json.bind-tck</dependenciesToScan>

--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -177,6 +177,7 @@
 					<trimStackTrace>false</trimStackTrace>
 					<failIfNoTests>true</failIfNoTests>
 					<dependenciesToScan>${jakarta.jsonb.tck.groupId}:jakarta.json.bind-tck</dependenciesToScan>
+					<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
 					<systemPropertyVariables>
 						<jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
 						<signature.sigTestClasspath>${project.build.directory}/signaturedirectory/jakarta.json.bind-api.jar:${project.build.directory}/jdk11-bundle/java.base:${project.build.directory}/jdk11-bundle/java.rmi:${project.build.directory}/jdk11-bundle/java.sql:${project.build.directory}/jdk11-bundle/java.naming</signature.sigTestClasspath>

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.jakarta.jsonp.tck;
 
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +26,7 @@ import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
@@ -40,6 +43,15 @@ import componenttest.topology.utils.tck.TCKRunner;
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 11)
 @MaximumJavaLevel(javaLevel = 21) //Possibility to fail on Java 23 due to CLDR updates https://jdk.java.net/23/release-notes#JDK-8319990
+/*
+ * Tests run on client JVM and each test requires a new JVM fork because the TCK itself has a provider
+ * which needs to be discovered in some tests, and ignored in other tests. When this fork is created on
+ * z/OS the maven-surefire-plugin fails with:
+ * - Corrupted channel by directly writing to native stream in forked JVM 1.
+ * - The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
+ * This seems to be a bug in the maven-surefire-plugin, which will hopefully be fixed in a future release
+ */
+@SkipIfSysProp(OS_ZOS)
 public class JsonpTckLauncher {
 
     //This is a standalone test no server needed

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -83,6 +83,10 @@
 							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). -->
 							<trimStackTrace>false</trimStackTrace>
 							<failIfNoTests>true</failIfNoTests>
+							<!-- Required configuration - each test requires a new JVM because the TCK itself has a provider
+							     which needs to be discovered in some tests, and ignored in other tests  -->
+							<forkCount>1</forkCount>
+							<reuseForks>false</reuseForks>
 							<dependenciesToScan>jakarta.json:jakarta.json-tck-tests</dependenciesToScan>
 							<systemPropertyVariables>
 								<jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
@@ -124,6 +128,10 @@
 							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). -->
 							<trimStackTrace>false</trimStackTrace>
 							<failIfNoTests>true</failIfNoTests>
+							<!-- Required configuration - each test requires a new JVM because the TCK itself has a provider
+							     which needs to be discovered in some tests, and ignored in other tests  -->
+							<forkCount>1</forkCount>
+							<reuseForks>false</reuseForks>
 							<dependenciesToScan>jakarta.json:jakarta.json-tck-tests-pluggability</dependenciesToScan>
 							<excludes>
 								<exclude>${exclude.tests}</exclude>

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -87,6 +87,7 @@
 							     which needs to be discovered in some tests, and ignored in other tests  -->
 							<forkCount>1</forkCount>
 							<reuseForks>false</reuseForks>
+							<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
 							<dependenciesToScan>jakarta.json:jakarta.json-tck-tests</dependenciesToScan>
 							<systemPropertyVariables>
 								<jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
@@ -132,6 +133,7 @@
 							     which needs to be discovered in some tests, and ignored in other tests  -->
 							<forkCount>1</forkCount>
 							<reuseForks>false</reuseForks>
+							<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
 							<dependenciesToScan>jakarta.json:jakarta.json-tck-tests-pluggability</dependenciesToScan>
 							<excludes>
 								<exclude>${exclude.tests}</exclude>

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2022, 2024 IBM Corporation and others. All rights reserved. 
+<!-- Copyright (c) 2022, 2025 IBM Corporation and others. All rights reserved. 
 	This program and the accompanying materials are made available under the 
 	terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	and is available at http://www.eclipse.org/legal/epl-2.0/ Contributors: 
@@ -125,7 +125,7 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>3.1.2</version>
 						<configuration>
-							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). -->
+							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBytes(). -->
 							<trimStackTrace>false</trimStackTrace>
 							<failIfNoTests>true</failIfNoTests>
 							<!-- Required configuration - each test requires a new JVM because the TCK itself has a provider

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -87,7 +87,6 @@
 							     which needs to be discovered in some tests, and ignored in other tests  -->
 							<forkCount>1</forkCount>
 							<reuseForks>false</reuseForks>
-							<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
 							<dependenciesToScan>jakarta.json:jakarta.json-tck-tests</dependenciesToScan>
 							<systemPropertyVariables>
 								<jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
@@ -133,7 +132,6 @@
 							     which needs to be discovered in some tests, and ignored in other tests  -->
 							<forkCount>1</forkCount>
 							<reuseForks>false</reuseForks>
-							<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
 							<dependenciesToScan>jakarta.json:jakarta.json-tck-tests-pluggability</dependenciesToScan>
 							<excludes>
 								<exclude>${exclude.tests}</exclude>

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -78,12 +78,11 @@
 		        <plugins>
 			        <plugin>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.0.0-M5</version>
+						<version>3.1.2</version>
 						<configuration>
+							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). -->
 							<trimStackTrace>false</trimStackTrace>
 							<failIfNoTests>true</failIfNoTests>
-							<forkCount>1</forkCount>
-		                    <reuseForks>false</reuseForks>
 							<dependenciesToScan>jakarta.json:jakarta.json-tck-tests</dependenciesToScan>
 							<systemPropertyVariables>
 								<jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
@@ -120,12 +119,11 @@
 		        <plugins>
 			        <plugin>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.0.0-M5</version>
+						<version>3.1.2</version>
 						<configuration>
+							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). -->
 							<trimStackTrace>false</trimStackTrace>
 							<failIfNoTests>true</failIfNoTests>
-							<forkCount>1</forkCount>
-		                    <reuseForks>false</reuseForks>
 							<dependenciesToScan>jakarta.json:jakarta.json-tck-tests-pluggability</dependenciesToScan>
 							<excludes>
 								<exclude>${exclude.tests}</exclude>


### PR DESCRIPTION
The maven surfire plugin creates a forked JVM with default setting. Ensure the forked JVM encodes characters on z/OS to a format supported by all systems.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
