### PR TITLE
test: verify db2 can log to seperate file

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/DB2Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/DB2Test.java
@@ -12,10 +12,16 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.db2;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.Db2Container;
 
@@ -56,6 +62,24 @@ public class DB2Test extends FATServletClient {
         server.startServer();
 
         runTest(server, APP_NAME + '/' + SERVLET_NAME, "initDatabase");
+    }
+
+    @Test
+    public void testCustomTrace() throws Exception {
+        File logDir = new File(server.getLogsRoot());
+        assertTrue(logDir.exists());
+        assertTrue(logDir.isDirectory());
+
+        File jccTraceFile = new File(logDir, "jcc.trace");
+        assertTrue(jccTraceFile.exists());
+        assertEquals(0, Files.lines(jccTraceFile.toPath()).count());
+
+        runTest(server, APP_NAME + '/' + SERVLET_NAME, getTestMethodSimpleName());
+
+        //TODO an additional file jcc.trace_cpds_2 is also generated, is this expected?
+        // if so we could assert that file is always generated.
+
+        assertTrue(Files.lines(jccTraceFile.toPath()).count() > 0);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
@@ -65,13 +65,13 @@
   
   <dataSource jndiName="jdbc/db2-using-driver">
     <jdbcDriver libraryRef="DB2Lib"/> 
-  	<properties url="jdbc:db2://${DB2_HOSTNAME}:${DB2_PORT}/${DB2_DBNAME}"
+    <properties url="jdbc:db2://${DB2_HOSTNAME}:${DB2_PORT}/${DB2_DBNAME}"
       user="${DB2_USER}" password="${DB2_PASS}" driverType="4"/>
   </dataSource>
   
   <dataSource jndiName="jdbc/db2-using-driver-type" type="java.sql.Driver">
     <jdbcDriver libraryRef="DB2Lib"/> 
-  	<properties.db2.jcc url="jdbc:db2://${DB2_HOSTNAME}:${DB2_PORT}/${DB2_DBNAME}"
+    <properties.db2.jcc url="jdbc:db2://${DB2_HOSTNAME}:${DB2_PORT}/${DB2_DBNAME}"
       user="${DB2_USER}" password="${DB2_PASS}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"/>
   </dataSource>
   
@@ -82,29 +82,29 @@
       user="${DB2_USER}" password="${DB2_PASS}" driverType="4"/>
   </dataSource>
   
-    <!-- 
-    	 Verify precedence of connection properties on Driver
-    	 NOTE: URL property only exists on Driver not DataSource 
-    -->
-    <dataSource id="driver-property-preferred" jndiName="jdbc/driver-property-preferred" type="java.sql.Driver">
-      <jdbcDriver libraryRef="DB2Lib"/>
-      <properties.db2.jcc url="jdbc:db2://$INVALID:000/$INVALID" 
+  <!-- 
+     Verify precedence of connection properties on Driver
+     NOTE: URL property only exists on Driver not DataSource 
+  -->
+  <dataSource id="driver-property-preferred" jndiName="jdbc/driver-property-preferred" type="java.sql.Driver">
+    <jdbcDriver libraryRef="DB2Lib"/>
+    <properties.db2.jcc url="jdbc:db2://$INVALID:000/$INVALID" 
       serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}" databaseName="${DB2_DBNAME}"
       user="${DB2_USER}" password="${DB2_PASS}"/> 
-    </dataSource>
+  </dataSource>
     
   <!-- 
-  	Verify default values no longer override URL on Driver
-	NOTE: portNumber still needs to be set otherwise the default value 50000 will be used.
+    Verify default values no longer override URL on Driver
+    NOTE: portNumber still needs to be set otherwise the default value 50000 will be used.
   -->  
   <dataSource id="driver-no-override" jndiName="jdbc/driver-no-override" type="java.sql.Driver">
     <jdbcDriver libraryRef="DB2Lib"/>
     <properties.db2.jcc url="jdbc:db2://${DB2_HOSTNAME}:${DB2_PORT}/${DB2_DBNAME}" 
-    					portNumber="${DB2_PORT}" user="${DB2_USER}" password="${DB2_PASS}"/>
+                        portNumber="${DB2_PORT}" user="${DB2_USER}" password="${DB2_PASS}"/>
   </dataSource>
   
   <!-- 
-  	Verify defaults without URL on DataSource
+    Verify defaults without URL on DataSource
   -->  
   <dataSource id="ds-no-url-defaults" jndiName="jdbc/ds-no-url-defaults" type="javax.sql.DataSource">
     <jdbcDriver libraryRef="DB2Lib"/>
@@ -117,9 +117,9 @@
   <dataSource id="ds-client-reroute" jndiName="jdbc/ds-client-reroute">
     <jdbcDriver libraryRef="DB2Lib"/>
     <properties.db2.jcc serverName="host.name.invalid" portNumber="1234" 
-    user="${DB2_USER}" password="${DB2_PASS}" databaseName="${DB2_DBNAME}"
-    clientRerouteAlternateServerName="${DB2_HOSTNAME}" clientRerouteAlternatePortNumber="${DB2_PORT}"
-    maxRetriesForClientReroute="1" retryIntervalForClientReroute="15"/>
+      user="${DB2_USER}" password="${DB2_PASS}" databaseName="${DB2_DBNAME}"
+      clientRerouteAlternateServerName="${DB2_HOSTNAME}" clientRerouteAlternatePortNumber="${DB2_PORT}"
+      maxRetriesForClientReroute="1" retryIntervalForClientReroute="15"/>
   </dataSource>
   
   <!--
@@ -128,10 +128,10 @@
   <dataSource id="ds-client-reroute-cert" jndiName="jdbc/ds-client-reroute-cert">
     <jdbcDriver libraryRef="DB2Lib"/>
     <properties.db2.jcc serverName="host.name.invalid" portNumber="1234" 
-    user="${DB2_USER}" password="${DB2_PASS}" databaseName="${DB2_DBNAME}"
-    clientRerouteAlternateServerName="${DB2_HOSTNAME}" clientRerouteAlternatePortNumber="${DB2_PORT_SECURE}"
-    maxRetriesForClientReroute="1" retryIntervalForClientReroute="15"
-    sslConnection="true" sslVersion="TLSv1.2" sslCertLocation="${server.config.dir}/security/server.crt"/>
+      user="${DB2_USER}" password="${DB2_PASS}" databaseName="${DB2_DBNAME}"
+      clientRerouteAlternateServerName="${DB2_HOSTNAME}" clientRerouteAlternatePortNumber="${DB2_PORT_SECURE}"
+      maxRetriesForClientReroute="1" retryIntervalForClientReroute="15"
+      sslConnection="true" sslVersion="TLSv1.2" sslCertLocation="${server.config.dir}/security/server.crt"/>
   </dataSource>
   
   <!--
@@ -140,21 +140,21 @@
   <dataSource id="ds-client-reroute-wrong-cert" jndiName="jdbc/ds-client-reroute-wrong-cert">
     <jdbcDriver libraryRef="DB2Lib"/>
     <properties.db2.jcc serverName="host.name.invalid" portNumber="1234" 
-    user="${DB2_USER}" password="${DB2_PASS}" databaseName="${DB2_DBNAME}"
-    clientRerouteAlternateServerName="${DB2_HOSTNAME}" clientRerouteAlternatePortNumber="${DB2_PORT_SECURE}"
-    maxRetriesForClientReroute="1" retryIntervalForClientReroute="15"
-    sslConnection="true" sslVersion="TLSv1.2" sslCertLocation="${server.config.dir}/security/wrong.crt"/>
+      user="${DB2_USER}" password="${DB2_PASS}" databaseName="${DB2_DBNAME}"
+      clientRerouteAlternateServerName="${DB2_HOSTNAME}" clientRerouteAlternatePortNumber="${DB2_PORT_SECURE}"
+      maxRetriesForClientReroute="1" retryIntervalForClientReroute="15"
+      sslConnection="true" sslVersion="TLSv1.2" sslCertLocation="${server.config.dir}/security/wrong.crt"/>
   </dataSource>
   
   <!-- 
     Verify trace configuration will allow JCC trace to be output to a seperate file
   -->
   <dataSource id="ds-custom-trace" jndiName="jdbc/ds-custom-trace">
-	<jdbcDriver libraryRef="DB2Lib"/>
-  	    <properties.db2.jcc databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"
-  	    user="${DB2_USER}" password="${DB2_PASS}"
-  	    traceLevel="-1" traceDirectory="${server.output.dir}/logs/" traceFile="jcc.trace"
-  	    traceFileAppend="true" traceOption="0" />
+    <jdbcDriver libraryRef="DB2Lib"/>
+    <properties.db2.jcc databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"
+      user="${DB2_USER}" password="${DB2_PASS}"
+      traceLevel="-1" traceDirectory="${server.output.dir}/logs/" traceFile="jcc.trace"
+      traceFileAppend="true" traceOption="0" />
   </dataSource>
 
   <javaPermission codebase="${shared.resource.dir}db2/*" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
@@ -145,6 +145,17 @@
     maxRetriesForClientReroute="1" retryIntervalForClientReroute="15"
     sslConnection="true" sslVersion="TLSv1.2" sslCertLocation="${server.config.dir}/security/wrong.crt"/>
   </dataSource>
+  
+  <!-- 
+    Verify trace configuration will allow JCC trace to be output to a seperate file
+  -->
+  <dataSource id="ds-custom-trace" jndiName="jdbc/ds-custom-trace">
+	<jdbcDriver libraryRef="DB2Lib"/>
+  	    <properties.db2.jcc databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"
+  	    user="${DB2_USER}" password="${DB2_PASS}"
+  	    traceLevel="-1" traceDirectory="${server.output.dir}/logs/" traceFile="jcc.trace"
+  	    traceFileAppend="true" traceOption="0" />
+  </dataSource>
 
   <javaPermission codebase="${shared.resource.dir}db2/*" className="java.security.AllPermission"/>
   <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>

--- a/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
@@ -80,6 +80,9 @@ public class DB2TestServlet extends FATServlet {
     @Resource(lookup = "jdbc/ds-client-reroute-wrong-cert")
     private DataSource ds_client_reroute_wrong_cert;
 
+    @Resource(lookup = "jdbc/ds-custom-trace")
+    private DataSource ds_custom_trace;
+
     @Resource
     private UserTransaction tran;
 
@@ -386,6 +389,15 @@ public class DB2TestServlet extends FATServlet {
 
             // Caused by: sun.security.validator.ValidatorException
             // Caused by: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
+        }
+    }
+
+    @Test
+    public void testCustomTrace() throws Throwable {
+        try (Connection con = ds_custom_trace.getConnection(); PreparedStatement stmt = con.prepareStatement("INSERT INTO MYTABLE VALUES (?, ?)");) {
+            stmt.setInt(1, 39);
+            stmt.setString(2, "thirty-nine");
+            stmt.execute();
         }
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
@@ -392,7 +392,6 @@ public class DB2TestServlet extends FATServlet {
         }
     }
 
-    @Test
     public void testCustomTrace() throws Throwable {
         try (Connection con = ds_custom_trace.getConnection(); PreparedStatement stmt = con.prepareStatement("INSERT INTO MYTABLE VALUES (?, ?)");) {
             stmt.setInt(1, 39);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Verify that when we configure `traceFile="jcc.trace"` on DB2 that the DB2JCCHelper does not attempt to combine DB2 trace with Open Liberty trace.

Note: Only the output from this DataSource will be put into the separate trace file. We would need to look into using system properties if we wanted to have a server wide configuration for enabling trace to another file.  Similar to what we do with Oracle.
