### PR TITLE
recreate: escape characters within a LIKE clause on PostgreSQL

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -169,20 +169,20 @@ public class JakartaDataRecreateServlet extends FATServlet {
 
         assertEquals(character.getHexadecimal(), result);
     }
-    
+
     @Test
     @Ignore("Reference issue:https://github.com/OpenLiberty/open-liberty/issues/29459")
     public void testOLGH29459() throws Exception {
         int x1 = 0, y1 = 0, x2 = 120, y2 = 209;
         Segment segment = Segment.of(x1, y1, x2, y2);
         List<Exception> exceptions = new ArrayList<>();
-        
-        tx.begin();  
 
-        try {           
-            em.persist(segment);            
+        tx.begin();
+
+        try {
+            em.persist(segment);
             tx.commit();
-        } catch (Exception e) {            
+        } catch (Exception e) {
             if (tx.getStatus() == jakarta.transaction.Status.STATUS_ACTIVE) {
                 // Only rollback if it's not a RollbackException
                 if (!(e instanceof jakarta.transaction.RollbackException)) {
@@ -192,18 +192,18 @@ public class JakartaDataRecreateServlet extends FATServlet {
             exceptions.add(e);
         }
 
-        tx.begin();  
+        tx.begin();
 
         try {
             em.createNativeQuery("INSERT INTO Segment (id, pointA_x, pointA_y, pointB_x, pointB_y) VALUES (?, ?, ?, ?, ?)")
-                .setParameter(1, segment.id + 1)      
-                .setParameter(2, segment.pointA.x())  
-                .setParameter(3, segment.pointA.y())  
-                .setParameter(4, segment.pointB.x())  
-                .setParameter(5, segment.pointB.y())  
-                .executeUpdate();
+                            .setParameter(1, segment.id + 1)
+                            .setParameter(2, segment.pointA.x())
+                            .setParameter(3, segment.pointA.y())
+                            .setParameter(4, segment.pointB.x())
+                            .setParameter(5, segment.pointB.y())
+                            .executeUpdate();
             tx.commit();
-        } catch (Exception e) {            
+        } catch (Exception e) {
             if (tx.getStatus() == jakarta.transaction.Status.STATUS_ACTIVE) {
                 // Only rollback if it's not a RollbackException
                 if (!(e instanceof jakarta.transaction.RollbackException)) {
@@ -212,13 +212,13 @@ public class JakartaDataRecreateServlet extends FATServlet {
             }
             exceptions.add(e);
         }
-       
-        if (!exceptions.isEmpty()) {           
+
+        if (!exceptions.isEmpty()) {
             throw exceptions.get(0);
         }
 
         Segment retrievedSegment1 = em.find(Segment.class, segment.id);
-        Segment retrievedSegment2 = em.find(Segment.class, segment.id + 1); 
+        Segment retrievedSegment2 = em.find(Segment.class, segment.id + 1);
 
         // Assertions for the first segment
         assertEquals(segment.id, retrievedSegment1.id);
@@ -234,8 +234,6 @@ public class JakartaDataRecreateServlet extends FATServlet {
         assertEquals(x2, retrievedSegment2.pointB.x());
         assertEquals(y2, retrievedSegment2.pointB.y());
     }
-
-
 
     @Test //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28908
     public void testOLGH28908() throws Exception {
@@ -1421,10 +1419,10 @@ public class JakartaDataRecreateServlet extends FATServlet {
     public void testOLGH29781() throws Exception {
         ZoneId ET = ZoneId.of("America/New_York");
         Instant when = ZonedDateTime.of(2022, 4, 29, 12, 0, 0, 0, ET)
-                .toInstant();
+                        .toInstant();
         Store s1 = Store.of(2022, 4, 29, "Billy", 12L);
         Store s2 = Store.of(2024, 5, 12, "Bobby", 9L);
-        
+
         int count;
 
         tx.begin();
@@ -1435,8 +1433,8 @@ public class JakartaDataRecreateServlet extends FATServlet {
         tx.begin();
         try {
             count = em.createQuery("DELETE FROM Store WHERE this.time>:when")
-                    .setParameter("when", when)
-                    .executeUpdate();
+                            .setParameter("when", when)
+                            .executeUpdate();
             tx.commit();
         } catch (Exception e) {
             tx.rollback();

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -810,6 +810,7 @@ public class DataJPATestServlet extends FATServlet {
 
     /**
      * Verify that escape characters can be used to correctly match results.
+     * TODO PostgreSQL fails due to https://github.com/OpenLiberty/open-liberty/issues/30400
      */
     @Test
     public void testEscapeCharacters() {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
