### PR TITLE
Check for server not starting in TCK FATs

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -261,6 +261,11 @@ public class TCKRunner {
         // Validate configured settings
         TCKUtilities.requireDirectory(tckRunnerDir);
 
+        // Validate server started ok (for tests that start the server in advance)
+        if (server.isStarted()) {
+            TCKUtilities.assertServerHappy(server);
+        }
+
         // Configure Artifactory
         File wrapperPropertiesFile = TCKUtilities.exportMvnWrapper(this.tckRunnerDir);
 

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKUtilities.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKUtilities.java
@@ -14,6 +14,7 @@ package componenttest.topology.utils.tck;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 
@@ -52,6 +53,7 @@ import java.util.regex.Pattern;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.TCKJarInfo;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import junit.framework.AssertionFailedError;
@@ -848,5 +850,19 @@ public class TCKUtilities {
         if (!file.exists()) {
             throw new IOException(file + " does not exist");
         }
+    }
+
+    /**
+     * Assert that the server has started successfully and hasn't hit any known problems.
+     *
+     * @param  server    the server to check
+     * @throws Exception
+     */
+    static void assertServerHappy(LibertyServer server) throws Exception {
+        // LibertyServer.start will already have checked for the server started successfully message
+        // Look for errors that indicate a failure to start correctly but don't prevent liberty reporting a successful start
+        assertThat("Server log has errors after starting", server.findStringsInLogs("CWWKF0001E"), empty()); // A feature definition could not be found for ...
+        assertThat("Server log has errors after starting", server.findStringsInLogs("CWWKF0002E"), empty()); // A bundle could not be found for ...
+        assertThat("Server log has errors after starting", server.findStringsInLogs("CWWKE0702E"), empty()); // Could not resolve module ...
     }
 }


### PR DESCRIPTION
We're seeing some TCK FATs fail in the certification build when they run against servers which don't have the necessary features.

Fixes #30306

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
