### PR TITLE
Resetting Hibernate Validator compatibility range with EL

### DIFF
--- a/dev/io.openliberty.org.hibernate.validator.7.0/bnd.overrides
+++ b/dev/io.openliberty.org.hibernate.validator.7.0/bnd.overrides
@@ -39,7 +39,7 @@ Import-Package: \
   javax.xml.transform;version=!, \
   javax.xml.transform.stream;version=!, \
   javax.xml.validation;version=!, \
-  jakarta.el;version="[4.0.0,7.0.0)";resolution:=optional, \
+  jakarta.el;version="[4.0.0,6.0.0)";resolution:=optional, \
   org.xml.sax;version=!, \
   org.jboss.logging;version="[3.1.0,4.0.0)", \
   com.fasterxml.classmate;version="[1.3,2.0.0)", \


### PR DESCRIPTION
As the latest version of Hibernate Validator is available, with compatibility for EL 6.0, this commit needs to be undone:
https://github.com/OpenLiberty/open-liberty/commit/40f577e276fbb9eb585a52db1ef4128441dce4fc

fixes #26330