### PR TITLE
Remove security manager in Junit JVM for Java 24+

### DIFF
--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/AbstractJSPExtensionServletWrapper.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/AbstractJSPExtensionServletWrapper.java
@@ -17,6 +17,7 @@ import java.io.FilePermission;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.AccessController;
+import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
 import java.security.PrivilegedActionException;
@@ -617,28 +618,7 @@ public abstract class AbstractJSPExtensionServletWrapper extends GenericServletW
         }
         URL[] urls = null;
         try {
-            PermissionCollection permissionCollection = createPermissionCollection();
-            /*
-            PermissionCollection permissionCollection = Policy.getPolicy().getPermissions(codeSource);
-
-            ClassLoader loader = tcontext.getJspClassloaderContext().getClassLoader();
-            if (loader instanceof ReloadableClassLoader || loader instanceof CompoundClassLoader) {
-                Map csPerms = null;
-                if (loader instanceof ReloadableClassLoader)
-                    csPerms = ((ReloadableClassLoader) loader).getCodeSourcePermissions();
-                else
-                    csPerms = ((CompoundClassLoader) loader).getCodeSourcePermissions();
-                DynamicPolicy policy = DynamicPolicyFactory.getInstance();
-                if (policy != null) {
-                    URL webinfURL = new URL(codeSource.getLocation() + "/WEB-INF/classes/*");
-                    CodeSource webinfCS = new CodeSource(webinfURL, null);
-                    permissionCollection = ((DynamicPolicy) policy).getPermissions(webinfCS, csPerms);
-                }
-            }
-            */
-
-            String sourceDir = jspResources.getGeneratedSourceFile().getParentFile().toString() + File.separator + "*";
-            permissionCollection.add(new FilePermission(sourceDir, "read"));
+            PermissionCollection permissionCollection = createPermissionCollection0();
 
             Container container = tcontext.getServletContext().getModuleContainer();
             ArrayList<URL> urlList = new ArrayList<URL>();
@@ -694,6 +674,26 @@ public abstract class AbstractJSPExtensionServletWrapper extends GenericServletW
             com.ibm.ws.ffdc.FFDCFilter.processException(e, "com.ibm.ws.jsp.webcontainerext.JSPExtensionProcessor.createClassLoader", "312", this);
             logger.logp(Level.WARNING, CLASS_NAME, "createClassLoader", "failed to create JSP class loader", e);
         }
+    }
+
+    private static final PermissionCollection ALLPERMISSIONS;
+    static {
+        AllPermission allPerm = new AllPermission();
+        ALLPERMISSIONS = allPerm.newPermissionCollection();
+        if (ALLPERMISSIONS != null) {
+            ALLPERMISSIONS.add(allPerm);
+        }
+    }
+    private PermissionCollection createPermissionCollection0() throws MalformedURLException {
+        if (System.getSecurityManager() == null) {
+            // No need to do anything else when there is no security manager.
+            // This handles cases where the security manager isn't supported (e.g. Java 24).
+            return ALLPERMISSIONS;
+        }
+        PermissionCollection permissionCollection = createPermissionCollection();
+        String sourceDir = jspResources.getGeneratedSourceFile().getParentFile().toString() + File.separator + "*";
+        permissionCollection.add(new FilePermission(sourceDir, "read"));
+        return permissionCollection;
     }
 
     /* A request to a JSP page that has a request parameter with name jsp_precompile

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -179,11 +179,24 @@
 		</condition>
 
 		<!-- boolean for Java15+.  The assumption is that at this point forward (Java 15), we will only be building using LTS 
-		     or interium versions of Java -->
+		     or interim versions of Java -->
 		<condition property="is.java15.orHigher" value="true">
 			<not>
 				<or>
 					<equals arg1="11" arg2="${java.specification.version}"/>
+					<equals arg1="1.8" arg2="${java.specification.version}"/>
+				</or>
+		    </not>
+		</condition>
+		
+		<!-- boolean for Java24+.  The assumption is that at this point forward (Java 24), we will only be building using LTS 
+		     or interim versions of Java -->
+		<condition property="is.java24.orHigher" value="true">
+			<not>
+				<or>
+					<equals arg1="21"  arg2="${java.specification.version}"/>
+					<equals arg1="17"  arg2="${java.specification.version}"/>
+					<equals arg1="11"  arg2="${java.specification.version}"/>
 					<equals arg1="1.8" arg2="${java.specification.version}"/>
 				</or>
 		    </not>
@@ -199,12 +212,14 @@
 		<property name="illegal.access.permit.fat" value=""/>
 		
 		<!-- Java 17 began the security manager's deprecation process (https://openjdk.java.net/jeps/411).
-			     In Java 18, the `java.security.manager` system property's default changed from `allow` to `disallow`, which causes our build process to fail.  
-				 Setting up a gated property (use.java.security.manager) so that any builds that take place on Java 15+ use the JVM override 
-				 -Djava.security.manager=allow which is needed for our build process, but older versions will be skipped --> 
+             In Java 18, the `java.security.manager` system property's default changed from `allow` to `disallow`, which causes our build process to fail.  
+             Setting up a gated property (use.java.security.manager) so that any builds that take place on Java 15+ use the JVM override 
+             -Djava.security.manager=allow which is needed for our build process, but older versions will be skipped. 
+             In Java 24, they are permanently disabling the security manager (https://openjdk.org/jeps/486) and trying to specify `-Djava.security.manager=allow` throws an exception.  So not allowing that parameter to be set if Java 24 or higher. --> 
 		<condition property="use.java.security.manager" value="-Djava.security.manager=allow">
 			<and>
 				<istrue value="${is.java15.orHigher}"/>
+				<not><istrue value="${is.java24.orHigher}"/></not>
 				<not><istrue value="${supports.framework.java}"/></not>
 			</and>
 		</condition>


### PR DESCRIPTION
In Java 24, they are [permanently disabling the security manager](https://openjdk.org/jeps/486).  And in Java 24, build 24, they seemed to have introduced that code as almost none of our FATs passed.

```
[junit] Error occurred during initialization of VM
[junit] java.lang.Error: A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported.
[junit] 	at java.lang.System.initPhase3(java.base@24-ea/System.java:2070)
```

Added logic for our script variable `use.java.security.manager` to not allow it to be set to `-Djava.security.manager=allow` if we are running Java 24 or higher.

- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

