### PR TITLE
Increase logging level in JMSAsyncSendTests

### DIFF
--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/common/src/com/ibm/ws/messaging/open_clientcontainer/fat/Util.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/common/src/com/ibm/ws/messaging/open_clientcontainer/fat/Util.java
@@ -19,6 +19,7 @@ import java.util.logging.Logger;
 public class Util {
   public static final String    LS = System.lineSeparator();
   protected static Logger       logger_ = Logger.getLogger("FAT");
+  protected static Level defaultLogLevel = Level.INFO; // Sets the default logging level for Trace and Codepath logging. Allows this test to produce more trace by default. 
   static {
     Level l;
     String p = System.getProperty("fat.test.debug","INFO").toUpperCase();;
@@ -131,8 +132,8 @@ public class Util {
 
   public static void ALWAYS(Object ... args) { doAlways(args); }
   public static void LOG(Object ...  args) { if (logger_.isLoggable(Level.INFO)) doLog(args); }
-  public static void TRACE(Object ... args) { if (logger_.isLoggable(Level.FINEST)) doTrace(args); }
-  public static void CODEPATH() { if (logger_.isLoggable(Level.FINEST)) doTrace("CODEPATH"); }
+  public static void TRACE(Object ... args) { if (logger_.isLoggable(defaultLogLevel)) doTrace(args); }
+  public static void CODEPATH() { if (logger_.isLoggable(defaultLogLevel)) doTrace("CODEPATH"); }
 
   private static void doAlways(Object ... args) {
     Level keep = logger_.getLevel();
@@ -153,7 +154,7 @@ public class Util {
 
   private static void doTrace(Object ... args) {
     StackTraceElement e = Util.getCaller(2);
-    logger_.logp(Level.FINEST,e.getClassName(),e.getMethodName(),"["+e.getFileName()+":"+e.getLineNumber()+"] "+assembleMsg(args));
+    logger_.logp(defaultLogLevel,e.getClassName(),e.getMethodName(),"["+e.getFileName()+":"+e.getLineNumber()+"] "+assembleMsg(args));
   }
 
   private static String assembleMsg(Object ... args) {

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/common/src/com/ibm/ws/messaging/open_clientcontainer/fat/Util.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/common/src/com/ibm/ws/messaging/open_clientcontainer/fat/Util.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
- [ x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

There are some issues in the AsyncSend tests in the messaging clientcontainer test project.
These are intermittent and probably timing issues related to running tests concurrently.
The default logging in the test makes it difficult to triage and diagnose problems in the tests, so this change is simply to change the level at which some of the test information is logged. This should help future problem analysis.