### PR TITLE
Allow JSP test to skip feature check

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSP23JSP22ServerTest.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSP23JSP22ServerTest.java
@@ -71,7 +71,7 @@ public class JSP23JSP22ServerTest {
          * Calling the full version of the stopServer method in order to skip repeat feature set checking
          */
         if (server != null && server.isStarted()) {
-            server.stopServer(LibertyServer.IGNORE_STOPPED, LibertyServer.POST_ARCHIVES, LibertyServer.FORCE_STOP, LibertyServer.SKIP_ARCHIVES, true,
+            server.stopServer(LibertyServer.IGNORE_STOPPED, LibertyServer.POST_ARCHIVES, LibertyServer.FORCE_STOP, LibertyServer.SKIP_ARCHIVES, LibertyServer.SKIP_FEATURE_CHECK,
                               Arrays.asList(LibertyServer.LIBERTY_ERROR_REGEX));
         }
 

--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSP23JSP22ServerTest.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSP23JSP22ServerTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.jsp23.fat.tests;
@@ -12,8 +12,10 @@ package com.ibm.ws.jsp23.fat.tests;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 
 import org.junit.AfterClass;
@@ -48,11 +50,14 @@ public class JSP23JSP22ServerTest {
 
     @Server("jsp23jsp22Server")
     public static LibertyServer server;
+    private static Set<String> originalFeatures;
 
     @BeforeClass
     public static void setup() throws Exception {
         ShrinkHelper.defaultDropinApp(server,
                                       APP_NAME + ".war");
+
+        originalFeatures = server.getServerConfiguration().getFeatureManager().getFeatures();
 
         server.startServer(JSP23JSP22ServerTest.class.getSimpleName() + ".log");
     }
@@ -62,15 +67,17 @@ public class JSP23JSP22ServerTest {
         /**
          * Stopping the server before changing the server features
          * makes CWWKZ0014W to not happen.
+         *
+         * Calling the full version of the stopServer method in order to skip repeat feature set checking
          */
         if (server != null && server.isStarted()) {
-            server.stopServer();
+            server.stopServer(LibertyServer.IGNORE_STOPPED, LibertyServer.POST_ARCHIVES, LibertyServer.FORCE_STOP, LibertyServer.SKIP_ARCHIVES, true,
+                              Arrays.asList(LibertyServer.LIBERTY_ERROR_REGEX));
         }
 
-        //set it back to jsp-2.3
-        List<String> jsp23Feature = new ArrayList<String>();
-        jsp23Feature.add("jsp-2.3");
-        server.changeFeatures(jsp23Feature);
+        //set it back to the original version
+        List<String> features = new ArrayList<String>(originalFeatures);
+        server.changeFeatures(features);
     }
 
     /**
@@ -83,7 +90,7 @@ public class JSP23JSP22ServerTest {
      */
 
     @Test
-    @SkipForRepeat({SkipForRepeat.EE9_OR_LATER_FEATURES})
+    @SkipForRepeat({ SkipForRepeat.EE9_OR_LATER_FEATURES })
     public void testJsp23to22FeatureChange() throws Exception {
         WebConversation wc = new WebConversation();
         wc.setExceptionsThrownOnErrorStatus(false);
@@ -124,7 +131,7 @@ public class JSP23JSP22ServerTest {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat({SkipForRepeat.NO_MODIFICATION, SkipForRepeat.EE10_OR_LATER_FEATURES})
+    @SkipForRepeat({ SkipForRepeat.NO_MODIFICATION, SkipForRepeat.EE10_OR_LATER_FEATURES })
     public void testJsp30to23FeatureChange() throws Exception {
         WebConversation wc = new WebConversation();
         wc.setExceptionsThrownOnErrorStatus(false);
@@ -166,7 +173,7 @@ public class JSP23JSP22ServerTest {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat({SkipForRepeat.NO_MODIFICATION, SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE11_OR_LATER_FEATURES})
+    @SkipForRepeat({ SkipForRepeat.NO_MODIFICATION, SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE11_OR_LATER_FEATURES })
     public void testJsp31to23FeatureChange() throws Exception {
         WebConversation wc = new WebConversation();
         wc.setExceptionsThrownOnErrorStatus(false);
@@ -208,7 +215,7 @@ public class JSP23JSP22ServerTest {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat({SkipForRepeat.NO_MODIFICATION, SkipForRepeat.EE9_OR_LATER_FEATURES})
+    @SkipForRepeat({ SkipForRepeat.NO_MODIFICATION, SkipForRepeat.EE9_OR_LATER_FEATURES })
     public void testJsp40to31FeatureChange() throws Exception {
         WebConversation wc = new WebConversation();
         wc.setExceptionsThrownOnErrorStatus(false);

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3140,12 +3140,12 @@ public class LibertyServer implements LogMonitorClient {
 
     public ProgramOutput stopServer(boolean postStopServerArchive, boolean forceStop, boolean skipArchives,
                                     List<String> failuresRegExps, String... ignoredFailuresRegExps) throws Exception {
-        return stopServer(!IGNORE_STOPPED, postStopServerArchive, forceStop, skipArchives,
+        return stopServer(!IGNORE_STOPPED, postStopServerArchive, forceStop, skipArchives, SKIP_FEATURE_CHECK,
                           failuresRegExps, ignoredFailuresRegExps);
     }
 
     public ProgramOutput stopServerAlways(String... ignoredFailures) throws Exception {
-        return stopServer(IGNORE_STOPPED, POST_ARCHIVES, FORCE_STOP, SKIP_ARCHIVES,
+        return stopServer(IGNORE_STOPPED, POST_ARCHIVES, FORCE_STOP, SKIP_ARCHIVES, SKIP_FEATURE_CHECK,
                           Collections.emptyList(), ignoredFailures);
     }
 
@@ -3153,6 +3153,7 @@ public class LibertyServer implements LogMonitorClient {
     public static final boolean FORCE_STOP = true;
     public static final boolean POST_ARCHIVES = true;
     public static final boolean SKIP_ARCHIVES = true;
+    public static final boolean SKIP_FEATURE_CHECK = false;
 
     /**
      * Stops the server and checks for any warnings or errors that appeared in logs.
@@ -3164,6 +3165,7 @@ public class LibertyServer implements LogMonitorClient {
      * @param  forceStop              Force the server to stop, skipping the quiesce (default/usual value should be false)
      * @param  skipArchives           Skip postStopServer collection of archives (WARs, EARs, JARs, etc.)
      *                                    Only used if postStopServerArchive is true
+     * @param  skipFeatureCheck       Skip repeat feature set checking
      * @param  ignoredFailuresRegExps A list of reg expressions corresponding to warnings or errors that should be ignored.
      *                                    If ignoredFailuresRegExps is null, logs will not be checked for warnings/errors
      * @param  failuresRegExps        A list of reg expressions corresponding to warnings or errors that should be treated
@@ -3172,7 +3174,7 @@ public class LibertyServer implements LogMonitorClient {
      * @throws Exception              if the stop operation fails or there are warnings/errors found in server
      *                                    logs that were not in the list of ignored warnings/errors.
      */
-    public ProgramOutput stopServer(boolean ignoreStopped, boolean postStopServerArchive, boolean forceStop, boolean skipArchives,
+    public ProgramOutput stopServer(boolean ignoreStopped, boolean postStopServerArchive, boolean forceStop, boolean skipArchives, boolean skipFeatureCheck,
                                     List<String> failuresRegExps, String... ignoredFailuresRegExps) throws Exception {
         final String method = "stopServer";
         Log.info(c, method, "<<< STOPPING SERVER: " + getServerName());
@@ -3298,7 +3300,9 @@ public class LibertyServer implements LogMonitorClient {
 
             isTidy = true;
 
-            checkServerRepeatFeatures();
+            if (!skipFeatureCheck) {
+                checkServerRepeatFeatures();
+            }
             checkLogsForErrorsAndWarnings(failuresRegExps, ignoredFailuresRegExps);
 
             if (doCheckpoint() && checkpointInfo.isAssertNoAppRestartOnRestore() &&
@@ -3487,8 +3491,9 @@ public class LibertyServer implements LogMonitorClient {
             throw ex;
     }
 
-    //servers which are exempt from checking repeat features
-    //this list should eventually be removed once the tests are fixed
+    //servers which are exempt from checking repeat features in automated builds
+    //the vast majority of servers should eventually be removed once the tests are fixed
+    //the test will still fail when run locally
     private static final String[] EXEMPT_SERVERS = {
                                                      "cdi20EEServer", //com.ibm.ws.cdi.1.0_fat_EE
 
@@ -3510,8 +3515,6 @@ public class LibertyServer implements LogMonitorClient {
                                                      "com.ibm.ws.jpa.fat.emlocking", //com.ibm.ws.jpa.tests.jpa_fat
                                                      "ConcurrentEnhancementVerification", //com.ibm.ws.jpa.tests.jpa_fat
                                                      "com.ibm.ws.jpa.fat.ejbpassivation", //com.ibm.ws.jpa.tests.jpa_fat
-
-                                                     "jsp23jsp22Server", //com.ibm.ws.jsp.2.3_fat
 
                                                      "ApplicationProcessorServer", //io.openliberty.microprofile.openapi.2.0.internal_fat
                                                      "OpenAPITestServer", //io.openliberty.microprofile.openapi.2.0.internal_fat
@@ -3617,10 +3620,12 @@ public class LibertyServer implements LogMonitorClient {
                             if (FAT_TEST_LOCALRUN) {
                                 message = message + "\nYou should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS.";
                                 throw new Exception(message);
-                            } else if (!EXEMPT_SERVERS_SET.contains(serverName)) {
-                                throw new Exception(message);
                             } else {
-                                Log.info(c, method, message);
+                                if (!EXEMPT_SERVERS_SET.contains(serverName)) {
+                                    throw new Exception(message);
+                                } else {
+                                    Log.info(c, method, message);
+                                }
                             }
                         } else {
                             Log.info(c, method, message);

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3140,12 +3140,12 @@ public class LibertyServer implements LogMonitorClient {
 
     public ProgramOutput stopServer(boolean postStopServerArchive, boolean forceStop, boolean skipArchives,
                                     List<String> failuresRegExps, String... ignoredFailuresRegExps) throws Exception {
-        return stopServer(!IGNORE_STOPPED, postStopServerArchive, forceStop, skipArchives, SKIP_FEATURE_CHECK,
+        return stopServer(!IGNORE_STOPPED, postStopServerArchive, forceStop, skipArchives, !SKIP_FEATURE_CHECK,
                           failuresRegExps, ignoredFailuresRegExps);
     }
 
     public ProgramOutput stopServerAlways(String... ignoredFailures) throws Exception {
-        return stopServer(IGNORE_STOPPED, POST_ARCHIVES, FORCE_STOP, SKIP_ARCHIVES, SKIP_FEATURE_CHECK,
+        return stopServer(IGNORE_STOPPED, POST_ARCHIVES, FORCE_STOP, SKIP_ARCHIVES, !SKIP_FEATURE_CHECK,
                           Collections.emptyList(), ignoredFailures);
     }
 
@@ -3153,7 +3153,7 @@ public class LibertyServer implements LogMonitorClient {
     public static final boolean FORCE_STOP = true;
     public static final boolean POST_ARCHIVES = true;
     public static final boolean SKIP_ARCHIVES = true;
-    public static final boolean SKIP_FEATURE_CHECK = false;
+    public static final boolean SKIP_FEATURE_CHECK = true;
 
     /**
      * Stops the server and checks for any warnings or errors that appeared in logs.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

This change allows for a case where the test is intentionally running with an abnormal feature. Although the server was exempted, the test still fails when run locally (by design). This change allows that check to be skipped on a test by test basis.