### PR TITLE
CDI 4.1: Fix abstract methods in decorators

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.1/io.openliberty.cdi-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-4.1/io.openliberty.cdi-4.1.feature
@@ -31,6 +31,7 @@ IBM-API-Package: jakarta.decorator;  type="spec", \
  org.jboss.weld.module.ejb; type="internal", \
  org.jboss.weld.proxy; type="internal", \
  org.jboss.weld.security; type="internal", \
+ org.jboss.weld.util.reflection;type="internal", \
  org.jboss.weld.serialization.spi; type="internal", \
  org.jboss.weld.context;type="third-party", \
  org.jboss.weld.context.api;type="third-party", \

--- a/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/apps/abstractDecorator/AbstractDecorator.java
+++ b/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/apps/abstractDecorator/AbstractDecorator.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.annotations.fat.apps.abstractDecorator;
+
+import javax.annotation.Priority;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.inject.Inject;
+
+/**
+ * Abstract decorator that only decorates some methods
+ */
+@Decorator
+@Priority(1) // Enable for whole app
+public abstract class AbstractDecorator implements AbstractDecoratorTestInterface {
+
+    @Inject
+    @Delegate
+    private AbstractDecoratorTestInterface delegate;
+
+    @Override
+    public String test1() {
+        return delegate.test1() + "-decorated";
+    }
+
+    @Override
+    public abstract String test2();
+
+    // test3() not implemented
+
+}

--- a/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/apps/abstractDecorator/AbstractDecoratorServlet.java
+++ b/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/apps/abstractDecorator/AbstractDecoratorServlet.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.annotations.fat.apps.abstractDecorator;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/")
+public class AbstractDecoratorServlet extends FATServlet {
+
+    @Inject
+    private AbstractDecoratorTestInterface bean;
+
+    @Test
+    public void testDecoratedMethod() {
+        assertEquals("test1-decorated", bean.test1());
+    }
+
+    @Test
+    public void testAbstractDecoratedMethod() {
+        assertEquals("test2", bean.test2());
+    }
+
+    @Test
+    public void testUnimplementedDecoratedMethod() {
+        assertEquals("test3", bean.test3());
+    }
+}

--- a/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/apps/abstractDecorator/AbstractDecoratorTestBean.java
+++ b/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/apps/abstractDecorator/AbstractDecoratorTestBean.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.annotations.fat.apps.abstractDecorator;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class AbstractDecoratorTestBean implements AbstractDecoratorTestInterface {
+
+    @Override
+    public String test1() {
+        return "test1";
+    }
+
+    @Override
+    public String test2() {
+        return "test2";
+    }
+
+    @Override
+    public String test3() {
+        return "test3";
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/apps/abstractDecorator/AbstractDecoratorTestInterface.java
+++ b/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/apps/abstractDecorator/AbstractDecoratorTestInterface.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.annotations.fat.apps.abstractDecorator;
+
+public interface AbstractDecoratorTestInterface {
+
+    public String test1();
+
+    public String test2();
+
+    public String test3();
+}

--- a/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/tests/AnnotationsTests.java
+++ b/dev/com.ibm.ws.cdi.annotations_fat/fat/src/com/ibm/ws/cdi/annotations/fat/tests/AnnotationsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import com.ibm.websphere.simplicity.CDIArchiveHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.beansxml.BeansAsset.DiscoveryMode;
+import com.ibm.ws.cdi.annotations.fat.apps.abstractDecorator.AbstractDecoratorServlet;
 import com.ibm.ws.cdi.annotations.fat.apps.defaultDecorator.DefaultDecoratorServlet;
 import com.ibm.ws.cdi.annotations.fat.apps.dependentScopedProducer.AppScopedMethodServlet;
 import com.ibm.ws.cdi.annotations.fat.apps.dependentScopedProducer.AppScopedSteryotypedServlet;
@@ -60,6 +61,7 @@ public class AnnotationsTests extends FATServletClient {
     public static final String DEFAULT_DECORATOR_APP_NAME = "defaultDecoratorApp";
     public static final String GLOBAL_PRIORITY_APP_NAME = "globalPriorityWebApp";
     public static final String WITH_ANNOTATIONS_APP_NAME = "withAnnotationsApp";
+    public static final String ABSTRACT_DECORATOR_APP_NAME = "abstractDecoratorApp";
 
     @ClassRule
     public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE10, EERepeatActions.EE11, EERepeatActions.EE9, EERepeatActions.EE7); //not bothering to repeat with EE8 ... the EE9 version is mostly a transformed version of the EE8 code
@@ -71,7 +73,9 @@ public class AnnotationsTests extends FATServletClient {
                     @TestServlet(servlet = NullProducerServlet.class, contextRoot = DEP_PRODUCER_APP_NAME), //FULL
                     @TestServlet(servlet = DefaultDecoratorServlet.class, contextRoot = DEFAULT_DECORATOR_APP_NAME), //FULL
                     @TestServlet(servlet = GlobalPriorityTestServlet.class, contextRoot = GLOBAL_PRIORITY_APP_NAME), //FULL
-                    @TestServlet(servlet = WithAnnotationsServlet.class, contextRoot = WITH_ANNOTATIONS_APP_NAME) }) //FULL
+                    @TestServlet(servlet = WithAnnotationsServlet.class, contextRoot = WITH_ANNOTATIONS_APP_NAME), // FULL
+                    @TestServlet(servlet = AbstractDecoratorServlet.class, contextRoot = ABSTRACT_DECORATOR_APP_NAME), // FULL
+    })
     public static LibertyServer server;
 
     @BeforeClass
@@ -109,9 +113,14 @@ public class AnnotationsTests extends FATServletClient {
             CDIArchiveHelper.addBeansXML(withAnnotationsApp, DiscoveryMode.ALL);
             CDIArchiveHelper.addCDIExtensionService(withAnnotationsApp, WithAnnotationsExtension.class);
 
+            WebArchive abstractDecorator = ShrinkWrap.create(WebArchive.class, ABSTRACT_DECORATOR_APP_NAME + ".war")
+                                                     .addPackage(AbstractDecoratorServlet.class.getPackage());
+            CDIArchiveHelper.addBeansXML(abstractDecorator);
+
             ShrinkHelper.exportDropinAppToServer(server, withAnnotationsApp, DeployOptions.SERVER_ONLY);
             ShrinkHelper.exportDropinAppToServer(server, globalPriorityApp, DeployOptions.SERVER_ONLY);
             ShrinkHelper.exportDropinAppToServer(server, defaultDecorator, DeployOptions.SERVER_ONLY);
+            ShrinkHelper.exportDropinAppToServer(server, abstractDecorator, DeployOptions.SERVER_ONLY);
         }
 
         server.startServer();


### PR DESCRIPTION
The generated code for an abstract decorator method now needs access to `org.jboss.weld.util.reflection`.

Fixes  #30344

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".