### PR TITLE
feat: Enable use of verified docker images from public.aws.ecr

### DIFF
--- a/dev/build.example.testcontainers_fat/bnd.bnd
+++ b/dev/build.example.testcontainers_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -41,7 +41,7 @@ fat.project: true
 tested.features: \
     databaseRotation, servlet-5.0
 	
-fat.test.container.images: kyleaure/postgres-test-table:3.0
+fat.test.container.images: kyleaure/postgres-test-table:3.0, public.ecr.aws/docker/library/postgres:17.0-alpine
 
 # io.openliberty.org.testcontainers bundle should have all compile time
 # dependences you need for a testcontainer enabled fat project.

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ContainersTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ContainersTest.java
@@ -70,7 +70,7 @@ public class ContainersTest extends FATServletClient {
      * have been used here. This is just an example of how to setup a GenericContainer.
      */
     @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>("postgres:17.0-alpine")
+    public static GenericContainer<?> container = new GenericContainer<>("public.ecr.aws/docker/library/postgres:17.0-alpine")
                     .withExposedPorts(POSTGRE_PORT)
                     .withEnv("POSTGRES_DB", POSTGRES_DB)
                     .withEnv("POSTGRES_USER", POSTGRES_USER)

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/FATSuite.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import componenttest.containers.TestContainerSuite;
 import componenttest.rules.repeater.FeatureReplacementAction;
@@ -43,6 +44,9 @@ public class FATSuite extends TestContainerSuite {
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().fullFATOnly())
                     .andWith(FeatureReplacementAction.EE9_FEATURES());
 
+    private static final DockerImageName PostgreSQLImage = DockerImageName.parse("public.ecr.aws/docker/library/postgres:17.0-alpine")
+                    .asCompatibleSubstituteFor("postgres:17.0-alpine");
+
     /*
      * If you want to use the same container for the entire test suite you can
      * declare it here. Using the @ClassRule annotation will start the container
@@ -51,6 +55,6 @@ public class FATSuite extends TestContainerSuite {
      * In this example suite I am going to use a different container for each example.
      */
     @ClassRule
-    public static PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:17.0-alpine");
+    public static PostgreSQLContainer<?> container = new PostgreSQLContainer<>(PostgreSQLImage);
 
 }

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ProgrammaticImageTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ProgrammaticImageTest.java
@@ -82,12 +82,13 @@ public class ProgrammaticImageTest {
      * @see DockerfileTest
      */
 
+    private static final DockerImageName postgresql = ImageNameSubstitutor
+                    .instance() //
+                    .apply(DockerImageName.parse("public.ecr.aws/docker/library/postgres:17.0-alpine"));
+
     @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(//
-                    new ImageFromDockerfile().withDockerfileFromBuilder(builder -> builder.from(//
-                                                                                                ImageNameSubstitutor.instance()
-                                                                                                                .apply(DockerImageName.parse("postgres:17.0-alpine"))
-                                                                                                                .asCanonicalNameString()) //
+                    new ImageFromDockerfile().withDockerfileFromBuilder(builder -> builder.from(postgresql.asCanonicalNameString())//
                                     .copy("/docker-entrypoint-initdb.d/initDB.sql", "/docker-entrypoint-initdb.d/initDB.sql")
                                     .build())
                                     .withFileFromFile("/docker-entrypoint-initdb.d/initDB.sql", new File("lib/LibertyFATTestFiles/postgres/scripts/initDB.sql"), 644))

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryImageNameSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryImageNameSubstitutor.java
@@ -65,12 +65,8 @@ public class ArtifactoryImageNameSubstitutor extends ImageNameSubstitutor {
                 throw new RuntimeException("Not all developers of Open Liberty have access to artifactory, must use a public registry.");
             }
 
-//            // Priority 3: If a public registry was explicitly set on an image, do not substitute
-//            if (original.getRegistry() != null && !original.getRegistry().isEmpty()) {
-//                result = original;
-//                reason = "Image name is explicitally set with registry, cannot modify registry.";
-//                break;
-//            }
+            // Priority 3: If a public registry was explicitly set on an image, do not substitute
+            // This is now handled directly by the MIRROR substitutor
 
             // Priority 4: Always use Artifactory if using remote docker host.
             if (DockerClientFactory.instance().isUsing(EnvironmentAndSystemPropertyClientProviderStrategy.class)) {

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryMirrorSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryMirrorSubstitutor.java
@@ -39,26 +39,21 @@ public class ArtifactoryMirrorSubstitutor extends ImageNameSubstitutor {
     public DockerImageName apply(final DockerImageName original) {
 
         final String repository;
-        final DockerImageName result;
 
         if (original.getRegistry().isEmpty()) {
             repository = REGISTRY_MAP.get("NONE") + "/" + original.getRepository();
-            result = DockerImageName.parse(original.asCanonicalNameString())
-                            .withRepository(repository);
-            Log.info(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
-            return result;
-        }
-
-        if (REGISTRY_MAP.containsKey(original.getRegistry())) {
+        } else if (REGISTRY_MAP.containsKey(original.getRegistry())) {
             repository = REGISTRY_MAP.get(original.getRegistry()) + "/" + original.getRepository();
-            result = DockerImageName.parse(original.asCanonicalNameString())
-                            .withRepository(repository);
-            Log.info(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
-            return result;
+        } else {
+            repository = original.getRepository();
         }
 
-        Log.info(c, "apply", original.asCanonicalNameString() + " --> [UNCHANGED]");
-        return original;
+        DockerImageName result = original;
+        result = result.withRegistry(""); //Remove registry
+        result = result.withRepository(repository); //Substitute repository
+
+        Log.info(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
+        return result;
     }
 
     @Override

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryMirrorSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryMirrorSubstitutor.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package componenttest.containers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+/**
+ * Substitutes a known registry for a known remote mirror repository within Artifactory.
+ * Example: public.ecr.aws/docker/library/postgres:17.0-alpine --> wasliberty-aws-docker-remote/docker/library/postgres:17.0-alpine
+ */
+public class ArtifactoryMirrorSubstitutor extends ImageNameSubstitutor {
+
+    private static final Class<?> c = ArtifactoryMirrorSubstitutor.class;
+
+    private static final Map<String, String> REGISTRY_MAP = new HashMap<>();
+    static {
+        REGISTRY_MAP.put("NONE", "wasliberty-infrastructure-docker");
+        REGISTRY_MAP.put("docker.io", "wasliberty-docker-remote"); //Only for verified images
+//        REGISTRY_MAP.put("ghcr.io", "TODO");
+//        REGISTRY_MAP.put("icr.io", "TODO");
+//        REGISTRY_MAP.put("mcr.microsoft.com", "TODO");
+        REGISTRY_MAP.put("public.ecr.aws", "wasliberty-aws-docker-remote");
+    }
+
+    @Override
+    public DockerImageName apply(final DockerImageName original) {
+
+        final String repository;
+        final DockerImageName result;
+
+        if (original.getRegistry().isEmpty()) {
+            repository = REGISTRY_MAP.get("NONE") + "/" + original.getRepository();
+            result = DockerImageName.parse(original.asCanonicalNameString())
+                            .withRepository(repository);
+            Log.info(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
+            return result;
+        }
+
+        if (REGISTRY_MAP.containsKey(original.getRegistry())) {
+            repository = REGISTRY_MAP.get(original.getRegistry()) + "/" + original.getRepository();
+            result = DockerImageName.parse(original.asCanonicalNameString())
+                            .withRepository(repository);
+            Log.info(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
+            return result;
+        }
+
+        Log.info(c, "apply", original.asCanonicalNameString() + " --> [UNCHANGED]");
+        return original;
+    }
+
+    @Override
+    protected String getDescription() {
+        return "Substitutes a known registry for a known remote mirror repository within Artifactory.";
+    }
+}

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryMirrorSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryMirrorSubstitutor.java
@@ -52,7 +52,7 @@ public class ArtifactoryMirrorSubstitutor extends ImageNameSubstitutor {
         result = result.withRegistry(""); //Remove registry
         result = result.withRepository(repository); //Substitute repository
 
-        Log.info(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
+        Log.finer(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
         return result;
     }
 

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryMirrorSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryMirrorSubstitutor.java
@@ -45,7 +45,7 @@ public class ArtifactoryMirrorSubstitutor extends ImageNameSubstitutor {
         } else if (REGISTRY_MAP.containsKey(original.getRegistry())) {
             repository = REGISTRY_MAP.get(original.getRegistry()) + "/" + original.getRepository();
         } else {
-            repository = original.getRepository();
+            return original; //No mirror available, therefore return original
         }
 
         DockerImageName result = original;

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistry.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistry.java
@@ -39,7 +39,6 @@ public class ArtifactoryRegistry {
      * remote docker hosts.
      */
     static final String artifactoryRegistryKey = "fat.test.artifactory.docker.server";
-
     static final String artifactoryRegistryUser = "fat.test.artifactory.download.user";
     static final String artifactoryRegistryToken = "fat.test.artifactory.download.token";
 

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistrySubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistrySubstitutor.java
@@ -35,8 +35,8 @@ public class ArtifactoryRegistrySubstitutor extends ImageNameSubstitutor {
                                        + " This substitutor cannot replace an existing registry.");
         }
 
-        DockerImageName result = DockerImageName.parse(original.asCanonicalNameString())
-                        .withRegistry(ArtifactoryRegistry.instance().getRegistry());
+        DockerImageName result = original;
+        result = result.withRegistry(ArtifactoryRegistry.instance().getRegistry());
 
         Log.info(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
         return result;

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistrySubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistrySubstitutor.java
@@ -20,19 +20,19 @@ import com.ibm.websphere.simplicity.log.Log;
  */
 public class ArtifactoryRegistrySubstitutor extends ImageNameSubstitutor {
 
-    private static final Class<?> c = ArtifactoryMirrorSubstitutor.class;
+    private static final Class<?> c = ArtifactoryRegistrySubstitutor.class;
 
     @Override
     public DockerImageName apply(DockerImageName original) {
         if (!ArtifactoryRegistry.instance().isArtifactoryAvailable()) {
-            throw new RuntimeException("Need to append Artifactory registry to docker image name. "
-                                       + "However, no Artfiactory registry was available because "
+            throw new RuntimeException("Needed to append Artifactory registry to the docker image name: " + original.asCanonicalNameString()
+                                       + System.lineSeparator() + "No Artfiactory registry was available because "
                                        + ArtifactoryRegistry.instance().getSetupException().getMessage());
         }
 
         if (!original.getRegistry().isEmpty()) {
             throw new RuntimeException("A registry (" + original.getRegistry() + ") was already configured on the docker image name."
-                                       + " This substitutor cannot replace an existing registry.");
+                                       + System.lineSeparator() + "This substitutor cannot replace an existing registry.");
         }
 
         DockerImageName result = original;

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistrySubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistrySubstitutor.java
@@ -31,6 +31,15 @@ public class ArtifactoryRegistrySubstitutor extends ImageNameSubstitutor {
         }
 
         if (!original.getRegistry().isEmpty()) {
+            //TODO remove this workaround.  We should be pulling these from an artifactory mirror
+            // but thus far we have never run into any pull rate limits or slow speeds with these registries
+            // so the mirrors have not been set up yet.
+            if (original.getRegistry().equalsIgnoreCase("icr.io") || original.getRegistry().equalsIgnoreCase("mcr.microsoft.com")) {
+                Log.warning(c, "The registry (" + original.getRegistry() + ") was configured on the docker image name."
+                               + System.lineSeparator() + "This registry will NOT be replaced and we WILL pull from a non-artifactory registry.");
+                return original;
+            }
+
             throw new RuntimeException("A registry (" + original.getRegistry() + ") was already configured on the docker image name."
                                        + System.lineSeparator() + "This substitutor cannot replace an existing registry.");
         }
@@ -38,7 +47,7 @@ public class ArtifactoryRegistrySubstitutor extends ImageNameSubstitutor {
         DockerImageName result = original;
         result = result.withRegistry(ArtifactoryRegistry.instance().getRegistry());
 
-        Log.info(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
+        Log.finer(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
         return result;
     }
 

--- a/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistrySubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ArtifactoryRegistrySubstitutor.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package componenttest.containers;
+
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+/**
+ * Appends the Artifactory registry required for the mirror repositories.
+ * Example: wasliberty-aws-docker-remote/docker/library/postgres:17.0-alpine -> [artifactory_registry_url]/wasliberty-aws-docker-remote/docker/library/postgres:17.0-alpine
+ */
+public class ArtifactoryRegistrySubstitutor extends ImageNameSubstitutor {
+
+    private static final Class<?> c = ArtifactoryMirrorSubstitutor.class;
+
+    @Override
+    public DockerImageName apply(DockerImageName original) {
+        if (!ArtifactoryRegistry.instance().isArtifactoryAvailable()) {
+            throw new RuntimeException("Need to append Artifactory registry to docker image name. "
+                                       + "However, no Artfiactory registry was available because "
+                                       + ArtifactoryRegistry.instance().getSetupException().getMessage());
+        }
+
+        if (!original.getRegistry().isEmpty()) {
+            throw new RuntimeException("A registry (" + original.getRegistry() + ") was already configured on the docker image name."
+                                       + " This substitutor cannot replace an existing registry.");
+        }
+
+        DockerImageName result = DockerImageName.parse(original.asCanonicalNameString())
+                        .withRegistry(ArtifactoryRegistry.instance().getRegistry());
+
+        Log.info(c, "apply", original.asCanonicalNameString() + " --> " + result.asCanonicalNameString());
+        return result;
+    }
+
+    @Override
+    protected String getDescription() {
+        return "Appends the Artifactory registry required for the mirror repositories.";
+    }
+
+}

--- a/dev/fattest.simplicity/src/componenttest/containers/ImageVerifier.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ImageVerifier.java
@@ -63,17 +63,11 @@ public final class ImageVerifier {
         expectedImages = Collections.unmodifiableSet(_expectedImages);
     }
 
-    public static DockerImageName collectImage(DockerImageName image) {
-        return collectImage(image, null);
-    }
-
-    public static DockerImageName collectImage(DockerImageName image, DockerImageName output) {
+    public static void collectImage(DockerImageName image) {
         if (!expectedImages.contains(image)) {
             Log.info(c, "collectImage", "Found an unknown image: " + image);
             forgottenImages.add(image);
         }
-
-        return output != null ? output : image;
     }
 
     public static void assertImages() throws IllegalStateException {

--- a/dev/fattest.simplicity/test/componenttest/containers/ArtifactoryImageNameSubstitutorTest.java
+++ b/dev/fattest.simplicity/test/componenttest/containers/ArtifactoryImageNameSubstitutorTest.java
@@ -182,6 +182,78 @@ public class ArtifactoryImageNameSubstitutorTest {
         }
     }
 
+    // Priority 4: Always use Artifactory if using remote docker host.
+    // Break down chained substitutor step by step and verify the results
+    @Test
+    public void testRegistryMirrorSwap() throws Exception {
+        //Using our remote docker host
+        setArtifactoryRegistryAvailable(true);
+        setDockerClientStrategy(new EnvironmentAndSystemPropertyClientProviderStrategy());
+
+        // Step 1 of chained substitutor MIRROR
+        DockerImageName mongoAWS = DockerImageName.parse("public.ecr.aws/docker/library/mongo:6.0.6");
+        DockerImageName mirrorSwap = new ArtifactoryMirrorSubstitutor().apply(mongoAWS);
+        DockerImageName expectedSwap = DockerImageName.parse("wasliberty-aws-docker-remote/docker/library/mongo:6.0.6");
+
+        assertEquals(expectedSwap, mirrorSwap);
+
+        // Step 2 of chained substitutor REGISTRY
+        DockerImageName registryAppend = new ArtifactoryRegistrySubstitutor().apply(mirrorSwap);
+        DockerImageName expectedAppend = DockerImageName.parse("example.com/wasliberty-aws-docker-remote/docker/library/mongo:6.0.6");
+
+        assertEquals(expectedAppend, registryAppend);
+
+        // Combined use of chained substitutor
+        DockerImageName actualFull = new ArtifactoryImageNameSubstitutor().apply(mongoAWS);
+
+        assertEquals(expectedAppend, actualFull);
+    }
+
+    // Priority 4: Always use Artifactory if using remote docker host.
+    // Verify that if a public registry was explicitly set on an image, we do not have a mirror, and intend to use artifactory that we fail.
+    @Test
+    public void testRegistryAppendError() throws Exception {
+        //Using our remote docker host
+        setArtifactoryRegistryAvailable(true);
+        setDockerClientStrategy(new EnvironmentAndSystemPropertyClientProviderStrategy());
+
+        // If a developer attempts to use an unsupported registry, make sure we throw an error
+        DockerImageName unknownRegistry = DockerImageName.parse("quay.io/testcontainers/ryuk:1.0.0");
+
+        try {
+            DockerImageName transformed = new ArtifactoryImageNameSubstitutor().apply(unknownRegistry);
+            fail("Should not have been able to subsititute registry " + unknownRegistry.getRegistry() + " for " + transformed.getRegistry());
+        } catch (RuntimeException e) {
+            //expected
+        } catch (Exception e) {
+            fail("Incorrect exception was thrown by ArtifactoryImageNameSubstitutor: " + e.getMessage());
+        }
+    }
+
+    // Priority 4: Always use Artifactory if using remote docker host.
+    // Verify workaround behavior that should be removed in the future.
+    @Test //TODO remove once all existing supported registries have corresponding Artifactory mirrors
+    public void testRegistryAppendErrorSkip() throws Exception {
+        //Using our remote docker host
+        setArtifactoryRegistryAvailable(true);
+        setDockerClientStrategy(new EnvironmentAndSystemPropertyClientProviderStrategy());
+
+        DockerImageName db2 = DockerImageName.parse("icr.io/db2_community/db2:11.5.9.0");
+        DockerImageName sqlserver = DockerImageName.parse("mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04");
+
+        try {
+            assertEquals(db2, new ArtifactoryImageNameSubstitutor().apply(db2));
+        } catch (RuntimeException e) {
+            fail("icr.io should not have caused a failure from ArtifactoryImageNameSubstitutor: " + e.getMessage());
+        }
+
+        try {
+            assertEquals(sqlserver, new ArtifactoryImageNameSubstitutor().apply(sqlserver));
+        } catch (RuntimeException e) {
+            fail("mcr.microsoft.com should not have caused a failure from ArtifactoryImageNameSubstitutor" + e.getMessage());
+        }
+    }
+
     // Priority 5: System property artifactory.force.external.repo (NOTE: only honor this property if set to true)
     // Priority 6: If Artifactory registry is available assume user wants to use that.
     @Test

--- a/dev/fattest.simplicity/test/componenttest/containers/ArtifactoryImageNameSubstitutorTest.java
+++ b/dev/fattest.simplicity/test/componenttest/containers/ArtifactoryImageNameSubstitutorTest.java
@@ -224,6 +224,25 @@ public class ArtifactoryImageNameSubstitutorTest {
 
     }
 
+    // Ensure that the asCompatibleSubsituteFor configuration is maintained during substitution.
+    @Test
+    public void testCompatibleSubstitutionIsMaintained() throws Exception {
+        //Using our remote docker host
+        setArtifactoryRegistryAvailable(true);
+        setDockerClientStrategy(new EnvironmentAndSystemPropertyClientProviderStrategy());
+
+        //Create a DockerImageName for an image in a public registry that is compatibile with an image in DockerHub
+        DockerImageName original = DockerImageName.parse("postgres:17.0-alpine");
+        DockerImageName input = DockerImageName.parse("public.ecr.aws/docker/library/postgres:17.0-alpine")
+                        .asCompatibleSubstituteFor(original);
+        assertTrue("Input should have been compatibile with original", input.isCompatibleWith(original));
+
+        DockerImageName expected = DockerImageName.parse("example.com/wasliberty-aws-docker-remote/docker/library/postgres:17.0-alpine");
+        DockerImageName output = new ArtifactoryImageNameSubstitutor().apply(input);
+        assertEquals(expected, output);
+        assertTrue("Output should have been compatibile with original", output.isCompatibleWith(original));
+    }
+
     private static void setDockerClientStrategy(DockerClientProviderStrategy strategy) throws Exception {
         Field strategyField = DockerClientFactory.class.getDeclaredField("strategy");
         strategyField.setAccessible(true);

--- a/dev/io.openliberty.org.testcontainers/build.gradle
+++ b/dev/io.openliberty.org.testcontainers/build.gradle
@@ -26,8 +26,7 @@ task assembleTestContainerData(type: JavaExec) {
     }
     
     // Setup environment to mock external state
-    environment "TESTCONTAINERS_IMAGE_SUBSTITUTOR", "componenttest.containers.ArtifactoryImageNameSubstitutor"
-    environment "MOCK_ARTIFACTORY_BEHAVIOR", "true"
+    environment "TESTCONTAINERS_IMAGE_SUBSTITUTOR", "componenttest.containers.ArtifactoryMirrorSubstitutor"
     
     classpath = configurations.runtime.plus(sourceSets.main.runtimeClasspath)
     main = "io.openliberty.org.testcontainers.generate.CacheFiles"

--- a/dev/io.openliberty.org.testcontainers/cache/externals
+++ b/dev/io.openliberty.org.testcontainers/cache/externals
@@ -35,6 +35,7 @@ openzipkin/zipkin-slim:2.23
 otel/opentelemetry-collector-contrib:0.103.0
 otel/opentelemetry-collector:0.74.0
 postgres:17.0-alpine
+public.ecr.aws/docker/library/postgres:17.0-alpine
 ryanesch/acme-boulder:1.2
 seleniarm/standalone-chromium:4.8.3
 selenium/standalone-chrome:4.8.3

--- a/dev/io.openliberty.org.testcontainers/cache/images
+++ b/dev/io.openliberty.org.testcontainers/cache/images
@@ -2,6 +2,7 @@
 # Please check these changes into GitHub
 icr.io/db2_community/db2:11.5.9.0
 mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04
+wasliberty-aws-docker-remote/docker/library/postgres:17.0-alpine
 wasliberty-infrastructure-docker/alpine:3.17
 wasliberty-infrastructure-docker/confluentinc/cp-kafka:7.1.1
 wasliberty-infrastructure-docker/elastic/logstash:7.16.3


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Allow us to construct a new docker image name in steps depending on which registry the original image originates.
This will allow us to use images from alternative registries such as AWS, ICR, and GHCR.