### PR TITLE
OpenAPI: Use mark when checking for log messages

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
@@ -120,7 +120,7 @@ public class MergeConfigServerXMLTest {
             OpenAPITestUtil.checkPaths(openapiNode, 1, "/test");
 
             // Test that merging disabled message was output (at some point)
-            assertThat(server.findStringsInLogs(" I CWWKO1663I:.*Combining OpenAPI documentation from multiple modules is disabled."),
+            assertThat(server.findStringsInLogsUsingMark(" I CWWKO1663I:.*Combining OpenAPI documentation from multiple modules is disabled.", server.getDefaultLogFile()),
                        hasSize(1));
 
             // remove app 1
@@ -136,7 +136,7 @@ public class MergeConfigServerXMLTest {
             OpenAPITestUtil.checkPaths(openapiNode, 2, "/test1/test", "/test2/test");
 
             // Check there's no "first module only" message
-            assertThat(server.findStringsInLogs("CWWKO1663I"),
+            assertThat(server.findStringsInLogsUsingMark("CWWKO1663I", server.getDefaultLogFile()),
                        hasSize(0));
         }
     }


### PR DESCRIPTION
Tests in `MergeConfigServerXMLTest` that are checking for the presence or absence of messages created in the same test must use a log mark to avoid picking up messages created by other tests.

For RTC 302719

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".