### PR TITLE
Disable OpenAPI UI FAT screen recordings

### DIFF
--- a/dev/com.ibm.ws.openapi.ui_fat/fat/src/com/ibm/ws/openapi/ui/fat/tests/UIBasicTest.java
+++ b/dev/com.ibm.ws.openapi.ui_fat/fat/src/com/ibm/ws/openapi/ui/fat/tests/UIBasicTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,7 @@ public class UIBasicTest {
     @Rule
     public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>().withCapabilities(new ChromeOptions())
                                                                                   .withAccessToHost(true)
-                                                                                  .withRecordingMode(VncRecordingMode.RECORD_FAILING,
+                                                                                  .withRecordingMode(VncRecordingMode.SKIP,
                                                                                                      Props.getInstance().getFileProperty(Props.DIR_LOG),
                                                                                                      VncRecordingFormat.MP4)
                                                                                   .withLogConsumer(new SimpleLogConsumer(UIBasicTest.class, "selenium-driver"));

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIBasicTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIBasicTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -67,7 +67,7 @@ public class UIBasicTest {
     @Rule
     public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>().withCapabilities(new ChromeOptions())
                                                                                   .withAccessToHost(true)
-                                                                                  .withRecordingMode(VncRecordingMode.RECORD_FAILING,
+                                                                                  .withRecordingMode(VncRecordingMode.SKIP,
                                                                                                      Props.getInstance().getFileProperty(Props.DIR_LOG),
                                                                                                      VncRecordingFormat.MP4)
                                                                                   .withLogConsumer(new SimpleLogConsumer(UIBasicTest.class, "selenium-driver"));

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UICustomPathTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UICustomPathTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.time.Duration;
-import java.util.Arrays;
 
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -69,7 +68,7 @@ public class UICustomPathTest {
 
     @Rule
     public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>().withCapabilities(new ChromeOptions()).withAccessToHost(true)
-                                                                                  .withRecordingMode(VncRecordingMode.RECORD_FAILING,
+                                                                                  .withRecordingMode(VncRecordingMode.SKIP,
                                                                                                      Props.getInstance().getFileProperty(Props.DIR_LOG),
                                                                                                      VncRecordingFormat.MP4)
                                                                                   .withLogConsumer(new SimpleLogConsumer(UICustomPathTest.class, "selenium-driver"));

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIOauthTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIOauthTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -83,7 +83,7 @@ public class UIOauthTest {
     @Rule
     public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>().withCapabilities(new ChromeOptions())
                                                                                   .withAccessToHost(true)
-                                                                                  .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.RECORD_FAILING,
+                                                                                  .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.SKIP,
                                                                                                      Props.getInstance().getFileProperty(Props.DIR_LOG),
                                                                                                      VncRecordingFormat.MP4)
                                                                                   .withLogConsumer(new SimpleLogConsumer(UIBasicTest.class, "selenium-driver"));


### PR DESCRIPTION
Currently our OpenAPI FAT tests are set up to record a screen capture of the UI as the test runs, and to save it if any tests fail.

However, we're sometimes seeing failures where the Vnc container which does the recording doesn't start correctly. I'm not sure if that's the only problem or whether the Vnc container error is masking another failure.

To get more information on these failures, I'd like to disable screen recording for now so that we can see if there's an actual failure underneath.

It's possible that in future we'll need to reenable screen recording if we need it for debugging.

For RTC 295884

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

