### PR TITLE
query on embeddable id of record entity

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2610,6 +2610,7 @@ public class QueryInfo {
      * @param startAt starting position in the query language string.
      * @return position of the text ignoring case if it is the next non-whitespace characters. Otherwise -1;
      */
+    @Trivial
     private static int indexOfAfterWhitespace(String text, String ql, int startAt) {
         int length = ql.length();
         while (startAt < length && Character.isWhitespace(ql.charAt(startAt)))
@@ -3175,13 +3176,16 @@ public class QueryInfo {
             if (countPages) {
                 // TODO count query cannot always be accurately inferred if Query value is JPQL
                 StringBuilder c = new StringBuilder("SELECT COUNT(");
-                if (selectLen <= 0
-                    || ql.substring(select0, select0 + selectLen).indexOf(',') >= 0) // comma delimited multiple return values
+                if (selectLen <= 0) {
                     c.append(entityVar);
-                else // allows for COUNT(DISTINCT o.name)
-                    appendWithIdentifierName(ql, select0, select0 + selectLen,
-                                             entityVar_.length() == 0 ? "this." : entityVar_,
-                                             c);
+                } else {
+                    String selection = ql.substring(select0, select0 + selectLen);
+                    if (selection.indexOf(',') > 0)
+                        // comma delimited multiple return values
+                        c.append(entityVar);
+                    else
+                        c.append(selection);
+                }
 
                 c.append(") FROM");
                 if (from0 >= 0) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2619,6 +2619,58 @@ public class QueryInfo {
     }
 
     /**
+     * Infer the selection value to use for a COUNT query.
+     * Typically, the best we can do is to use the entity identifier variable,
+     * For example, COUNT(o). This works for:
+     *
+     * <pre>
+     * SELECT o ...
+     * SELECT o.col1 ...
+     * SELECT o.col1, o.col2 ...
+     * SELECT NEW org.example.ClassName(o.col1, o.col2) ...
+     * </pre>
+     *
+     * It should be noted we cannot use COUNT(o.col1) because it does not count
+     * null values, making it inconsistent with the number of values returned by
+     * SELECT o.col1.
+     *
+     * One place where COUNT(o) does not work is when selecting DISTINCT values.
+     *
+     * <pre>
+     * SELECT DISTINCT o.col1 ...
+     * </pre>
+     *
+     * In this case, the total number of matching entities would be incorrect.
+     * Instead, we want the number of distinct values. This will work well if there
+     * are no NULL values. But when there are NULL values, COUNT will omit then,
+     * but the SELECT DISTINCT query will includes one NULL value in its results,
+     * making the COUNT one less than it should be. It is unclear what to do
+     * about this, except to point out that Jakarta Data is only required to
+     * support JDQL and can choose to support as much of JPQL as it wishes, so here
+     * we have the limitation that we are only supporting JPQL DISTINCT for
+     * Page.totalElements and Page.totalPages when the results have no NULL values.
+     *
+     * @param ql        the query.
+     * @param select0   position after SELECT, if present.
+     * @param selectLen length of the text in the SELECT clause after SELECT,
+     *                      if present, otherwise -1.
+     * @return selection to use for a SELECT COUNT( {selection} ) query.
+     */
+    private String inferCountFromSelect(String ql, int select0, int selectLen) {
+        // Look for DISTINCT in the selections
+        for (int i = select0; i < select0 + selectLen - 9; i++) {
+            char ch = ql.charAt(i);
+            if ((ch == 'D' || ch == 'd') &&
+                (i == select0 || !Character.isJavaIdentifierPart(ql.charAt(i - 1))) &&
+                !Character.isJavaIdentifierPart(ql.charAt(i - 1)) &&
+                ql.regionMatches(true, i + 1, "ISTINCT", 0, 7))
+                return ql.substring(select0, select0 + selectLen);
+        }
+
+        return entityVar;
+    }
+
+    /**
      * Gathers the information that is needed to perform the query that the repository method represents.
      *
      * @param entityInfo entity information.
@@ -3176,16 +3228,7 @@ public class QueryInfo {
             if (countPages) {
                 // TODO count query cannot always be accurately inferred if Query value is JPQL
                 StringBuilder c = new StringBuilder("SELECT COUNT(");
-                if (selectLen <= 0) {
-                    c.append(entityVar);
-                } else {
-                    String selection = ql.substring(select0, select0 + selectLen);
-                    if (selection.indexOf(',') > 0)
-                        // comma delimited multiple return values
-                        c.append(entityVar);
-                    else
-                        c.append(selection);
-                }
+                c.append(inferCountFromSelect(ql, select0, selectLen));
 
                 c.append(") FROM");
                 if (from0 >= 0) {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Animal.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Animal.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2023,2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+/**
+ * Entity that is a Java record which has an embedded ID that is
+ * also a Java record.
+ */
+public record Animal(ScientificName id, String commonName, long version) {
+    public static record ScientificName(String genus, String species) {
+    }
+
+    public static Animal of(String commonName, String genus, String species) {
+        return new Animal(new ScientificName(genus, species), commonName, 0);
+    }
+
+    public Animal withCommonName(String newCommonName) {
+        return new Animal(id(), newCommonName, version());
+    }
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Animals.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Animals.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+
+import test.jakarta.data.web.Animal.ScientificName;
+
+/**
+ * Repository interface for the Animal entity which is a record
+ * with an embeddable ID that is also a record.
+ */
+@Repository
+public interface Animals extends CrudRepository<Animal, ScientificName> {
+    long countByIdNotNull();
+
+    boolean existsById(ScientificName id);
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -748,6 +748,75 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Tests a repository method that returns pages of a DISTINCT single value
+     * that can sometimes be null. Verify that the count of pages and total
+     * elements is correct.
+     */
+    @Test
+    public void testCountPagesWithDistinctValues() {
+        Page<String> page1 = primes.romanNumeralsDistinct(30L, 49L,
+                                                          4000L, 4009L,
+                                                          PageRequest.ofSize(3));
+
+        assertEquals(2, page1.totalPages());
+
+        // page1.totalElements();
+        // The above returns 5 instead of 6 because COUNT omits the
+        // NULL value that comes from (DISTINCT romanNumeral) when
+        // invoking SELECT COUNT(DISTINCT romanNumeral)
+
+        assertEquals(List.of("XXXI", "XXXVII", "XLI"),
+                     page1.content());
+
+        Page<String> page2 = primes.romanNumeralsDistinct(30L, 49L,
+                                                          4000L, 4009L,
+                                                          page1.nextPageRequest());
+
+        assertEquals(2, page2.totalPages());
+
+        assertEquals(Arrays.asList("XLIII", "XLVII", null),
+                     page2.content());
+    }
+
+    /**
+     * Tests a repository method that returns pages of a single value that can
+     * sometimes be null. Verify that the count of pages and total elements is
+     * correct.
+     */
+    @Test
+    public void testCountPagesWithNullValues() {
+        Page<String> page1 = primes.romanNumerals(30L, 49L,
+                                                  4000L, 4009L,
+                                                  PageRequest.ofSize(3));
+
+        assertEquals(8, page1.totalElements());
+        assertEquals(3, page1.totalPages());
+
+        assertEquals(List.of("XXXI", "XXXVII", "XLI"),
+                     page1.content());
+
+        Page<String> page2 = primes.romanNumerals(30L, 49L,
+                                                  4000L, 4009L,
+                                                  page1.nextPageRequest());
+
+        assertEquals(8, page2.totalElements());
+        assertEquals(3, page2.totalPages());
+
+        assertEquals(Arrays.asList("XLIII", "XLVII", null),
+                     page2.content());
+
+        Page<String> page3 = primes.romanNumerals(30L, 49L,
+                                                  4000L, 4009L,
+                                                  page2.nextPageRequest());
+
+        assertEquals(8, page3.totalElements());
+        assertEquals(3, page3.totalPages());
+
+        assertEquals(Arrays.asList(null, null),
+                     page3.content());
+    }
+
+    /**
      * Repository method that uses cursor-based pagination but does not specify
      * any sort criteria, which should default to ascending by Id.
      */

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -393,6 +393,22 @@ public interface Primes {
     @Query("SELECT DISTINCT LENGTH(p.romanNumeral) FROM Prime p WHERE p.numberId <= ?1 ORDER BY LENGTH(p.romanNumeral) DESC")
     Page<Integer> romanNumeralLengths(long maxNumber, PageRequest pagination);
 
+    @Query("SELECT romanNumeral" +
+           " WHERE (numberId BETWEEN ?1 AND ?2)" +
+           "    OR (numberId BETWEEN ?3 AND ?4)" +
+           " ORDER BY numberId ASC")
+    Page<String> romanNumerals(long min1, long max1,
+                               long min2, long max2,
+                               PageRequest pageRequest);
+
+    @Query("SELECT DISTINCT(romanNumeral)" +
+           " WHERE (numberId BETWEEN ?1 AND ?2)" +
+           "    OR (numberId BETWEEN ?3 AND ?4)" +
+           " ORDER BY numberId ASC")
+    Page<String> romanNumeralsDistinct(long min1, long max1,
+                                       long min2, long max2,
+                                       PageRequest pageRequest);
+
     @Query("SELECT hex WHERE numberId=:id")
     Optional<Character> singleHexDigit(long id);
 


### PR DESCRIPTION
Add test coverage for a record entity with an embedded id, and where queries are made based on the embedded id value.  Parts of the test are temporarily commented out as blocked by an EclipseLink issue.

Also, I'm removing appendWithIdentifierName from the code path where we generate COUNT queries, in preparation for when we will be able to remove the appendWithIdentifierName method entirely after another EclipseLink bug is fixed.

This PR also adds scenarios for COUNT queries for pagination where pages have null elements and/or where JPA's DISTINCT is used in query language, which has limitations when combined with null results.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
