### PR TITLE
29582 run fewer repeats on io.openliberty.microprofile.telemetry.2.0.logging.internal_fat

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryApplicationConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryApplicationConfigTest.java
@@ -45,7 +45,7 @@ public class TelemetryApplicationConfigTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
+    public static RepeatTests rt = TelemetryActions.latestTelemetry20Repeats();
 
     @Before
     public void testSetup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryDropinsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryDropinsTest.java
@@ -47,7 +47,7 @@ public class TelemetryDropinsTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
+    public static RepeatTests rt = TelemetryActions.latestTelemetry20Repeats();
 
     @BeforeClass
     public static void initialSetup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryFFDCCheckpointTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryFFDCCheckpointTest.java
@@ -43,6 +43,8 @@ public class TelemetryFFDCCheckpointTest extends FATServletClient {
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
+    //This test will run on all mp 2.0 repeats to ensure we have some test coverage on all versions.
+    //I picked it for this because checkpoint is strategic so I picked one of the checkpoint tests
     @ClassRule
     public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryFFDCTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryFFDCTest.java
@@ -45,7 +45,7 @@ public class TelemetryFFDCTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
+    public static RepeatTests rt = TelemetryActions.latestTelemetry20Repeats();
 
     private static final String USER_FEATURE_PATH = "usr/extension/lib/features/";
     private static final String USER_BUNDLE_PATH = "usr/extension/lib/";

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesCheckpointTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesCheckpointTest.java
@@ -43,7 +43,7 @@ public class TelemetryMessagesCheckpointTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
+    public static RepeatTests rt = TelemetryActions.latestTelemetry20Repeats();
 
     @BeforeClass
     public static void testSetup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryMessagesTest.java
@@ -46,6 +46,8 @@ public class TelemetryMessagesTest extends FATServletClient {
     public static final String APP_NAME = "MpTelemetryLogApp";
     public static final String SERVER_NAME = "TelemetryMessage";
 
+    //This test will run on all mp 2.0 repeats to ensure we have some test coverage on all versions.
+    //I chose this one because TelemetryMessages is core to this bucket
     @ClassRule
     public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetrySourcesTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetrySourcesTest.java
@@ -48,7 +48,7 @@ public class TelemetrySourcesTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
+    public static RepeatTests rt = TelemetryActions.latestTelemetry20Repeats();
 
     public static final String SERVER_XML_ALL_SOURCES = "allSources.xml";
     public static final String SERVER_XML_EMPTY_SOURCE = "emptySource.xml";

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryTraceCheckpointTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryTraceCheckpointTest.java
@@ -42,7 +42,7 @@ public class TelemetryTraceCheckpointTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
+    public static RepeatTests rt = TelemetryActions.latestTelemetry20Repeats();
 
     @BeforeClass
     public static void initialSetup() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryTraceTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryTraceTest.java
@@ -46,6 +46,8 @@ public class TelemetryTraceTest extends FATServletClient {
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
+    //This test will run on all mp 2.0 repeats to ensure we have some test coverage on all versions.
+    //I chose this one because TelemetryTrace is core to this bucket
     @ClassRule
     public static RepeatTests rt = TelemetryActions.telemetry20Repeats();
 

--- a/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/TelemetryActions.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal_fat.common/src/io/openliberty/microprofile/telemetry/internal_fat/shared/TelemetryActions.java
@@ -158,6 +158,18 @@ public class TelemetryActions {
                       MicroProfileActions.MP60);
     }
 
+    /*
+     * This returns one repeat for every released version of MPTelemetry >= 2.0; the latest 2.0, and more to come when they exist.
+     * It also returns a repeat to cover ongoing development if that is not covered by one of the above.
+     */
+    public static RepeatTests latestTelemetry20Repeats() {
+        return latestTelemetry20Repeats(FeatureReplacementAction.ALL_SERVERS);
+    }
+
+    public static RepeatTests latestTelemetry20Repeats(String serverName) {
+        return repeat(serverName, MicroProfileActions.MP70_EE11);
+    }
+
     public static RepeatTests telemetry11Repeats(String serverName) {
         return repeat(serverName, MP14_MPTEL11, MP41_MPTEL11, MP50_MPTEL11, MicroProfileActions.MP61);
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This test bucket was timing out on full mode, so I've moved all but a few core tests to run on fewer repeats. 

Fixes #29582
