### PR TITLE
empty list of entities redelivery

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -125,9 +125,9 @@ CWWKD1009.lifecycle.param.err.explanation=Lifecycle methods must have a single \
 CWWKD1009.lifecycle.param.err.useraction=Update the repository method to have a \
  single parameter that is an entity or an array of List of the entity.
 
-CWWKD1010.unknown.entity.prop=CWWKD1010E: The {0} method of the {1} repository \
- interface expects an entity property named {2} that is not found on the \
- {3} entity class. Valid property names for the entity are: {4}.
+CWWKD1010.unknown.entity.prop=CWWKD1010E: An entity property named {0} is \
+ not found on the {1} entity class for the {2} method of the {3} repository \
+ interface. Valid property names for the entity are: {4}.
 CWWKD1010.unknown.entity.prop.explanation=The repository method is attempting \
  to use an entity property that does not exist.
 CWWKD1010.unknown.entity.prop.useraction=Update the repository method to match \
@@ -909,6 +909,18 @@ CWWKD1090.orderby.conflict.explanation=The OrderBy annotation is not compatible 
 CWWKD1090.orderby.conflict.useraction=Use only the OrderBy annotation or the \
  OrderBy keyword.
 
+CWWKD1091.method.name.parse.err=CWWKD1091E: An entity property named {0} is \
+ not found on the {1} entity class for the {2} method of the {3} repository \
+ interface. Confirm that the repository method either has a name that conforms \
+ to the Query by Method Name pattern or is annotated with one of: {4}. \
+ Valid property names for the entity are: {5}.
+CWWKD1091.method.name.parse.err.explanation=The repository method name was parsed \
+ according to the Query by Method Name pattern because the repository method \
+ does not have a Jakarta Data annotation that indicates the type of operation.
+CWWKD1091.method.name.parse.err.useraction=Correct the repository method name \
+ or annotate the repository method to indicate a Jakarta Data operation such as \
+ Query, Find, or Save.
+
 CWWKD1092.lifecycle.arg.empty=CWWKD1092E: The {0} method of the {1} repository \
  does not accept an empty {2} parameter. The parameter value must contain at \
  least one entity.
@@ -916,3 +928,12 @@ CWWKD1092.lifecycle.arg.empty.explanation=Insert, Update, Save, and Delete metho
  require at least one entity.
 CWWKD1092.lifecycle.arg.empty.useraction=Ensure that the array, List, or Stream \
  that is supplied to the method contains at least one entity.
+
+CWWKD1093.fn.not.applicable=CWWKD1093E: The {0} function cannot be evaluated \
+ for the {1} entity that is used by the {2} method of the {3} repository \
+ interface. The entity does not have a property that is annotated with {4} \
+ or from which {0} can be inferred.
+CWWKD1093.fn.not.applicable.explanation=The function cannot be used on the entity \
+ because the entity lacks an ID or version property.
+CWWKD1093.fn.not.applicable.useraction=Do not use the function in query language \
+ or parameters for the repository method.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -908,3 +908,11 @@ CWWKD1090.orderby.conflict.explanation=The OrderBy annotation is not compatible 
  with the OrderBy keyword.
 CWWKD1090.orderby.conflict.useraction=Use only the OrderBy annotation or the \
  OrderBy keyword.
+
+CWWKD1092.lifecycle.arg.empty=CWWKD1092E: The {0} method of the {1} repository \
+ does not accept an empty {2} parameter. The parameter value must contain at \
+ least one entity.
+CWWKD1092.lifecycle.arg.empty.explanation=Insert, Update, Save, and Delete methods
+ require at least one entity.
+CWWKD1092.lifecycle.arg.empty.useraction=Ensure that the array, List, or Stream \
+ that is supplied to the method contains at least one entity.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2464,15 +2464,23 @@ public class QueryInfo {
                     // id(this)
                     attributeName = entityInfo.attributeNames.get(By.ID);
                     if (attributeName == null && failIfNotFound)
-                        throw new MappingException("Entity class " + entityInfo.getType().getName() +
-                                                   " does not have a property named " + name +
-                                                   " or which is designated as the @Id."); // TODO NLS
+                        throw exc(UnsupportedOperationException.class,
+                                  "CWWKD1093.fn.not.applicable",
+                                  name,
+                                  entityInfo.getType().getName(),
+                                  method.getName(),
+                                  repositoryInterface.getName(),
+                                  "@Id");
                 } else if (len == 13 && name.regionMatches(true, 0, "version", 0, 7)) {
                     // version(this)
                     if (entityInfo.versionAttributeName == null && failIfNotFound)
-                        throw new MappingException("Entity class " + entityInfo.getType().getName() +
-                                                   " does not have a property named " + name +
-                                                   " or which is designated as the @Version."); // TODO NLS
+                        throw exc(UnsupportedOperationException.class,
+                                  "CWWKD1093.fn.not.applicable",
+                                  name,
+                                  entityInfo.getType().getName(),
+                                  method.getName(),
+                                  repositoryInterface.getName(),
+                                  "@Version");
                     else
                         attributeName = entityInfo.versionAttributeName;
                 } else {
@@ -2487,10 +2495,10 @@ public class QueryInfo {
             else
                 throw exc(MappingException.class,
                           "CWWKD1010.unknown.entity.prop",
-                          method.getName(),
-                          repositoryInterface.getName(),
                           name,
                           entityInfo.getType().getName(),
+                          method.getName(),
+                          repositoryInterface.getName(),
                           entityInfo.attributeTypes.keySet());
         } else {
             String lowerName = name.toLowerCase();
@@ -2512,15 +2520,23 @@ public class QueryInfo {
                         lowerName = lowerName.replace("_", "");
                         attributeName = entityInfo.attributeNames.get(lowerName);
                         if (attributeName == null && failIfNotFound) {
-                            // TODO If attempting to parse Query by Method Name without a By keyword, then the message
-                            // should also include the possibility that repository method is missing an annotation.
-                            throw exc(MappingException.class,
-                                      "CWWKD1010.unknown.entity.prop",
-                                      method.getName(),
-                                      repositoryInterface.getName(),
-                                      name,
-                                      entityInfo.getType().getName(),
-                                      entityInfo.attributeTypes.keySet());
+                            if (Util.hasOperationAnno(method))
+                                throw exc(MappingException.class,
+                                          "CWWKD1010.unknown.entity.prop",
+                                          name,
+                                          entityInfo.getType().getName(),
+                                          method.getName(),
+                                          repositoryInterface.getName(),
+                                          entityInfo.attributeTypes.keySet());
+                            else
+                                throw exc(MappingException.class,
+                                          "CWWKD1091.method.name.parse.err",
+                                          name,
+                                          entityInfo.getType().getName(),
+                                          method.getName(),
+                                          repositoryInterface.getName(),
+                                          Util.OP_ANNOS,
+                                          entityInfo.attributeTypes.keySet());
                         }
                     }
                 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -974,7 +974,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
                         if (numExpected == 0)
                             throw exc(IllegalArgumentException.class,
-                                      "CWWKD1091.lifecycle.arg.empty",
+                                      "CWWKD1092.lifecycle.arg.empty",
                                       method.getName(),
                                       repositoryInterface.getName(),
                                       method.getGenericParameterTypes()[0].getTypeName());

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -847,7 +847,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                            queryInfo.returnArrayType.isInstance(firstNonNullResult)
                                         || queryInfo.returnArrayType.isPrimitive() &&
                                            Util.isWrapperClassFor(queryInfo.returnArrayType,
-                                                                   firstNonNullResult.getClass())) {
+                                                                  firstNonNullResult.getClass())) {
                                         returnValue = Array.newInstance(queryInfo.returnArrayType, size);
                                         int i = 0;
                                         for (Object result : results)
@@ -972,6 +972,13 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             updateCount = queryInfo.remove(arg, em);
                         }
 
+                        if (numExpected == 0)
+                            throw exc(IllegalArgumentException.class,
+                                      "CWWKD1091.lifecycle.arg.empty",
+                                      method.getName(),
+                                      repositoryInterface.getName(),
+                                      method.getGenericParameterTypes()[0].getTypeName());
+
                         if (updateCount < numExpected)
                             if (numExpected == 1)
                                 throw exc(OptimisticLockingFailureException.class,
@@ -1015,6 +1022,13 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             numExpected = 1;
                             updateCount = queryInfo.update(arg, em);
                         }
+
+                        if (numExpected == 0)
+                            throw exc(IllegalArgumentException.class,
+                                      "CWWKD1092.lifecycle.arg.empty",
+                                      method.getName(),
+                                      repositoryInterface.getName(),
+                                      method.getGenericParameterTypes()[0].getTypeName());
 
                         if (updateCount < numExpected)
                             if (numExpected == 1)

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -27,6 +29,12 @@ import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.page.PageRequest;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Save;
+import jakarta.data.repository.Update;
 
 /**
  * A location for helper methods that do not require any state.
@@ -43,6 +51,11 @@ public class Util {
     static final Set<Class<?>> PRIMITIVE_NUMERIC_TYPES = //
                     Set.of(long.class, int.class, short.class, byte.class,
                            double.class, float.class);
+
+    /**
+     * List of Jakarta Data operation annotations for use in NLS messages.
+     */
+    static final String OP_ANNOS = "Delete, Find, Insert, Query, Save, Update";
 
     /**
      * Return types for deleteBy that distinguish delete-only from find-and-delete.
@@ -118,6 +131,31 @@ public class Util {
                c.isEnum() ||
                Modifier.isInterface(modifiers = c.getModifiers()) ||
                Modifier.isAbstract(modifiers);
+    }
+
+    /**
+     * Identifies whether a method is annotated with a Jakarta Data annotation
+     * that performs and operation, such as Query, Find, or Save. This method is
+     * for use by error reporting only, so it does not need to be very efficient.
+     *
+     * @param method repository method.
+     * @return if the repository method has an annotation indicating an operation.
+     */
+    @Trivial
+    static final boolean hasOperationAnno(Method method) {
+        Set<Class<? extends Annotation>> operationAnnos = //
+                        Set.of(Delete.class,
+                               Insert.class,
+                               Find.class,
+                               Query.class,
+                               Save.class,
+                               Update.class);
+
+        for (Annotation anno : method.getAnnotations())
+            if (operationAnnos.contains(anno.annotationType()))
+                return true;
+
+        return false;
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -5940,8 +5940,6 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(3, persons.updateSome(ulysses, ursula, uriah));
 
-        assertEquals(0, persons.updateSome());
-
         assertEquals(4, people.deleteBySSN_IdBetween(0L, 999999999L));
     }
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -19,6 +19,7 @@ import java.time.Month;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Stream;
 
 import jakarta.annotation.Resource;
 import jakarta.annotation.sql.DataSourceDefinition;
@@ -173,6 +174,74 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1083E:") ||
                 !x.getMessage().contains("bornOn"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify IllegalArgumentException is raised if you attempt to delete an
+     * empty list of entities.
+     */
+    @Test
+    public void testEmptyDelete() {
+        try {
+            voters.deleteAll(List.of());
+            fail("Deleted an empty list of entities.");
+        } catch (IllegalArgumentException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1092E:") ||
+                !x.getMessage().contains("deleteAll"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify IllegalArgumentException is raised if you attempt to delete an
+     * empty array of entities.
+     */
+    @Test
+    public void testEmptyInsert() {
+        try {
+            voters.register(new Voter[] {});
+            fail("Inserted an empty array of entities.");
+        } catch (IllegalArgumentException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1092E:") ||
+                !x.getMessage().contains("register"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify IllegalArgumentException is raised if you attempt to save an
+     * empty list of entities.
+     */
+    @Test
+    public void testEmptySave() {
+        try {
+            List<Voter> saved = voters.saveAll(List.of());
+            fail("Saved an empty list of entities. Result: " + saved);
+        } catch (IllegalArgumentException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1092E:") ||
+                !x.getMessage().contains("saveAll"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify IllegalArgumentException is raised if you attempt to update an
+     * empty stream of entities.
+     */
+    @Test
+    public void testEmptyUpdate() {
+        try {
+            List<Voter> updated = voters.changeAll(Stream.of());
+            fail("Updated an empty stream of entities. Result: " + updated);
+        } catch (IllegalArgumentException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1092E:") ||
+                !x.getMessage().contains("changeAll"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -14,6 +14,7 @@ package test.jakarta.data.errpaths.web;
 
 import java.time.Month;
 import java.util.List;
+import java.util.stream.Stream;
 
 import jakarta.data.Sort;
 import jakarta.data.repository.BasicRepository;
@@ -22,6 +23,7 @@ import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Update;
 
 /**
  * Repository with a valid entity.
@@ -59,6 +61,9 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                        @Param("month") Month monthBorn,
                        @Param("month") int monthNum, // duplicate parameter name
                        @Param("day") int dayBorn);
+
+    @Update
+    List<Voter> changeAll(Stream<Voter> v);
 
     /**
      * This invalid method has a conflict between its OrderBy annotation and

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
@@ -42,7 +42,6 @@ public class DataJPATest extends FATServletClient {
      */
     static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
-                                   "CWWKD1010E.*countBySurgePriceGreaterThanEqual",
                                    "CWWKD1026E.*allSorted",
                                    "CWWKD1046E.*publicDebtAsByte",
                                    "CWWKD1046E.*publicDebtAsDouble",
@@ -55,7 +54,8 @@ public class DataJPATest extends FATServletClient {
                                    "CWWKD1046E.*numFullTimeWorkersAsShort",
                                    "CWWKD1054E.*findByIsControlTrueAndNumericValueBetween",
                                    "CWWKD1075E.*Apartment2",
-                                   "CWWKD1075E.*Apartment3"
+                                   "CWWKD1075E.*Apartment3",
+                                   "CWWKD1091E.*countBySurgePriceGreaterThanEqual"
                     };
 
     @ClassRule


### PR DESCRIPTION
fixes #30215

This is a redelivery of #30145 which had to be [reverted](https://github.com/OpenLiberty/open-liberty/pull/30213) because code used the wrong message id in one place, causing a test failure, which went unnoticed because I mistook a different build result that said "completed successfully!" for the personal build, which had actually failed.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
