### PR TITLE
Set JAVA_HOME correctly

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -400,6 +400,7 @@ serverEnvDefaults()
     unset PID_FILE
   fi
 
+   # Determine location of java command.
   if [ -z "${JAVA_HOME}" ]
   then
     if [ -z "${JRE_HOME}" ]
@@ -547,31 +548,35 @@ serverEnvAndJVMOptions()
     mergeJVMOptions "${WLP_INSTALL_DIR}/etc/jvm.options"
   fi
 
-  # Determine location of Java Platform Module System (JPMS) modules directory
-  # Set JAVA_HOME if it is not already set.
+  # Try to find and set JAVA_HOME without invoking java, which is expensive.
+  # If all else fails, invoke java as a last resort.
   if [ -z "${JAVA_HOME}" ]; then
 
     # JAVA_HOME not set.  Locate java using the PATH.
     JAVA_PATH=$(command -v java)
     if [ -n "${JAVA_PATH}" ] ; then
-
+      
+      # Resolve symlinks.  JAVA_HOME is parent of parent of 'java'
       REAL_JAVA_PATH=$(findRealPath "${JAVA_PATH}")
-      JAVA_HOME=$(dirname "${REAL_JAVA_PATH}")/..
-      # The "exit" will cause JAVA_HOME to be unset in the unlikely case that JAVA_HOME is not a directory
-      JAVA_HOME="$(unset CDPATH; cd "${JAVA_HOME}" || exit; pwd)"
-      export JAVA_HOME
+      JAVA_HOME=$(dirname "$(dirname "${REAL_JAVA_PATH}")")
 
-      if [ -n "${REAL_JAVA_PATH}" ]; then
-         JPMS_MODULE_FILE_LOCATION=$(dirname "$(dirname "${REAL_JAVA_PATH}")")/lib/modules
-      fi
-    fi
-  else
-    JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
+     # If this is NOT a true java home, determined by no 'lib' or no 'include',
+     # then, as a last resort, invoke java to extract java.home value    
+     if ! [ -d "$JAVA_HOME/lib" ] && ! [ -d "$JAVA_HOME/jre/lib" ] || ! [ -d "$JAVA_HOME/include" ]; then      
+      JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 | awk -F'=' '/java\.home/ {gsub(/^ +| +$/, "", $2); print $2}')
+     fi
+
+     export JAVA_HOME
+    fi  # if JAVA_HOME is not set and java is not in the PATH, then we cannot find Java.
   fi
 
-  # If we are running on Java 9 and up, apply Liberty's built-in java 9 options  
-  if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
-    mergeJVMOptions "${WLP_INSTALL_DIR}/lib/platform/java/java9.options"
+  if [ -n "${JAVA_HOME}" ]; then
+    JPMS_MODULE_FILE_LOCATION=${JAVA_HOME}/lib/modules
+
+    # If we are running on Java 9 and up, apply Liberty's built-in java 9 options  
+    if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
+       mergeJVMOptions "${WLP_INSTALL_DIR}/lib/platform/java/java9.options"
+    fi
   fi
 
   return $rc

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -2,7 +2,7 @@
 ###############################################################################
 # WebSphere Application Server liberty launch script
 #
-# Copyright (c) 2011, 2023 IBM Corporation and others.
+# Copyright (c) 2011, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -511,7 +511,6 @@ serverEnvAndJVMOptions()
 
   rc=0
 
-
   # The order of merging the jvm.option files sets the precedence.
   # Once a given jvm option is set, it will be overridden if a duplicate
   # is seen later. They will both be written in to the options parameter
@@ -548,8 +547,7 @@ serverEnvAndJVMOptions()
     mergeJVMOptions "${WLP_INSTALL_DIR}/etc/jvm.options"
   fi
 
-  # Try to find and set JAVA_HOME without invoking java, which is expensive.
-  # If all else fails, invoke java as a last resort.
+  # Try to find and set JAVA_HOME.  Need JAVA_HOME to determine if we are running Java 9+.  Possibly other reasons.
   if [ -z "${JAVA_HOME}" ]; then
 
     # JAVA_HOME not set.  Locate java using the PATH.
@@ -558,22 +556,31 @@ serverEnvAndJVMOptions()
       
       # Resolve symlinks.  JAVA_HOME is parent of parent of 'java'
       REAL_JAVA_PATH=$(findRealPath "${JAVA_PATH}")
-      JAVA_HOME=$(dirname "$(dirname "${REAL_JAVA_PATH}")")
+      JAVA_HOME=$(dirname "${REAL_JAVA_PATH}")/..
 
-     # If this is NOT a true java home, determined by no 'lib' or no 'include',
-     # then, as a last resort, invoke java to extract java.home value    
-     if ! [ -d "$JAVA_HOME/lib" ] && ! [ -d "$JAVA_HOME/jre/lib" ] || ! [ -d "$JAVA_HOME/include" ]; then      
-      JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 | awk -F'=' '/java\.home/ {gsub(/^ +| +$/, "", $2); print $2}')
+      # The next statement resolves the ".." and verifies JAVA_HOME is a directory.
+      # If JAVA_HOME is not a directory, the cd command will exit the subshell causing JAVA_HOME to be unset.
+      JAVA_HOME="$(unset CDPATH; cd "${JAVA_HOME}" || exit; pwd)"
+
+     # If JAVA_HOME does not appear to be a valid Java installation (missing 'lib' or 'include' directories), display a warning.
+     # Split into 3 tests for portability.  As a one-line test, it is problematic for IBM i and possibly other shells.
+     if [ -z "$JAVA_HOME" ]; then
+       issueMessage --message:warning.javaHomeNotSet
+     elif [ ! -d "$JAVA_HOME/lib" ] && [ ! -d "$JAVA_HOME/jre/lib" ]; then
+       issueMessage --message:warning.javaHomeNotSet
+     elif [ ! -d "$JAVA_HOME/include" ]; then
+       issueMessage --message:warning.javaHomeNotSet
+     else
+       export JAVA_HOME
      fi
 
-     export JAVA_HOME
     fi  # if JAVA_HOME is not set and java is not in the PATH, then we cannot find Java.
   fi
 
+  # If there is a lib/modules directory under JAVA_HOME, then it is at least Java 9.   Ensure java9.options gets loaded.
   if [ -n "${JAVA_HOME}" ]; then
     JPMS_MODULE_FILE_LOCATION=${JAVA_HOME}/lib/modules
-
-    # If we are running on Java 9 and up, apply Liberty's built-in java 9 options  
+  
     if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
        mergeJVMOptions "${WLP_INSTALL_DIR}/lib/platform/java/java9.options"
     fi
@@ -604,7 +611,6 @@ findRealPath() {
 
     # If unsuccessful, try cd -P command. 
     if [ -z "${resolvedPath}" ]; then
-
       resolvedPath=$(unset CDPATH; cd -P "${path}" >/dev/null 2>&1 && pwd)
     fi
 
@@ -648,6 +654,10 @@ findRealPath() {
 		  
           # Get the target of the symbolic link
           target=$(ls -l "$resolvedPath" | awk '{print $NF}')
+          # The line above might have problems with special characters. Possible replacement to consider and test:
+          # lsOutput=$(ls -ld "$resolvedPath")
+          # lsoutput should look something like: 'lrwxr-xr-x  1 user group  16 Jan  1 12:00 myLink -> /some/real/path'
+          # target=${lsOutput#* -> }
 
           # Don't lose the remaining path past the symlink
           if [ "$resolvedPath" = "$path" ]; then

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -564,11 +564,14 @@ serverEnvAndJVMOptions()
 
      # If JAVA_HOME does not appear to be a valid Java installation (missing 'lib' or 'include' directories), display a warning.
      # Split into 3 tests for portability.  As a one-line test, it is problematic for IBM i and possibly other shells.
+     # Need to unset JAVA_HOME when location is not valid, otherwise it causes a hang on the warning message.
      if [ -z "$JAVA_HOME" ]; then
        issueMessage --message:warning.javaHomeNotSet
      elif [ ! -d "$JAVA_HOME/lib" ] && [ ! -d "$JAVA_HOME/jre/lib" ]; then
+       unset JAVA_HOME
        issueMessage --message:warning.javaHomeNotSet
      elif [ ! -d "$JAVA_HOME/include" ]; then
+       unset JAVA_HOME
        issueMessage --message:warning.javaHomeNotSet
      else
        export JAVA_HOME

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010, 2022 IBM Corporation and others.
+# Copyright (c) 2010, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -443,7 +443,7 @@ warning.tooManySymbolicLinks.explanation=Symbolic links are shortcuts that point
 warning.tooManySymbolicLinks.useraction=To resolve this issue, check the symbolic links in the path and ensure that they do not create circular references. You might also use the 'readlink' command to inspect individual links in the chain.
 
 warning.javaHomeNotSet=CWWKE0097W: The JAVA_HOME environment variable is not set.
-warning.javaHomeNotSet.explanation=The server script cannot determine the location of the Java installation. This issue does not occur if the JAVA_HOME environment variable is set properly, or if the "java" executable, found by searching the PATH, is located in a complete Java installation. The Java installation location is needed to find version-specific configuration files, such as java9.options. If the Java installation cannot be found, these files will not be loaded, and applications that rely on them might not behave as expected.
+warning.javaHomeNotSet.explanation=The server script cannot determine the location of the Java installation. This issue does not occur if the JAVA_HOME environment variable is set properly, or if the "java" executable, found by searching the PATH, is located in a complete Java installation. The Java installation location is needed to find version-specific configuration files, such as java9.options. If the Java installation cannot be found, these files are not loaded, and applications that rely on them might not behave as expected.
 warning.javaHomeNotSet.useraction=Set the JAVA_HOME environment variable.
 
 warn.packageRuntime.include.unknownOption=CWWKE0099W: Unable to use option --include={0}, will use --include=wlp instead.

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -442,6 +442,10 @@ warning.tooManySymbolicLinks=CWWKE0096W: Too many symbolic links were encountere
 warning.tooManySymbolicLinks.explanation=Symbolic links are shortcuts that point to other files or directories. This error occurs when the system encounters too many symbolic links in a chain and it is unable to resolve the path.
 warning.tooManySymbolicLinks.useraction=To resolve this issue, check the symbolic links in the path and ensure that they do not create circular references. You might also use the 'readlink' command to inspect individual links in the chain.
 
+warning.javaHomeNotSet=CWWKE0097W: The JAVA_HOME environment variable is not set.
+warning.javaHomeNotSet.explanation=The server script cannot determine the location of the Java installation. This issue does not occur if the JAVA_HOME environment variable is set properly, or if the "java" executable, found by searching the PATH, is located in a complete Java installation. The Java installation location is needed to find version-specific configuration files, such as java9.options. If the Java installation cannot be found, these files will not be loaded, and applications that rely on them might not behave as expected.
+warning.javaHomeNotSet.useraction=Set the JAVA_HOME environment variable.
+
 warn.packageRuntime.include.unknownOption=CWWKE0099W: Unable to use option --include={0}, will use --include=wlp instead.
 warn.packageRuntime.include.unknownOption.explanation=The option was ignored because it was not recognized.
 warn.packageRuntime.include.unknownOption.useraction=Retry the command using valid options. Try using --help for a list of valid options.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #30420" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

**Alternatives:**

- Add a warning about performance when it falls into the last resort of invoking java to get the java.home property
- Instead of invoking java,  just display an error message and exit.  Though, that probably wouldn't please the author of the stackoverflow question who has a custom java command script, that dynamically selects a version of java
