### PR TITLE
Issue #30399: Fix NoClassDefFoundError for EJB ExceptionUtil

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/WSEJBWrapper.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/WSEJBWrapper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2012 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,6 +15,8 @@ package com.ibm.ejs.container;
 import java.lang.reflect.Method;
 import java.rmi.RemoteException;
 import java.util.Map;
+
+import javax.ejb.EJBException;
 
 import com.ibm.ejs.container.util.ExceptionUtil;
 import com.ibm.websphere.ras.Tr;
@@ -478,4 +480,21 @@ public class WSEJBWrapper extends EJSWrapperBase implements WSEJBEndpointManager
         return hasAroundInvoke;
     }
 
+    /**
+     * Returns an EJBException with the message text "See nested exception"
+     * and the specified cause, or the cause itself, if it is already an
+     * EJBException. <p>
+     *
+     * Included in this IBM API "internal" interface to provide the generated
+     * WSEJBProxy implementations access to EJB container internal code that
+     * provides this exception handling behavior. <p>
+     *
+     * @param cause the cause of the EJBException. If already an EJBException
+     *            it will just be returned; null is permitted.
+     * @returns an EJBException with appropriate nested exception, stack,
+     *          and message text.
+     **/
+    public static EJBException EJBException(Throwable cause) {
+        return ExceptionUtil.EJBException(cause);
+    }
 }

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/jitdeploy/WSEJBProxy.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/jitdeploy/WSEJBProxy.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -33,10 +33,26 @@ import static com.ibm.ws.ejbcontainer.jitdeploy.JITUtils.getTypes;
 import static com.ibm.ws.ejbcontainer.jitdeploy.JITUtils.unbox;
 import static com.ibm.ws.ejbcontainer.jitdeploy.JITUtils.writeToClassFile;
 
-import static org.objectweb.asm.Opcodes.*;
 import static com.ibm.ws.ejbcontainer.jitdeploy.JITUtils.INDENT;
 import static com.ibm.ws.ejbcontainer.jitdeploy.JITUtils.TYPE_Exception;
 import static com.ibm.ws.ejbcontainer.jitdeploy.JITUtils.TYPE_Object_ARRAY;
+
+import static org.objectweb.asm.Opcodes.AASTORE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ACONST_NULL;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ANEWARRAY;
+import static org.objectweb.asm.Opcodes.ATHROW;
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.GETFIELD;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.NEW;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_2;
 
 /**
  * Provides Just In Time runtime deployment of WebService Endpoint EJB Proxys. <p>
@@ -535,19 +551,19 @@ public final class WSEJBProxy
         // -----------------------------------------------------------------------
         // Bean instance could not possibly have thrown this (unless Throwable
         // itself), so this must be coming from a poorly behaving interceptor.
-        // This is a spec violation and cannot be reported dirctly.  Do the best
+        // This is a spec violation and cannot be reported directly.  Do the best
         // we can, and wrap it in an EJBException (i.e. RuntimeException).
         //
         // catch (Throwable <ex>)
         // {
-        //   throw ExceptionUtil.EJBException( <ex> );
+        //   throw WSEJBWrapper.EJBException( <ex> );
         // }
         // -----------------------------------------------------------------------
         Label main_catch_throwable = new Label();
         mg.visitLabel(main_catch_throwable);
         mg.storeLocal(caught_ex);
         mg.loadLocal(caught_ex);
-        mg.visitMethodInsn(INVOKESTATIC, "com/ibm/ejs/container/util/ExceptionUtil",
+        mg.visitMethodInsn(INVOKESTATIC, "com/ibm/ejs/container/WSEJBWrapper",
                            "EJBException", "(Ljava/lang/Throwable;)Ljavax/ejb/EJBException;");
         mg.visitInsn(ATHROW);
 


### PR DESCRIPTION
ExceptionUtil is an internal class not available to applications, so change the generated WSEJBProxy code to instead access a new method on WSEJBWrapper that is an IBM API "internal" interface

fixes #30399 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".