### PR TITLE
NLS messages for new Jakarta Concurrency function

### DIFF
--- a/dev/io.openliberty.concurrent.internal.cdi/resources/io/openliberty/concurrent/internal/cdi/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal.cdi/resources/io/openliberty/concurrent/internal/cdi/resources/CWWKCMessages.nlsprops
@@ -38,19 +38,20 @@ CWWKC1410.schedule.lacks.seconds.useraction=Modify the seconds field of the \
  Schedule annotation to specify a non-empty value, or omit the seconds field \
  from the Schedule.
 
-CWWKC1411.qualified.res.err=CWWKC1411E: An error occurred creating a {0} bean \
- for the {1} annotation or {2} deployment descriptor element with the \
- {3} name and {4} qualifiers that is defined in the {5} application artifact. \
- The error is: {5}
-CWWKC1411.qualified.res.err.explanation=An error occurred when creating the \
- resource or attempting to register it as a bean.
+CWWKC1411.qualified.res.err=CWWKC1411E: The server did not create a {0} bean \
+ for the {1} annotation or {2} deployment descriptor element. \
+ The annotation or deployment descriptor element has the \
+ {3} name and {4} qualifiers and is defined in the {5} application artifact. \
+ The error is {6}
+CWWKC1411.qualified.res.err.explanation=The code did not create the resource \
+ or did not register the resource as a bean.
 CWWKC1411.qualified.res.err.useraction=Ensure that the resource is configured \
  correctly.
 
 CWWKC1412.qualifier.conflict=CWWKC1412E: The {0} application artifact includes \
  multiple {1} resource definitions that have the {2} qualifiers. The names of \
- the conflicting {1} resource definitions are: {3}.
-CWWKC1412.qualifier.conflict.explanation=Qualifiers must uniquely identify a \
- resource type.
-CWWKC1412.qualifier.conflict.useraction=Each resource definition of the same \
- type must have different qualifiers or must not have any qualifiers.
+ the conflicting {1} resource definitions are {3}.
+CWWKC1412.qualifier.conflict.explanation=Each resource definition of the \
+ same type that has a qualifier must have a different qualifier.
+CWWKC1412.qualifier.conflict.useraction=Ensure that each resource definition \
+ of the same type has a different qualifier or does not have any qualifiers.

--- a/dev/io.openliberty.concurrent.internal.cdi/resources/io/openliberty/concurrent/internal/cdi/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal.cdi/resources/io/openliberty/concurrent/internal/cdi/resources/CWWKCMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2023 IBM Corporation and others.
+# Copyright (c) 2022,2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -24,5 +24,33 @@
 #   which do NOT contain replacement variables are NOT processed by the MessageFormat class 
 #   (single quote must be coded as one single quote '). 
 
-# All messages must use the range CWWCK1410 to CWWCK1499
+# All messages must use the range CWWKC1410 to CWWKC1499
 
+CWWKC1410.schedule.lacks.seconds=CWWKC1410E: The Schedule, {0}, specifies an \
+ empty value for the seconds at which to run. You must specify a non-empty value. \
+ Alternatively, omit the seconds from the Schedule and rely on the default \
+ behavior of scheduling the task to run at the second at the start of the minute.
+CWWKC1410.schedule.lacks.seconds.explanation=The empty array value indicates that \
+ the field must be disregarded when computing scheduled times. The seconds field \
+ cannot accept an empty value because it is the most granular unit and cannot be \
+ disregarded.
+CWWKC1410.schedule.lacks.seconds.useraction=Modify the seconds field of the \
+ Schedule annotation to specify a non-empty value, or omit the seconds field \
+ from the Schedule.
+
+CWWKC1411.qualified.res.err=CWWKC1411E: An error occurred creating a {0} bean \
+ for the {1} annotation or {2} deployment descriptor element with the \
+ {3} name and {4} qualifiers that is defined in the {5} application artifact. \
+ The error is: {5}
+CWWKC1411.qualified.res.err.explanation=An error occurred when creating the \
+ resource or attempting to register it as a bean.
+CWWKC1411.qualified.res.err.useraction=Ensure that the resource is configured \
+ correctly.
+
+CWWKC1412.qualifier.conflict=CWWKC1412E: The {0} application artifact includes \
+ multiple {1} resource definitions that have the {2} qualifiers. The names of \
+ the conflicting {1} resource definitions are: {3}.
+CWWKC1412.qualifier.conflict.explanation=Qualifiers must uniquely identify a \
+ resource type.
+CWWKC1412.qualifier.conflict.useraction=Each resource definition of the same \
+ type must have different qualifiers or must not have any qualifiers.

--- a/dev/io.openliberty.concurrent.internal.cdi/resources/io/openliberty/concurrent/internal/cdi/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal.cdi/resources/io/openliberty/concurrent/internal/cdi/resources/CWWKCMessages.nlsprops
@@ -26,17 +26,17 @@
 
 # All messages must use the range CWWKC1410 to CWWKC1499
 
-CWWKC1410.schedule.lacks.seconds=CWWKC1410E: The Schedule, {0}, specifies an \
- empty value for the seconds at which to run. You must specify a non-empty value. \
- Alternatively, omit the seconds from the Schedule and rely on the default \
- behavior of scheduling the task to run at the second at the start of the minute.
+CWWKC1410.schedule.lacks.seconds=CWWKC1410E: The Schedule annotation, {0}, \
+ specifies an empty value for the seconds at which the task runs. \
+ Specify a nonempty value for the seconds field, or omit the seconds field \
+ from the Schedule annotation. Omitting the seconds field schedules the task \
+ to run at the start of the minute.
 CWWKC1410.schedule.lacks.seconds.explanation=The empty array value indicates that \
- the field must be disregarded when computing scheduled times. The seconds field \
- cannot accept an empty value because it is the most granular unit and cannot be \
- disregarded.
+ the seconds field must be disregarded when scheduled times are computed. \
+ Omitting the seconds field schedules the task to run at the start of the minute.
 CWWKC1410.schedule.lacks.seconds.useraction=Modify the seconds field of the \
- Schedule annotation to specify a non-empty value, or omit the seconds field \
- from the Schedule.
+ Schedule annotation to specify a nonempty value, or omit the seconds field \
+ from the Schedule annotation.
 
 CWWKC1411.qualified.res.err=CWWKC1411E: The server did not create a {0} bean \
  for the {1} annotation or {2} deployment descriptor element. \

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.cdi;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,8 +26,14 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 
 import com.ibm.websphere.csi.J2EEName;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.cdi.CDIServiceUtils;
+import com.ibm.ws.runtime.metadata.ApplicationMetaData;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaData;
+import com.ibm.ws.runtime.metadata.ModuleMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.openliberty.concurrent.internal.cdi.interceptor.AsyncInterceptor;
@@ -33,9 +41,13 @@ import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.concurrent.ContextService;
+import jakarta.enterprise.concurrent.ContextServiceDefinition;
+import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
+import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
@@ -51,6 +63,8 @@ import jakarta.enterprise.inject.spi.Extension;
  * CDI Extension for Jakarta Concurrency 3.1+ in Jakarta EE 11+, which corresponds to CDI 4.1+
  */
 public class ConcurrencyExtension implements Extension {
+    private static final TraceComponent tc = Tr.register(ConcurrencyExtension.class);
+
     private static final Annotation[] DEFAULT_QUALIFIER_ARRAY = new Annotation[] { Default.Literal.INSTANCE };
 
     private static final Set<Annotation> DEFAULT_QUALIFIER_SET = Set.of(Default.Literal.INSTANCE);
@@ -149,11 +163,14 @@ public class ConcurrencyExtension implements Extension {
             try {
                 event.addBean(new ContextServiceBean(factory));
             } catch (Throwable x) {
-                // TODO NLS
-                System.out.println(" E Unable to create a bean for the " +
-                                   factory + " ContextServiceDefinition with the " + factory.getQualifiers() + " qualifiers" +
-                                   " due to the following error: ");
-                x.printStackTrace();
+                Tr.error(tc, "CWWKC1411.qualified.res.err",
+                         ContextService.class.getSimpleName(),
+                         ContextServiceDefinition.class.getSimpleName(),
+                         "context-service",
+                         factory.getName(),
+                         factory.getQualifiers(),
+                         toArtifactName(factory.getDeclaringMetadata()),
+                         toStackTrace(x));
             }
         }
 
@@ -164,11 +181,14 @@ public class ConcurrencyExtension implements Extension {
             try {
                 event.addBean(new ManagedExecutorBean(factory));
             } catch (Throwable x) {
-                // TODO NLS
-                System.out.println(" E Unable to create a bean for the " +
-                                   factory + " ManagedExecutorDefinition with the " + factory.getQualifiers() + " qualifiers" +
-                                   " due to the following error: ");
-                x.printStackTrace();
+                Tr.error(tc, "CWWKC1411.qualified.res.err",
+                         ManagedExecutorService.class.getSimpleName(),
+                         ManagedExecutorDefinition.class.getSimpleName(),
+                         "managed-executor",
+                         factory.getName(),
+                         factory.getQualifiers(),
+                         toArtifactName(factory.getDeclaringMetadata()),
+                         toStackTrace(x));
             }
         }
 
@@ -179,11 +199,14 @@ public class ConcurrencyExtension implements Extension {
             try {
                 event.addBean(new ManagedScheduledExecutorBean(factory));
             } catch (Throwable x) {
-                // TODO NLS
-                System.out.println(" E Unable to create a bean for the " +
-                                   factory + " ManagedScheduledExecutorDefinition with the " + factory.getQualifiers() + " qualifiers" +
-                                   " due to the following error: ");
-                x.printStackTrace();
+                Tr.error(tc, "CWWKC1411.qualified.res.err",
+                         ManagedScheduledExecutorService.class.getSimpleName(),
+                         ManagedScheduledExecutorDefinition.class.getSimpleName(),
+                         "managed-scheduled-executor",
+                         factory.getName(),
+                         factory.getQualifiers(),
+                         toArtifactName(factory.getDeclaringMetadata()),
+                         toStackTrace(x));
             }
         }
 
@@ -194,11 +217,14 @@ public class ConcurrencyExtension implements Extension {
             try {
                 event.addBean(new ManagedThreadFactoryBean(factory, extSvc));
             } catch (Throwable x) {
-                // TODO NLS
-                System.out.println(" E Unable to create a bean for the " +
-                                   factory + " ManagedThreadFactoryDefinition with the " + factory.getQualifiers() + " qualifiers" +
-                                   " due to the following error: ");
-                x.printStackTrace();
+                Tr.error(tc, "CWWKC1411.qualified.res.err",
+                         ManagedThreadFactory.class.getSimpleName(),
+                         ManagedThreadFactoryDefinition.class.getSimpleName(),
+                         "managed-thread-factory",
+                         factory.getName(),
+                         factory.getQualifiers(),
+                         toArtifactName(factory.getDeclaringMetadata()),
+                         toStackTrace(x));
             }
         }
     }
@@ -222,5 +248,37 @@ public class ConcurrencyExtension implements Extension {
             }
             qualifierSetsPerMTF = null;
         }
+    }
+
+    /**
+     * Utility method to obtain the JEE name for a MetaData instance if possible,
+     * and otherwise the name.
+     *
+     * @param metadata ComponentMetaData, ModuleMetaData, or ApplicationMetaData.
+     * @return the artifact name, preferably as a JEE name string.
+     */
+    @Trivial
+    private static String toArtifactName(MetaData metadata) {
+        if (metadata instanceof ComponentMetaData)
+            return ((ComponentMetaData) metadata).getJ2EEName().toString();
+        else if (metadata instanceof ModuleMetaData)
+            return ((ModuleMetaData) metadata).getJ2EEName().toString();
+        else if (metadata instanceof ApplicationMetaData)
+            return ((ApplicationMetaData) metadata).getJ2EEName().toString();
+        else
+            return metadata.getName();
+    }
+
+    /**
+     * Utility method that converts an exception to a stack trace string.
+     *
+     * @param x exception.
+     * @return stack trace string.
+     */
+    @Trivial
+    private static String toStackTrace(Throwable x) {
+        StringWriter s = new StringWriter();
+        x.printStackTrace(new PrintWriter(s));
+        return s.toString();
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduleCronTrigger.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduleCronTrigger.java
@@ -17,6 +17,8 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 import jakarta.enterprise.concurrent.CronTrigger;
@@ -27,6 +29,7 @@ import jakarta.enterprise.concurrent.Schedule;
  * so that multiple triggers can compute from the same time.
  */
 class ScheduleCronTrigger extends CronTrigger {
+    private static final TraceComponent tc = Tr.register(ScheduleCronTrigger.class);
 
     private static final Month[] ALL_MONTHS = Month.values();
 
@@ -105,7 +108,12 @@ class ScheduleCronTrigger extends CronTrigger {
 
             int[] seconds = schedule.seconds();
             if (seconds.length == 0)
-                throw new IllegalArgumentException("seconds: {}"); // TODO NLS The seconds field cannot be ignored because no other units of Schedule are more granular.
+                // The seconds field cannot be ignored because no other
+                // units of Schedule are more granular.
+                throw new IllegalArgumentException(Tr //
+                                .formatMessage(tc,
+                                               "CWWKC1410.schedule.lacks.seconds",
+                                               schedule));
 
             trigger.months(months) //
                             .daysOfMonth(daysOfMonth) //

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/AppDefinedResourceFactory.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/AppDefinedResourceFactory.java
@@ -307,6 +307,12 @@ public class AppDefinedResourceFactory implements QualifiedResourceFactory {
         return declaringMetadata;
     }
 
+    @Override
+    @Trivial
+    public String getName() {
+        return jndiName;
+    }
+
     /**
      * Returns text showing an example of a valid qualifier with the specified
      * class name.

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/QualifiedResourceFactory.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/qualified/QualifiedResourceFactory.java
@@ -48,6 +48,14 @@ public interface QualifiedResourceFactory extends ResourceFactory {
     MetaData getDeclaringMetadata();
 
     /**
+     * Returns the name of the resource definition, which is typically a
+     * JNDI name in java:comp, java:module, java:app, or java:global
+     *
+     * @return the name.
+     */
+    String getName();
+
+    /**
      * Returns instances of the qualifier annotations for this resource factory.
      *
      * @return qualifier annotations for this resource factory.


### PR DESCRIPTION
Add NLS message for error paths from new Jakarta Concurrency function that is implemented in the bundle where we have the CDI extension for Concurrency.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
