### PR TITLE
Update Jakarta authorization / JACC function to work with Java 24

### DIFF
--- a/dev/com.ibm.ws.security.authorization.jacc.ejb/bnd.bnd
+++ b/dev/com.ibm.ws.security.authorization.jacc.ejb/bnd.bnd
@@ -57,4 +57,5 @@ Import-Package: \
 	com.ibm.ws.logging;version=latest,\
 	io.openliberty.security.authorization.internal.jacc.1.5;project=com.ibm.ws.security.authorization.jacc;source=none,\
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
-	org.jmock:jmock;strategy=exact;version=2.5.1
+	org.jmock:jmock;strategy=exact;version=2.5.1, \
+	com.ibm.ws.kernel.service;version=latest

--- a/dev/com.ibm.ws.security.authorization.jacc.web/bnd.bnd
+++ b/dev/com.ibm.ws.security.authorization.jacc.web/bnd.bnd
@@ -59,5 +59,6 @@ Import-Package: \
 	com.ibm.ws.kernel.boot;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	io.openliberty.security.authorization.internal.jacc.1.5;project=com.ibm.ws.security.authorization.jacc;source=none,\
-	com.ibm.websphere.org.osgi.core
+	com.ibm.websphere.org.osgi.core, \
+	com.ibm.ws.kernel.service;version=latest
 	

--- a/dev/com.ibm.ws.security.authorization.jacc/bnd.bnd
+++ b/dev/com.ibm.ws.security.authorization.jacc/bnd.bnd
@@ -37,7 +37,8 @@ instrument.classesExcludes: com/ibm/ws/security/authorization/jacc/internal/reso
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest, \
 	com.ibm.websphere.security;version=latest, \
 	com.ibm.ws.security;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+	com.ibm.ws.kernel.service;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.authorization.jacc/src/io/openliberty/security/authorization/jacc/internal/proxy/JavaSePolicyProxyImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/io/openliberty/security/authorization/jacc/internal/proxy/JavaSePolicyProxyImpl.java
@@ -17,12 +17,14 @@ import java.security.ProtectionDomain;
 
 import javax.security.auth.Subject;
 
+import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.ws.security.authorization.jacc.common.PolicyProxy;
 
 public class JavaSePolicyProxyImpl implements PolicyProxy {
 
     private static ProtectionDomain nullPd = new ProtectionDomain(new CodeSource(null, (java.security.cert.Certificate[]) null), null, null, null);
     private static CodeSource nullCs = new CodeSource(null, (java.security.cert.Certificate[]) null);
+    private static final boolean isJava24OrLater = JavaInfo.majorVersion() >= 24;
 
     private final Policy policy;
 
@@ -42,7 +44,9 @@ public class JavaSePolicyProxyImpl implements PolicyProxy {
 
     @Override
     public void setPolicy() {
-        Policy.setPolicy(policy);
+        if (!isJava24OrLater) {
+            Policy.setPolicy(policy);
+        }
     }
 
     @Override
@@ -54,6 +58,6 @@ public class JavaSePolicyProxyImpl implements PolicyProxy {
         } else {
             pd = nullPd;
         }
-        return Policy.getPolicy().implies(pd, permission);
+        return (isJava24OrLater ? policy : Policy.getPolicy()).implies(pd, permission);
     }
 }


### PR DESCRIPTION
Do not call Policy.setPolicy() and Policy.getPolicy() methods when using Java 24 or later.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
