### PR TITLE
mismatch of record as return type

### DIFF
--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -40,6 +40,7 @@ public class DataErrPathsTest extends FATServletClient {
     private static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
                                    "CWWJP9991W.*4002", // 2 persistence units attempt to autocreate same table
+                                   "CWWKD1006E.*removeBySSN", // delete method attempts to return record
                                    "CWWKD1019E.*livingAt", // mix of named/positional parameters
                                    "CWWKD1019E.*residingAt", // unused parameters
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -44,6 +44,7 @@ import javax.naming.NamingException;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
+import test.jakarta.data.errpaths.web.Voters.NameAndZipCode;
 
 @DataSourceDefinition(name = "java:app/jdbc/DerbyDataSource",
                       className = "org.apache.derby.jdbc.EmbeddedXADataSource",
@@ -566,6 +567,22 @@ public class DataErrPathsTestServlet extends FATServlet {
                 !x.getMessage().startsWith("CWWKD1077E:") ||
                 !x.getMessage().contains("<dataSource id=\"DefaultDataSource\""))
                 throw x;
+        }
+    }
+
+    /**
+     * Tests an error path where a repository method attempts to return a subset of
+     * an entity as a record where the record component names do not all match the
+     * entity attribute names.
+     */
+    @Test
+    public void testReturnInvalidSubsetOfEntity() {
+        try {
+            NameAndZipCode result = voters.nameAndZipCode(789001234).orElseThrow();
+            fail("Should not be able to obtain result as a record with" +
+                 " component names that do not all match entity attributes: " +
+                 result);
+        } catch (MappingException x) {
         }
     }
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -470,6 +470,25 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Tests an error path where a repository method attempts to return a subset of
+     * an entity as a record where the record component names do not all match the
+     * entity attribute names.
+     */
+    @Test
+    public void testRemoveAsSubsetOfEntity() {
+        try {
+            NameAndZipCode removed = voters.removeBySSN(789001234).orElseThrow();
+            fail("Should not be able to remove an entity as a record: " +
+                 removed);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1006E") ||
+                !x.getMessage().contains("NameAndZipCode"))
+                throw x;
+        }
+    }
+
+    /**
      * Tests an error path where the application specifies the repository dataStore
      * to be a JNDI name that does not exist.
      */

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 import jakarta.data.Sort;
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.By;
+import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
@@ -138,6 +139,12 @@ public interface Voters extends BasicRepository<Voter, Integer> {
      */
     @Insert
     Voter register(Voter... v);
+
+    /**
+     * Delete method that attempts to return a record instead of an entity.
+     */
+    @Delete
+    Optional<NameAndZipCode> removeBySSN(@By("ssn") int socialSecurityNumber);
 
     /**
      * This invalid method has matching named parameters and Param annotation,

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -14,10 +14,13 @@ package test.jakarta.data.errpaths.web;
 
 import java.time.Month;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.data.Sort;
 import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
@@ -32,6 +35,8 @@ import jakarta.data.repository.Update;
  */
 @Repository(dataStore = "java:app/jdbc/DerbyDataSource")
 public interface Voters extends BasicRepository<Voter, Integer> {
+    static record NameAndZipCode(String name, int zipCode) {
+    }
 
     /**
      * This invalid method neglects to include the Param annotation for a
@@ -118,6 +123,14 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     List<Voter> livingOn(@Param("street") String street,
                          @Param("city") String city, // extra, unused Param
                          @Param("state") String stateCode); // extra, unused Param
+
+    /**
+     * Find method that returns a record instead of an entity,
+     * but where the names of record components do not all match
+     * entity attribute names.
+     */
+    @Find
+    Optional<NameAndZipCode> nameAndZipCode(@By("ssn") int socialSecurityNumber);
 
     /**
      * For testing an error where the method parameter allows multiple entities,


### PR DESCRIPTION
Add tests cases for error paths where
a find method attempts to return a record where some record components do not match the entity attributes
a delete method that attempts to return a subset of an entity as a record


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
