### PR TITLE
Skip -Xfuture test for Java 24+

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartTest.java
@@ -35,6 +35,7 @@ import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -175,6 +176,7 @@ public class ServerStartTest {
     }
 
     @Test
+    @MaximumJavaLevel(javaLevel = 23)  // -Xfuture argument is no longer available in Java 24+
     /**
      * This test ensures that the servers starts without error when using the -Xfuture command line
      * argument. This argument enforces strict class file verification. One customer ran into


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #30451 

Limits the test that uses the `-Xfuture` argument to only run on Java 23 or earlier.
