### PR TITLE
correct post test cleanup

### DIFF
--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/CDICurrentTestServlet.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/CDICurrentTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corporation and others.
+ * Copyright (c) 2015, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/CDICurrentTestServlet.java
+++ b/dev/com.ibm.ws.cdi.api_fat/fat/src/com/ibm/ws/cdi/api/fat/apps/current/CDICurrentTestServlet.java
@@ -16,6 +16,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.time.Duration;
 import java.util.logging.Logger;
@@ -92,7 +93,7 @@ public class CDICurrentTestServlet extends FATServlet {
             LOGGER.info("About to throw exception");
             assertTrue("The thread with CDI.current never completed", false);
         } finally {
-            wasCDICurrentFound = false;
+            wasCDICurrentFound = null;
         }
     }
 
@@ -119,9 +120,9 @@ public class CDICurrentTestServlet extends FATServlet {
             }
 
             LOGGER.info("About to throw exception");
-            assertTrue("The thread with CDI.current never completed", false);
+            fail("The thread with CDI.current never completed");
         } finally {
-            wasCDICurrentFound = false;
+            wasCDICurrentFound = null;
         }
     }
 
@@ -146,6 +147,7 @@ public class CDICurrentTestServlet extends FATServlet {
                 LOGGER.info("Calling setter for test variable with true");
             } else {
                 LOGGER.info("Calling setter for test variable with false");
+                CDICurrentTestServlet.setWasCDICurrentFound(false);
             }
         }
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Corrects the post test cleanup to set the Boolean result to null rather than false (false = failed, null = still looking). 

Resolves https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=302305