### PR TITLE
Remove security manager in Java 24

### DIFF
--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -179,11 +179,24 @@
 		</condition>
 
 		<!-- boolean for Java15+.  The assumption is that at this point forward (Java 15), we will only be building using LTS 
-		     or interium versions of Java -->
+		     or interim versions of Java -->
 		<condition property="is.java15.orHigher" value="true">
 			<not>
 				<or>
 					<equals arg1="11" arg2="${java.specification.version}"/>
+					<equals arg1="1.8" arg2="${java.specification.version}"/>
+				</or>
+		    </not>
+		</condition>
+		
+		<!-- boolean for Java24+.  The assumption is that at this point forward (Java 24), we will only be building using LTS 
+		     or interim versions of Java -->
+		<condition property="is.java24.orHigher" value="true">
+			<not>
+				<or>
+					<equals arg1="21"  arg2="${java.specification.version}"/>
+					<equals arg1="17"  arg2="${java.specification.version}"/>
+					<equals arg1="11"  arg2="${java.specification.version}"/>
 					<equals arg1="1.8" arg2="${java.specification.version}"/>
 				</or>
 		    </not>
@@ -199,12 +212,14 @@
 		<property name="illegal.access.permit.fat" value=""/>
 		
 		<!-- Java 17 began the security manager's deprecation process (https://openjdk.java.net/jeps/411).
-			     In Java 18, the `java.security.manager` system property's default changed from `allow` to `disallow`, which causes our build process to fail.  
-				 Setting up a gated property (use.java.security.manager) so that any builds that take place on Java 15+ use the JVM override 
-				 -Djava.security.manager=allow which is needed for our build process, but older versions will be skipped --> 
+             In Java 18, the `java.security.manager` system property's default changed from `allow` to `disallow`, which causes our build process to fail.  
+             Setting up a gated property (use.java.security.manager) so that any builds that take place on Java 15+ use the JVM override 
+             -Djava.security.manager=allow which is needed for our build process, but older versions will be skipped. 
+             In Java 24, they are permanently disabling the security manager (https://openjdk.org/jeps/486) and trying to specify `-Djava.security.manager=allow` throws an exception.  So not allowing that parameter to be set if Java 24 or higher. --> 
 		<condition property="use.java.security.manager" value="-Djava.security.manager=allow">
 			<and>
 				<istrue value="${is.java15.orHigher}"/>
+				<not><istrue value="${is.java24.orHigher}"/></not>
 				<not><istrue value="${supports.framework.java}"/></not>
 			</and>
 		</condition>


### PR DESCRIPTION
This PR is to cover a branch rename of #30226 since I used a + sign and the CSI team said to avoid using that character.

In Java 24, they are [permanently disabling the security manager](https://openjdk.org/jeps/486). And in Java 24, build 24, they seemed to have introduced that code as almost none of our FATs passed.

[junit] Error occurred during initialization of VM
[junit] java.lang.Error: A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported.
[junit] 	at java.lang.System.initPhase3(java.base@24-ea/System.java:2070)

Added logic for our script variable use.java.security.manager to not allow it to be set to -Djava.security.manager=allow if we are running Java 24 or higher.

While this helped, there were still many build breaks that generate FFDC files with stack traces like:
```
Stack Dump = java.lang.SecurityException: attempt to add a Permission to a readonly Permissions object
	at java.base/java.security.Permissions.add(Permissions.java:129)
	at java.base/java.security.Policy$UnsupportedEmptyCollection.add(Policy.java:506)
	at com.ibm.ws.jsp.webcontainerext.AbstractJSPExtensionServletWrapper.createClassLoader(AbstractJSPExtensionServletWrapper.java:641)
	at com.ibm.ws.jsp.webcontainerext.AbstractJSPExtensionServletWrapper._checkForTranslation(AbstractJSPExtensionServletWrapper.java:527)
	at com.ibm.ws.jsp.webcontainerext.AbstractJSPExtensionServletWrapper.checkForTranslation(AbstractJSPExtensionServletWrapper.java:250)
	at com.ibm.ws.jsp.webcontainerext.AbstractJSPExtensionProcessor.findWrapper(AbstractJSPExtensionProcessor.java:494)
	at com.ibm.ws.jsp.webcontainerext.AbstractJSPExtensionProcessor.getServletWrapper(AbstractJSPExtensionProcessor.java:336)
	at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5066)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:328)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1047)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:293)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1260)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:476)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:435)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:569)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:503)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:363)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:330)
	at com.ibm.ws.channel.ssl.internal.SSLConnectionLink.determineNextChannel(SSLConnectionLink.java:1135)
	at com.ibm.ws.channel.ssl.internal.SSLConnectionLink$MyReadCompletedCallback.complete(SSLConnectionLink.java:686)
	at com.ibm.ws.channel.ssl.internal.SSLReadServiceContext$SSLReadCompletedCallback.complete(SSLReadServiceContext.java:1826)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:516)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:586)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:970)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1059)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:298)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1447)
```

So @tjwatson was gracious to provide a fix for that to combine with my script changes.


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
