### PR TITLE
remove workarounds for 30093, 29893, and part of 28931

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2951,17 +2951,7 @@ public class QueryInfo {
                         entityVar = "this";
                         entityVar_ = "";
 
-                        // TODO remove this workaround for #28931 once fixed
-                        boolean insertEntityVar = !entityInfo.relationAttributeNames.isEmpty();
-                        if (insertEntityVar) {
-                            entityVar_ = entityVar + ".";
-                            StringBuilder q = new StringBuilder(ql.length() * 3 / 2) //
-                                            .append("DELETE FROM ").append(entityInfo.name) //
-                                            .append(' ').append(entityVar).append(" WHERE");
-                            appendWithIdentifierName(ql, startAt + 5, ql.length(), entityVar_, q);
-                            jpql = q.toString();
-                            // The following if block is not part of the workaround and is still needed:
-                        } else if (entityInfo.recordClass != null)
+                        if (entityInfo.recordClass != null)
                             // Switch from record name to entity name
                             jpql = new StringBuilder(ql.length() + 6) //
                                             .append("DELETE FROM ") //
@@ -3009,16 +2999,7 @@ public class QueryInfo {
                         entityVar = "this";
                         entityVar_ = "";
 
-                        // TODO remove this workaround for #28931 once fixed
-                        boolean insertEntityVar = !entityInfo.relationAttributeNames.isEmpty();
-                        if (insertEntityVar) {
-                            entityVar = "o";
-                            entityVar_ = "o.";
-                            StringBuilder q = new StringBuilder(ql.length() * 3 / 2) //
-                                            .append("UPDATE ").append(entityInfo.name).append(" o SET");
-                            appendWithIdentifierName(ql, startAt + 3, ql.length(), entityVar_, q);
-                            jpql = q.toString();
-                        } else if (entityName.length() != entityInfo.name.length() || entityName.indexOf(entityInfo.name) != 0)
+                        if (entityName.length() != entityInfo.name.length() || entityName.indexOf(entityInfo.name) != 0)
                             jpql = new StringBuilder(ql.length() * 3 / 2) //
                                             .append("UPDATE ").append(entityInfo.name).append(" SET") //
                                             .append(jpql.substring(startAt + 3, ql.length())) //
@@ -3229,7 +3210,7 @@ public class QueryInfo {
 
             boolean hasEntityVar = entityVar_.length() > 0;
 
-            // TODO remove this workaround for #28931 once fixed
+            // TODO remove this workaround for #30351 once fixed and run the _fat_jpa bucket to verify
             boolean insertEntityVar = entityVar_.length() == 0 && !entityInfo.relationAttributeNames.isEmpty();
             if (insertEntityVar)
                 entityVar_ = entityVar + ".";
@@ -3333,7 +3314,7 @@ public class QueryInfo {
             }
 
             if (whereLen > 0)
-                // TODO once fixed, test #28931 by adding: && !"this.".equalsIgnoreCase(entityVar_)
+                // TODO once fixed, test #30351 by adding: && !"this.".equalsIgnoreCase(entityVar_)
                 // and running DataJPATestServlet.testCountQueryWithFromAndWhereClausesOnly
                 if (insertEntityVar) {
                     q.append("WHERE");

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3892,8 +3892,7 @@ public class DataTestServlet extends FATServlet {
      * Verify a repository method that supplies id(this) as the sort criteria
      * hard coded within a JDQL query.
      */
-    // TODO enable once #30093 is fixed
-    //@Test
+    @Test
     public void testOrderByIdFunction() {
         assertIterableEquals(List.of(19L, 17L, 13L, 11L, 7L, 5L, 3L, 2L),
                              primes.below(20L));

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
@@ -66,8 +66,6 @@ public interface Vehicles {
 
     boolean updateByVinIdAddPrice(String vin, float priceIncrease);
 
-    // TODO switch to the following once #29893 is fixed
-    //@Query("WHERE LOWER(ID(THIS)) = ?1")
-    @Query("WHERE LOWER(vinId) = ?1")
+    @Query("WHERE LOWER(ID(THIS)) = ?1")
     Optional<Vehicle> withVINLowerCase(String lowerCaseVIN);
 }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -470,9 +470,8 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
-     * Tests an error path where a repository method attempts to return a subset of
-     * an entity as a record where the record component names do not all match the
-     * entity attribute names.
+     * Tests an error path where a repository method attempts to remove an entity
+     * but return it as a record instead.
      */
     @Test
     public void testRemoveAsSubsetOfEntity() {

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -524,23 +524,6 @@ public class DataExperimentalServlet extends FATServlet {
 
     /**
      * Repository method performing a parameter-based query on a compound entity Id which is an IdClass,
-     * where the method parameter is annotated with By.
-     */
-    // TODO enable once #29893 is fixed. EclipseLink rejects LOWER(id(o)) with:
-    // The encapsulated expression is not a valid expression.
-    //@Test
-    public void testIdClassFindByAnnotatedParameter() {
-
-        assertEquals(List.of("Springfield Massachusetts",
-                             "Rochester Minnesota",
-                             "Kansas City Missouri"),
-                     towns.largerThan(100000, TownId.of("springfield", "missouri"), "M%s")
-                                     .map(c -> c.name + ' ' + c.stateName)
-                                     .collect(Collectors.toList()));
-    }
-
-    /**
-     * Repository method performing a parameter-based query on a compound entity Id which is an IdClass,
      * without annotating the method parameter.
      */
     // TODO enable once #29073 is fixed
@@ -721,6 +704,20 @@ public class DataExperimentalServlet extends FATServlet {
 
         assertEquals(List.of("seventeen"),
                      primes.withRomanNumeralSuffixAndWithoutNameSuffix("VII", "seven", 50));
+    }
+
+    /**
+     * Test the NotIgnoreCase enumerated value for a parameter that is
+     * annotated with the By annotation.
+     */
+    @Test
+    public void testNotIgnoreCase() {
+
+        assertEquals(List.of("Rochester Minnesota",
+                             "Kansas City Missouri"),
+                     towns.largerThan(100000, "springfield", "M%s")
+                                     .map(c -> c.name + ' ' + c.stateName)
+                                     .collect(Collectors.toList()));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -585,11 +585,10 @@ public class DataExperimentalServlet extends FATServlet {
 
     /**
      * Use cursor-based pagination with the OrderBy annotation on a composite id
-     * that is defined by an IdClass attribute. Also use named parameters, which
-     * means the cursor portion of the query will also need to use named parameters.
+     * that is defined by an IdClass attribute.
      */
     @Test
-    public void testIdClassOrderByAnnotationWithCursorPaginationAndNamedParameters() {
+    public void testIdClassOrderByAnnotationWithCursorPaginations() {
         PageRequest pagination = PageRequest.ofSize(2);
 
         CursoredPage<Town> page1 = towns.sizedWithin(100000, 1000000, pagination);

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Towns.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Towns.java
@@ -85,7 +85,7 @@ public interface Towns {
     @OrderBy("stateName")
     @OrderBy("name")
     Stream<Town> largerThan(@By("population") @Is(GreaterThan) int minPopulation,
-                            @By(ID) @Is(NotIgnoreCase) TownId exceptFor,
+                            @By("name") @Is(NotIgnoreCase) String cityToExclude,
                             @By("stateName") @Is(Prefixed) String statePattern);
 
     @Update

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -131,6 +131,12 @@ public interface Cities {
     @Save
     City save(City c);
 
+    @Query("WHERE population < :maxPopulation OR name <> :nameToExclude")
+    @OrderBy(ID)
+    CursoredPage<City> smallerThanOrNotNamed(int maxPopulation,
+                                             String nameToExclude,
+                                             PageRequest pageReq);
+
     @Find
     @OrderBy("stateName")
     Stream<City> withNameOf(String name);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -707,6 +707,42 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Test that a query with named parameters can be used for pagination
+     * where the cursor is an IdClass value.
+     */
+    @Test
+    public void testCursoredPagesWithNamedParametersAndIdClass() {
+        PageRequest page1req = PageRequest
+                        .ofSize(3)
+                        .afterCursor(Cursor.forKey(CityId.of("Indianapolis",
+                                                             "Indiana")));
+
+        CursoredPage<City> page1 = cities.smallerThanOrNotNamed(100000,
+                                                                "Springfield",
+                                                                page1req);
+
+        assertEquals(List.of("Kansas City in Kansas",
+                             "Kansas City in Missouri",
+                             "Rochester in Minnesota"),
+                     page1.stream()
+                                     .map(c -> c.name + " in " + c.stateName)
+                                     .collect(Collectors.toList()));
+
+        CursoredPage<City> page2 = cities.smallerThanOrNotNamed(100000,
+                                                                "Springfield",
+                                                                page1.nextPageRequest());
+
+        assertEquals(List.of("Rochester in New York",
+                             "Springfield in Ohio",
+                             "Springfield in Oregon"),
+                     page2.stream()
+                                     .map(c -> c.name + " in " + c.stateName)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(false, page2.hasNext());
+    }
+
+    /**
      * Verify that an EntityManager can be obtained for a repository and used to perform database operations.
      */
     @Test


### PR DESCRIPTION
The following were fixed in EclipseLink, and this PR updates code and tests to remove workarounds for:
fixes #30093
fixes #29893 
fixes #28931 

Also, adds test coverage for a cursor with one of its components being an IdClass value, while also using a query that has named parameters

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
