### PR TITLE
Fix ClassLoading Failures OIDC Spnego Bucket

### DIFF
--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/build.gradle
@@ -37,7 +37,8 @@ dependencies {
                'org.apache.sshd:sshd-scp:2.9.2',
                'org.brotli:dec:0.1.2',
                'rhino:js:1.6R5',
-               'xalan:xalan:2.7.2'
+               'xalan:xalan:2.7.2',
+               'xml-apis:xml-apis:1.4.01'
 }
 
 /******************************************************************


### PR DESCRIPTION
We saw some CNF failures in the oidc spnego bucket. This MR fixes that failure.

For reference
```sh
[2024-11-10T10:53:00.017Z] Caused by: java.lang.ClassNotFoundException: org.w3c.dom.ElementTraversal
[2024-11-10T10:53:00.017Z] at org.apache.tools.ant.AntClassLoader.findClassInComponents(AntClassLoader.java:1365)
[2024-11-10T10:53:00.017Z] at org.apache.tools.ant.AntClassLoader.findClass(AntClassLoader.java:1315)
[2024-11-10T10:53:00.017Z] at org.apache.tools.ant.AntClassLoader.loadClass(AntClassLoader.java:1068)
[2024-11-10T10:53:00.017Z] at org.apache.tools.ant.util.SplitClassLoader.loadClass(SplitClassLoader.java:58)
[2024-11-10T10:53:00.017Z] at java.lang.ClassLoader.loadClass(ClassLoader.java:887)
[2024-11-10T10:53:00.017Z] ... 63 more
```


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
