### PR TITLE
Rest Client TCK: set heap to 2GB instead of 20GB

### DIFF
--- a/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=60000
--Xmx20484m
+-Xmx2048m


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fix typo from previous PR

For RTC 300864