### PR TITLE
DEACTIVATED_CWWKD0202E message missing from exception

### DIFF
--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -354,7 +354,8 @@ public class DatabaseStoreImpl implements DatabaseStore {
             if (deactivated) {
                 if (trace && tc.isEntryEnabled())
                     Tr.exit(this, tc, "createPersistenceServiceUnit", "deactivated");
-                throw new IllegalStateException();
+                String errMsg = Tr.formatMessage(tc, "DEACTIVATED_CWWKD0202E");
+                throw new IllegalStateException(errMsg);
             }
 
             // ignore table creation for extra PersistenceServiceUnit that persistent executor creates to allow TRANSACTION_READ_UNCOMMITTED
@@ -370,7 +371,8 @@ public class DatabaseStoreImpl implements DatabaseStore {
             if (deactivated) {
                 if (trace && tc.isEntryEnabled())
                     Tr.exit(this, tc, "createPersistenceServiceUnit", "deactivated");
-                throw new IllegalStateException();
+                String errMsg = Tr.formatMessage(tc, "DEACTIVATED_CWWKD0202E");
+                throw new IllegalStateException(errMsg);
             }
 
             successful = true;


### PR DESCRIPTION
While debugging an error that appeared while the server was shutting down, I saw an exception out of the persistence service with no message on it.  It looks like the message for it exists and is used elsewhere in the same class for similar `if (deactivated)` code blocks, but was missed in a couple of places, including the one I ran into.  This PR adds the message to those spots.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
