### PR TITLE
Updates to get things building cleanly in eclipse

### DIFF
--- a/dev/com.ibm.ws.com.sun.xml.messaging.saaj/bnd.bnd
+++ b/dev/com.ibm.ws.com.sun.xml.messaging.saaj/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -14,4 +14,5 @@
 
 src: src
 
--buildpath: com.sun.xml.messaging.saaj:saaj-impl;version=1.5.3
+-buildpath: com.sun.xml.messaging.saaj:saaj-impl;version=1.5.3, \
+  com.ibm.websphere.javaee.jws.1.0;version=latest

--- a/dev/com.ibm.ws.com.sun.xml.messaging.saaj/bnd.overrides
+++ b/dev/com.ibm.ws.com.sun.xml.messaging.saaj/bnd.overrides
@@ -37,10 +37,14 @@ app-resources= \
   META-INF/services/javax.xml.soap.MessageFactory | \
   META-INF/services/javax.xml.soap.SAAJMetaFactory
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
   !com.sun.xml.fastinfoset.dom, \
   !javax.xml.messaging, \
   !org.jvnet.fastinfoset, \
+  javax.xml.soap;version=!, \
   *
 
 Service-Component: \

--- a/dev/com.ibm.ws.security.authentication.builtin/bnd.bnd
+++ b/dev/com.ibm.ws.security.authentication.builtin/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -145,8 +145,7 @@ instrument.classesExcludes: com/ibm/ws/security/authentication/internal/resource
 	com.ibm.websphere.security.authentication;version=latest,\
 	io.openliberty.jcache.internal;version=latest,\
 	com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
-	org.eclipse.osgi,\
-	osgi.core
+	org.eclipse.osgi;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \


### PR DESCRIPTION
- Remove osgi.core from buildpath
  - With osgi.core in the buildpath eclipse can pick up an older version since no version is listed.  The needed dependency is already in the buildpath so it isn't needed anyway.
- Add bundle that contains javax.xml.soap package to buildpath so things build in Eclipse with only Java 11+ JDKs
  - When building with only Java 17 or 21 in eclipse, the saaj impl bundle fails to find javax.xml.soap since it was removed in Java 9+.  
  - Updated to add the javaee api bundle to the buildpath and updated import package to import javax.xml.soap without a version so it works when using Java 8 or Java greater than 8.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
