### PR TITLE
life cycle operations with invalid parameters

### DIFF
--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -82,7 +82,7 @@ public class Data_1_0 implements DataVersionCompatibility {
     @Override
     @Trivial
     public String[] getUpdateAttributeAndOperation(Annotation[] annos) {
-        throw new UnsupportedOperationException(); // unreachable
+        return null; // let the caller raise an appropriate error
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -963,3 +963,10 @@ CWWKD1096.orderby.incompat=CWWKD1096E: The {0} method of the {1} repository \
 CWWKD1096.orderby.incompat.explanation=The OrderBy annotation is not compatible \
  with the type of repository operation.
 CWWKD1096.orderby.incompat.useraction=Remove the OrderBy annotation.
+
+CWWKD1097.param.incompat=CWWKD1097E: The {0} method of the {1} repository \
+ has a {2} parameter, but the {0} method is not a find operation or a \
+ delete operation that returns entities.
+CWWKD1097.param.incompat.explanation=Order, Sort, and Limit parameters are \
+ not compatible with the type of repository operation.
+CWWKD1097.param.incompat.useraction=Remove the Order, Sort, or Limit parameter.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -26,8 +26,10 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
+import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
+import jakarta.data.page.PageRequest.Mode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
@@ -52,6 +54,15 @@ public class PageImpl<T> implements Page<T> {
 
         if (pageRequest == null)
             queryInfo.missingPageRequest();
+
+        if (pageRequest.mode() != Mode.OFFSET)
+            throw exc(IllegalArgumentException.class,
+                      "CWWKD1035.incompat.page.mode",
+                      Mode.OFFSET,
+                      queryInfo.method.getName(),
+                      queryInfo.repositoryInterface.getName(),
+                      queryInfo.method.getGenericReturnType().getTypeName(),
+                      CursoredPage.class.getName());
 
         this.queryInfo = queryInfo;
         this.pageRequest = pageRequest;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1967,6 +1967,19 @@ public class QueryInfo {
                         }
                     }
                 }
+
+                if (first)
+                    // No parameters are annotated to indicate update.
+                    // Raise an error that considers this an invalid life cycle
+                    // operation attempt. In the future, we could raise an error
+                    // that also mentions the possibility of invalid parameter-based
+                    // update operation.
+                    throw exc(UnsupportedOperationException.class,
+                              "CWWKD1009.lifecycle.param.err",
+                              method.getName(),
+                              repositoryInterface.getName(),
+                              method.getParameterCount(),
+                              Update.class.getSimpleName());
             } else {
                 type = Type.FIND;
                 q = generateSelectClause().append(" FROM ").append(entityInfo.name).append(' ').append(o);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -677,10 +677,6 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             }
                         }
 
-                        boolean asyncCompatibleResultForPagination = pagination != null &&
-                                                                     (void.class.equals(returnType) || CompletableFuture.class.equals(returnType)
-                                                                      || CompletionStage.class.equals(returnType));
-
                         Class<?> multiType = queryInfo.multiType;
 
                         if (CursoredPage.class.equals(multiType)) {

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -85,10 +85,12 @@ public interface DataVersionCompatibility {
     /**
      * Return a 2-element array where the first element is the entity attribute name
      * and the second element is the operation (=, +, -, *, or /).
-     * Null if none of the annotations indicate an update.
+     * Null if none of the annotations indicate an update
+     * of if the version used does not support parameter-based update.
      *
      * @param annos annotations on the method parameter. Must not be null.
-     * @return operation and entity attribute name. Null if not an update.
+     * @return operation and entity attribute name. Null if not an update
+     *         of if the version used does not support parameter-based update.
      */
     String[] getUpdateAttributeAndOperation(Annotation[] annos);
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -49,6 +49,7 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1009E.*storeInDatabase", // Save method with multiple parameters
                                    "CWWKD1019E.*livingAt", // mix of named/positional parameters
                                    "CWWKD1019E.*residingAt", // unused parameters
+                                   "CWWKD1022E.*discardPage", // Delete operation with a PageRequest
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",
                                    "CWWKD1078E.*test.jakarta.data.errpaths.web.InvalidNonJNDIRepo",
                                    "CWWKD1079E.*test.jakarta.data.errpaths.web.InvalidJNDIRepo",
@@ -63,7 +64,10 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1090E.*findByAddressOrderBy", // OrderBy anno/keyword conflict
                                    "CWWKD1091E.*deleteByAddressOrderByName", // OrderBy without return type
                                    "CWWKD1094E.*register", // incompatible return type
-                                   "CWWKD1096E.*discardInOrder" // OrderBy annotation without return type
+                                   "CWWKD1096E.*discardInOrder", // OrderBy annotation without return type
+                                   "CWWKD1097E.*discardLimited", // Limit parameter on Delete method
+                                   "CWWKD1097E.*discardOrdered", // Order parameter on Delete method
+                                   "CWWKD1097E.*discardSorted" // Sort parameter on Delete method
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -41,6 +41,12 @@ public class DataErrPathsTest extends FATServletClient {
                     new String[] {
                                    "CWWJP9991W.*4002", // 2 persistence units attempt to autocreate same table
                                    "CWWKD1006E.*removeBySSN", // delete method attempts to return record
+                                   "CWWKD1009E.*addNothing", // Insert method without parameters
+                                   "CWWKD1009E.*addSome", // Insert method with multiple parameters
+                                   "CWWKD1009E.*changeNothing", // Update method without parameters
+                                   "CWWKD1009E.*changeBoth", // Update method with multiple entity parameters
+                                   "CWWKD1009E.*storeNothing", // Save method without parameters
+                                   "CWWKD1009E.*storeInDatabase", // Save method with multiple parameters
                                    "CWWKD1019E.*livingAt", // mix of named/positional parameters
                                    "CWWKD1019E.*residingAt", // unused parameters
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 import java.time.Month;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
@@ -23,6 +24,7 @@ import java.util.stream.Stream;
 
 import jakarta.annotation.Resource;
 import jakarta.annotation.sql.DataSourceDefinition;
+import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.exceptions.DataException;
@@ -355,6 +357,136 @@ public class DataErrPathsTestServlet extends FATServlet {
                 !x.getMessage().startsWith("CWWKD1094E:") ||
                 !x.getMessage().contains("register") ||
                 !x.getMessage().contains("Voter[]"))
+                throw x;
+        }
+    }
+
+    /**
+     * Use a repository method with multiple entity parameters, which is not
+     * allowed for life cycle methods such as Insert.
+     */
+    @Test
+    public void testLifeCycleInsertMethodWithMultipleParameters() {
+        List<Voter> list = List //
+                        .of(new Voter(999887777, "New Voter 1", //
+                                        LocalDate.of(1999, Month.DECEMBER, 9), //
+                                        "213 13th Ave NW, Rochester, MN 55901"),
+
+                            new Voter(777665555, "New Voter 2", //
+                                            LocalDate.of(1987, Month.NOVEMBER, 7), //
+                                            "300 7th St SW, Rochester, MN 55902"));
+
+        try {
+            list = voters.addSome(list, Limit.of(1));
+            fail("Did not reject Insert method with multiple parameters. Result: " +
+                 list);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1009E") ||
+                !x.getMessage().contains("addSome"))
+                throw x;
+        }
+    }
+
+    /**
+     * Use a repository method with no parameters, which is not
+     * allowed for life cycle methods such as Insert.
+     */
+    @Test
+    public void testLifeCycleInsertMethodWithoutParameters() {
+        try {
+            Voter[] added = voters.addNothing();
+            fail("Did not reject Insert method without parameters. Result: " +
+                 Arrays.toString(added));
+
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1009E") ||
+                !x.getMessage().contains("addNothing"))
+                throw x;
+        }
+    }
+
+    /**
+     * Use a repository method with multiple entity parameters, which is not
+     * allowed for life cycle methods such as Save.
+     */
+    @Test
+    public void testLifeCycleSaveMethodWithMultipleParameters() {
+        Voter v = new Voter(123445678, "Updated Name", //
+                        LocalDate.of(1951, Month.SEPTEMBER, 25), //
+                        "4051 E River Rd NE, Rochester, MN 55906");
+        try {
+            Voter saved = voters.storeInDatabase(v, PageRequest.ofSize(5));
+
+            fail("Did not reject Save life cycle method that has" +
+                 " multiple parameters. Result: " + saved);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1009E") ||
+                !x.getMessage().contains("storeInDatabase"))
+                throw x;
+        }
+    }
+
+    /**
+     * Use a repository method with no parameters, which is not
+     * allowed for life cycle methods such as Save.
+     */
+    @Test
+    public void testLifeCycleSaveMethodWithoutParameters() {
+        try {
+            voters.storeNothing();
+            fail("Did not reject Save method without parameters.");
+
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1009E") ||
+                !x.getMessage().contains("storeNothing"))
+                throw x;
+        }
+    }
+
+    /**
+     * Use a repository method with multiple entity parameters, which are not
+     * allowed for life cycle methods such as Update.
+     */
+    @Test
+    public void testLifeCycleUpdateMethodWithMultipleParameters() {
+        Voter v1 = new Voter(123445678, "New Name 1", //
+                        LocalDate.of(1951, Month.SEPTEMBER, 25), //
+                        "4051 E River Rd NE, Rochester, MN 55906");
+        Voter v2 = new Voter(987665432, "New Name 2", //
+                        LocalDate.of(1971, Month.OCTOBER, 1), //
+                        "701 Silver Creek Rd NE, Rochester, MN 55906");
+        try {
+            List<Voter> list = voters.changeBoth(v1, v2);
+
+            fail("Did not reject Update life cycle method that has" +
+                 " multiple parameters. Result: " + list);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1009E") ||
+                !x.getMessage().contains("changeBoth"))
+                throw x;
+        }
+    }
+
+    /**
+     * Use a repository method with no parameters, which is not
+     * allowed for life cycle methods such as Update.
+     */
+    @Test
+    public void testLifeCycleUpdateMethodWithoutParameters() {
+        try {
+            voters.changeNothing();
+
+            fail("Did not reject Update life cycle method that has" +
+                 " no parameters.");
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1009E") ||
+                !x.getMessage().contains("changeNothing"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.errpaths.web;
 
+import static jakarta.data.repository.By.ID;
 import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
@@ -164,6 +165,44 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Verify an error is raised for a repository method that attempts to
+     * delete a page of results by specifying a PageRequest on a Delete operation.
+     */
+    @Test
+    public void testDeletePageOfResults() {
+        try {
+            voters.discardPage("701 Silver Creek Rd NE, Rochester, MN 55906",
+                               PageRequest.ofSize(15));
+            fail("Should not be able to perform a delete operation by supplying"
+                 + " a PageRequest.");
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1022E:") ||
+                !x.getMessage().contains("discardPage"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that specifies a
+     * Limit parameter on a Delete operation with void return type.
+     */
+    @Test
+    public void testDeleteWithLimitParameterButNoResult() {
+        try {
+            voters.discardLimited("701 Silver Creek Rd NE, Rochester, MN 55906",
+                                  Limit.of(3));
+            fail("Should not be able to define an Limit parameter on a method that" +
+                 " deletes entities but does not return them");
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1097E:") ||
+                !x.getMessage().contains("discardLimited"))
+                throw x;
+        }
+    }
+
+    /**
      * Verify an error is raised for a repository method that specifies an
      * OrderBy annotation on a Delete operation with void return type.
      */
@@ -189,6 +228,44 @@ public class DataErrPathsTestServlet extends FATServlet {
                  " deletes entities but does not return them");
         } catch (MappingException x) {
             // expected
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that specifies an
+     * Order parameter on a Delete operation with void return type.
+     */
+    @Test
+    public void testDeleteWithOrderParameterButNoResult() {
+        try {
+            voters.discardOrdered("701 Silver Creek Rd NE, Rochester, MN 55906",
+                                  Order.by(Sort.desc(ID)));
+            fail("Should not be able to define an Order parameter on a method that" +
+                 " deletes entities but does not return them");
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1097E:") ||
+                !x.getMessage().contains("discardOrdered"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that specifies a
+     * Sort parameter on a Delete operation with int return type.
+     */
+    @Test
+    public void testDeleteWithSortParameterButNoResult() {
+        try {
+            int count = voters.discardSorted("701 Silver Creek Rd NE, Rochester, MN 55906",
+                                             Sort.asc("ssn"));
+            fail("Should not be able to define a Sort parameter on a method that" +
+                 " deletes entities and returns an update count: " + count);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1097E:") ||
+                !x.getMessage().contains("discardSorted"))
+                throw x;
         }
     }
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.data.Limit;
+import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.BasicRepository;
@@ -101,6 +102,33 @@ public interface Voters extends BasicRepository<Voter, Integer> {
      */
     @Update
     void changeNothing();
+
+    /**
+     * This invalid method defines a limit on results of a delete operation
+     * but has a return type that disallows returning results.
+     */
+    @Delete
+    void discardLimited(@By("address") String mailingAddress, Limit limit);
+
+    /**
+     * This invalid method defines an ordering for results of a delete operation
+     * but has a return type that disallows returning results.
+     */
+    @Delete
+    void discardOrdered(@By("address") String mailingAddress, Order<Voter> order);
+
+    /**
+     * This invalid method attempts to delete a page of results.
+     */
+    @Delete
+    void discardPage(@By("address") String mailingAddress, PageRequest pageReq);
+
+    /**
+     * This invalid method defines sorting of results of a delete operation
+     * but has a return type that disallows returning results.
+     */
+    @Delete
+    int discardSorted(@By("address") String mailingAddress, Sort<Voter> sort);
 
     /**
      * This invalid method has a conflict between its OrderBy annotation and

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
+import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.By;
@@ -56,6 +57,11 @@ public interface Voters extends BasicRepository<Voter, Integer> {
      */
     @Insert
     List<Voter> addSome(List<Voter> v, Limit limit);
+
+    @Find
+    Page<Voter> atAddress(@By("address") String homeAddress,
+                          PageRequest pageReq,
+                          Order<Voter> order);
 
     /**
      * This invalid method neglects to include the Param annotation for a

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -17,7 +17,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import jakarta.data.Limit;
 import jakarta.data.Sort;
+import jakarta.data.page.PageRequest;
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
@@ -27,6 +29,7 @@ import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 
 /**
@@ -38,6 +41,20 @@ import jakarta.data.repository.Update;
 public interface Voters extends BasicRepository<Voter, Integer> {
     static record NameAndZipCode(String name, int zipCode) {
     }
+
+    /**
+     * Invalid method. A method with a life cycle annotation must have exactly
+     * 1 parameter.
+     */
+    @Insert
+    Voter[] addNothing();
+
+    /**
+     * Invalid method. A method with a life cycle annotation must have exactly
+     * 1 parameter, not multiple.
+     */
+    @Insert
+    List<Voter> addSome(List<Voter> v, Limit limit);
 
     /**
      * This invalid method neglects to include the Param annotation for a
@@ -70,6 +87,20 @@ public interface Voters extends BasicRepository<Voter, Integer> {
 
     @Update
     List<Voter> changeAll(Stream<Voter> v);
+
+    /**
+     * Invalid method. A method with a life cycle annotation must have exactly
+     * 1 parameter, not multiple.
+     */
+    @Update
+    List<Voter> changeBoth(Voter v1, Voter v2);
+
+    /**
+     * Invalid method. A method with a life cycle annotation must have exactly
+     * 1 parameter.
+     */
+    @Update
+    void changeNothing();
 
     /**
      * This invalid method has a conflict between its OrderBy annotation and
@@ -174,6 +205,20 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                            @Param("street") String street,
                            String city, // extra, unused parameter
                            String stateCode); // extra, unused parameter
+
+    /**
+     * Invalid method. A method with a life cycle annotation must have exactly
+     * 1 parameter.
+     */
+    @Save
+    void storeNothing();
+
+    /**
+     * Invalid method. A method with a life cycle annotation must have exactly
+     * 1 parameter, not multiple.
+     */
+    @Save
+    Voter storeInDatabase(Voter voter, PageRequest pageReq);
 
     /**
      * This invalid method has a query that requires a single positional parameter,


### PR DESCRIPTION
This PR includes various error path scenarios, including:
* life cycle operations with too few or too many parameters
* delete operations with invalid special parameters
* cursor supplied to method that returns an offset-based page

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
