### PR TITLE
Use AllPermissionCollection when there is no security manager.

### DIFF
--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/AbstractJSPExtensionServletWrapper.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/webcontainerext/AbstractJSPExtensionServletWrapper.java
@@ -17,6 +17,7 @@ import java.io.FilePermission;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.AccessController;
+import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
 import java.security.PrivilegedActionException;
@@ -617,28 +618,7 @@ public abstract class AbstractJSPExtensionServletWrapper extends GenericServletW
         }
         URL[] urls = null;
         try {
-            PermissionCollection permissionCollection = createPermissionCollection();
-            /*
-            PermissionCollection permissionCollection = Policy.getPolicy().getPermissions(codeSource);
-
-            ClassLoader loader = tcontext.getJspClassloaderContext().getClassLoader();
-            if (loader instanceof ReloadableClassLoader || loader instanceof CompoundClassLoader) {
-                Map csPerms = null;
-                if (loader instanceof ReloadableClassLoader)
-                    csPerms = ((ReloadableClassLoader) loader).getCodeSourcePermissions();
-                else
-                    csPerms = ((CompoundClassLoader) loader).getCodeSourcePermissions();
-                DynamicPolicy policy = DynamicPolicyFactory.getInstance();
-                if (policy != null) {
-                    URL webinfURL = new URL(codeSource.getLocation() + "/WEB-INF/classes/*");
-                    CodeSource webinfCS = new CodeSource(webinfURL, null);
-                    permissionCollection = ((DynamicPolicy) policy).getPermissions(webinfCS, csPerms);
-                }
-            }
-            */
-
-            String sourceDir = jspResources.getGeneratedSourceFile().getParentFile().toString() + File.separator + "*";
-            permissionCollection.add(new FilePermission(sourceDir, "read"));
+            PermissionCollection permissionCollection = createPermissionCollection0();
 
             Container container = tcontext.getServletContext().getModuleContainer();
             ArrayList<URL> urlList = new ArrayList<URL>();
@@ -694,6 +674,26 @@ public abstract class AbstractJSPExtensionServletWrapper extends GenericServletW
             com.ibm.ws.ffdc.FFDCFilter.processException(e, "com.ibm.ws.jsp.webcontainerext.JSPExtensionProcessor.createClassLoader", "312", this);
             logger.logp(Level.WARNING, CLASS_NAME, "createClassLoader", "failed to create JSP class loader", e);
         }
+    }
+
+    private static final PermissionCollection ALLPERMISSIONS;
+    static {
+        AllPermission allPerm = new AllPermission();
+        ALLPERMISSIONS = allPerm.newPermissionCollection();
+        if (ALLPERMISSIONS != null) {
+            ALLPERMISSIONS.add(allPerm);
+        }
+    }
+    private PermissionCollection createPermissionCollection0() throws MalformedURLException {
+        if (System.getSecurityManager() == null) {
+            // No need to do anything else when there is no security manager.
+            // This handles cases where the security manager isn't supported (e.g. Java 24).
+            return ALLPERMISSIONS;
+        }
+        PermissionCollection permissionCollection = createPermissionCollection();
+        String sourceDir = jspResources.getGeneratedSourceFile().getParentFile().toString() + File.separator + "*";
+        permissionCollection.add(new FilePermission(sourceDir, "read"));
+        return permissionCollection;
     }
 
     /* A request to a JSP page that has a request parameter with name jsp_precompile


### PR DESCRIPTION
This avoids trying to add permissions to the collection from the Policy.  That is no longer allowed on Java 24.  There is no need to use the Policy if there is no security manager available.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

