### PR TITLE
Change schema definition (xmlns:xsi) to use http in Faces 4.1 Apps

### DIFF
--- a/dev/io.openliberty.org.apache.myfaces.4.1_fat/test-applications/FacesConfigVersion41.war/resources/WEB-INF/faces-config.xml
+++ b/dev/io.openliberty.org.apache.myfaces.4.1_fat/test-applications/FacesConfigVersion41.war/resources/WEB-INF/faces-config.xml
@@ -10,7 +10,7 @@
  -->
 <faces-config 
     xmlns="https://jakarta.ee/xml/ns/jakartaee"
-    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd"
     version="4.1">
 

--- a/dev/io.openliberty.org.apache.myfaces.4.1_fat/test-applications/RenderId_Spec1760.war/resources/WEB-INF/faces-config.xml
+++ b/dev/io.openliberty.org.apache.myfaces.4.1_fat/test-applications/RenderId_Spec1760.war/resources/WEB-INF/faces-config.xml
@@ -10,7 +10,7 @@
  -->
  <faces-config 
  xmlns="https://jakarta.ee/xml/ns/jakartaee"
- xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" 
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd"
  version="4.1">
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fix test cases.

HTTP is correct, not HTTP_S_.

See: https://jakarta.ee/specifications/faces/4.1/jakarta-faces-4.1#a6254

```


<faces-config
    xmlns="https://jakarta.ee/xml/ns/jakartaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
        https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd"
    version="4.1">


```

This was discovered via XML validation testing. 