### PR TITLE
Consolidate classic api persistent deliveryDelay tests

### DIFF
--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/test-applications/DeliveryDelay/src/deliverydelay/web/DeliveryDelayServlet.java
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/test-applications/DeliveryDelay/src/deliverydelay/web/DeliveryDelayServlet.java
@@ -1583,258 +1583,84 @@ public class DeliveryDelayServlet extends HttpServlet {
     }
     
     
+    private String testPersistentQueueMessageClassicIdentifier = "testPersistentQueueMessageClassic";
+
     public void testPersistentMessageClassicApi(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
-
-            QueueConnection con = jmsQCFBindings.createQueueConnection();
-            con.start();
-
-            QueueSession sessionSender = con.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
-
-            QueueSender producer1 = sessionSender.createSender(jmsQueue);
-            emptyQueue(jmsQCFBindings, jmsQueue);
-
-            QueueSender producer2 = sessionSender.createSender(jmsQueue1);
-            emptyQueue(jmsQCFBindings, jmsQueue1);
-
-            producer1.setDeliveryMode(DeliveryMode.PERSISTENT);
-            producer1.setDeliveryDelay(1000);
-            TextMessage msg1 = sessionSender.createTextMessage("testPersistentMessage_PersistentMsgClassicApi");
-            producer1.send(msg1);
-
-            producer2.setDeliveryDelay(1000);
-            producer2.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
-            TextMessage msg2 = sessionSender.createTextMessage("testPersistentMessage_NonPersistentMsgClassicApi");
-            producer2.send(msg2);
-
-            sessionSender.close();
-            con.close();
+    	
+    	testPersistentMessageClassicAPI_send(jmsQCFBindings, jmsQueue, jmsQueue1, testPersistentQueueMessageClassicIdentifier);
+    	
+    	return;
         }
 
         public void testPersistentMessageReceiveClassicApi(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-            boolean testFailed = false;
+        	boolean testPassed = testPersistentMessageClassicAPI_receive(jmsQCFBindings, jmsQueue, jmsQueue1, testPersistentQueueMessageClassicIdentifier);
 
-            QueueConnection con = jmsQCFBindings.createQueueConnection();
-            con.start();
-
-            QueueSession sessionSender = con.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
-
-            QueueReceiver jmsConsumer1 = sessionSender.createReceiver(jmsQueue);
-            QueueReceiver jmsConsumer2 = sessionSender.createReceiver(jmsQueue);
-
-            QueueSender producer = sessionSender.createSender(jmsQueue1);
-
-            TextMessage msg1 = (TextMessage) jmsConsumer1.receive(30000);
-            TextMessage msg2 = (TextMessage) jmsConsumer2.receive(30000);
-
-            if ( ((msg1 == null) ||
-                  (msg1.getText() == null) ||
-                  !msg1.getText().equals("testPersistentMessage_PersistentMsgClassicApi")) ||
-                 (msg2 != null) ) {
-                testFailed = true;
-            }
-
-            sessionSender.close();
-            con.close();
-
-            if ( testFailed ) {
+            if ( !testPassed ) {
                 throw new Exception("testPersistentMessageReceiveClassicApi failed");
             }
         }
+        
+
+        private String testPersistentQueueMessageClassicTcpIdentifier = "testPersistentQueueMessageClassicTcp";
 
         public void testPersistentMessageClassicApi_Tcp(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-            QueueConnection con = jmsQCFTCP.createQueueConnection();
-            con.start();
-
-            QueueSession sessionSender = con.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
-
-            QueueSender producer1 = sessionSender.createSender(jmsQueue);
-            emptyQueue(jmsQCFBindings, jmsQueue);
-
-            QueueSender producer2 = sessionSender.createSender(jmsQueue1);
-            emptyQueue(jmsQCFBindings, jmsQueue1);
-
-            producer1.setDeliveryMode(DeliveryMode.PERSISTENT);
-            producer1.setDeliveryDelay(1000);
-            TextMessage msg1 = sessionSender.createTextMessage("testPersistentMessage_PersistentMsgClassicApi");
-            producer1.send(msg1);
-
-            producer2.setDeliveryDelay(1000);
-            producer2.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
-            TextMessage msg2 = sessionSender.createTextMessage("testPersistentMessage_NonPersistentMsgClassicApi");
-            producer2.send(msg2);
-
-            sessionSender.close();
-            con.close();
+        	testPersistentMessageClassicAPI_send(jmsQCFTCP, jmsQueue, jmsQueue1, testPersistentQueueMessageClassicTcpIdentifier);
+        	
+        	return;
         }
 
         public void testPersistentMessageReceiveClassicApi_Tcp(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-            boolean testFailed = false;
+        	boolean testPassed = testPersistentMessageClassicAPI_receive(jmsQCFTCP, jmsQueue, jmsQueue1, testPersistentQueueMessageClassicTcpIdentifier);
 
-            QueueConnection con = jmsQCFTCP.createQueueConnection();
-            con.start();
-
-            QueueSession sessionSender = con.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
-
-            MessageConsumer jmsConsumer1 = sessionSender.createConsumer(jmsQueue);
-            MessageConsumer jmsConsumer2 = sessionSender.createConsumer(jmsQueue);
-
-            QueueSender producer = sessionSender.createSender(jmsQueue1);
-
-            TextMessage msg1 = (TextMessage) jmsConsumer1.receive(30000);
-            TextMessage msg2 = (TextMessage) jmsConsumer2.receive(30000);
-
-            if ( ((msg1 == null) ||
-                  (msg1.getText() == null) ||
-                  !msg1.getText().equals("testPersistentMessage_PersistentMsgClassicApi")) ||
-                 (msg2 != null) ) {
-                testFailed = true;
-            }
-
-            sessionSender.close();
-            con.close();
-
-            if ( testFailed ) {
+            if ( !testPassed ) {
                 throw new Exception("testPersistentMessageReceiveClassicApi failed");
             }
         }
 
+        
+        private String testPersistentTopicMessageClassicIdentifier = "testPersistentTopicMessageClassic";
+
         public void testPersistentMessageTopicClassicApi(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-            TopicConnection con = jmsTCFBindings.createTopicConnection();
-            con.start();
-
-            TopicSession sessionSender = con.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
-
-            TopicSubscriber jmsConsumer1 = sessionSender.createDurableSubscriber(jmsTopic, "durPersMsgCA1");
-            TopicSubscriber jmsConsumer2 = sessionSender.createDurableSubscriber(jmsTopic1, "durPersMsgCA2");
-
-            TopicPublisher jmsProducer1 = sessionSender.createPublisher(jmsTopic);
-            TopicPublisher jmsProducer2 = sessionSender.createPublisher(jmsTopic1);
-
-            jmsProducer1.setDeliveryMode(DeliveryMode.PERSISTENT);
-            jmsProducer1.setDeliveryDelay(1000);
-            TextMessage msg1 = sessionSender.createTextMessage("testPersistentMessage_PersistentMsgTopicClassicApi");
-            jmsProducer1.send(msg1);
-
-            jmsProducer2.setDeliveryDelay(1000);
-            jmsProducer2.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
-            TextMessage msg2 = sessionSender.createTextMessage("testPersistentMessage_NonPersistentMsgTopicClassicApi");
-            jmsProducer2.send(msg2);
-
-            con.close();
+        	testPersistentMessageClassicAPI_send(jmsTCFBindings, jmsTopic, jmsTopic1, testPersistentTopicMessageClassicIdentifier);
+        	
+        	return;
         }
 
         public void testPersistentMessageReceiveTopicClassicApi(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-            boolean testFailed = false;
+        	boolean testPassed = testPersistentMessageClassicAPI_receive(jmsTCFBindings, jmsTopic, jmsTopic1, testPersistentTopicMessageClassicIdentifier);
 
-            TopicConnection con = jmsTCFBindings.createTopicConnection();
-            con.start();
-
-            TopicSession sessionSender = con.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
-
-            TopicSubscriber jmsConsumer1 = sessionSender.createDurableSubscriber(jmsTopic, "durPersMsgCA1");
-            TopicSubscriber jmsConsumer2 = sessionSender.createDurableSubscriber(jmsTopic1, "durPersMsgCA2");
-
-            TopicPublisher jmsProducer = sessionSender.createPublisher(jmsTopic);
-
-            TextMessage msg1 = (TextMessage) jmsConsumer1.receive(30000);
-            TextMessage msg2 = (TextMessage) jmsConsumer2.receive(30000);
-
-            if ( ((msg1 == null) ||
-                  (msg1.getText() == null) ||
-                  !msg1.getText().equals("testPersistentMessage_PersistentMsgTopicClassicApi")) ||
-                 (msg2 != null) ) {
-                testFailed = true;
-            }
-
-            jmsConsumer1.close();
-            jmsConsumer2.close();
-
-            sessionSender.unsubscribe("durPersMsgCA1");
-            sessionSender.unsubscribe("durPersMsgCA2");
-            sessionSender.close();
-
-            con.close();
-
-            if ( testFailed ) {
+            if ( !testPassed ) {
                 throw new Exception("testPersistentMessageReceiveTopicClassicApi failed");
             }
         }
 
+        private String testPersistentTopicMessageClassicTcpIdentifier = "testPersistentTopicMessageClassicTcp";
+
         public void testPersistentMessageTopicClassicApi_Tcp(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-            boolean testFailed = false;
-
-            TopicConnection con = jmsTCFTCP.createTopicConnection();
-            con.start();
-
-            TopicSession sessionSender = con.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
-
-            TopicSubscriber jmsConsumer1 = sessionSender.createDurableSubscriber(jmsTopic, "durPersMsgCATcp1");
-            TopicSubscriber jmsConsumer2 = sessionSender.createDurableSubscriber(jmsTopic1, "durPersMsgCATcp2");
-
-            TopicPublisher jmsProducer1 = sessionSender.createPublisher(jmsTopic);
-            TopicPublisher jmsProducer2 = sessionSender.createPublisher(jmsTopic1);
-
-            jmsProducer1.setDeliveryMode(DeliveryMode.PERSISTENT);
-            jmsProducer1.setDeliveryDelay(1000);
-            TextMessage msg1 = sessionSender.createTextMessage("testPersistentMessage_PersistentMsgTopicClassicApiTcp");
-            jmsProducer1.send(msg1);
-
-            jmsProducer2.setDeliveryDelay(1000);
-            jmsProducer2.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
-            TextMessage msg2 = sessionSender.createTextMessage("testPersistentMessage_NonPersistentMsgTopicClassicApiTcp");
-            jmsProducer2.send(msg2);
-
-            con.close();
+        	testPersistentMessageClassicAPI_send(jmsTCFTCP, jmsTopic, jmsTopic1, testPersistentTopicMessageClassicTcpIdentifier);
+        	
+        	return;
         }
 
         public void testPersistentMessageReceiveTopicClassicApi_Tcp(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-            boolean testFailed = false;
+        	boolean testPassed = testPersistentMessageClassicAPI_receive(jmsTCFTCP, jmsTopic, jmsTopic1, testPersistentTopicMessageClassicTcpIdentifier);
 
-            TopicConnection con = jmsTCFTCP.createTopicConnection();
-            con.start();
-
-            TopicSession sessionSender = con.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
-
-            TopicSubscriber jmsConsumer1 = sessionSender.createDurableSubscriber(jmsTopic, "durPersMsgCATcp1");
-            TopicSubscriber jmsConsumer2 = sessionSender.createDurableSubscriber(jmsTopic1, "durPersMsgCATcp2");
-
-            TopicPublisher jmsProducer = sessionSender.createPublisher(jmsTopic);
-
-            TextMessage msg1 = (TextMessage) jmsConsumer1.receive(30000);
-            TextMessage msg2 = (TextMessage) jmsConsumer2.receive(30000);
-
-            if ( ((msg1 == null) ||
-                  (msg1.getText() == null) ||
-                  !msg1.getText().equals("testPersistentMessage_PersistentMsgTopicClassicApiTcp")) ||
-                 (msg2 != null) ) {
-                testFailed = true;
-            }
-
-            jmsConsumer1.close();
-            jmsConsumer2.close();
-
-            sessionSender.unsubscribe("durPersMsgCATcp1");
-            sessionSender.unsubscribe("durPersMsgCATcp2");
-            sessionSender.close();
-
-            con.close();
-
-            if ( testFailed ) {
+            if ( !testPassed ) {
                 throw new Exception("testPersistentMessageStoreReceiveTopicClassicApi_Tcp failed");
             }
         }


### PR DESCRIPTION
- [ x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Consolidate the persistent deliveryDelay ClassicAPI tests in the same way as was done for the equivalent simplifiedAPI tests in PRs:
https://github.com/OpenLiberty/open-liberty/pull/30229
https://github.com/OpenLiberty/open-liberty/pull/30249
