### PR TITLE
reject cursored page of non-entity

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -989,3 +989,14 @@ CWWKD1099.first.keyword.incompat.explanation=A Query by Method Name method \
  that includes a Limit or PageRequest parameter cannot use the First keyword.
 CWWKD1099.first.keyword.incompat.useraction=Remove the First keyword from the \
  method name.
+
+CWWKD1100.cursor.requires.sort=CWWKD1100E: The {0} method of the {1} repository \
+ returns {2} but does not have an OrderBy annotation or any of the following \
+ parameters to specify sort criteria: {3}. Sort criteria is required for \
+ cursor-based pagination and must not be specified within an ORDER BY clause of \
+ a Query annotation value.
+CWWKD1100.cursor.requires.sort.explanation=Cursor-based pagination requires \
+ sort criteria.
+CWWKD1100.cursor.requires.sort.useraction=Remove the ORDER BY clause from the \
+ Query annotation value if one is found there. Add an OrderBy annotation or a \
+ repository method parameter to specify the sort criteria.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -993,7 +993,7 @@ CWWKD1099.first.keyword.incompat.useraction=Remove the First keyword from the \
 CWWKD1100.cursor.requires.sort=CWWKD1100E: The {0} method of the {1} repository \
  returns {2} but does not have an OrderBy annotation or any of the following \
  parameters to specify sort criteria: {3}. Sort criteria is required for \
- cursor-based pagination and must not be specified within an ORDER BY clause of \
+ cursor-based pagination and cannot be specified within an ORDER BY clause of \
  a Query annotation value.
 CWWKD1100.cursor.requires.sort.explanation=Cursor-based pagination requires \
  sort criteria.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -241,16 +241,17 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
         s.append(isForward ? ", CURSOR_NEXT(" : " CURSOR_PREVIOUS(");
 
         boolean firstSort = true;
-        for (Sort<?> sort : queryInfo.sorts) {
-            if (firstSort)
-                firstSort = false;
-            else
-                s.append(", ");
-            s.append(sort.property()); //
-            s.append(sort.isAscending() //
-                            ? sort.ignoreCase() ? " ASC IgnoreCase" : " ASC" //
-                            : sort.ignoreCase() ? " DESC IgnoreCase" : " DESC");
-        }
+        if (queryInfo.sorts != null)
+            for (Sort<?> sort : queryInfo.sorts) {
+                if (firstSort)
+                    firstSort = false;
+                else
+                    s.append(", ");
+                s.append(sort.property()); //
+                s.append(sort.isAscending() //
+                                ? sort.ignoreCase() ? " ASC IgnoreCase" : " ASC" //
+                                : sort.ignoreCase() ? " DESC IgnoreCase" : " DESC");
+            }
 
         s.append(") @").append(Integer.toHexString(hashCode()));
         return s.toString();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -4847,15 +4847,25 @@ public class QueryInfo {
         }
 
         if (type == Type.FIND &&
-            CursoredPage.class.equals(multiType) &&
-            !singleType.equals(entityInfo.getType()))
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1037.cursor.rtrn.mismatch",
-                      singleType.getSimpleName(),
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      entityInfo.getType().getName(),
-                      method.getGenericReturnType().getTypeName());
+            CursoredPage.class.equals(multiType)) {
+
+            if (!singleType.equals(entityInfo.getType()))
+                throw exc(UnsupportedOperationException.class,
+                          "CWWKD1037.cursor.rtrn.mismatch",
+                          singleType.getSimpleName(),
+                          method.getName(),
+                          repositoryInterface.getName(),
+                          entityInfo.getType().getName(),
+                          method.getGenericReturnType().getTypeName());
+
+            if (sortPositions == NONE_QUERY_LANGUAGE_ONLY && sorts == null)
+                throw exc(UnsupportedOperationException.class,
+                          "CWWKD1100.cursor.requires.sort",
+                          method.getName(),
+                          repositoryInterface.getName(),
+                          method.getGenericReturnType().getTypeName(),
+                          "Order, Sort, Sort[]");
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2639,15 +2639,6 @@ public class QueryInfo {
      */
     @Trivial
     Object[] getCursorValues(Object entity) {
-        if (!entityInfo.getType().isInstance(entity))
-            throw exc(MappingException.class,
-                      "CWWKD1037.cursor.rtrn.mismatch",
-                      loggable(entity),
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      entityInfo.getType().getName(),
-                      method.getGenericReturnType().getTypeName());
-
         ArrayList<Object> cursorValues = new ArrayList<>();
         for (Sort<?> sort : sorts)
             try {
@@ -4854,6 +4845,17 @@ public class QueryInfo {
                       methodParamCount,
                       jpql);
         }
+
+        if (type == Type.FIND &&
+            CursoredPage.class.equals(multiType) &&
+            !singleType.equals(entityInfo.getType()))
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1037.cursor.rtrn.mismatch",
+                      singleType.getSimpleName(),
+                      method.getName(),
+                      repositoryInterface.getName(),
+                      entityInfo.getType().getName(),
+                      method.getGenericReturnType().getTypeName());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -5234,6 +5234,37 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Tests a repository method that returns a Page with a single boolean
+     * result on it.
+     */
+    @Test
+    public void testSingularResultPageOfBoolean() {
+        PageRequest pageReq = PageRequest.ofSize(6);
+        Page<Boolean> page = primes.pageOfExists(pageReq);
+
+        assertEquals(List.of(true), page.content());
+        assertEquals(false, page.hasNext());
+        assertEquals(false, page.hasPrevious());
+        assertEquals(1L, page.totalElements());
+        assertEquals(1L, page.totalPages());
+    }
+
+    /**
+     * Tests a repository method that returns a Page with a single numeric
+     * result on it.
+     */
+    @Test
+    public void testSingularResultPageNumeric() {
+        Page<Long> page = primes.pageOfCountUpTo(20L, PageRequest.ofSize(4));
+
+        assertEquals(List.of(8L), page.content());
+        assertEquals(false, page.hasNext());
+        assertEquals(false, page.hasPrevious());
+        assertEquals(1L, page.totalElements());
+        assertEquals(1L, page.totalPages());
+    }
+
+    /**
      * A repository might define a method that returns a Page with a Limit parameter.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -393,6 +393,14 @@ public interface Primes {
     @Query("SELECT numberId WHERE ID(THIS)=:num")
     Optional<Short> numberAsShortWrapper(long num);
 
+    // discouraged usage, but testing what happens
+    @Query("SELECT COUNT(THIS) WHERE ID(THIS) < :max")
+    Page<Long> pageOfCountUpTo(long max, PageRequest pageReq);
+
+    // discouraged usage, but testing what happens
+    @Query("SELECT CASE WHEN COUNT(THIS) > 0 THEN TRUE ELSE FALSE END")
+    Page<Boolean> pageOfExists(PageRequest pageReq);
+
     @Insert
     void persist(Prime... primes);
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -56,6 +56,7 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1019E.*livingAt", // mix of named/positional parameters
                                    "CWWKD1019E.*residingAt", // unused parameters
                                    "CWWKD1022E.*discardPage", // Delete operation with a PageRequest
+                                   "CWWKD1033E.*selectByFirstName", // CursoredPage with ORDER BY in Query
                                    "CWWKD1037E.*findByBirthdayOrderBySSN", // CursoredPage of non-entity
                                    "CWWKD1037E.*registrations", // CursoredPage of non-entity
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",
@@ -81,7 +82,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1098E.*withNameLongerThan", // Limit ahead of query params
                                    "CWWKD1098E.*withNameShorterThan", // Sort ahead of query params
                                    "CWWKD1099E.*findFirst2", // Limit incompatible with First
-                                   "CWWKD1099E.*findFirst3" // PageRequest incompatible with First
+                                   "CWWKD1099E.*findFirst3", // PageRequest incompatible with First
+                                   "CWWKD1100E.*selectByLastName" // CursoredPage with ORDER BY clause
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -56,6 +56,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1019E.*livingAt", // mix of named/positional parameters
                                    "CWWKD1019E.*residingAt", // unused parameters
                                    "CWWKD1022E.*discardPage", // Delete operation with a PageRequest
+                                   "CWWKD1037E.*findByBirthdayOrderBySSN", // CursoredPage of non-entity
+                                   "CWWKD1037E.*registrations", // CursoredPage of non-entity
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",
                                    "CWWKD1078E.*test.jakarta.data.errpaths.web.InvalidNonJNDIRepo",
                                    "CWWKD1079E.*test.jakarta.data.errpaths.web.InvalidJNDIRepo",

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -210,6 +210,135 @@ public class DataErrPathsTestServlet extends FATServlet {
 
     /**
      * Verify an error is raised for a repository method that attempts to
+     * return a CursoredPage with the OrderBy annotation omitted
+     * and no other sort criteria present.
+     */
+    @Test
+    public void testCursoredPageOrderByOmitted() {
+        try {
+            CursoredPage<Voter> page = //
+                            voters.selectByLastName("TestCursoredPageOrderByOmitted",
+                                                    PageRequest.ofSize(23));
+            fail("Should not be able to retrieve a CursoredPage when OrderBy is" +
+                 " omitted from the Query method and there is no other sort." +
+                 " criteria. Found: " + page);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1100E:") ||
+                !x.getMessage().contains("Sort[]"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that attempts to
+     * return a CursoredPage with an ORDER BY clause present.
+     */
+    @Test
+    public void testCursoredPageOrderClauseIncluded() {
+        String firstName = "TestCursoredPageOrderClauseIncluded";
+        try {
+            CursoredPage<Voter> page = //
+                            voters.selectByFirstName(firstName,
+                                                     PageRequest.ofSize(24),
+                                                     Order.by(Sort.desc(ID)));
+            fail("Should not be able to retrieve a CursoredPage when ORDER BY is" +
+                 " included in the Query value. Found: " + page);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1033E:") ||
+                !x.getMessage().contains("ORDER BY"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that attempts to
+     * return a CursoredPage with NULL ordering.
+     */
+    @Test
+    public void testCursoredPageOrderNull() {
+        LocalDate date = LocalDate.of(2024, 12, 20);
+        try {
+            CursoredPage<Voter> page = //
+                            voters.selectByBirthday(date,
+                                                    PageRequest.ofSize(20),
+                                                    null);
+            fail("Should not be able to retrieve a CursoredPage with results that" +
+                 " have a NULL order: " + page);
+        } catch (NullPointerException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1087E:") ||
+                !x.getMessage().contains("jakarta.data.Order"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that attempts to
+     * return a CursoredPage with NULL sorting.
+     */
+    @Test
+    public void testCursoredPageSortNull() {
+        try {
+            CursoredPage<Voter> page = //
+                            voters.selectByName("Vincent",
+                                                PageRequest.ofSize(33),
+                                                null);
+            fail("Should not be able to retrieve a CursoredPage with results that" +
+                 " have a NULL value for the Sort parameter: " + page);
+        } catch (NullPointerException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1087E:") ||
+                !x.getMessage().contains("jakarta.data.Sort"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that attempts to
+     * return an unordered CursoredPage.
+     */
+    @Test
+    public void testCursoredPageUnordered() {
+        LocalDate date = LocalDate.of(2024, 12, 19);
+        try {
+            CursoredPage<Voter> page = //
+                            voters.selectByBirthday(date,
+                                                    PageRequest.ofSize(19),
+                                                    Order.by());
+            fail("Should not be able to retrieve a CursoredPage with results that" +
+                 " are not ordered: " + page);
+        } catch (IllegalArgumentException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1088E:") ||
+                !x.getMessage().contains("jakarta.data.Order"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that attempts to
+     * return an unsorted CursoredPage.
+     */
+    @Test
+    public void testCursoredPageUnsorted() {
+        String address = "701 Silver Creek Rd NE, Rochester, MN 55906";
+        try {
+            CursoredPage<Voter> page = //
+                            voters.selectByAddress(address, PageRequest.ofSize(3));
+            fail("Should not be able to retrieve a CursoredPage with results that" +
+                 " are not sorted: " + page);
+        } catch (IllegalArgumentException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1088E:") ||
+                !x.getMessage().contains("Sort[]"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that attempts to
      * delete a page of results by specifying a PageRequest on a Delete operation.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -31,6 +31,7 @@ import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.MappingException;
+import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Cursor;
@@ -162,6 +163,47 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1019E:") ||
                 !x.getMessage().contains("livingAt"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that attempts to
+     * return a CursoredPage of a record, rather than of the entity.
+     */
+    @Test
+    public void testCursoredPageOfRecord() {
+        try {
+            CursoredPage<VoterRegistration> page = //
+                            voters.registrations(LocalDate.of(2024, 12, 17),
+                                                 PageRequest.ofSize(7));
+            fail("Should not be able to retrieve CursoredPage of a non-entity." +
+                 " Found: " + page);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1037E:") ||
+                !x.getMessage().contains("VoterRegistration"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised for a repository method that attempts to
+     * return a CursoredPage of an entity attribute, rather than of the entity.
+     */
+    @Test
+    public void testCursoredPageOfString() {
+        LocalDate date = LocalDate.of(2024, 12, 18);
+        try {
+            CursoredPage<Integer> page = //
+                            voters.findByBirthdayOrderBySSN(date,
+                                                            PageRequest.ofSize(8));
+            fail("Should not be able to retrieve CursoredPage of a non-entity." +
+                 " Found: " + page);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1037E:") ||
+                !x.getMessage().contains("CursoredPage<java.lang.Integer>"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/VoterRegistration.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/VoterRegistration.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import java.time.LocalDate;
+
+/**
+ * A Java record with record components that match the fields of the
+ * Voter entity.
+ */
+public record VoterRegistration(
+                int ssn,
+                String name,
+                String address,
+                LocalDate birthday) {
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.errpaths.web;
 
+import java.time.LocalDate;
 import java.time.Month;
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +22,7 @@ import java.util.stream.Stream;
 import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
+import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.BasicRepository;
@@ -164,6 +166,12 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     List<Voter> findByAddressOrderBySSN(int ssn, Sort<Voter> sort);
 
     /**
+     * This invalid method attempts to return a CursoredPage of a non-entity type.
+     */
+    CursoredPage<Integer> findByBirthdayOrderBySSN(LocalDate birthday,
+                                                   PageRequest pageReq);
+
+    /**
      * This invalid method has both a First keyword and a Limit parameter.
      */
     @OrderBy("ssn")
@@ -286,6 +294,14 @@ public interface Voters extends BasicRepository<Voter, Integer> {
      */
     @Insert
     Voter register(Voter... v);
+
+    /**
+     * This invalid method attempts to return a CursoredPage of a non-entity type.
+     */
+    @Find
+    @OrderBy("ssn")
+    CursoredPage<VoterRegistration> registrations(@By("birthday") LocalDate birthday,
+                                                  PageRequest pageReq);
 
     /**
      * Delete method that attempts to return a record instead of an entity.

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -333,6 +333,36 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                            String city, // extra, unused parameter
                            String stateCode); // extra, unused parameter
 
+    @Find
+    CursoredPage<Voter> selectByAddress(@By("address") String homeAddress,
+                                        PageRequest pageReq,
+                                        Sort<?>... sorts);
+
+    @Find
+    CursoredPage<Voter> selectByBirthday(@By("birthday") LocalDate date,
+                                         PageRequest pageReq,
+                                         Order<Voter> order);
+
+    /**
+     * This invalid method includes an ORDER BY clause with cursor pagination.
+     */
+    @Query("WHERE name LIKE (:fname || ' %') ORDER BY name ASC, ssn ASC")
+    CursoredPage<Voter> selectByFirstName(@Param("fname") String lastName,
+                                          PageRequest pageReq,
+                                          Order<Voter> order);
+
+    /**
+     * This invalid method lacks an OrderBy annotation or any sort parameters.
+     */
+    @Query("WHERE name LIKE ('% ' || :lname)")
+    CursoredPage<Voter> selectByLastName(@Param("lname") String lastName,
+                                         PageRequest pageReq);
+
+    @Find
+    CursoredPage<Voter> selectByName(@By("name") String name,
+                                     PageRequest pageReq,
+                                     Sort<Voter> sort);
+
     /**
      * Invalid method. A method with a life cycle annotation must have exactly
      * 1 parameter.


### PR DESCRIPTION
This PR includes:
* Reject CursoredPage of non-entity.
* Various scenarios where a repository method returning CursoredPage omits sort criteria.
* Scenarios where a repository method returning CursoredPage includes an ORDER BY clause.
* Edge case scenarios where Page is used with a Query that produces a single result.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
