### PR TITLE
escape characters and comparison of char property ignoring case

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -451,6 +451,28 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Comparison ignoring case on an entity property of type char.
+     */
+    @Test
+    public void testCharIgnoreCase() {
+        // Clear out data before test
+        employees.deleteByLastName("TestCharIgnoreCase");
+
+        businesses.save(new Employee(33, "Charlotte", "TestCharIgnoreCase", (short) 1033, 'C'),
+                        new Employee(14, "Christina", "TestCharIgnoreCase", (short) 1014, 'c'),
+                        new Employee(22, "Claudia", "TestCharIgnoreCase", (short) 1022, 'b'),
+                        new Employee(54, "Cecilia", "TestCharIgnoreCase", (short) 1073, 'D'),
+                        new Employee(73, "Cindy", "TestCharIgnoreCase", (short) 1054, 'c'));
+
+        assertEquals(List.of(14, 33, 73, 54),
+                     employees.findByBadgeAccessLevelIgnoreCaseGreaterThan("B")
+                                     .map(e -> e.empNum)
+                                     .collect(Collectors.toList()));
+
+        employees.deleteByLastName("TestCharIgnoreCase");
+    }
+
+    /**
      * Use repository methods that return a collection attribute as a single value
      * and multiple attributes including a collection attribute via a record.
      */

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
@@ -39,7 +39,7 @@ public interface Demographics {
 
     // Methods with conversion from BigInteger to other types:
 
-    @Query("SELECT numFullTimeWorkers WHERE collectedOn=:when")
+    @Query("SELECT this.numFullTimeWorkers WHERE this.collectedOn=:when")
     Optional<BigDecimal> numFullTimeWorkersAsBigDecimal(Instant when);
 
     @Query("SELECT numFullTimeWorkers WHERE collectedOn=:when")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
@@ -30,6 +30,12 @@ public interface Employees {
 
     void deleteByLastName(String lastName);
 
+    @OrderBy(value = "badge.accessLevel", ignoreCase = true)
+    @OrderBy("empNum")
+    // The parameter would more naturally be char because the entity property
+    // has type char, but JPA only allows String for LOWER(string_expression)
+    Stream<Employee> findByBadgeAccessLevelIgnoreCaseGreaterThan(String exclusiveMin);
+
     Employee findByBadgeNumber(long badgeNumber);
 
     Employee findByEmpNum(long employeeNumber);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
@@ -28,6 +28,7 @@ import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Update;
+import jakarta.persistence.EntityManager;
 
 /**
  * Experiments with auto-generated keys.
@@ -55,6 +56,8 @@ public interface Orders extends CrudRepository<PurchaseOrder, UUID> {
     @Delete
     void deleteAll();
 
+    EntityManager entityMgr();
+
     @OrderBy("id")
     Optional<PurchaseOrder> findFirstByPurchasedBy(String purchaser);
 
@@ -74,6 +77,10 @@ public interface Orders extends CrudRepository<PurchaseOrder, UUID> {
 
     @Update
     PurchaseOrder modifyOne(PurchaseOrder orders);
+
+    @Query("SELECT total WHERE purchasedBy LIKE ?1")
+    @OrderBy("total")
+    List<Float> purchaseTotalsFor(String purchaser);
 
     @Query("SELECT VERSION(THIS)")
     @OrderBy("version(this)")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseOrder.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseOrder.java
@@ -41,4 +41,12 @@ public class PurchaseOrder {
 
     @Version
     public int versionNum;
+
+    static PurchaseOrder of(float total, String purchasedBy) {
+        PurchaseOrder order = new PurchaseOrder();
+        order.total = total;
+        order.purchasedBy = purchasedBy;
+        order.purchasedOn = OffsetDateTime.now();
+        return order;
+    }
 }


### PR DESCRIPTION
Add test coverage of an entity property of char type compared ignoring case.
Also, adds some exploration of escape character capability, which requires accessing the EntityManager because Data does not externalize the ability to set an escape character. Some built-in function related to this is being discussed on the spec side.
Also adds test coverage for #29781 by updating a query to include `this.` on a temporal typed entity property.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
