### PR TITLE
Return type checking for exists methods and Limit/PageRequest and First conflict detection

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -985,7 +985,7 @@ CWWKD1098.spec.param.position.err.useraction=Move the special Jakarta Data defin
 CWWKD1099.first.keyword.incompat=CWWKD1099E: The {0} method of the {1} repository \
  has a name that includes the First keyword, which is incompatible with the \
  {2} parameter of the method.
-CWWKD1099.first.keyword.incompat.explanation=The First keyword cannot be used \
- in a Query by Method Name method that also has a Limit or PageRequest parameter.
+CWWKD1099.first.keyword.incompat.explanation=A Query by Method Name method \
+ that includes a Limit or PageRequest parameter cannot use the First keyword.
 CWWKD1099.first.keyword.incompat.useraction=Remove the First keyword from the \
  method name.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -980,3 +980,11 @@ CWWKD1098.spec.param.position.err.explanation=When special Jakarta Data defined 
  positioned after all the query parameters.
 CWWKD1098.spec.param.position.err.useraction=Move the special Jakarta Data defined \
  parameter types to positions at the end of the repository method signature.
+
+CWWKD1099.first.keyword.incompat=CWWKD1099E: The {0} method of the {1} repository \
+ has a name that includes the First keyword, which is incompatible with the \
+ {2} parameter of the method.
+CWWKD1099.first.keyword.incompat.explanation=The First keyword cannot be used \
+ in a Query by Method Name method that also has a Limit or PageRequest parameter.
+CWWKD1099.first.keyword.incompat.useraction=Remove the First keyword from the \
+ method name.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -51,13 +51,14 @@ CWWKD1002.method.annos.err.explanation=This combination of annotations is not \
 CWWKD1002.method.annos.err.useraction=Locate the repository interface and method \
  and determine the correct combination of method annotations.
 
-CWWKD1003.lifecycle.rtrn.err=CWWKD1003E: The {0} return type of the {1} method \
+CWWKD1003.rtrn.err=CWWKD1003E: The {0} return type of the {1} method \
  of the {2} repository interface is not a valid return type for a repository \
  {3} method. Valid return types include: {4}.
-CWWKD1003.lifecycle.rtrn.err.explanation=The return type of the method is not \
- one of the supported return types for Insert, Update, and Save methods.
-CWWKD1003.lifecycle.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
- information for the Insert, Update, and Save annotations for valid return types.
+CWWKD1003.rtrn.err.explanation=The return type of the method is not \
+ one of the supported return types for the stated type of repository method.
+CWWKD1003.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
+ information for the Insert, Update, and Save annotations and the \
+ Query by Method name documentation for valid return types.
 
 CWWKD1004.general.rtrn.err=CWWKD1004E: The {0} return type of the {1} method \
  of the {2} repository interface is not a valid return type for a repository \

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -290,6 +289,47 @@ public class RepositoryImpl<R> implements InvocationHandler {
                            Page.class.getSimpleName(),
                            CursoredPage.class.getSimpleName(),
                            Stream.class.getSimpleName()));
+    }
+
+    /**
+     * Create a new UnsupportedOperationException for a conflicting Limit or
+     * PageRequest parameter.
+     *
+     * @param param   method parameter that is an instance of Limit or PageRequest.
+     * @param limit   other Limit parameter value. Otherwise null.
+     * @param pageReq other PageRequest parameter value. Otherwise null.
+     * @param method  repository method
+     * @return UnsupportedOperationException
+     */
+    @Trivial
+    private UnsupportedOperationException excIncompatible(Object param,
+                                                          Limit limit,
+                                                          PageRequest pageReq,
+                                                          Method method) {
+        Class<?> type = param instanceof Limit ? Limit.class : PageRequest.class;
+
+        if (limit == null && pageReq == null)
+            // conflicts with First keyword
+            return exc(UnsupportedOperationException.class,
+                       "CWWKD1099.first.keyword.incompat",
+                       method.getName(),
+                       repositoryInterface.getName(),
+                       type.getSimpleName());
+        else if (param instanceof Limit ? limit != null : pageReq != null)
+            // conflicts with another parameter of the same time
+            return exc(UnsupportedOperationException.class,
+                       "CWWKD1017.dup.special.param",
+                       method.getName(),
+                       repositoryInterface.getName(),
+                       type.getSimpleName());
+        else
+            // conflict between Limit and PageRequest parameters
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1018.confl.special.param",
+                      method.getName(),
+                      repositoryInterface.getName(),
+                      Limit.class.getSimpleName(),
+                      PageRequest.class.getSimpleName());
     }
 
     /**
@@ -582,8 +622,9 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     case FIND:
                     case FIND_AND_DELETE: {
                         Limit limit = null;
-                        PageRequest pagination = null;
+                        PageRequest pageReq = null;
                         List<Sort<Object>> sortList = null;
+                        int maxResults = queryInfo.maxResults;
 
                         // The first method parameters are used as query parameters.
                         // Beyond that, they can have other purposes such as
@@ -593,27 +634,19 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                         i++) {
                             Object param = args[i];
                             if (param instanceof Limit) {
-                                if (limit == null)
-                                    limit = (Limit) param;
+                                if (maxResults == 0 && limit == null && pageReq == null)
+                                    maxResults = (limit = (Limit) param).maxResults();
                                 else
-                                    throw exc(UnsupportedOperationException.class,
-                                              "CWWKD1017.dup.special.param",
-                                              method.getName(),
-                                              repositoryInterface.getName(),
-                                              "Limit");
+                                    throw excIncompatible(param, limit, pageReq, method);
                             } else if (param instanceof Order) {
                                 @SuppressWarnings("unchecked")
                                 Iterable<Sort<Object>> order = (Iterable<Sort<Object>>) param;
                                 sortList = queryInfo.supplySorts(sortList, order);
                             } else if (param instanceof PageRequest) {
-                                if (pagination == null)
-                                    pagination = (PageRequest) param;
+                                if (maxResults == 0 && pageReq == null && limit == null)
+                                    maxResults = (pageReq = (PageRequest) param).size();
                                 else
-                                    throw exc(UnsupportedOperationException.class,
-                                              "CWWKD1017.dup.special.param",
-                                              method.getName(),
-                                              repositoryInterface.getName(),
-                                              "PageRequest");
+                                    throw excIncompatible(param, limit, pageReq, method);
                             } else if (param instanceof Sort) {
                                 @SuppressWarnings("unchecked")
                                 List<Sort<Object>> newList = queryInfo.supplySorts(sortList, (Sort<Object>) param);
@@ -635,18 +668,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                               method.getName(),
                                               repositoryInterface.getName());
                             } else {
-                                // look for mispositioned special parameter
-                                Set<Class<?>> specParamTypes = //
-                                                provider.compat.specialParamTypes();
-                                Class<?>[] paramTypes = method.getParameterTypes();
-                                for (int j = 0; j < queryInfo.jpqlParamCount; j++)
-                                    if (specParamTypes.contains(paramTypes[j]))
-                                        throw exc(UnsupportedOperationException.class,
-                                                  "CWWKD1098.spec.param.position.err",
-                                                  method.getName(),
-                                                  repositoryInterface.getName(),
-                                                  paramTypes[j].getName(),
-                                                  provider.compat.specialParamsForFind());
+                                queryInfo.validateParameterPositions();
 
                                 throw exc(DataException.class,
                                           "CWWKD1023.extra.param",
@@ -658,22 +680,15 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             }
                         }
 
-                        if (pagination != null && limit != null)
-                            throw exc(UnsupportedOperationException.class,
-                                      "CWWKD1018.confl.special.param",
-                                      method.getName(),
-                                      repositoryInterface.getName(),
-                                      "Limit",
-                                      "PageRequest");
-
                         if (sortList == null && queryInfo.sortPositions.length > 0)
                             sortList = queryInfo.sorts;
 
                         if (sortList == null || sortList.isEmpty()) {
-                            if (pagination != null)
+                            if (pageReq != null)
                                 queryInfo.requireOrderedPagination(args);
                         } else {
-                            boolean forward = pagination == null || pagination.mode() != PageRequest.Mode.CURSOR_PREVIOUS;
+                            boolean forward = pageReq == null ||
+                                              pageReq.mode() != PageRequest.Mode.CURSOR_PREVIOUS;
                             StringBuilder q = new StringBuilder(queryInfo.jpql);
                             StringBuilder order = null; // ORDER BY clause based on Sorts
                             for (Sort<?> sort : sortList) {
@@ -682,7 +697,8 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 queryInfo.generateSort(order, sort, forward);
                             }
 
-                            if (pagination == null || pagination.mode() == PageRequest.Mode.OFFSET) {
+                            if (pageReq == null ||
+                                pageReq.mode() == PageRequest.Mode.OFFSET) {
                                 // offset pagination can be a starting point for cursor pagination
                                 queryInfo = queryInfo.withJPQL(q.append(order).toString(), sortList);
                             } else { // CURSOR_NEXT or CURSOR_PREVIOUS
@@ -694,16 +710,17 @@ public class RepositoryImpl<R> implements InvocationHandler {
                         Class<?> multiType = queryInfo.multiType;
 
                         if (CursoredPage.class.equals(multiType)) {
-                            returnValue = new CursoredPageImpl<>(queryInfo, pagination, args);
+                            returnValue = new CursoredPageImpl<>(queryInfo, pageReq, args);
                         } else if (Page.class.equals(multiType)) {
                             PageRequest req = limit == null //
-                                            ? pagination //
+                                            ? pageReq //
                                             : queryInfo.toPageRequest(limit);
                             returnValue = new PageImpl<>(queryInfo, req, args);
-                        } else if (pagination != null && !PageRequest.Mode.OFFSET.equals(pagination.mode())) {
+                        } else if (pageReq != null &&
+                                   !PageRequest.Mode.OFFSET.equals(pageReq.mode())) {
                             throw exc(IllegalArgumentException.class,
                                       "CWWKD1035.incompat.page.mode",
-                                      pagination.mode(),
+                                      pageReq.mode(),
                                       method.getName(),
                                       repositoryInterface.getName(),
                                       method.getGenericReturnType().getTypeName(),
@@ -720,12 +737,10 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             if (queryInfo.type == QueryInfo.Type.FIND_AND_DELETE)
                                 query.setLockMode(LockModeType.PESSIMISTIC_WRITE);
 
-                            int maxResults = limit != null ? limit.maxResults() //
-                                            : pagination != null ? pagination.size() //
-                                                            : queryInfo.maxResults;
-
-                            int startAt = limit != null ? queryInfo.computeOffset(limit) //
-                                            : pagination != null ? queryInfo.computeOffset(pagination) //
+                            int startAt = limit != null //
+                                            ? queryInfo.computeOffset(limit) //
+                                            : pageReq != null //
+                                                            ? queryInfo.computeOffset(pageReq) //
                                                             : 0;
 
                             if (maxResults > 0) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1085,18 +1085,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     }
                     case EXISTS: {
                         em = entityInfo.builder.createEntityManager();
-
-                        jakarta.persistence.Query query = em.createQuery(queryInfo.jpql);
-                        query.setMaxResults(1);
-                        queryInfo.setParameters(query, args);
-
-                        returnValue = !query.getResultList().isEmpty();
-
-                        if (Optional.class.equals(returnType)) {
-                            returnValue = Optional.of(returnValue);
-                        } else if (CompletableFuture.class.equals(returnType) || CompletionStage.class.equals(returnType)) {
-                            returnValue = CompletableFuture.completedFuture(returnValue);
-                        }
+                        returnValue = queryInfo.exists(em, args);
                         break;
                     }
                     case RESOURCE_ACCESS: {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1570,6 +1570,35 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Use exists methods in the Query by Method Name pattern where the return type
+     * is a CompletionStage or CompletableFuture and the repository method is
+     * annotated to run Asynchronous.
+     */
+    @Test
+    public void testExistsAsync() throws ExecutionException, //
+                    InterruptedException, TimeoutException {
+        CompletionStage<Boolean> stage1 = primes.existsByNameIgnoreCase("thirty-one");
+        CompletionStage<Boolean> stage2 = primes.existsByNameIgnoreCase("thirty-two");
+
+        assertEquals(Boolean.TRUE,
+                     stage1.toCompletableFuture()
+                                     .get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
+
+        assertEquals(Boolean.FALSE,
+                     stage2.toCompletableFuture()
+                                     .get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
+
+        CompletableFuture<Boolean> cf1 = primes.existsByRomanNumeralIgnoreCase("XLI");
+        CompletableFuture<Boolean> cf2 = primes.existsByRomanNumeralIgnoreCase("XLII");
+
+        assertEquals(Boolean.TRUE,
+                     cf1.get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
+
+        assertEquals(Boolean.FALSE,
+                     cf2.get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
+    }
+
+    /**
      * Query-by-method name repository operation to remove and return one or more entities.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -110,6 +110,16 @@ public interface Primes {
                                                  PageRequest req,
                                                  Order<Prime> order);
 
+    @Asynchronous
+    CompletionStage<Boolean> existsByNameIgnoreCase(String name);
+
+    boolean existsByNumberId(long number);
+
+    Boolean existsByNumberIdBetween(Long first, Long last);
+
+    @Asynchronous
+    CompletableFuture<Boolean> existsByRomanNumeralIgnoreCase(String romanNumeral);
+
     @Find
     Stream<Prime> find(boolean even, int sumOfBits, Limit limit, Sort<?>... sorts);
 
@@ -256,10 +266,6 @@ public interface Primes {
 
     @OrderBy(value = ID, descending = true)
     IntStream findSumOfBitsByNumberIdBetween(long min, long max);
-
-    boolean existsByNumberId(long number);
-
-    Boolean existsByNumberIdBetween(Long first, Long last);
 
     @Query(value = "Select name" +
                    " Where numberId < 50 and" +

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -40,6 +40,8 @@ public class DataErrPathsTest extends FATServletClient {
     private static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
                                    "CWWJP9991W.*4002", // 2 persistence units attempt to autocreate same table
+                                   "CWWKD1003E.*existsByAddress", // exists method returning int
+                                   "CWWKD1003E.*existsByName", // exists method returning CompletableFuture<Long>
                                    "CWWKD1006E.*removeBySSN", // delete method attempts to return record
                                    "CWWKD1009E.*addNothing", // Insert method without parameters
                                    "CWWKD1009E.*addSome", // Insert method with multiple parameters

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -72,8 +72,12 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1097E.*discardLimited", // Limit parameter on Delete method
                                    "CWWKD1097E.*discardOrdered", // Order parameter on Delete method
                                    "CWWKD1097E.*discardSorted", // Sort parameter on Delete method
-                                   "CWWKD1098E.*findFirst5ByAddress", // Order after query params
-                                   "CWWKD1098E.*occupantsOf" // PageRequest/Order after query params
+                                   "CWWKD1098E.*findFirst5ByAddress", // Order ahead of query params
+                                   "CWWKD1098E.*occupantsOf", // PageRequest/Order ahead of query params
+                                   "CWWKD1098E.*withNameLongerThan", // Limit ahead of query params
+                                   "CWWKD1098E.*withNameShorterThan", // Sort ahead of query params
+                                   "CWWKD1099E.*findFirst2", // Limit incompatible with First
+                                   "CWWKD1099E.*findFirst3" // PageRequest incompatible with First
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -440,6 +440,44 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * A repository method with the First keyword and a Limit parameter
+     * must raise an error.
+     */
+    @Test
+    public void testIntermixFirstAndLimit() {
+        try {
+            Voter[] found = voters.findFirst2(Limit.of(3));
+
+            fail("Did not reject repository method that has both a First keyword" +
+                 " and a Limit parameter. Instead found: " + Arrays.toString(found));
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1099E") ||
+                !x.getMessage().contains("Limit"))
+                throw x;
+        }
+    }
+
+    /**
+     * A repository method with the First keyword and a PageRequest parameter
+     * must raise an error.
+     */
+    @Test
+    public void testIntermixFirstAndPageRequest() {
+        try {
+            Page<Voter> page = voters.findFirst3(PageRequest.ofSize(2));
+
+            fail("Did not reject repository method that has both a First keyword" +
+                 " and a PageRequest parameter. Instead found: " + page);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1099E") ||
+                !x.getMessage().contains("PageRequest"))
+                throw x;
+        }
+    }
+
+    /**
      * A repository method with both Limit and PageRequest parameters
      * must raise an error.
      */
@@ -859,6 +897,44 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1086E:") ||
                 !x.getMessage().contains("(maxLength)"))
+                throw x;
+        }
+    }
+
+    /**
+     * Tests an error path where a Query by Method Name repository method
+     * attempts to place the special parameters ahead of the query parameters.
+     */
+    @Test
+    public void testQueryWithSpecialParameterAheadOfQueryNamedParameter() {
+        try {
+            List<Voter> found = voters.withNameLongerThan(Limit.of(16),
+                                                          5);
+            fail("Should fail when special parameters are positioned elsewhere" +
+                 " than at the end. Instead: " + found);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1098E:") ||
+                !x.getMessage().contains("withNameLongerThan"))
+                throw x;
+        }
+    }
+
+    /**
+     * Tests an error path where a Query by Method Name repository method
+     * attempts to place the special parameters ahead of the query parameters.
+     */
+    @Test
+    public void testQueryWithSpecialParameterAheadOfQueryPositionalParameter() {
+        try {
+            List<Voter> found = voters.withNameShorterThan(Sort.asc(ID),
+                                                           17);
+            fail("Should fail when special parameters are positioned elsewhere" +
+                 " than at the end. Instead: " + found);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1098E:") ||
+                !x.getMessage().contains("withNameShorterThan"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -20,6 +20,7 @@ import java.time.Month;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Stream;
 
@@ -352,6 +353,43 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1092E:") ||
                 !x.getMessage().contains("changeAll"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised when an exists Query by Method Name method
+     * tries to return a true/false value as int.
+     */
+    @Test
+    public void testExistsAsInt() {
+        try {
+            int found = voters.existsByAddress("4051 E River Rd NE, Rochester, MN 55906");
+            fail("Should not be able to use an exists query that returns a" +
+                 " numeric value rather than boolean. Result: " + found);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1003E:") ||
+                !x.getMessage().contains("boolean")) // recommended type
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised when an exists Query by Method Name method
+     * tries to return a true/false value as a Long value that is wrapped in
+     * a CompletableFuture.
+     */
+    @Test
+    public void testExistsAsLong() {
+        try {
+            CompletableFuture<Long> cf = voters.existsByName("Vincent");
+            fail("Should not be able to use an exists query that returns a" +
+                 " numeric value rather than boolean. Future: " + cf);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1003E:") ||
+                !x.getMessage().contains("CompletableFuture<java.lang.Long>"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -15,6 +15,7 @@ package test.jakarta.data.errpaths.web;
 import java.time.Month;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import jakarta.data.Limit;
@@ -135,6 +136,18 @@ public interface Voters extends BasicRepository<Voter, Integer> {
      */
     @Delete
     int discardSorted(@By("address") String mailingAddress, Sort<Voter> sort);
+
+    /**
+     * This invalid method attempts to return a true/false exists results as int.
+     */
+    int existsByAddress(String homeAddress);
+
+    /**
+     * This invalid method attempts to return a true/false exists results as a
+     * Long value within a CompletableFuture. The CompletableFuture is fine, but
+     * Long does not match the true/false result type.
+     */
+    CompletableFuture<Long> existsByName(String name);
 
     /**
      * This invalid method has a conflict between its OrderBy annotation and

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -151,6 +151,18 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     List<Voter> findByAddressOrderBySSN(int ssn, Sort<Voter> sort);
 
     /**
+     * This invalid method has both a First keyword and a Limit parameter.
+     */
+    @OrderBy("ssn")
+    Voter[] findFirst2(Limit limit);
+
+    /**
+     * This invalid method has both a First keyword and a PageRequest parameter.
+     */
+    @OrderBy("ssn")
+    Page<Voter> findFirst3(PageRequest pageRequest);
+
+    /**
      * This invalid method places the Order special parameter ahead of
      * the query parameter.
      */
@@ -320,4 +332,18 @@ public interface Voters extends BasicRepository<Voter, Integer> {
      */
     @Query("WHERE LENGTH(address) < ?1 ORDER BY ssn ASC")
     List<Voter> withAddressShorterThan(@Param("maxLength") int maxAddressLength);
+
+    /**
+     * This invalid method places the Limit special parameter ahead of
+     * the query parameter.
+     */
+    @Query("WHERE LENGTH(name) > :min ORDER BY ssn ASC")
+    List<Voter> withNameLongerThan(Limit limit, @Param("min") int minLength);
+
+    /**
+     * This invalid method places the Sort special parameter ahead of
+     * the query parameter.
+     */
+    @Query("WHERE LENGTH(name) < ?1")
+    List<Voter> withNameShorterThan(Sort<Voter> sort, int maxLength);
 }


### PR DESCRIPTION
* Validate return types for exists methods, and add tests
* Reject findFirst methods that have a Limit or PageRequest parameter, and add tests
* Detect misordered special parameters on Query methods, and add tests

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
