### PR TITLE
Remove test auto features from build.image/wlp/lib/features directory that can affect jakarta ee fat tests

### DIFF
--- a/dev/com.ibm.ws.cdi.visibility_fat/publish/features/visTest-1.2.mf
+++ b/dev/com.ibm.ws.cdi.visibility_fat/publish/features/visTest-1.2.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: visTest-1.2
 Subsystem-Version: 1.0.0
 Subsystem-Content: 

--- a/dev/com.ibm.ws.cdi.visibility_fat/publish/features/visTest-3.0.mf
+++ b/dev/com.ibm.ws.cdi.visibility_fat/publish/features/visTest-3.0.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: visTest-3.0
 Subsystem-Version: 1.0.0
 Subsystem-Content: 

--- a/dev/com.ibm.ws.logging_fat/publish/features/logServiceTest-1.0.mf
+++ b/dev/com.ibm.ws.logging_fat/publish/features/logServiceTest-1.0.mf
@@ -5,7 +5,7 @@ Subsystem-SymbolicName: com.ibm.websphere.appserver.logServiceTest-1.0; visibili
 Subsystem-Version: 1.0.0
 Subsystem-Content:  logservice.tester;  version="[1,1.1)",
  com.ibm.wsspi.appserver.webBundle-1.0; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2
 Subsystem-Localization: OSGI-INF/l10n/subsystem 

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/IBMShortNameManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/IBMShortNameManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.ibmshortname-1.0; visibility:=private
 IBM-ShortName: IBMShortName-1.0
 Subsystem-Version: 1.0.0

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/SubsystemNameManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/SubsystemNameManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.subsystemname-1.0; visibility:=private
 Subsystem-Name: SubsystemName Display Name
 Subsystem-Version: 1.0.0

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/SubsystemSymbolicNameManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/SubsystemSymbolicNameManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.subsystemsymbolicname-1.0; visibility:=private
 Subsystem-Version: 1.0.0
 Subsystem-Type: osgi.subsystem.feature

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/basicAutoFeatureTool.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/basicAutoFeatureTool.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: BasicAutoFeatureTool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.basicautofeaturetool-1.0; visibility:=private
 Subsystem-Version: 1.0.0
@@ -10,7 +11,7 @@ Subsystem-Category: adminCenter
 Subsystem-Icon: icons/toolicon48.png;size=48,icons/toolicon64.png;size=64,icons/toolicon128.png;size=128
 Subsystem-Content: com.ibm.ws.appserver.basicAutoFeatureTool; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"  
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"  
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 IBM-Install-Policy: manual
 Subsystem-Vendor: IBM

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/basicProtectedAutoFeatureTool.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/basicProtectedAutoFeatureTool.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: BasicProtectedAutoFeatureTool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.basicprotectedautofeaturetool-1.0; visibility:=protected
 Subsystem-Name: BasicProtectedAutoFeatureTool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/basicPublicAutoFeatureTool.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/basicPublicAutoFeatureTool.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: BasicPublicAutoFeatureTool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.basicpublicautofeaturetool-1.0; visibility:=public
 Subsystem-Name: BasicPublicAutoFeatureTool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/emptyIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/emptyIconHeaderManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.nosizediconheadermanifest-1.0; visibility:=private
 Subsystem-Name: No Sized Icon Header Display Name
 Subsystem-Version: 1.0.0
@@ -8,7 +9,7 @@ Subsystem-Description: This is the description for No Sized IconHeader.
 Subsystem-Icon:
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"  
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"  
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/gifIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/gifIconHeaderManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.gificonheadermanifest-1.0; visibility:=private
 Subsystem-Name: gif Icon Header Display Name
 Subsystem-Version: 1.0.0
@@ -8,7 +9,7 @@ Subsystem-Description: This is the description for gif IconHeader.
 Subsystem-Icon: icons/toolicon9.gif
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature" 
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature" 
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/invalidRelativeIconURIHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/invalidRelativeIconURIHeaderManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.invalidrelativeiconuriheadermanifest-1.0; visibility:=private
 Subsystem-Name: Invalid Relative Icon URI Header Display Name
 Subsystem-Version: 1.0.0
@@ -8,7 +9,7 @@ Subsystem-Description: This is the description for Invalid Relative Icon URI Hea
 Subsystem-Icon: /../../icons/toolicon1.jpg
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/jpegIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/jpegIconHeaderManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.jpgiconheadermanifest-1.0; visibility:=private
 Subsystem-Name: Jpg Icon Header Display Name
 Subsystem-Version: 1.0.0
@@ -8,7 +9,7 @@ Subsystem-Description: This is the description for Jpg IconHeader.
 Subsystem-Icon: icons/toolicon9.jpg
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/mixedSizedIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/mixedSizedIconHeaderManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.mixedsizediconheadermanifest-1.0; visibility:=private
 Subsystem-Name: mixedsized Header Display Name
 Subsystem-Version: 1.0.0
@@ -8,7 +9,7 @@ Subsystem-Description: This is the description for mixedsized IconHeader.
 Subsystem-Icon: icons/toolicon1.png;size=142, icons/toolicon2.png;size=77
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/mixedSizedWithUnsizedIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/mixedSizedWithUnsizedIconHeaderManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.mixedsizedwithunsizediconheadermanifest-1.0; visibility:=private
 Subsystem-Name: mixedsizedwithunsized Header Display Name
 Subsystem-Version: 1.0.0
@@ -8,7 +9,7 @@ Subsystem-Description: This is the description for mixedsizedwithunsized IconHea
 Subsystem-Icon: icons/toolicon1.png, icons/toolicon2.png;size=142
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/multiUIEndpointManifestHeader.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/multiUIEndpointManifestHeader.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: uriManifestHeader-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.multiuiendpointmanifestHeader-1.0; visibility:=private
 Subsystem-Name: Multi UI Endpoint Manifest Header Tool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/multiUnsizedIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/multiUnsizedIconHeaderManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.multiunsizediconheadermanifest-1.0; visibility:=private
 Subsystem-Name: multiunsized Header Display Name
 Subsystem-Version: 1.0.0
@@ -8,7 +9,7 @@ Subsystem-Description: This is the description for multiunsized IconHeader.
 Subsystem-Icon: icons/toolicon1.png, icons/toolicon2.png
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/noIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/noIconHeaderManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.noiconheadermanifest-1.0; visibility:=private
 Subsystem-Name: No Icon Header Display Name
 Subsystem-Version: 1.0.0
@@ -7,7 +8,7 @@ Subsystem-Category: adminCenter
 Subsystem-Description: This is the description for No IconHeader.
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/noSizedIconHeaderManifest.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/noSizedIconHeaderManifest.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 Subsystem-SymbolicName: com.ibm.websphere.appserver.nosizediconheadermanifest-1.0; visibility:=private
 Subsystem-Name: No Sized Icon Header Display Name
 Subsystem-Version: 1.0.0
@@ -8,7 +9,7 @@ Subsystem-Description: This is the description for No Sized IconHeader.
 Subsystem-Icon: icons/toolicon1.png
 Subsystem-Content: com.ibm.ws.appserver.toolbundle1; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 Subsystem-Vendor: IBM
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/originalUpdateAutoFeatureTool.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/originalUpdateAutoFeatureTool.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: UpdateAutoFeatureTool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.updateautofeaturetool-1.0; visibility:=private
 Subsystem-Name: Original AutoFeatureTool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/singleUIEndpointAndNonEndpointWABManifestHeader.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/singleUIEndpointAndNonEndpointWABManifestHeader.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: singleUIEndpointAndNonEndpointWABManifestHeader-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.singleUIEndpointAndNonEndpointWABManifestHeader-1.0; visibility:=private
 Subsystem-Name: Single UIEndpoint And Non Endpoint WAB Manifest Header Tool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/singleUIEndpointManifestHeader.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/singleUIEndpointManifestHeader.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: uriManifestHeader-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.singleuiendpointmanifestHeader-1.0; visibility:=private
 Subsystem-Name: Single UI Endpoint Manifest Header Tool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/updatedUpdateAutoFeatureTool.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/updatedUpdateAutoFeatureTool.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: UpdateAutoFeatureTool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.updateautofeaturetool-1.0; visibility:=private
 Subsystem-Name: Updated AutoFeatureTool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/urlInMultipleWabs.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/urlInMultipleWabs.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: urlinmultiplewab-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.urlinmultiplewab-1.0; visibility:=private
 Subsystem-Name: URL in Multiple Wab Tool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/urlInSingleWab.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/urlInSingleWab.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: urlInSingleWab-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.urlinsinglewab-1.0; visibility:=private
 Subsystem-Name: URL in Single Wab Tool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/features/usr.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/features/usr.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: usrtool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.usrtool-1.0; visibility:=private
 Subsystem-Version: 1.0.0
@@ -11,7 +12,7 @@ Subsystem-Icon: icons/toolicon7.png,icons/toolicon8.png;size=58
 IBM-AdminCenter-Endpoint: usrtool/welcome
 Subsystem-Content: com.ibm.ws.appserver.usrtoolbundle; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 IBM-Install-Policy: manual
 Subsystem-Vendor: IBM

--- a/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn1.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn1.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: prodextn1tool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.prodextn1-1.0; visibility:=private
 Subsystem-Version: 1.0.0
@@ -11,7 +12,7 @@ Subsystem-Icon: icons/toolicon3.png,icons/toolicon4.png;size=58
 IBM-AdminCenter-Endpoint: prodextn1/welcome
 Subsystem-Content: com.ibm.ws.appserver.prodextn1toolbundle; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 IBM-Install-Policy: manual
 Subsystem-Vendor: IBM

--- a/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn1originalUpdateAutoFeatureTool.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn1originalUpdateAutoFeatureTool.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: ProdExtn1UpdateAutoFeatureTool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.prodextn1updateautofeaturetool-1.0; visibility:=private
 Subsystem-Name: ProdExtn1 Original AutoFeatureTool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn1updatedUpdateAutoFeatureTool.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn1updatedUpdateAutoFeatureTool.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: ProdExtn1UpdateAutoFeatureTool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.prodextn1updateautofeaturetool-1.0; visibility:=private
 Subsystem-Name: ProdExtn1 Updated AutoFeatureTool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn2.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn2.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: prodextn2tool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.prodextn2-2.0; visibility:=private
 Subsystem-Name: Prod Extn 2 Tool Display Name
@@ -10,7 +11,7 @@ Subsystem-Description: This is the description for prodextn2. It is used to test
 IBM-AdminCenter-Endpoint: prodextn2/welcome
 Subsystem-Content: com.ibm.ws.appserver.prodextn2toolbundle; version="[1,1.1)",
  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1"; type="osgi.subsystem.feature"
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))"
 IBM-Install-Policy: manual
 Subsystem-Vendor: IBM

--- a/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn3.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/prodextn3.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: prodextn3tool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.prodextn3-1.0; visibility:=private
 Subsystem-Name: Prod Extn 3 Tool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/protectedprodextn.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/protectedprodextn.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: protectedprodextntool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.protectedprodextn-1.0; visibility:=protected
 Subsystem-Name: Protected Prod Extn Tool Display Name

--- a/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/publicprodextn.mf
+++ b/dev/com.ibm.ws.ui_rest_fat/publish/productfeatures/publicprodextn.mf
@@ -1,4 +1,5 @@
 Subsystem-ManifestVersion: 1
+IBM-Test-Feature: true
 IBM-ShortName: publicprodextntool-1.0
 Subsystem-SymbolicName: com.ibm.websphere.appserver.publicprodextn-1.0; visibility:=public
 Subsystem-Name: Public Prod Extn Tool Display Name

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10Features.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10Features.java
@@ -117,6 +117,7 @@ public class EE10Features {
     //
 
     public EE10Features(String installRoot) throws Exception {
+        FeatureUtilities.removeTestAutoFeatures(new File(installRoot));
         this.serverFeatures_ol = getInstalledFeatures(installRoot, OPEN_LIBERTY_ONLY);
         this.versionedFeatures_ol = getVersionedFeatures(serverFeatures_ol);
 

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/JakartaEE10Test.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/JakartaEE10Test.java
@@ -143,7 +143,7 @@ public class JakartaEE10Test extends FATServletClient {
         ShrinkHelper.exportDropinAppToServer(server, earApp, DeployOptions.SERVER_ONLY);
 
         String consoleName = JakartaEE10Test.class.getSimpleName() + RepeatTestFilter.getRepeatActionsAsString();
-        if (RepeatTestFilter.isRepeatActionActive(COMPAT_WL_FEATURES)) {
+        if (RepeatTestFilter.isRepeatActionActive(COMPAT_WL_FEATURES) || RepeatTestFilter.isRepeatActionActive(COMPAT_OL_FEATURES)) {
             server.setServerStartTimeout(15 * 60 * 1000L); // 15 minutes
         }
         server.startServer(consoleName + ".log");

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11Features.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11Features.java
@@ -126,6 +126,7 @@ public class EE11Features {
     //
 
     public EE11Features(String installRoot) {
+        FeatureUtilities.removeTestAutoFeatures(new File(installRoot));
         this.serverFeatures_ol = getInstalledFeatures(installRoot, OPEN_LIBERTY_ONLY);
         this.versionedFeatures_ol = getVersionedFeatures(serverFeatures_ol);
 

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/JakartaEE11Test.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/JakartaEE11Test.java
@@ -115,7 +115,7 @@ public class JakartaEE11Test extends FATServletClient {
         ShrinkHelper.exportDropinAppToServer(server, earApp, DeployOptions.SERVER_ONLY);
 
         String consoleName = JakartaEE11Test.class.getSimpleName() + RepeatTestFilter.getRepeatActionsAsString();
-        if (RepeatTestFilter.isRepeatActionActive(COMPAT_WL_FEATURES)) {
+        if (RepeatTestFilter.isRepeatActionActive(COMPAT_WL_FEATURES) || RepeatTestFilter.isRepeatActionActive(COMPAT_OL_FEATURES)) {
             server.setServerStartTimeout(15 * 60 * 1000L); // 15 min
         }
         server.startServer(consoleName + ".log");

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9Features.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9Features.java
@@ -120,6 +120,7 @@ public class EE9Features {
     //
 
     public EE9Features(String installRoot) {
+        FeatureUtilities.removeTestAutoFeatures(new File(installRoot));
         this.serverFeatures_ol = getInstalledFeatures(installRoot, OPEN_LIBERTY_ONLY);
         this.versionedFeatures_ol = getVersionedFeatures(serverFeatures_ol);
 

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
@@ -143,7 +143,7 @@ public class JakartaEE9Test extends FATServletClient {
         ShrinkHelper.exportDropinAppToServer(server, earApp, DeployOptions.SERVER_ONLY);
 
         String consoleName = JakartaEE9Test.class.getSimpleName() + RepeatTestFilter.getRepeatActionsAsString();
-        if (RepeatTestFilter.isRepeatActionActive(COMPAT_WL_FEATURES)) {
+        if (RepeatTestFilter.isRepeatActionActive(COMPAT_WL_FEATURES) || RepeatTestFilter.isRepeatActionActive(COMPAT_OL_FEATURES)) {
             server.setServerStartTimeout(15 * 60 * 1000L); // 15 MIN
         }
         server.startServer(consoleName + ".log");


### PR DESCRIPTION
- When running jakarta ee fat tests that admincenter is enabled which can cause errors when the com.ibm.ws.ui.rest_fat test times out leaving auto features behind
- Update test auto features to have the IBM-Test-Feature attribute added
- Update the jakartaee fat tests to remove the test auto features before starting the server so that they left over features do not cause problems
- Update test features that have servlet feature with tolerates to include a tolerates for 6.1 as well to support jakarta ee 11 test scenarios
- Update timeout for OL all compat features to also be 15 minutes.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
