### PR TITLE
Memory leak in sipcontainer when dnsAutoResolve is enabled

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/naptr/NaptrSenderContainer.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/naptr/NaptrSenderContainer.java
@@ -60,8 +60,8 @@ public class NaptrSenderContainer extends SendProcessor implements INaptrSender{
 	 */
 	public NaptrSenderContainer() {
 		if (c_logger.isTraceDebugEnabled()) {
-			c_logger.traceDebug(this, "NaptrSender", 
-					"New NaptrSender created  = " + toString());
+			c_logger.traceDebug(this, "NaptrSenderContainer", 
+					"New NaptrSenderContainer created  = " + toString());
 		}
 		_naptrHandler = new NaptrHandler(this);
 	}
@@ -78,7 +78,7 @@ public class NaptrSenderContainer extends SendProcessor implements INaptrSender{
 		super.cleanItself();
 		if (c_logger.isTraceDebugEnabled()) {
 			c_logger.traceDebug(this, "cleanItself", 
-					" Clean NaptrSender = " + toString());
+					"Clean NaptrSenderContainer = " + toString());
 		}
 	}
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/naptr/NaptrSenderContainer.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/naptr/NaptrSenderContainer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2009 IBM Corporation and others.
+ * Copyright (c) 2008, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -7,8 +7,6 @@
  * 
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.sip.container.naptr;
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/transaction/ClientTransaction.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/transaction/ClientTransaction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -7,8 +7,6 @@
  * 
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.sip.container.transaction;
 


### PR DESCRIPTION
the sipcontainer will exhibit a memory leak in case the dialog flow includes outgoing client ACK requests and dnsAutoResolve is enabled
