### PR TITLE
add fattest.simplicity method to check if feature files exist before running a repeat

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/config13/tck/Config13TCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/config13/tck/Config13TCKLauncher.java
@@ -28,6 +28,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
+import componenttest.topology.utils.tck.TCKUtilities;
 
 /**
  * This is a test class that runs a whole Maven TCK as one test FAT test.
@@ -41,7 +42,7 @@ public class Config13TCKLauncher {
     public static LibertyServer server;
 
     @ClassRule //EE7 + EE8 repeats
-    public static RepeatTests r = MicroProfileActions.repeat("Config13TCKServer", MicroProfileActions.MP14, MicroProfileActions.MP32);
+    public static RepeatTests r = MicroProfileActions.repeatWithPredicate("Config13TCKServer", TCKUtilities::areFeaturesMissing, MicroProfileActions.MP14, MicroProfileActions.MP32);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/config13/tck/Config13TCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/fat/src/com/ibm/ws/microprofile/config13/tck/Config13TCKLauncher.java
@@ -28,7 +28,6 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
-import componenttest.topology.utils.tck.TCKUtilities;
 
 /**
  * This is a test class that runs a whole Maven TCK as one test FAT test.
@@ -42,7 +41,7 @@ public class Config13TCKLauncher {
     public static LibertyServer server;
 
     @ClassRule //EE7 + EE8 repeats
-    public static RepeatTests r = MicroProfileActions.repeatWithPredicate("Config13TCKServer", TCKUtilities::areFeaturesMissing, MicroProfileActions.MP14, MicroProfileActions.MP32);
+    public static RepeatTests r = MicroProfileActions.repeat("Config13TCKServer", MicroProfileActions.MP14, MicroProfileActions.MP32);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/DisabledAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/DisabledAction.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package componenttest.rules.repeater;
+
+import java.util.function.Predicate;
+
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+//An action that is never enabled
+public class DisabledAction implements RepeatTestAction {
+
+    private static final Class<?> c = DisabledAction.class;
+
+    public static final String ID = "DISABLED_ACTION";
+
+    @Override
+    public void setup() {}
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+    public RepeatTestAction fullFATOnly() {
+        return this;
+    }
+
+    public DisabledAction conditionalFullFATOnly(Predicate<DisabledAction> conditional) {
+        return this;
+    }
+
+    /**
+     * Run the {@link DisabledAction} only when the testing mode is {@link TestMode#LITE}.
+     *
+     * @return this instance.
+     */
+    public RepeatTestAction liteFATOnly() {
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Disabled Action";
+    }
+
+    @Override
+    public String getID() {
+        return ID;
+    }
+
+}

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/DisabledAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/DisabledAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -7,16 +7,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.rules.repeater;
 
-import java.util.function.Predicate;
-
-import componenttest.custom.junit.runner.Mode.TestMode;
-
-//An action that is never enabled
+/**
+ * An action that is never enabled
+ */
 public class DisabledAction implements RepeatTestAction {
 
     private static final Class<?> c = DisabledAction.class;
@@ -29,23 +25,6 @@ public class DisabledAction implements RepeatTestAction {
     @Override
     public boolean isEnabled() {
         return false;
-    }
-
-    public RepeatTestAction fullFATOnly() {
-        return this;
-    }
-
-    public DisabledAction conditionalFullFATOnly(Predicate<DisabledAction> conditional) {
-        return this;
-    }
-
-    /**
-     * Run the {@link DisabledAction} only when the testing mode is {@link TestMode#LITE}.
-     *
-     * @return this instance.
-     */
-    public RepeatTestAction liteFATOnly() {
-        return this;
     }
 
     @Override

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKUtilities.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKUtilities.java
@@ -36,23 +36,32 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.common.apiservices.Bootstrap;
+import componenttest.rules.repeater.FeatureSet;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.TCKJarInfo;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
@@ -864,5 +873,82 @@ public class TCKUtilities {
         assertThat("Server log has errors after starting", server.findStringsInLogs("CWWKF0001E"), empty()); // A feature definition could not be found for ...
         assertThat("Server log has errors after starting", server.findStringsInLogs("CWWKF0002E"), empty()); // A bundle could not be found for ...
         assertThat("Server log has errors after starting", server.findStringsInLogs("CWWKE0702E"), empty()); // Could not resolve module ...
+    }
+
+    private static Set<String> detectedShortNames = null;
+
+    private static Set<String> getDetectedShortNames() {
+        if (detectedShortNames != null) {
+            return detectedShortNames;
+        }
+
+        detectedShortNames = new HashSet<String>();
+        Bootstrap b;
+        try {
+            b = Bootstrap.getInstance();
+        } catch (Exception e) {
+            Log.info(c, "getDetectedShortNames", "Bootstrap.getInstance() failed. This will likely cause the current repeat to skip " + e.toString());
+            detectedShortNames = null; //if bootstrap is broken we've got bigger problems, but we can avoid caching an exception
+            return new HashSet<String>();
+        }
+
+        String installRoot = b.getValue("libertyInstallPath");
+        String libPath = installRoot + "/lib/features/";
+
+        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:*.mf");
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(libPath))) {
+            for (Path path : stream) {
+                if (!Files.isDirectory(path) && matcher.matches(path.getFileName())) {
+                    Files.lines(path)
+                                    .filter(line -> line.startsWith("IBM-ShortName: "))
+                                    .map(line -> line.replaceAll("IBM-ShortName: ", ""))
+                                    .forEach(detectedShortNames::add);
+                }
+            }
+        } catch (IOException e) {
+            Log.info(c, "getDetectedShortNames", "IO exception while reading .mf Files. This will likely cause the current repeat to skip " + e.toString());
+            detectedShortNames = null; //avoid caching an exception
+            return new HashSet<String>();
+        }
+
+        return detectedShortNames;
+
+    }
+
+    /**
+     * Checks if a feature or features are present in wlp/lib/features by reading the mf files
+     * and checking if all the provided IBM-ShortName are present.
+     *
+     * @param  featureSet A FeatureSet, all the names returned by getFeatures() will be checked for a matching IBM-ShortName in a mf file
+     * @return            true if all provided IBM-ShortName can be found in a .mf file in wlp/lib/features.
+     */
+    public static boolean areFeaturesMissing(FeatureSet featureSet) {
+        return areFeaturesMissing(featureSet.getFeatures());
+    }
+
+    /**
+     * Checks if a feature or features are present in wlp/lib/features by reading the mf files
+     * and checking if all the provided IBM-ShortName are present.
+     *
+     * @param  featuresToCheck IBM-ShortNames that are required to be available on the server
+     * @return                 true if all provided IBM-ShortName can be found in a .mf file in wlp/lib/features.
+     */
+    public static boolean areFeaturesMissing(Set<String> featuresToCheck) {
+
+        final String m = "areFeaturesPresent";
+        Log.info(c, m, "checking for " + String.join(", ", featuresToCheck));
+        Set<String> shortNames = getDetectedShortNames();
+
+        for (String s : featuresToCheck) {
+            boolean result = shortNames.contains(s);
+            if (!result) {
+                Log.info(c, m, "checked for " + s + " found " + result);
+                return true;
+            }
+        }
+
+        Log.info(c, m, "found all features");
+        return false;
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKUtilities.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -37,10 +37,8 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -57,6 +55,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import com.ibm.websphere.simplicity.log.Log;
 
@@ -889,27 +888,27 @@ public class TCKUtilities {
         } catch (Exception e) {
             Log.info(c, "getDetectedShortNames", "Bootstrap.getInstance() failed. This will likely cause the current repeat to skip " + e.toString());
             detectedShortNames = null; //if bootstrap is broken we've got bigger problems, but we can avoid caching an exception
-            return new HashSet<String>();
+            throw new RuntimeException(e);
         }
 
         String installRoot = b.getValue("libertyInstallPath");
         String libPath = installRoot + "/lib/features/";
 
-        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:*.mf");
-
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(libPath))) {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(libPath), "*.mf")) {
             for (Path path : stream) {
-                if (!Files.isDirectory(path) && matcher.matches(path.getFileName())) {
-                    Files.lines(path)
-                                    .filter(line -> line.startsWith("IBM-ShortName: "))
-                                    .map(line -> line.replaceAll("IBM-ShortName: ", ""))
-                                    .forEach(detectedShortNames::add);
+                if (!Files.isDirectory(path)) {
+                    try (Stream<String> lineStream = Files.lines(path)) {
+                        lineStream
+                                        .filter(line -> line.startsWith("IBM-ShortName: "))
+                                        .map(line -> line.replaceAll("IBM-ShortName: ", ""))
+                                        .forEach(detectedShortNames::add);
+                    }
                 }
             }
         } catch (IOException e) {
             Log.info(c, "getDetectedShortNames", "IO exception while reading .mf Files. This will likely cause the current repeat to skip " + e.toString());
             detectedShortNames = null; //avoid caching an exception
-            return new HashSet<String>();
+            throw new RuntimeException(e);
         }
 
         return detectedShortNames;
@@ -923,8 +922,8 @@ public class TCKUtilities {
      * @param  featureSet A FeatureSet, all the names returned by getFeatures() will be checked for a matching IBM-ShortName in a mf file
      * @return            true if all provided IBM-ShortName can be found in a .mf file in wlp/lib/features.
      */
-    public static boolean areFeaturesMissing(FeatureSet featureSet) {
-        return areFeaturesMissing(featureSet.getFeatures());
+    public static boolean areAllFeaturesPresent(FeatureSet featureSet) {
+        return areAllFeaturesPresent(featureSet.getFeatures());
     }
 
     /**
@@ -934,9 +933,9 @@ public class TCKUtilities {
      * @param  featuresToCheck IBM-ShortNames that are required to be available on the server
      * @return                 true if all provided IBM-ShortName can be found in a .mf file in wlp/lib/features.
      */
-    public static boolean areFeaturesMissing(Set<String> featuresToCheck) {
+    public static boolean areAllFeaturesPresent(Set<String> featuresToCheck) {
 
-        final String m = "areFeaturesPresent";
+        final String m = "areAllFeaturesPresent";
         Log.info(c, m, "checking for " + String.join(", ", featuresToCheck));
         Set<String> shortNames = getDetectedShortNames();
 
@@ -944,11 +943,11 @@ public class TCKUtilities {
             boolean result = shortNames.contains(s);
             if (!result) {
                 Log.info(c, m, "checked for " + s + " found " + result);
-                return true;
+                return false;
             }
         }
 
         Log.info(c, m, "found all features");
-        return false;
+        return true;
     }
 }

--- a/dev/io.openliberty.microprofile.config.internal_repeat_tests/src/io/openliberty/microprofile/config/fat/repeat/ConfigRepeatActions.java
+++ b/dev/io.openliberty.microprofile.config.internal_repeat_tests/src/io/openliberty/microprofile/config/fat/repeat/ConfigRepeatActions.java
@@ -12,6 +12,7 @@ package io.openliberty.microprofile.config.fat.repeat;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.utils.tck.TCKUtilities;
 
 /**
  * Contains static methods for creating standard RepeatTests rules for Config tests
@@ -44,12 +45,15 @@ public class ConfigRepeatActions {
      * @return the RepeatTests rule
      */
     public static RepeatTests repeatDefault(String server) {
-        return MicroProfileActions.repeat(server, TestMode.FULL,
-                                          MicroProfileActions.MP70_EE10, //Config 3.1
-                                          MicroProfileActions.MP70_EE11, //Config 3.1
-                                          MicroProfileActions.MP60, //Config 3.0
-                                          MicroProfileActions.MP41, //Config 2.0
-                                          MicroProfileActions.MP33); //Config 1.4
+        return MicroProfileActions.repeatIf(server,
+                                            TCKUtilities::areAllFeaturesPresent,
+                                            TestMode.FULL,
+                                            false,
+                                            MicroProfileActions.MP70_EE10, //Config 3.1
+                                            MicroProfileActions.MP70_EE11, //Config 3.1
+                                            MicroProfileActions.MP60, //Config 3.0
+                                            MicroProfileActions.MP41, //Config 2.0
+                                            MicroProfileActions.MP33); //Config 1.4
     }
 
     /**
@@ -62,11 +66,14 @@ public class ConfigRepeatActions {
      * @return the RepeatTests rule
      */
     public static RepeatTests repeatDefault20Up(String server) {
-        return MicroProfileActions.repeat(server, TestMode.FULL,
-                                          MicroProfileActions.MP70_EE10, //Config 3.1
-                                          MicroProfileActions.MP70_EE11, //Config 3.1
-                                          MicroProfileActions.MP60, //Config 3.0
-                                          MicroProfileActions.MP41); //Config 2.0
+        return MicroProfileActions.repeatIf(server,
+                                            TCKUtilities::areAllFeaturesPresent,
+                                            TestMode.FULL,
+                                            false,
+                                            MicroProfileActions.MP70_EE10, //Config 3.1
+                                            MicroProfileActions.MP70_EE11, //Config 3.1
+                                            MicroProfileActions.MP60, //Config 3.0
+                                            MicroProfileActions.MP41); //Config 2.0
     }
 
     /**
@@ -93,10 +100,13 @@ public class ConfigRepeatActions {
      * @return the RepeatTests rule
      */
     public static RepeatTests repeatDefault30Up(String server, boolean skipTransformation) {
-        return MicroProfileActions.repeat(server, TestMode.FULL, skipTransformation,
-                                          MicroProfileActions.MP70_EE10, //Config 3.1
-                                          MicroProfileActions.MP70_EE11, //Config 3.1
-                                          MicroProfileActions.MP60); //Config 3.0
+        return MicroProfileActions.repeatIf(server,
+                                            TCKUtilities::areAllFeaturesPresent,
+                                            TestMode.FULL,
+                                            skipTransformation,
+                                            MicroProfileActions.MP70_EE10, //Config 3.1
+                                            MicroProfileActions.MP70_EE11, //Config 3.1
+                                            MicroProfileActions.MP60); //Config 3.0
     }
 
     /**
@@ -109,10 +119,13 @@ public class ConfigRepeatActions {
      * @return the RepeatTests rule
      */
     public static RepeatTests repeatDefault31(String server) {
-        return MicroProfileActions.repeat(server, TestMode.FULL,
-                                          MicroProfileActions.MP70_EE10, //Config 3.1
-                                          MicroProfileActions.MP70_EE11, //Config 3.1
-                                          MicroProfileActions.MP61); //Config 3.1
+        return MicroProfileActions.repeatIf(server,
+                                            TCKUtilities::areAllFeaturesPresent,
+                                            TestMode.FULL,
+                                            false,
+                                            MicroProfileActions.MP70_EE10, //Config 3.1
+                                            MicroProfileActions.MP70_EE11, //Config 3.1
+                                            MicroProfileActions.MP61); //Config 3.1
     }
 
     /**
@@ -124,20 +137,23 @@ public class ConfigRepeatActions {
      * @return the RepeatTests rule
      */
     public static RepeatTests repeatAll(String server) {
-        return MicroProfileActions.repeat(server, TestMode.FULL,
-                                          MicroProfileActions.MP70_EE10,
-                                          MicroProfileActions.MP70_EE11,
-                                          MicroProfileActions.MP61,
-                                          MicroProfileActions.MP60,
-                                          MicroProfileActions.MP50,
-                                          MicroProfileActions.MP41,
-                                          MicroProfileActions.MP40,
-                                          MicroProfileActions.MP33,
-                                          MicroProfileActions.MP32,
-                                          MicroProfileActions.MP30,
-                                          MicroProfileActions.MP22,
-                                          MicroProfileActions.MP20,
-                                          MicroProfileActions.MP13,
-                                          MicroProfileActions.MP12);
+        return MicroProfileActions.repeatIf(server,
+                                            TCKUtilities::areAllFeaturesPresent,
+                                            TestMode.FULL,
+                                            false,
+                                            MicroProfileActions.MP70_EE10,
+                                            MicroProfileActions.MP70_EE11,
+                                            MicroProfileActions.MP61,
+                                            MicroProfileActions.MP60,
+                                            MicroProfileActions.MP50,
+                                            MicroProfileActions.MP41,
+                                            MicroProfileActions.MP40,
+                                            MicroProfileActions.MP33,
+                                            MicroProfileActions.MP32,
+                                            MicroProfileActions.MP30,
+                                            MicroProfileActions.MP22,
+                                            MicroProfileActions.MP20,
+                                            MicroProfileActions.MP13,
+                                            MicroProfileActions.MP12);
     }
 }

--- a/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance41/tck/FaultToleranceTck41Launcher.java
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance41/tck/FaultToleranceTck41Launcher.java
@@ -50,7 +50,7 @@ public class FaultToleranceTck41Launcher {
     private static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun");
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeatWithPredicate(SERVER_NAME, TCKUtilities::areFeaturesMissing, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
+    public static RepeatTests r = MicroProfileActions.repeatIf(SERVER_NAME, TCKUtilities::areAllFeaturesPresent, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance41/tck/FaultToleranceTck41Launcher.java
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance41/tck/FaultToleranceTck41Launcher.java
@@ -33,6 +33,7 @@ import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
+import componenttest.topology.utils.tck.TCKUtilities;
 
 /**
  * This is a test class that runs the whole Fault Tolerance TCK. The TCK results
@@ -49,7 +50,7 @@ public class FaultToleranceTck41Launcher {
     private static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun");
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
+    public static RepeatTests r = MicroProfileActions.repeatWithPredicate(SERVER_NAME, TCKUtilities::areFeaturesMissing, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/health40/tck/Health40TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/health40/tck/Health40TCKLauncher.java
@@ -40,12 +40,12 @@ public class Health40TCKLauncher {
     private static final String SERVER_NAME = "Health40TCKServer";
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeatWithPredicate(SERVER_NAME,
-                                                             TCKUtilities::areFeaturesMissing,
-                                                             MicroProfileActions.MP70_EE10,
-                                                             MicroProfileActions.MP70_EE11,
-                                                             MicroProfileActions.MP61,
-                                                             MicroProfileActions.MP50);
+    public static RepeatTests r = MicroProfileActions.repeatIf(SERVER_NAME,
+                                                               TCKUtilities::areAllFeaturesPresent,
+                                                               MicroProfileActions.MP70_EE10,
+                                                               MicroProfileActions.MP70_EE11,
+                                                               MicroProfileActions.MP61,
+                                                               MicroProfileActions.MP50);
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/health40/tck/Health40TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/health40/tck/Health40TCKLauncher.java
@@ -28,6 +28,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
+import componenttest.topology.utils.tck.TCKUtilities;
 
 /**
  * This is a test class that runs a whole Maven TCK as one test FAT test.
@@ -39,7 +40,8 @@ public class Health40TCKLauncher {
     private static final String SERVER_NAME = "Health40TCKServer";
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
+    public static RepeatTests r = MicroProfileActions.repeatWithPredicate(SERVER_NAME,
+                                                             TCKUtilities::areFeaturesMissing,
                                                              MicroProfileActions.MP70_EE10,
                                                              MicroProfileActions.MP70_EE11,
                                                              MicroProfileActions.MP61,

--- a/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi40/fat/tck/OpenAPITckTest.java
+++ b/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi40/fat/tck/OpenAPITckTest.java
@@ -43,7 +43,7 @@ public class OpenAPITckTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests repeatTests = MicroProfileActions.repeatWithPredicate(SERVER_NAME, TCKUtilities::areFeaturesMissing, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
+    public static RepeatTests repeatTests = MicroProfileActions.repeatIf(SERVER_NAME, TCKUtilities::areAllFeaturesPresent, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi40/fat/tck/OpenAPITckTest.java
+++ b/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/fat/src/io/openliberty/microprofile/openapi40/fat/tck/OpenAPITckTest.java
@@ -28,6 +28,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
+import componenttest.topology.utils.tck.TCKUtilities;
 
 /**
  * This is a test class that runs a whole Maven TCK as one test FAT test.
@@ -42,7 +43,7 @@ public class OpenAPITckTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests repeatTests = MicroProfileActions.repeat(SERVER_NAME, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
+    public static RepeatTests repeatTests = MicroProfileActions.repeatWithPredicate(SERVER_NAME, TCKUtilities::areFeaturesMissing, MicroProfileActions.MP70_EE10, MicroProfileActions.MP70_EE11);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -44,10 +44,10 @@ public class RestClientTckPackageTest {
     public static final String SERVER_NAME = "FATServer";
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeatWithPredicate(SERVER_NAME,
-                                                             TCKUtilities::areFeaturesMissing,
-                                                             MicroProfileActions.MP70_EE10, // 4.0+EE10
-                                                             MicroProfileActions.MP70_EE11); // 4.0+EE11
+    public static RepeatTests r = MicroProfileActions.repeatIf(SERVER_NAME,
+                                                               TCKUtilities::areAllFeaturesPresent,
+                                                               MicroProfileActions.MP70_EE10, // 4.0+EE10
+                                                               MicroProfileActions.MP70_EE11); // 4.0+EE11
 
     @Server(SERVER_NAME)
     public static LibertyServer server;

--- a/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -30,6 +30,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
+import componenttest.topology.utils.tck.TCKUtilities;
 
 /**
  * This is a test class that runs a whole Maven TCK as one test FAT test.
@@ -43,7 +44,8 @@ public class RestClientTckPackageTest {
     public static final String SERVER_NAME = "FATServer";
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(SERVER_NAME,
+    public static RepeatTests r = MicroProfileActions.repeatWithPredicate(SERVER_NAME,
+                                                             TCKUtilities::areFeaturesMissing,
                                                              MicroProfileActions.MP70_EE10, // 4.0+EE10
                                                              MicroProfileActions.MP70_EE11); // 4.0+EE11
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/telemetry/internal_fat_tck/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/telemetry/internal_fat_tck/FATSuite.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,10 +18,9 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
-import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
-import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryActions;
+import componenttest.topology.utils.tck.TCKUtilities;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -34,7 +33,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
 public class FATSuite {
 
     public static RepeatTests allMPTel20Repeats(String serverName) {
-        return TelemetryActions
-            .repeat(serverName, MicroProfileActions.MP70_EE11, MicroProfileActions.MP70_EE10);
+        return MicroProfileActions
+                        .repeatWithPredicate(serverName, TCKUtilities::areFeaturesMissing, MicroProfileActions.MP70_EE11, MicroProfileActions.MP70_EE10);
     }
 }

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/telemetry/internal_fat_tck/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/telemetry/internal_fat_tck/FATSuite.java
@@ -34,6 +34,6 @@ public class FATSuite {
 
     public static RepeatTests allMPTel20Repeats(String serverName) {
         return MicroProfileActions
-                        .repeatWithPredicate(serverName, TCKUtilities::areFeaturesMissing, MicroProfileActions.MP70_EE11, MicroProfileActions.MP70_EE10);
+                        .repeatIf(serverName, TCKUtilities::areAllFeaturesPresent, MicroProfileActions.MP70_EE11, MicroProfileActions.MP70_EE10);
     }
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This resolves #30391 but may only be part of the resolution to the underlying issue linked to under that defect

This adds to fattest.simplicity a way to say that a FeatureReplacementAction should only run if the .mf files for its features are present. 

The codepath I'm using to activate it is MicroProfileActions static FeatureSets are flagged that they should only run if the features are present. That flag is passed into a FeatureReplacementAction via RepeatSet.forFeatureSet. 