### PR TITLE
get caught up on nls messages for data

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -937,3 +937,22 @@ CWWKD1093.fn.not.applicable.explanation=The function cannot be used on the entit
  because the entity lacks an ID or version property.
 CWWKD1093.fn.not.applicable.useraction=Do not use the function in query language \
  or parameters for the repository method.
+
+CWWKD1094.return.mismatch=CWWKD1094E: The {0} method of the {1} repository \
+ interface has the {2} return type, which is not capable of returning the number \
+ of entities, {3}, that the repository method accepts as a parameter. \
+ Valid return types for a {4} method that accepts multiple entities include: {5}.
+CWWKD1094.return.mismatch.explanation=A repository life cycle method that \
+ returns entities must be able to return the same number of entities as are \
+ accepted by the method.
+CWWKD1094.return.mismatch.useraction=Update the repository method to either use \
+ a return type that can return multiple entities or update the repository method \
+ to accept only a single entity.
+
+CWWKD1095.repo.err=CWWKD1095E: An implementation of the {0} repository interface \
+ cannot be provided due to an error. The repository annotation is {1}. \
+ The primary entity class is {2}. The error is: {3}
+CWWKD1095.repo.err.explanation=The built-in Jakarta Data provider is unable \
+ to provide an instance of the repository due to an error.
+CWWKD1095.repo.err.useraction=Investigate the error and make corrections \
+ to the repository interface, entities, data store configuration, or database.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -954,5 +954,5 @@ CWWKD1095.repo.err=CWWKD1095E: An implementation of the {0} repository interface
  The primary entity class is {2}. The error is: {3}
 CWWKD1095.repo.err.explanation=The built-in Jakarta Data provider is unable \
  to provide an instance of the repository due to an error.
-CWWKD1095.repo.err.useraction=Investigate the error and make corrections \
- to the repository interface, entities, data store configuration, or database.
+CWWKD1095.repo.err.useraction=Investigate the error and correct \
+ the repository interface, entities, data store configuration, or database.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3590,15 +3590,16 @@ public class QueryInfo {
                     else if (results.isEmpty())
                         returnValue = null;
                     else
-                        // TODO temporarily reusing this message, which is somewhat close.
-                        // Need a more specific one, possibly resuing parts of CWWKD1054,
-                        // but without the Find suggestions
                         throw exc(ClassCastException.class,
-                                  "CWWKD1046.result.convert.err",
-                                  entityInfo.getType().getSimpleName() + "[]",
+                                  "CWWKD1094.return.mismatch",
                                   method.getName(),
                                   repositoryInterface.getName(),
-                                  method.getGenericReturnType().getTypeName());
+                                  method.getGenericReturnType().getTypeName(),
+                                  results.size(),
+                                  "@Insert",
+                                  lifeCycleReturnTypes(entityInfo.getType().getName(),
+                                                       hasSingularEntityParam,
+                                                       false));
                 else if (multiType.isInstance(results))
                     returnValue = results;
                 else if (Stream.class.equals(multiType))
@@ -4088,15 +4089,16 @@ public class QueryInfo {
                     else if (results.isEmpty())
                         returnValue = null;
                     else
-                        // TODO temporarily reusing this message, which is somewhat close.
-                        // Need a more specific one, possibly resuing parts of CWWKD1054,
-                        // but without the Find suggestions
                         throw exc(ClassCastException.class,
-                                  "CWWKD1046.result.convert.err",
-                                  entityInfo.getType().getSimpleName() + "[]",
+                                  "CWWKD1094.return.mismatch",
                                   method.getName(),
                                   repositoryInterface.getName(),
-                                  method.getGenericReturnType().getTypeName());
+                                  method.getGenericReturnType().getTypeName(),
+                                  results.size(),
+                                  "@Save",
+                                  lifeCycleReturnTypes(entityInfo.getType().getName(),
+                                                       hasSingularEntityParam,
+                                                       false));
                 else if (multiType.isInstance(results))
                     returnValue = results;
                 else if (Stream.class.equals(multiType))

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -82,7 +82,6 @@ import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.Inheritance;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.OptimisticLockException;
@@ -153,8 +152,6 @@ public class RepositoryImpl<R> implements InvocationHandler {
             if (Query.class.equals(entityClass)) {
                 entitylessQueryInfos = entry.getValue();
             } else {
-                boolean inheritance = entityClass.getAnnotation(Inheritance.class) != null; // TODO what do we need to do this with?
-
                 CompletableFuture<EntityInfo> entityInfoFuture = //
                                 builder.entityInfoMap.computeIfAbsent(entityClass,
                                                                       EntityInfo::newFuture);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -30,6 +30,7 @@ import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.QueryInfo;
 import io.openliberty.data.internal.persistence.RepositoryImpl;
 import jakarta.data.exceptions.DataException;
+import jakarta.data.repository.Repository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.Any;
@@ -187,7 +188,11 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
             if (x instanceof DataException || x.getCause() instanceof DataException)
                 ; // already logged the error
             else
-                x.printStackTrace(); // TODO NLS error message
+                Tr.error(tc, "CWWKD1095.repo.err",
+                         repositoryInterface.getName(),
+                         repositoryInterface.getAnnotation(Repository.class),
+                         primaryEntityClass == null ? null : primaryEntityClass.getName(),
+                         x);
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "produce", x);
             throw x;

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -42,7 +42,6 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWJP9991W.*4002", // 2 persistence units attempt to autocreate same table
                                    "CWWKD1019E.*livingAt", // mix of named/positional parameters
                                    "CWWKD1019E.*residingAt", // unused parameters
-                                   "CWWKD1046E.*register", // incompatible return type
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",
                                    "CWWKD1078E.*test.jakarta.data.errpaths.web.InvalidNonJNDIRepo",
                                    "CWWKD1079E.*test.jakarta.data.errpaths.web.InvalidJNDIRepo",
@@ -54,7 +53,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1084E.*livingIn", // named parameter mismatch
                                    "CWWKD1085E.*livingOn", // extra Param annotations
                                    "CWWKD1086E.*withAddressShorterThan", // Param used for positional parameter
-                                   "CWWKD1090E.*findByAddressOrderBy" // OrderBy anno/keyword conflict
+                                   "CWWKD1090E.*findByAddressOrderBy", // OrderBy anno/keyword conflict
+                                   "CWWKD1094E.*register" // incompatible return type
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -322,8 +322,9 @@ public class DataErrPathsTestServlet extends FATServlet {
                  "insert two entities. Instead returned: " + inserted);
         } catch (ClassCastException x) {
             if (x.getMessage() == null ||
-                !x.getMessage().startsWith("CWWKD1046E:") ||
-                !x.getMessage().contains("register"))
+                !x.getMessage().startsWith("CWWKD1094E:") ||
+                !x.getMessage().contains("register") ||
+                !x.getMessage().contains("Voter[]"))
                 throw x;
         }
     }


### PR DESCRIPTION
Cover the remaining TODOs in the Jakarta Data code where NLS messages are needed.  I'm sure there will be more after this as we implement remaining function and investigate usability, but this at least gets us caught up with the known ones for the current codebase.

Also, a second commit refactors the paramNames field name of QueryInfo to be jpqlParamNames in order to make it clear that these are named parameter names for the JPQL query vs names of method parameters.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
