### PR TITLE
Supressing warning messages on Netty deprecated Handler object

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/HttpPipelineInitializer.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/HttpPipelineInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/HttpPipelineInitializer.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/HttpPipelineInitializer.java
@@ -53,6 +53,8 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.ReferenceCountUtil;
+import io.openliberty.http.netty.channel.AllocatorContextSetter;
+import io.openliberty.http.netty.channel.LoggingRecvByteBufAllocator;
 import io.openliberty.netty.internal.ChannelInitializerWrapper;
 import io.openliberty.netty.internal.exception.NettyException;
 import io.openliberty.netty.internal.impl.NettyConstants;
@@ -118,7 +120,7 @@ public class HttpPipelineInitializer extends ChannelInitializerWrapper {
         LoggingRecvByteBufAllocator loggingAllocator = new LoggingRecvByteBufAllocator(channelAllocator);
         channel.config().setRecvByteBufAllocator(loggingAllocator);
 
-        pipeline.addLast("AllocatorContextSetter", new AllocatorContextSetter(loggingAllocator));
+        pipeline.addLast("AllocatorContextSetter", new AllocatorContextSetter());
 
         if(chain.isHttps()){
             setupSecurePipeline(pipeline);
@@ -376,24 +378,4 @@ public class HttpPipelineInitializer extends ChannelInitializerWrapper {
         this.httpConfig.clear();
 
     }
-
-    @Sharable
-    private static class AllocatorContextSetter extends ChannelInboundHandlerAdapter{
-        private final LoggingRecvByteBufAllocator loggingAllocator;
-
-        AllocatorContextSetter(LoggingRecvByteBufAllocator loggingAllocator){
-            this.loggingAllocator = loggingAllocator;
-        }
-
-        @Override
-        public void handlerAdded(ChannelHandlerContext context) throws Exception{
-            super.handlerAdded(context);
-
-            RecvByteBufAllocator.Handle handle = context.channel().unsafe().recvBufAllocHandle();
-            if(handle instanceof LoggingRecvByteBufAllocator.LoggingHandle){
-                ((LoggingRecvByteBufAllocator.LoggingHandle) handle).setChannelHandlerContext(context);
-            }
-        }
-    }
-
 }

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/AllocatorContextSetter.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/AllocatorContextSetter.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.http.netty.channel;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.RecvByteBufAllocator;
+
+/**
+ * A handler that, when added to the pipeline, checks if the current channel's
+ * {@link RecvByteBufAllocator.Handle} is a {@link LoggingRecvByteBufAllocator.LoggingHandle}
+ * and sets the {@link ChannelHandlerContext} so the allocator can log
+ * read requests with contextual information.
+ */
+public class AllocatorContextSetter extends ChannelInboundHandlerAdapter {
+
+    /**
+     * Constructs a new context setter for the specified logging allocator.
+     *
+     */
+    public AllocatorContextSetter() {}
+
+    /**
+     * Called when the handler is added to the pipeline. Checks the current
+     * {@link RecvByteBufAllocator.Handle} and sets the context if it's a logging handle.
+     *
+     * @param ctx the context for this handler
+     * @throws Exception if any error occurs
+     */
+    @Override
+    @SuppressWarnings("deprecation")
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        super.handlerAdded(ctx);
+
+        // Netty doesn't have an non-deprecated approach, so for now
+        // suppress the warnings.
+        RecvByteBufAllocator.Handle handle = ctx.channel().unsafe().recvBufAllocHandle();
+
+        // If the handle is one of our logging handles, set the context to enable logging
+        if (handle instanceof LoggingRecvByteBufAllocator.LoggingHandle) {
+            ((LoggingRecvByteBufAllocator.LoggingHandle) handle).setChannelHandlerContext(ctx);
+        }
+    }
+}

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/LoggingRecvByteBufAllocator.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/LoggingRecvByteBufAllocator.java
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package com.ibm.ws.http.netty.pipeline;
+package io.openliberty.http.netty.channel;
 
 import java.net.SocketAddress;
 import java.util.Objects;
@@ -17,11 +17,11 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.http.channel.internal.HttpMessages;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.RecvByteBufAllocator;
-
- import io.netty.buffer.ByteBufAllocator;
 
 /**
  * This class is a custom {@link RecvByteBufAllocator} that wraps an existing allocator to intercept buffer
@@ -34,38 +34,62 @@ import io.netty.channel.RecvByteBufAllocator;
     private final RecvByteBufAllocator delegate;
 
     /**
-     * Constructor that wraps an existing allocator
+     * Constructor that wraps an existing allocator to add logging in {@code allocate(...)}
+     * 
      * @param delegate
      */
     public LoggingRecvByteBufAllocator(RecvByteBufAllocator delegate){
         this.delegate = delegate;
     }
 
+    /**
+     * Returns a handle that intercepts the buffer allocation call to log read operations.
+     *
+     * @return a new {@link Handle}
+     */
     @Override
+    @SuppressWarnings("deprecation")
     public Handle newHandle() {
         return new LoggingHandle(delegate.newHandle());
     }
 
+    /**
+     * A handle that {@link #allocate(ByteBufAllocator)} call in order to log read operations.
+     * Delegates all other operations to the wrapped {@link ExtendedHandle}.
+     * 
+     * Netty has not provided a non-depracated alternative to some calls. In the
+     * meantime, the deprecation warnings are supressed.
+     */
+    @SuppressWarnings("deprecation")
     public class LoggingHandle implements Handle{
         private final Handle delegateHandle;
         private ChannelHandlerContext context;
 
-        LoggingHandle(Handle delegateHandle){
-            this.delegateHandle = delegateHandle;
+        @SuppressWarnings("deprecation")
+        LoggingHandle(Handle handle){
+            this.delegateHandle = handle;
         }
 
+        /**
+         * Sets the context for logging addresses. This is expected
+         * to be called from the pipeline to ensure the handle can see addresses.
+         *
+         * @param context the channel handler context
+         */
         public void setChannelHandlerContext(ChannelHandlerContext context){
             this.context = context;
         }
 
+        /**
+         * Logs the read request, then delegates allocation.
+         *
+         * @param allocator the {@link ByteBufAllocator}
+         * @return the allocated {@link ByteBuf}
+         */
         @Override
-        public void reset(ChannelConfig config){
-            delegateHandle.reset(config);
-        }
-
-        @Override
-        public ByteBuf allocate(ByteBufAllocator allocator){
-            if (Objects.nonNull(context)){
+        @SuppressWarnings("deprecation")
+        public ByteBuf allocate(ByteBufAllocator allocator) {
+            if (context != null) {
                 SocketAddress localAddress = context.channel().localAddress();
                 SocketAddress remoteAddress = context.channel().remoteAddress();
 
@@ -77,44 +101,57 @@ import io.netty.channel.RecvByteBufAllocator;
         }
 
         @Override
+        @SuppressWarnings("deprecation")
+        public void reset(ChannelConfig config){
+            delegateHandle.reset(config);
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
         public int guess(){
             return delegateHandle.guess();
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public void incMessagesRead(int numMessages){
             delegateHandle.incMessagesRead(numMessages);
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public void lastBytesRead(int bytes){
             delegateHandle.lastBytesRead(bytes);
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public int lastBytesRead(){
             return delegateHandle.lastBytesRead();
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public boolean continueReading(){
             return delegateHandle.continueReading();
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public void readComplete(){
             delegateHandle.readComplete();
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public void attemptedBytesRead(int bytes){
             delegateHandle.attemptedBytesRead(bytes);
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public int attemptedBytesRead(){
             return delegateHandle.attemptedBytesRead();
         }
-    }
-    
+    } 
 }

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/LoggingRecvByteBufAllocator.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/LoggingRecvByteBufAllocator.java
@@ -57,7 +57,7 @@ import io.netty.channel.RecvByteBufAllocator;
      * A handle that {@link #allocate(ByteBufAllocator)} call in order to log read operations.
      * Delegates all other operations to the wrapped {@link ExtendedHandle}.
      * 
-     * Netty has not provided a non-depracated alternative to some calls. In the
+     * Netty has not provided a non-deprecated alternative to some calls. In the
      * meantime, the deprecation warnings are supressed.
      */
     @SuppressWarnings("deprecation")

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/package-info.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/package-info.java
@@ -1,0 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+@org.osgi.annotation.versioning.Version("1.0")
+package io.openliberty.http.netty.channel;


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

