### PR TITLE
query language returning boolean and untested partial queries

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -740,6 +740,18 @@ public class QueryInfo {
                 else if (chars.isEmpty() && Character.class.equals(toType))
                     return null;
             }
+        } else if (boolean.class.equals(toType) ||
+                   Boolean.class.equals(toType)) {
+            if (value instanceof Boolean)
+                return value;
+            else if (value instanceof CharSequence) {
+                // conversion from true/false text to boolean
+                String str = ((CharSequence) value).toString();
+                if ("true".equalsIgnoreCase(str))
+                    return true;
+                else if ("false".equalsIgnoreCase(str))
+                    return false;
+            }
         }
 
         if (failIfNotConverted) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -923,12 +923,12 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                         }
                                     } else {
                                         throw exc(MappingException.class,
-                                                  "CWWKD1055.incompat.result",
+                                                  "CWWKD1046.result.convert.err",
                                                   queryInfo.loggableAppend(firstNonNullResult.getClass().getName(),
                                                                            " (", firstNonNullResult, ")"),
-                                                  method.getGenericReturnType().getTypeName(),
                                                   method.getName(),
-                                                  repositoryInterface.getName());
+                                                  repositoryInterface.getName(),
+                                                  method.getGenericReturnType().getTypeName());
                                     }
                                 } else if (results.isEmpty()) {
                                     throw excEmptyResult(method);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Business.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Business.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 
 /**
- *
+ * This entity has multiple levels of embeddables.
  */
 @Entity
 public class Business {

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
@@ -12,7 +12,11 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import jakarta.data.page.CursoredPage;
@@ -28,10 +32,38 @@ import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 
 /**
- *
+ * Repository for an entity with multiple levels of embeddables.
  */
 @Repository
 public interface Businesses extends BasicRepository<Business, Integer> {
+
+    @Query("WHERE name >= :beginAtName AND name <= :endAtName")
+    @OrderBy("name")
+    @OrderBy(ID)
+    CursoredPage<?> findAsCursoredPage(String beginAtName,
+                                       String endAtName,
+                                       PageRequest pageReq);
+
+    @OrderBy("name")
+    List<?> findAsListByNameBetween(String beginAtName, String endAtName);
+
+    @OrderBy("location.address.houseNum")
+    Object[] findAsObjectArrayByNameBetween(String beginAtName, String endAtName);
+
+    @Find
+    Optional<?> findAsOptional(String name);
+
+    @OrderBy(value = "location.address.houseNum", descending = true)
+    @OrderBy(value = ID)
+    Page<Object> findAsPageByNameBetween(String beginAtName,
+                                         String endAtName,
+                                         PageRequest pageReq);
+
+    @Find
+    @OrderBy("name")
+    @OrderBy(ID)
+    CompletableFuture<Stream<?>> findAsStreamByCity(String locationAddressCity,
+                                                    String locationAddressState);
 
     // embeddable 1 level deep
     List<Business> findByLocationLatitudeBetweenOrderByLocationLongitudeDesc(float min, float max);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -3188,6 +3188,51 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Use a repository method with Page<Object> return type.
+     * The primary entity type of the repository should be used.
+     */
+    @Test
+    public void testPageOfObjectReturnType() {
+        Page<Object> page1 = businesses
+                        .findAsPageByNameBetween("Crenlo",
+                                                 "RAC",
+                                                 PageRequest.ofSize(4));
+
+        assertEquals(List.of("Metafile", // 3428
+                             "RAC", // 3100
+                             "IBM", // 2800
+                             "Custom Alarm"), // 1661
+                     page1.stream()
+                                     .map(b -> ((Business) b).name)
+                                     .collect(Collectors.toList()));
+
+        Page<Object> page2 = businesses
+                        .findAsPageByNameBetween("Crenlo",
+                                                 "RAC",
+                                                 page1.nextPageRequest());
+
+        assertEquals(List.of("Crenlo", // 1600
+                             "Geotek", // 1421
+                             "Home Federal Savings Bank", // 1016
+                             "HALCON"), // 345
+                     page2.stream()
+                                     .map(b -> ((Business) b).name)
+                                     .collect(Collectors.toList()));
+
+        Page<Object> page3 = businesses
+                        .findAsPageByNameBetween("Crenlo",
+                                                 "RAC",
+                                                 page2.nextPageRequest());
+
+        assertEquals(List.of("Olmsted Medical", // 210
+                             "Mayo Clinic"), // 200
+                     page3.stream()
+                                     .map(b -> ((Business) b).name)
+                                     .collect(Collectors.toList()));
+
+    }
+
+    /**
      * Tests entity attribute names from embeddables and MappedSuperclass that
      * can have delimiters. Includes tests for name collisions with attributes from an
      * embeddable or superinteface.
@@ -4808,5 +4853,90 @@ public class DataJPATestServlet extends FATServlet {
         } catch (OptimisticLockingFailureException x) {
             // pass
         }
+    }
+
+    /**
+     * Use a repository method with CursoredPage<?> return type.
+     * The primary entity type of the repository should be used.
+     */
+    @Test
+    public void testWildcardCursoredPageReturnType() {
+        CursoredPage<?> page1 = businesses.findAsCursoredPage("Crenlo",
+                                                              "RAC",
+                                                              PageRequest.ofSize(4));
+
+        assertEquals(List.of("Crenlo",
+                             "Custom Alarm",
+                             "Geotek",
+                             "HALCON"),
+                     page1.stream()
+                                     .map(b -> ((Business) b).name)
+                                     .collect(Collectors.toList()));
+
+        CursoredPage<?> page2 = businesses.findAsCursoredPage(
+                                                              "Crenlo",
+                                                              "RAC",
+                                                              page1.nextPageRequest());
+
+        assertEquals(List.of("Home Federal Savings Bank",
+                             "IBM",
+                             "Mayo Clinic",
+                             "Metafile"),
+                     page2.stream()
+                                     .map(b -> ((Business) b).name)
+                                     .collect(Collectors.toList()));
+
+        CursoredPage<?> page3 = businesses.findAsCursoredPage("Crenlo",
+                                                              "RAC",
+                                                              page2.nextPageRequest());
+
+        assertEquals(List.of("Olmsted Medical",
+                             "RAC"),
+                     page3.stream()
+                                     .map(b -> ((Business) b).name)
+                                     .collect(Collectors.toList()));
+
+    }
+
+    /**
+     * Use a repository method with List<?> return type.
+     * The primary entity type of the repository should be used.
+     */
+    @Test
+    public void testWildcardListReturnType() {
+        assertEquals(List.of("IBM",
+                             "Mayo Clinic",
+                             "Metafile",
+                             "Olmsted Medical",
+                             "RAC"),
+                     businesses.findAsListByNameBetween("IBM", "RAC")
+                                     .stream()
+                                     .map(b -> ((Business) b).name)
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
+     * Use a repository method with Optional<?> return type.
+     * The primary entity type of the repository should be used.
+     */
+    @Test
+    public void testWildcardOptionalReturnType() {
+        Business found = (Business) businesses.findAsOptional("IBM")
+                        .orElseThrow();
+        assertEquals("IBM", found.name);
+    }
+
+    /**
+     * Use a repository method with CompletableFuture<Stream<?>> return type.
+     * The primary entity type of the repository should be used.
+     */
+    @Test
+    public void testWildcardStreamReturnType() {
+        assertEquals(List.of("Geotek",
+                             "HALCON"),
+                     businesses.findAsStreamByCity("Stewartville", "MN")
+                                     .join()
+                                     .map(b -> ((Business) b).name)
+                                     .collect(Collectors.toList()));
     }
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1760,6 +1760,16 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Use a repository method that uses query language to perform an exists query
+     * that returns a boolean true/false value.
+     */
+    @Test
+    public void testExistsViaQueryLanguage() {
+        assertEquals(true, businesses.isLocatedAt(2800, "37th St", "NW", "IBM"));
+        assertEquals(false, businesses.isLocatedAt(200, "1st St", "SW", "IBM"));
+    }
+
+    /**
      * Verify WithYear, WithQuarter, WithMonth, and WithDay Functions to compare different parts of a date.
      */
     @Test
@@ -1942,6 +1952,89 @@ public class DataJPATestServlet extends FATServlet {
                      list.stream()
                                      .map(c -> c.name + ":" + c.stateName)
                                      .collect(Collectors.toList()));
+    }
+
+    /**
+     * Use a repository method with query language that includes only the
+     * FROM and ORDER BY clauses and returns a Page. Verify the page count
+     * and the total count of matching entities.
+     */
+    @Test
+    public void testFromAndOrderByClausesOnlyWithPageCount() {
+
+        Page<Business> page1 = businesses.sorted(PageRequest.ofSize(5));
+
+        assertEquals(3l, page1.totalPages());
+        assertEquals(15l, page1.totalElements());
+
+        assertEquals(List.of("RAC",
+                             "IBM",
+                             "Crenlo",
+                             "Home Federal Savings Bank",
+                             "Benike Construction"),
+                     page1.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        Page<Business> page2 = businesses.sorted(page1.nextPageRequest());
+
+        assertEquals(List.of("Metafile",
+                             "Think Bank",
+                             "Reichel Foods",
+                             "Custom Alarm",
+                             "Olmsted Medical"),
+                     page2.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        Page<Business> page3 = businesses.sorted(page2.nextPageRequest());
+
+        assertEquals(List.of("Mayo Clinic",
+                             "Silver Lake Foods",
+                             "Cardinal",
+                             "Geotek",
+                             "HALCON"),
+                     page3.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(false, page3.hasNext());
+    }
+
+    /**
+     * Use a repository method with query language that includes only the
+     * FROM and WHERE and ORDER BY clauses and returns a Page. Verify the
+     * page count and the total count of matching entities.
+     */
+    @Test
+    public void testFromAndWhereAndOrderByClausesOnly() {
+
+        Page<Business> page1 = businesses
+                        .withStreetDirection("NW", PageRequest.ofSize(4));
+
+        assertEquals(8l, page1.totalElements());
+        assertEquals(2l, page1.totalPages());
+
+        assertEquals(List.of("Think Bank",
+                             "Metafile",
+                             "RAC",
+                             "IBM"),
+                     page1.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        Page<Business> page2 = businesses
+                        .withStreetDirection("NW", page1.nextPageRequest());
+
+        assertEquals(List.of("Crenlo",
+                             "Geotek",
+                             "Home Federal Savings Bank",
+                             "HALCON"),
+                     page2.stream()
+                                     .map(b -> b.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(false, page2.hasNext());
     }
 
     /**


### PR DESCRIPTION
Add coverage for
* Query method that returns boolean
* Query method with only FROM/WHERE/ORDER clauses, and test page count
* Query method with only FROM/ORDER clauses, and test page count
* Find method returning various types with wildcard type parameter
* Find method returning type with Object type parameter

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

