### PR TITLE
OpenAPI: Don't use default ports for CacheTest

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTest.java
@@ -44,7 +44,7 @@ import io.openliberty.microprofile.openapi20.fat.cache.filter.MyOASFilter;
 @RunWith(FATRunner.class)
 public class CacheTest {
 
-    private static final String SERVER_NAME = "ApplicationProcessorServer";
+    private static final String SERVER_NAME = "OpenAPITestServer";
 
     @Server(SERVER_NAME)
     public static LibertyServer server;


### PR DESCRIPTION
CacheTest was using ApplicationProcessorServer which expects the test to manually set the ports. Use a different generic mpOpenAPI server instead.

For RTC 298558

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

