### PR TITLE
Modify mpHealth delayedServlet mechanism to reduce time.

### DIFF
--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/.classpath
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/.classpath
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/ConfigAdminXmlCheckApp/src"/>
+	<classpathentry kind="src" path="test-applications/ConfigAdminDropinsCheckApp/src"/>
+	<classpathentry kind="src" path="test-applications/FailsToStartHealthCheckApp/src"/>
 	<classpathentry kind="src" path="test-applications/DelayedHealthCheckApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/.classpath
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/DelayedHealthCheckAppFast/src"/>
 	<classpathentry kind="src" path="test-applications/ConfigAdminXmlCheckApp/src"/>
 	<classpathentry kind="src" path="test-applications/ConfigAdminDropinsCheckApp/src"/>
 	<classpathentry kind="src" path="test-applications/FailsToStartHealthCheckApp/src"/>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/bnd.bnd
@@ -13,6 +13,7 @@ bVersion=1.0
 src: \
 	fat/src, \
 	test-applications/DelayedHealthCheckApp/src, \
+	test-applications/DelayedHealthCheckAppFast/src, \
 	test-applications/ConfigAdminDropinsCheckApp/src, \
 	test-applications/FailsToStartHealthCheckApp/src, \
 	test-applications/ConfigAdminXmlCheckApp/src

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/ConfigAdminHealthCheckTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/ConfigAdminHealthCheckTest.java
@@ -297,7 +297,7 @@ public class ConfigAdminHealthCheckTest {
         }
 
         log("testReadinessEndpointOnServerStart", "Waiting for Application to start.");
-        String line = server1.waitForStringInLog("Application MultiWarApps started", 110000);
+        String line = server1.waitForStringInLog("Application MultiWarApps started", 30000);
         log("testReadinessEndpointOnServerStart", "Application started. Line Found : " + line);
         assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
 

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/ConfigAdminHealthCheckTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/ConfigAdminHealthCheckTest.java
@@ -67,7 +67,7 @@ public class ConfigAdminHealthCheckTest {
 
     public static final String MULTIPLE_APP_NAME = "MultipleHealthCheckApp";
     public static final String DIFFERENT_APP_NAME = "DifferentApplicationNameHealthCheckApp";
-    public static final String DELAYED_APP_NAME = "DelayedHealthCheckApp";
+    public static final String DELAYED_APP_NAME = "DelayedHealthCheckAppFast";
     public static final String FAILS_TO_START_APP_NAME = "FailsToStartHealthCheckApp";
     public static final String SUCCESSFUL_APP_NAME = "SuccessfulHealthCheckApp";
 
@@ -284,7 +284,7 @@ public class ConfigAdminHealthCheckTest {
     public void testMultiWarDetectionDropinsTest() throws Exception {
 
         try {
-            WebArchive war1 = ShrinkHelper.buildDefaultApp(DELAYED_APP_NAME, "io.openliberty.microprofile.health31.delayed.health.check.app");
+            WebArchive war1 = ShrinkHelper.buildDefaultApp(DELAYED_APP_NAME, "io.openliberty.microprofile.health31.delayed.health.check.fast.app");
             WebArchive war2 = ShrinkHelper.buildDefaultApp(APP_NAME, "io.openliberty.microprofile.health31.config.admin.dropins.checks.app");
             EnterpriseArchive testEar = ShrinkWrap.create(EnterpriseArchive.class, "MultiWarApps.ear");
             testEar.addAsModule(war2);

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/DefaultOverallStartupStatusUpAppStartupFastTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/DefaultOverallStartupStatusUpAppStartupFastTest.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.health31.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.net.HttpURLConnection;
+import java.util.List;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+@RunWith(FATRunner.class)
+/*
+ * This is similar to DefaultOverallStartupStatusUpAppStartupTest. But is "faster'.
+ * this mocks a late startup by allowing server to start first and then deploying the app into
+ * the dropins.
+ */
+public class DefaultOverallStartupStatusUpAppStartupFastTest {
+
+    private static final String[] EXPECTED_FAILURES = { "CWWKE1102W", "CWWKE1105W", "CWMMH0052W", "CWMMH0054W", "SRVE0302E" };
+
+    public static final String APP_NAME = "DelayedHealthCheckAppFast";
+    private static final String MESSAGE_LOG = "logs/messages.log";
+
+    private final String HEALTH_ENDPOINT = "/health";
+    private final String STARTED_ENDPOINT = "/health/started";
+
+    private final int SUCCESS_RESPONSE_CODE = 200;
+    private final int FAILED_RESPONSE_CODE = 503; // Response when port is open but Application has not started yet.
+
+    final static String SERVER_NAME = "DefaultStartupOverallStatusHealthCheckFast";
+
+    final static String INVALID_SERVER_NAME = "InvalidDefaultStartupOverallStatusPropertyFast";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server1;
+
+    @Server(INVALID_SERVER_NAME)
+    public static LibertyServer server2;
+
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(FeatureReplacementAction.ALL_SERVERS,
+                                                             MicroProfileActions.MP70_EE10, // mpHealth-4.0 LITE
+                                                             MicroProfileActions.MP70_EE11, // mpHealth-4.0 FULL
+                                                             MicroProfileActions.MP41); // mpHealth-3.1 FULL
+
+    public void setupClass(LibertyServer server, String testName) throws Exception {
+        log("setupClass", testName + "Starting the server.");
+
+        if (!server.isStarted())
+            server.startServer(false, false);
+
+        // Read to run a smarter planet
+        server.waitForStringInLogUsingMark("CWWKF0011I");
+    }
+
+    private void deployApp(LibertyServer server, String testName) throws Exception {
+        log("deployApp", testName + " - Deploying the Delayed App into the apps directory");
+        WebArchive app = ShrinkHelper.buildDefaultApp(APP_NAME, "io.openliberty.microprofile.health31.delayed.health.check.fast.app");
+
+        //ShrinkHelper.exportAppToServer(server, app, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
+        ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
+
+        String line = server.waitForStringInLogUsingMark("CWWKT0016I: Web application available.*" + APP_NAME + "*");
+        log("deployApp - " + testName, "Web Application available message found?: " + line);
+        assertNotNull("The CWWKT0016I Web Application available message did not appear in messages.log", line);
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        log("cleanUp", " - Stopping the server, if servers are started.");
+
+        if ((server1 != null) && (server1.isStarted()))
+            server1.stopServer(EXPECTED_FAILURES);
+
+        if ((server2 != null) && (server2.isStarted()))
+            server2.stopServer(EXPECTED_FAILURES);
+    }
+
+    /*
+     * Sets the MpConfig property. e.g. "mp.health.default.startup.empty.response=UP", the started endpoint should return UP even if the application is still starting up.
+     */
+    @Test
+    public void testDefaultStartupOverallStatusUpAtStartUpSingleApp() throws Exception {
+        setupClass(server1, "testDefaultStartupOverallStatusUpAtStartUpSingleApp");
+        deployApp(server1, "testDefaultStartupOverallStatusUpAtStartUpSingleApp");
+        log("testDefaultStartupOverallStatusUpAtStartUpSingleApp", "Testing the /health/started endpoint, before application has started.");
+        HttpURLConnection conStarted = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, STARTED_ENDPOINT);
+        assertEquals("The Response Code was not 200 for the following endpoint: " + conStarted.getURL().toString(), SUCCESS_RESPONSE_CODE, conStarted.getResponseCode());
+
+        log("testDefaultStartupOverallStatusUpAtStartUpSingleApp",
+            "Testing the /health endpoint, before application has started, it should be DOWN since the Readiness check status will still be DOWN.");
+        HttpURLConnection conHealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, HEALTH_ENDPOINT);
+        assertEquals("The Response Code was not 503 for the following endpoint: " + conHealth.getURL().toString(), FAILED_RESPONSE_CODE, conHealth.getResponseCode());
+
+        JsonObject jsonResponse = getJSONPayload(conStarted);
+        JsonArray checks = (JsonArray) jsonResponse.get("checks");
+        assertTrue("The JSON response was not empty.", checks.isEmpty());
+        assertEquals("The status of the Startup health check was not UP.", jsonResponse.getString("status"), "UP");
+
+        List<String> lines = server1.findStringsInFileInLibertyServerRoot("CWMMH0054W:", MESSAGE_LOG);
+        assertEquals("The CWMMH0054W warning should not appear in messages.log", 0, lines.size());
+
+        String line = server1.waitForStringInLogUsingMark("(CWWKZ0001I: Application " + APP_NAME + " started)+", 30000);
+        log("testDefaultStartupOverallStatusUpAtStartUpSingleApp", "Application Started message found: " + line);
+        assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
+
+        log("testDefaultStartupOverallStatusUpAtStartUpSingleApp", "Testing the /health/started endpoint, after application has started.");
+        HttpURLConnection conStarted2 = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, STARTED_ENDPOINT);
+        assertEquals("The Response Code was not the 200 for the following endpoint: " + conStarted2.getURL().toString(), SUCCESS_RESPONSE_CODE,
+                     conStarted2.getResponseCode());
+
+        JsonObject jsonResponse2 = getJSONPayload(conStarted2);
+        JsonArray checks2 = (JsonArray) jsonResponse2.get("checks");
+        assertEquals("The size of the JSON Startup health check was not 1.", 1, checks2.size());
+        assertEquals("The status of the Startup health check was not UP for the user-defined health checks.", jsonResponse2.getString("status"), "UP");
+    }
+
+    /*
+     * Set the invalid value for the MpConfig property. e.g. "mp.health.default.startup.empty.response=UPs", it should be default behaviour (DOWN)
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testInvalidDefaultStartupOverallStatusProperty() throws Exception {
+        setupClass(server2, "testInvalidDefaultStartupOverallStatusProperty");
+        deployApp(server2, "testInvalidDefaultStartupOverallStatusProperty");
+        log("testInvalidDefaultStartupOverallStatusProperty", "Testing the /health/started endpoint, before application has started.");
+        HttpURLConnection conStarted = HttpUtils.getHttpConnectionWithAnyResponseCode(server2, STARTED_ENDPOINT);
+        assertEquals("The Response Code was not 503 for the following endpoint: " + conStarted.getURL().toString(), FAILED_RESPONSE_CODE, conStarted.getResponseCode());
+
+        log("testInvalidDefaultStartupsOverallStatusProperty", "Testing the /health endpoint, before application has started.");
+        HttpURLConnection conHealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server2, HEALTH_ENDPOINT);
+        assertEquals("The Response Code was not 503 for the following endpoint: " + conHealth.getURL().toString(), FAILED_RESPONSE_CODE, conHealth.getResponseCode());
+
+        JsonObject jsonResponse = getJSONPayload(conStarted);
+        JsonArray checks = (JsonArray) jsonResponse.get("checks");
+        assertTrue("The JSON response was not empty.", checks.isEmpty());
+        assertEquals("The status of the Startup health check was not DOWN.", jsonResponse.getString("status"), "DOWN");
+
+        server2.setMarkToEndOfLog();
+
+        List<String> lines = server2.findStringsInFileInLibertyServerRoot("CWMMH0054W:", MESSAGE_LOG);
+        assertEquals("The CWMMH0054W warning did not appear in messages.log", 1, lines.size());
+
+        String line = server2.waitForStringInLogUsingMark("(CWWKZ0001I: Application " + APP_NAME + " started)+", 90000);
+        log("testInvalidDefaultStartupOverallStatusProperty", "Application Started message found: " + line);
+        assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
+
+        log("testInvalidDefaultStartupOverallStatusProperty", "Testing the /health/started endpoint, after application has started.");
+        HttpURLConnection conStarted2 = HttpUtils.getHttpConnectionWithAnyResponseCode(server2, STARTED_ENDPOINT);
+
+        JsonObject jsonResponse2 = getJSONPayload(conStarted2);
+        JsonArray checks2 = (JsonArray) jsonResponse2.get("checks");
+        assertEquals("The size of the JSON Startup health check was not 1.", 1, checks2.size());
+        assertEquals("The status of the Startup health check was not UP for user-defined health checks.", jsonResponse2.getString("status"), "UP");
+    }
+
+    public JsonObject getJSONPayload(HttpURLConnection con) throws Exception {
+        assertEquals("application/json; charset=UTF-8", con.getHeaderField("Content-Type"));
+
+        BufferedReader br = HttpUtils.getResponseBody(con, "UTF-8");
+        Json.createReader(br);
+        JsonObject jsonResponse = Json.createReader(br).readObject();
+        br.close();
+
+        log("getJSONPayload", "Response: jsonResponse= " + jsonResponse.toString());
+        assertNotNull("The contents of the health endpoint must not be null.", jsonResponse.getString("status"));
+
+        return jsonResponse;
+    }
+
+    /**
+     * Helper for simple logging.
+     */
+    private static void log(String method, String msg) {
+        Log.info(DefaultOverallStartupStatusUpAppStartupFastTest.class, method, msg);
+    }
+}

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/DefaultOverallStartupStatusUpAppStartupFastTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/DefaultOverallStartupStatusUpAppStartupFastTest.java
@@ -90,7 +90,6 @@ public class DefaultOverallStartupStatusUpAppStartupFastTest {
         log("deployApp", testName + " - Deploying the Delayed App into the apps directory");
         WebArchive app = ShrinkHelper.buildDefaultApp(APP_NAME, "io.openliberty.microprofile.health31.delayed.health.check.fast.app");
 
-        //ShrinkHelper.exportAppToServer(server, app, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
         ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
 
         String line = server.waitForStringInLogUsingMark("CWWKT0016I: Web application available.*" + APP_NAME + "*");

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/DefaultOverallStartupStatusUpAppStartupTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/DefaultOverallStartupStatusUpAppStartupTest.java
@@ -72,16 +72,24 @@ public class DefaultOverallStartupStatusUpAppStartupTest {
                                                              MicroProfileActions.MP41); // mpHealth-3.1 FULL
 
     public void setupClass(LibertyServer server, String testName) throws Exception {
-        log("setupClass", testName + " - Deploying the Delayed App into the apps directory and starting the server.");
-
-        WebArchive app = ShrinkHelper.buildDefaultApp(APP_NAME, "io.openliberty.microprofile.health31.delayed.health.check.app");
-        ShrinkHelper.exportAppToServer(server, app, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
+        log("setupClass", testName + "Starting the server.");
 
         if (!server.isStarted())
             server.startServer(false, false);
 
-        String line = server.waitForStringInLog("CWWKT0016I: Web application available.*DelayedHealthCheckApp*");
-        log("setupClass - " + testName, "Web Application available message found: " + line);
+        // Read to run a smarter planet
+        server.waitForStringInLogUsingMark("CWWKF0011I");
+    }
+
+    private void deployApp(LibertyServer server, String testName) throws Exception {
+        log("deployApp", testName + " - Deploying the Delayed App into the apps directory");
+        WebArchive app = ShrinkHelper.buildDefaultApp(APP_NAME, "io.openliberty.microprofile.health31.delayed.health.check.app");
+
+        //ShrinkHelper.exportAppToServer(server, app, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
+        ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
+
+        String line = server.waitForStringInLogUsingMark("CWWKT0016I: Web application available.*DelayedHealthCheckApp*");
+        log("deployApp - " + testName, "Web Application available message found?: " + line);
         assertNotNull("The CWWKT0016I Web Application available message did not appear in messages.log", line);
     }
 
@@ -102,6 +110,7 @@ public class DefaultOverallStartupStatusUpAppStartupTest {
     @Test
     public void testDefaultStartupOverallStatusUpAtStartUpSingleApp() throws Exception {
         setupClass(server1, "testDefaultStartupOverallStatusUpAtStartUpSingleApp");
+        deployApp(server1, "testDefaultStartupOverallStatusUpAtStartUpSingleApp");
         log("testDefaultStartupOverallStatusUpAtStartUpSingleApp", "Testing the /health/started endpoint, before application has started.");
         HttpURLConnection conStarted = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, STARTED_ENDPOINT);
         assertEquals("The Response Code was not 200 for the following endpoint: " + conStarted.getURL().toString(), SUCCESS_RESPONSE_CODE, conStarted.getResponseCode());
@@ -143,6 +152,7 @@ public class DefaultOverallStartupStatusUpAppStartupTest {
     @Mode(TestMode.FULL)
     public void testInvalidDefaultStartupOverallStatusProperty() throws Exception {
         setupClass(server2, "testInvalidDefaultStartupOverallStatusProperty");
+        deployApp(server2, "testInvalidDefaultStartupOverallStatusProperty");
         log("testInvalidDefaultStartupOverallStatusProperty", "Testing the /health/started endpoint, before application has started.");
         HttpURLConnection conStarted = HttpUtils.getHttpConnectionWithAnyResponseCode(server2, STARTED_ENDPOINT);
         assertEquals("The Response Code was not 503 for the following endpoint: " + conStarted.getURL().toString(), FAILED_RESPONSE_CODE, conStarted.getResponseCode());

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckFastTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckFastTest.java
@@ -1,0 +1,298 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.health31.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+@RunWith(FATRunner.class)
+public class SlowAppStartupHealthCheckFastTest {
+
+    private static final String[] EXPECTED_FAILURES = { "CWWKE1102W", "CWWKE1105W", "CWMMH0052W", "CWMMH0054W", "SRVE0302E" };
+
+    public static final String APP_NAME = "DelayedHealthCheckAppFast";
+    private static final String MESSAGE_LOG = "logs/messages.log";
+
+    private final String STARTED_ENDPOINT = "/health/started";
+
+    private final int SUCCESS_RESPONSE_CODE = 200;
+    private final int FAILED_RESPONSE_CODE = 503; // Response when port is open but Application is not started
+
+    private final String APP_ENDPOINT = "/" + APP_NAME + "/DelayedServlet";
+    final static String SERVER_NAME = "SlowAppStartupHealthCheckFast";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server1;
+
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
+                                                             MicroProfileActions.MP70_EE10, // mpHealth-4.0 LITE
+                                                             MicroProfileActions.MP70_EE11, // mpHealth-4.0 FULL
+                                                             MicroProfileActions.MP41); // mpHealth-3.1 FULL
+
+    public void setupClass(LibertyServer server, String testName) throws Exception {
+        log("setupClass", testName + "Starting the server.");
+
+        if (!server.isStarted())
+            server.startServer(false, false);
+
+        // Read to run a smarter planet
+        server.waitForStringInLogUsingMark("CWWKF0011I");
+    }
+
+    private void deployApp(LibertyServer server, String testName) throws Exception {
+        log("deployApp", testName + " - Deploying the Delayed App into the apps directory");
+        WebArchive app = ShrinkHelper.buildDefaultApp(APP_NAME, "io.openliberty.microprofile.health31.delayed.health.check.fast.app");
+
+        ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
+
+        String line = server.waitForStringInLogUsingMark("CWWKT0016I: Web application available.*" + APP_NAME + "*");
+        log("deployApp - " + testName, "Web Application available message found?: " + line);
+        assertNotNull("The CWWKT0016I Web Application available message did not appear in messages.log", line);
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        log("cleanUp", " - Stopping the server, if servers are started.");
+
+        if ((server1 != null) && (server1.isStarted()))
+            server1.stopServer(EXPECTED_FAILURES);
+
+        boolean flag = server1.removeDropinsApplications(APP_NAME + ".war");
+        log("cleanUp", " - Removed the app? [" + flag + "]");
+    }
+
+    /*
+     * Test the Startup end point, as soon as the server starts. The startup end point will be continuously polled, until it returns a
+     * 200 response code, once all the deployed applications have started. This test mimics how the Kubernetes Startup probe work.
+     */
+    @Test
+    public void testStartupEndpointOnServerStart() throws Exception {
+        setupClass(server1, "testStartupEndpointOnServerStart");
+        deployApp(server1, "testStartupEndpointOnServerStart");
+        log("testReadinessEndpointOnServerStart", "Begin execution of testReadinessEndpointOnServerStart");
+        server1.setMarkToEndOfLog();
+        server1.stopServer(EXPECTED_FAILURES);
+
+        class StartServerOnThread extends Thread {
+            @Override
+            public void run() {
+                try {
+                    server1.startServer();
+                } catch (Exception e) {
+                    assertTrue("Failure to start server on a seperate thread.", server1.isStarted());
+                }
+            }
+        }
+
+        StartServerOnThread startServerThread;
+        HttpURLConnection conStarted = null;
+        int num_of_attempts = 0;
+        int max_num_of_attempts = 5;
+        int responseCode = -1;
+        long start_time = System.currentTimeMillis();
+        long time_out = 240000; // 240000ms = 4min
+        boolean connectionExceptionEncountered = false;
+        boolean first_time = true;
+        boolean app_started = false;
+        boolean repeat = true;
+        boolean runTest = true;
+
+        while (repeat) {
+            Assume.assumeTrue(runTest); // Skip the test, if runTest is false.
+
+            num_of_attempts += 1;
+
+            // Need to ensure the server is not finish starting when startup endpoint is hit so start the server on a separate thread
+            // Note: this does not guarantee that we hit the endpoint during server startup, but it is highly likely that it will
+            startServerThread = new StartServerOnThread();
+            log("testStartupEndpointOnServerStart", "Starting DelayedHealthCheck server on separate thread.");
+            startServerThread.start();
+
+            try {
+                conStarted = null;
+                responseCode = -1;
+                connectionExceptionEncountered = false;
+                first_time = true;
+                app_started = false;
+                start_time = System.currentTimeMillis();
+
+                // Repeatedly hit the readiness endpoint until a response of 200 is received
+                while (!app_started) {
+                    try {
+                        conStarted = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, STARTED_ENDPOINT);
+                        responseCode = conStarted.getResponseCode();
+                    } catch (ConnectException ce) {
+                        if (ce.getMessage().contains("Connection refused")) {
+                            connectionExceptionEncountered = true;
+                        }
+                    } catch (SocketTimeoutException ste) {
+                        log("testStartupEndpointOnServerStart", "Encountered a SocketTimeoutException. Retrying connection. Exception: " + ste.getMessage());
+                        continue;
+                    } catch (SocketException se) {
+                        log("testStartupEndpointOnServerStart", "Encountered a SocketException. Retrying connection. Exception: " + se.getMessage());
+                        continue;
+                    }
+
+                    // We need to ensure we get a connection refused in the case of the server not finished starting up
+                    // We expect a connection refused as the ports are not open until server is fully started
+                    if (first_time) {
+                        log("testStartupEndpointOnServerStart", "Testing the /health/started endpoint as the server is still starting up.");
+                        String message = "The connection was not refused as required, but instead completed with response code: " + responseCode +
+                                         " This is likely due to a rare timing issue where the server starts faster than we can hit the startup endpoint.";
+
+                        if (conStarted == null && connectionExceptionEncountered) {
+                            first_time = false;
+                        } else {
+                            if (num_of_attempts == max_num_of_attempts) {
+                                log("testStartupEndpointOnServerStart",
+                                    message + " Skipping test case due to multiple failed attempts in hitting the startup endpoint faster than the server can start.");
+                                startServerThread.join();
+                                runTest = false; // Skip the test.
+                                break;
+                            }
+
+                            log("testStartupEndpointOnServerStart", message + " At this point the test will be re-run. Number of current attempts ---> " + num_of_attempts);
+                            startServerThread.join();
+                            cleanUp();
+                            break; // We repeat the test case
+                        }
+                    } else {
+                        if (responseCode == 200) {
+                            log("testStartupEndpointOnServerStart", "The /health/started endpoint response code was 200.");
+                            app_started = true;
+                            repeat = false;
+                            startServerThread.join();
+                        } else if (System.currentTimeMillis() - start_time > time_out) {
+                            List<String> lines = server1.findStringsInFileInLibertyServerRoot("(CWWKZ0001I: Application " + APP_NAME + " started)+", MESSAGE_LOG);
+                            if (lines.size() == 0) {
+                                log("testStartupEndpointOnServerStart", "Waiting for Application to start.");
+                                String line = server1.waitForStringInLog("(CWWKZ0001I: Application " + APP_NAME + " started)+", time_out);
+                                log("testStartupEndpointOnServerStart", "Application started. Line Found : " + line);
+                                assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
+                            } else {
+                                log("testReadinessEndpointOnServerStart", "Application started but timeout still reached.");
+                                throw new TimeoutException("Timed out waiting for server and app to be started. Timeout set to " + time_out + "ms.");
+                            }
+                        }
+                    }
+
+                }
+            } catch (Exception e) {
+                startServerThread.join();
+                fail("Encountered an issue while Testing the /health/started endpoint as the server and/or application(s) are starting up ---> " + e);
+            }
+
+        }
+
+        log("testStartupEndpointOnServerStart", "Waiting for Application to start message, after Health check reports 200.");
+        String line = server1.waitForStringInLog("(CWWKZ0001I: Application " + APP_NAME + " started)+", 60000);
+        assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
+        log("testSlowAppStartUpHealthCheck", "Application Started message found: " + line);
+
+        // Access an application endpoint to verify the application is actually started
+        log("testStartupEndpointOnServerStart", "Testing an application endpoint, after server and application has started.");
+        conStarted = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, APP_ENDPOINT);
+        assertEquals("The Response Code was not 200 for the following endpoint: " + conStarted.getURL().toString(), SUCCESS_RESPONSE_CODE,
+                     conStarted.getResponseCode());
+        HttpUtils.findStringInUrl(server1, APP_ENDPOINT, "Testing Delayed Servlet initialization.");
+    }
+
+    /*
+     * Tests the Startup endpoint with a slow starting application which ensures that the startup health check returns DOWN, when the application
+     * is still starting up, and should return the status of the user-defined startup health checks.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testSlowAppStartUpHealthCheck() throws Exception {
+        setupClass(server1, "testSlowAppStartUpHealthCheck");
+        deployApp(server1, "testStartupEndpointOnServerStart");
+        log("testSlowAppStartUpHealthCheck", "Testing the /health/started endpoint, before application has started.");
+        HttpURLConnection conStarted = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, STARTED_ENDPOINT);
+        assertEquals("The Response Code was not 503 for the following endpoint: " + conStarted.getURL().toString(), FAILED_RESPONSE_CODE, conStarted.getResponseCode());
+
+        JsonObject jsonResponse = getJSONPayload(conStarted);
+        JsonArray checks = (JsonArray) jsonResponse.get("checks");
+        assertTrue("The JSON response was not empty.", checks.isEmpty());
+        assertEquals("The status of the Startup health check was not DOWN.", jsonResponse.getString("status"), "DOWN");
+
+        List<String> lines = server1.findStringsInFileInLibertyServerRoot("CWMMH0054W:", MESSAGE_LOG);
+        assertEquals("The CWMMH0054W warning did not appear in messages.log", 1, lines.size());
+
+        String line = server1.waitForStringInLogUsingMark("(CWWKZ0001I: Application " + APP_NAME + " started)+", 60000);
+        log("testSlowAppStartUpHealthCheck", "Application Started message found: " + line);
+        assertNotNull("The CWWKZ0001I Application started message did not appear in messages.log", line);
+
+        log("testSlowAppStartUpHealthCheck", "Testing the /health/started endpoint, after application has started.");
+        HttpURLConnection conStarted2 = HttpUtils.getHttpConnectionWithAnyResponseCode(server1, STARTED_ENDPOINT);
+        assertEquals("The Response Code was not 200 for the following endpoint: " + conStarted2.getURL().toString(), SUCCESS_RESPONSE_CODE,
+                     conStarted2.getResponseCode());
+
+        JsonObject jsonResponse2 = getJSONPayload(conStarted2);
+        JsonArray checks2 = (JsonArray) jsonResponse2.get("checks");
+        assertEquals("The size of the JSON Readiness health check was not 1.", 1, checks2.size());
+        assertEquals("The status of the Startup health check was not UP.", jsonResponse2.getString("status"), "UP");
+    }
+
+    public JsonObject getJSONPayload(HttpURLConnection con) throws Exception {
+        assertEquals("application/json; charset=UTF-8", con.getHeaderField("Content-Type"));
+
+        BufferedReader br = HttpUtils.getResponseBody(con, "UTF-8");
+        Json.createReader(br);
+        JsonObject jsonResponse = Json.createReader(br).readObject();
+        br.close();
+
+        log("getJSONPayload", "Response: jsonResponse= " + jsonResponse.toString());
+        assertNotNull("The contents of the health endpoint must not be null.", jsonResponse.getString("status"));
+
+        return jsonResponse;
+    }
+
+    /**
+     * Helper for simple logging.
+     */
+    private static void log(String method, String msg) {
+        Log.info(SlowAppStartupHealthCheckFastTest.class, method, msg);
+    }
+}

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/suite/FATSuite.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/suite/FATSuite.java
@@ -17,13 +17,17 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import io.openliberty.microprofile.health31.fat.ConfigAdminHealthCheckTest;
+import io.openliberty.microprofile.health31.fat.DefaultOverallStartupStatusUpAppStartupFastTest;
 import io.openliberty.microprofile.health31.fat.DefaultOverallStartupStatusUpAppStartupTest;
+import io.openliberty.microprofile.health31.fat.SlowAppStartupHealthCheckFastTest;
 import io.openliberty.microprofile.health31.fat.SlowAppStartupHealthCheckTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
                 DefaultOverallStartupStatusUpAppStartupTest.class,
+                DefaultOverallStartupStatusUpAppStartupFastTest.class,
                 SlowAppStartupHealthCheckTest.class,
+                SlowAppStartupHealthCheckFastTest.class,
                 ConfigAdminHealthCheckTest.class
 })
 

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/DefaultStartupOverallStatusHealthCheck/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/DefaultStartupOverallStatusHealthCheck/server.xml
@@ -11,8 +11,8 @@
         <feature>jsonp-1.1</feature>
     </featureManager>
 	
-	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
-
+    <logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
+    <application location="DelayedHealthCheckApp.war"/>
     <webContainer deferServletLoad="false"/> 
 	
 </server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/DefaultStartupOverallStatusHealthCheck/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/DefaultStartupOverallStatusHealthCheck/server.xml
@@ -13,7 +13,6 @@
 	
 	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
 
-	<application location="DelayedHealthCheckApp.war"/>
     <webContainer deferServletLoad="false"/> 
 	
 </server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/DefaultStartupOverallStatusHealthCheckFast/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/DefaultStartupOverallStatusHealthCheckFast/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+osgi.console=7771
+mp.health.default.startup.empty.response=UP

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/DefaultStartupOverallStatusHealthCheckFast/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/DefaultStartupOverallStatusHealthCheckFast/server.xml
@@ -1,0 +1,18 @@
+<server description="Server for testing multiple health checks with the default Readiness overall status MP Config property enabled">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>osgiConsole-1.0</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>appSecurity-2.0</feature>
+        <feature>mpHealth-3.1</feature>
+        <feature>mpConfig-2.0</feature>
+        <feature>jsonp-1.1</feature>
+    </featureManager>
+	
+	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
+
+    <webContainer deferServletLoad="false"/> 
+	
+</server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/DefaultStartupOverallStatusHealthCheckFast/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/DefaultStartupOverallStatusHealthCheckFast/server.xml
@@ -11,7 +11,7 @@
         <feature>jsonp-1.1</feature>
     </featureManager>
 	
-	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
+    <logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
 
     <webContainer deferServletLoad="false"/> 
 	

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/InvalidDefaultStartupOverallStatusProperty/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/InvalidDefaultStartupOverallStatusProperty/server.xml
@@ -13,7 +13,6 @@
 	
 	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
 
-	<application location="DelayedHealthCheckApp.war"/>
     <webContainer deferServletLoad="false"/> 
 	
 </server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/InvalidDefaultStartupOverallStatusProperty/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/InvalidDefaultStartupOverallStatusProperty/server.xml
@@ -12,7 +12,7 @@
     </featureManager>
 	
 	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
-
+    <application location="DelayedHealthCheckApp.war"/>
     <webContainer deferServletLoad="false"/> 
 	
 </server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/InvalidDefaultStartupOverallStatusPropertyFast/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/InvalidDefaultStartupOverallStatusPropertyFast/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+osgi.console=7771
+mp.health.default.startup.empty.response=UPs

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/InvalidDefaultStartupOverallStatusPropertyFast/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/InvalidDefaultStartupOverallStatusPropertyFast/server.xml
@@ -1,0 +1,17 @@
+<server description="Server for testing multiple health checks with the default Readiness overall status MP Config property enabled">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>osgiconsole-1.0</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>appSecurity-2.0</feature>
+        <feature>mpHealth-3.1</feature>
+        <feature>mpConfig-2.0</feature>
+        <feature>jsonp-1.1</feature>
+    </featureManager>
+	
+	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
+    <webContainer deferServletLoad="false"/> 
+	
+</server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/InvalidDefaultStartupOverallStatusPropertyFast/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/InvalidDefaultStartupOverallStatusPropertyFast/server.xml
@@ -11,7 +11,7 @@
         <feature>jsonp-1.1</feature>
     </featureManager>
 	
-	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
+    <logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
     <webContainer deferServletLoad="false"/> 
 	
 </server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheck/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheck/server.xml
@@ -12,8 +12,8 @@
         <feature>servlet-4.0</feature>
     </featureManager>
 	
-	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
-
+    <logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
+    <application location="DelayedHealthCheckApp.war"/>
     <webContainer deferServletLoad="false"/> 
 	
 </server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheck/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheck/server.xml
@@ -14,7 +14,6 @@
 	
 	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
 
-	<application location="DelayedHealthCheckApp.war"/>
     <webContainer deferServletLoad="false"/> 
 	
 </server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheckFast/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheckFast/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+osgi.console=7771

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheckFast/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheckFast/server.xml
@@ -1,0 +1,19 @@
+<server description="Server for testing multiple health checks with the default Readiness overall status MP Config property enabled">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>osgiConsole-1.0</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>appSecurity-2.0</feature>
+        <feature>mpHealth-3.1</feature>
+        <feature>mpConfig-2.0</feature>
+        <feature>jsonp-1.1</feature>
+        <feature>servlet-4.0</feature>
+    </featureManager>
+	
+	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
+
+    <webContainer deferServletLoad="false"/> 
+	
+</server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheckFast/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheckFast/server.xml
@@ -12,7 +12,7 @@
         <feature>servlet-4.0</feature>
     </featureManager>
 	
-	<logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
+    <logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
 
     <webContainer deferServletLoad="false"/> 
 	

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health31/delayed/health/check/app/DelayedServlet.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health31/delayed/health/check/app/DelayedServlet.java
@@ -37,7 +37,7 @@ public class DelayedServlet extends HttpServlet {
     public void init() {
         System.out.println("Entering init function - Starting Thread.sleep for 95 seconds.");
         try {
-            Thread.sleep(95000); // 95 seconds = 95000 ms
+            Thread.sleep(15000); // 15 seconds = 15000 ms
         } catch (InterruptedException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health31/delayed/health/check/app/DelayedServlet.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health31/delayed/health/check/app/DelayedServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -37,7 +37,7 @@ public class DelayedServlet extends HttpServlet {
     public void init() {
         System.out.println("Entering init function - Starting Thread.sleep for 95 seconds.");
         try {
-            Thread.sleep(15000); // 15 seconds = 15000 ms
+            Thread.sleep(95000); // 95 seconds = 95000 ms
         } catch (InterruptedException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/resources/META-INF/MANIFEST.MF
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Class-Path: 

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/resources/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+<web-app id="WebApp_ID" version="3.0" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+  <display-name>Delayed Servlet</display-name>
+  <description>Delayed Servlet for delayed application start up</description>
+
+  <servlet>
+    <display-name>DelayedServlet</display-name>
+    <servlet-name>DelayedServlet</servlet-name>
+    <servlet-class>io.openliberty.microprofile.health31.delayed.health.check.fast.app.DelayedServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  
+  <servlet-mapping>
+    <servlet-name>DelayedServlet</servlet-name>
+    <url-pattern>/DelayedServlet</url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/src/io/openliberty/microprofile/health31/delayed/health/check/fast/app/DelayedLivenessCheck.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/src/io/openliberty/microprofile/health31/delayed/health/check/fast/app/DelayedLivenessCheck.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health31.delayed.health.check.fast.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+/**
+ *
+ */
+@Liveness
+@ApplicationScoped
+public class DelayedLivenessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("delayed-successful-liveness-check").up().build();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/src/io/openliberty/microprofile/health31/delayed/health/check/fast/app/DelayedReadinessCheck.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/src/io/openliberty/microprofile/health31/delayed/health/check/fast/app/DelayedReadinessCheck.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health31.delayed.health.check.fast.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+/**
+ *
+ */
+@Readiness
+@ApplicationScoped
+public class DelayedReadinessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("delayed-successful-readiness-check").up().build();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/src/io/openliberty/microprofile/health31/delayed/health/check/fast/app/DelayedServlet.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/src/io/openliberty/microprofile/health31/delayed/health/check/fast/app/DelayedServlet.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health31.delayed.health.check.fast.app;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ *
+ */
+public class DelayedServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @see HttpServlet#HttpServlet()
+     */
+    public DelayedServlet() {
+        super();
+    }
+
+    @Override
+    public void init() {
+        System.out.println("Entering init function - Starting Thread.sleep for 15 seconds.");
+        try {
+            Thread.sleep(15000); // 15 seconds = 15000 ms
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        System.out.println("Exiting init function - Thread.sleep completed.");
+    }
+
+    /**
+     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // TODO Auto-generated method stub
+        response.setContentType("text/plain");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().append("Served at: ").append(request.getContextPath()).append("\n");
+        response.getWriter().println("Testing Delayed Servlet initialization.");
+    }
+
+    /**
+     * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // TODO Auto-generated method stub
+        doGet(request, response);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/src/io/openliberty/microprofile/health31/delayed/health/check/fast/app/DelayedStartupCheck.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/DelayedHealthCheckAppFast/src/io/openliberty/microprofile/health31/delayed/health/check/fast/app/DelayedStartupCheck.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health31.delayed.health.check.fast.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Startup;
+
+/**
+ *
+ */
+@Startup
+@ApplicationScoped
+public class DelayedStartupCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("delayed-success-startup-check").up().build();
+    }
+
+}


### PR DESCRIPTION
Update delayed servlet to only wait 15 seconds. We will deploy it in dropins in after server is started to mock the scenario where the server has started but the app is still struggling to start. This is better than a blind 90 second wait.


From first pass review, kept the original test but only runs one Repeat. Created new subsequent test classes and test application (with suffix Fast) that duplicate the original test but runs the modified quick version of the tests. This also runs the bulk of the repeats.

The new classes being `DefaultOverallStartupStatusUpAppStartupFastTest` and `SlowAppStartupHealthCheckFastTest`

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################


