### PR TITLE
Update tracespec in logging fat

### DIFF
--- a/dev/com.ibm.ws.logging_fat/publish/files/accessLogging/server-logformat-ports.xml
+++ b/dev/com.ibm.ws.logging_fat/publish/files/accessLogging/server-logformat-ports.xml
@@ -25,6 +25,6 @@
        <accessLogging logFormat='%p %{remote}p'/>
     </httpEndpoint>
     
-    <logging jsonAccessLogFields="logFormat" traceSpecification="*=info:com.ibm.ws.tcpchannel.internal.TCPReadRequestContextImpl=all" />
+    <logging jsonAccessLogFields="logFormat" traceSpecification="*=info:TCPChannel=all" />
     
 </server>

--- a/dev/com.ibm.ws.logging_fat/publish/files/accessLogging/server-logformat-ports.xml
+++ b/dev/com.ibm.ws.logging_fat/publish/files/accessLogging/server-logformat-ports.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.logging_fat/publish/files/accessLogging/server-logformat-ports2.xml
+++ b/dev/com.ibm.ws.logging_fat/publish/files/accessLogging/server-logformat-ports2.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2024 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.logging_fat/publish/files/accessLogging/server-logformat-ports2.xml
+++ b/dev/com.ibm.ws.logging_fat/publish/files/accessLogging/server-logformat-ports2.xml
@@ -25,6 +25,6 @@
        <accessLogging logFormat='%{remote}p %p'/>
     </httpEndpoint>
     
-    <logging jsonAccessLogFields="logFormat" traceSpecification="*=info:com.ibm.ws.tcpchannel.internal.TCPReadRequestContextImpl=all" />
+    <logging jsonAccessLogFields="logFormat" traceSpecification="*=info:TCPChannel=all" />
     
 </server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves 

Updating logging FAT trace specification for future Netty changes. Tracing will change from the originating class with these changes but will be enabled through the same trace group. After some discussion with serviceability, since the trace group is the same and the must gather information uses these trace groups, these changes are valid since only for internal support will these specific classes be used.