### PR TITLE
repository methods that return entity attribute subsets as records

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1003,10 +1003,10 @@ CWWKD1100.cursor.requires.sort.useraction=Remove the ORDER BY clause from the \
 
 CWWKD1101.attr.subset.mismatch=CWWKD1101E: The {0} return type of the \
  {1} method of the {2} repository uses the {3} Java record type to define the \
- results to be a subset of entity attributes: {5}. However, at least one of the \
- requested attribute names is not present on the {4} entity. To return a subset \
+ results to be a subset of entity attributes: {4}. However, at least one of the \
+ requested attribute names is not present on the {5} entity. To return a subset \
  of entity attributes as a Java record, ensure that the record component names \
- are within the following set of valid attribute names for the {4} entity: {6}. \
+ are within the following set of valid attribute names for the {5} entity: {6}. \
  Alternatively, use the Select annotation to assign valid entity attribute names. \
  To return a single entity attribute that has a Java record type, annotate \
  the {1} method to have a Select annotation and assign its member value \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1002,14 +1002,14 @@ CWWKD1100.cursor.requires.sort.useraction=Remove the ORDER BY clause from the \
  repository method parameter to specify the sort criteria.
 
 CWWKD1101.attr.subset.mismatch=CWWKD1101E: The {0} return type of the \
- {1} method of the {2} repository attempts to return results as the subset \
- of entity attributes that are represented by the {3} Java record type, \
- expecting the {4} entity to have attributes named: {5}. To return a subset \
+ {1} method of the {2} repository uses the {3} Java record type to define the \
+ results to be a subset of entity attributes: {5}. However, at least one of the \
+ requested attribute names is not present on the {4} entity. To return a subset \
  of entity attributes as a Java record, ensure that the record component names \
- are within the set of valid attribute names for the {4} entity: {6}. \
+ are within the following set of valid attribute names for the {4} entity: {6}. \
  Alternatively, use the Select annotation to assign valid entity attribute names. \
- To instead return a single entity attribute that has a Java record type, annotate \
- the {1} method to have a Select annotation with its member value assigned \
+ To return a single entity attribute that has a Java record type, annotate \
+ the {1} method to have a Select annotation and assign its member value \
  to the name of the entity attribute.
 CWWKD1101.attr.subset.mismatch.explanation=When Java records are used to \
  retrieve a subset of entity attributes, all of the record components must \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2024 IBM Corporation and others.
+# Copyright (c) 2022,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -1000,3 +1000,20 @@ CWWKD1100.cursor.requires.sort.explanation=Cursor-based pagination requires \
 CWWKD1100.cursor.requires.sort.useraction=Remove the ORDER BY clause from the \
  Query annotation value if one is found there. Add an OrderBy annotation or a \
  repository method parameter to specify the sort criteria.
+
+CWWKD1101.attr.subset.mismatch=CWWKD1101E: The {0} return type of the \
+ {1} method of the {2} repository attempts to return results as the subset \
+ of entity attributes that are represented by the {3} Java record type, \
+ expecting the {4} entity to have attributes named: {5}. To return a subset \
+ of entity attributes as a Java record, ensure that the record component names \
+ are within the set of valid attribute names for the {4} entity: {6}. \
+ Alternatively, use the Select annotation to assign valid entity attribute names. \
+ To instead return a single entity attribute that has a Java record type, annotate \
+ the {1} method to have a Select annotation with its member value assigned \
+ to the name of the entity attribute.
+CWWKD1101.attr.subset.mismatch.explanation=When Java records are used to \
+ retrieve a subset of entity attributes, all of the record components must \
+ correspond to valid entity attributes.
+CWWKD1101.attr.subset.mismatch.useraction=Rename the record components to \
+ match valid entity attribute names, or use the Select annotation to explicitly \
+ request entity attributes by their name.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -124,6 +124,7 @@ public class EntityInfo {
         validate();
     }
 
+    @Trivial
     Collection<String> getAttributeNames() {
         return attributeNames.values();
     }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -2135,6 +2135,7 @@ public class QueryInfo {
      *
      * @return the SELECT clause.
      */
+    @FFDCIgnore(RuntimeException.class) // caught to switch to better error
     private StringBuilder generateSelectClause() {
         StringBuilder q = new StringBuilder(200);
         String o = entityVar;
@@ -2184,65 +2185,92 @@ public class QueryInfo {
                 // Whole entity
                 if (!"this".equals(o))
                     q.append("SELECT ").append(o);
-            } else {
-                // Look for single entity attribute with the desired type:
-                String singleAttributeName = null;
-                for (Map.Entry<String, Class<?>> entry : entityInfo.attributeTypes.entrySet()) {
-                    Class<?> attributeType = entry.getValue();
-                    if (attributeType.isPrimitive())
-                        attributeType = Util.wrapperClassIfPrimitive(attributeType);
-                    if (singleType.isAssignableFrom(attributeType))
-                        if (singleAttributeName == null)
-                            singleAttributeName = entry.getKey();
-                        else
-                            throw exc(MappingException.class,
-                                      "CWWKD1008.ambig.rtrn.err",
-                                      method.getGenericReturnType().getTypeName(),
-                                      method.getName(),
-                                      repositoryInterface.getName(),
-                                      List.of(singleAttributeName, entry.getKey()));
+            } else if (entityInfo.idClassAttributeAccessors != null &&
+                       singleType.equals(entityInfo.idType)) {
+                // IdClass
+                // TODO remove once #29073 is fixed
+                // The following guess of alphabetic order is not valid in most cases, but this
+                // whole code block will be removed before GA, so there is no reason to correct it.
+                q.append("SELECT NEW ").append(singleType.getName()).append('(');
+                boolean first = true;
+                for (String idClassAttributeName : entityInfo.idClassAttributeAccessors.keySet()) {
+                    String name = getAttributeName(idClassAttributeName, true);
+                    q.append(first ? "" : ", ").append(o_).append(name);
+                    first = false;
                 }
-
-                if (singleAttributeName == null) {
-                    // TODO enable this once #29073 is fixed
-                    //if (entityInfo.idClassAttributeAccessors != null && singleType.equals(entityInfo.idType)) {
-                    //    // IdClass
-                    //    q.append("SELECT ID(").append(entityVar).append(')');
-                    // } else
-                    {
-                        // Construct new instance for record
-                        q.append("SELECT NEW ").append(singleType.getName()).append('(');
-                        RecordComponent[] recordComponents;
-                        boolean first = true;
-                        if ((recordComponents = singleType.getRecordComponents()) != null)
-                            for (RecordComponent component : recordComponents) {
-                                String name = component.getName();
-                                q.append(first ? "" : ", ").append(o_).append(name);
-                                first = false;
-                            }
-                        // TODO remove else block once #29073 is fixed
-                        else if (entityInfo.idClassAttributeAccessors != null && singleType.equals(entityInfo.idType))
-                            // The following guess of alphabetic order is not valid in most cases, but the
-                            // whole code block that will be removed before GA, so there is no reason to correct it.
-                            for (String idClassAttributeName : entityInfo.idClassAttributeAccessors.keySet()) {
-                                String name = getAttributeName(idClassAttributeName, true);
-                                q.append(first ? "" : ", ").append(o_).append(name);
-                                first = false;
-                            }
-                        else
-                            throw exc(MappingException.class,
-                                      "CWWKD1005.find.rtrn.err",
-                                      method.getName(),
-                                      repositoryInterface.getName(),
-                                      method.getGenericReturnType().getTypeName(),
-                                      entityInfo.entityClass.getName(),
-                                      List.of("List", "Optional",
-                                              "Page", "CursoredPage",
-                                              "Stream"));
-                        q.append(')');
+                q.append(')');
+                // TODO enable this once #29073 is fixed
+                // q.append("SELECT ID(").append(entityVar).append(')');
+            } else {
+                // Is the result type a record or a single attribute?
+                RecordComponent[] recordComponents = singleType.getRecordComponents();
+                if (recordComponents == null) {
+                    // Look for single entity attribute with the desired type:
+                    String singleAttributeName = null;
+                    for (Map.Entry<String, Class<?>> entry : entityInfo
+                                    .attributeTypes.entrySet()) {
+                        Class<?> attributeType = entry.getValue();
+                        if (attributeType.isPrimitive())
+                            attributeType = Util.wrapperClassIfPrimitive(attributeType);
+                        if (singleType.isAssignableFrom(attributeType))
+                            if (singleAttributeName == null)
+                                singleAttributeName = entry.getKey();
+                            else
+                                throw exc(MappingException.class,
+                                          "CWWKD1008.ambig.rtrn.err",
+                                          method.getGenericReturnType().getTypeName(),
+                                          method.getName(),
+                                          repositoryInterface.getName(),
+                                          List.of(singleAttributeName, entry.getKey()));
                     }
+
+                    if (singleAttributeName == null)
+                        throw exc(MappingException.class,
+                                  "CWWKD1005.find.rtrn.err",
+                                  method.getName(),
+                                  repositoryInterface.getName(),
+                                  method.getGenericReturnType().getTypeName(),
+                                  entityInfo.entityClass.getName(),
+                                  List.of("List", "Optional",
+                                          "Page", "CursoredPage",
+                                          "Stream"));
+
+                    else
+                        q.append("SELECT ").append(o_).append(singleAttributeName);
                 } else {
-                    q.append("SELECT ").append(o_).append(singleAttributeName);
+                    // Construct new instance for record
+                    q.append("SELECT NEW ").append(singleType.getName()).append('(');
+
+                    String[] names = new String[recordComponents.length];
+                    for (int i = 0; i < recordComponents.length; i++) {
+                        // 1.1 TODO first check for Select annotation on record component
+                        names[i] = recordComponents[i].getName();
+                    }
+
+                    try {
+                        boolean first = true;
+                        for (String name : names) {
+                            name = getAttributeName(name, true);
+                            q.append(first ? "" : ", ");
+                            appendAttributeName(name, q);
+                            first = false;
+                        }
+                    } catch (RuntimeException x) {
+                        // Raise a more precise error that relates to using records
+                        // for a subset of entity attributes
+                        MappingException mx;
+                        mx = exc(MappingException.class,
+                                 "CWWKD1101.attr.subset.mismatch",
+                                 method.getGenericReturnType().getTypeName(),
+                                 method.getName(),
+                                 repositoryInterface.getName(),
+                                 singleType.getName(),
+                                 entityInfo.getType().getName(),
+                                 Arrays.toString(names),
+                                 entityInfo.getAttributeNames());
+                        throw (MappingException) mx.initCause(x);
+                    }
+                    q.append(')');
                 }
             }
         } else { // Individual columns are requested by @Select

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -12,11 +12,6 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
-import static io.openliberty.data.internal.persistence.Util.SORT_PARAM_TYPES;
-import static io.openliberty.data.internal.persistence.Util.lifeCycleReturnTypes;
-import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
-import static jakarta.data.repository.By.ID;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
@@ -2207,8 +2202,7 @@ public class QueryInfo {
                 if (recordComponents == null) {
                     // Look for single entity attribute with the desired type:
                     String singleAttributeName = null;
-                    for (Map.Entry<String, Class<?>> entry : entityInfo
-                                    .attributeTypes.entrySet()) {
+                    for (Map.Entry<String, Class<?>> entry : entityInfo.attributeTypes.entrySet()) {
                         Class<?> attributeType = entry.getValue();
                         if (attributeType.isPrimitive())
                             attributeType = Util.wrapperClassIfPrimitive(attributeType);
@@ -2265,8 +2259,8 @@ public class QueryInfo {
                                  method.getName(),
                                  repositoryInterface.getName(),
                                  singleType.getName(),
-                                 entityInfo.getType().getName(),
                                  Arrays.toString(names),
+                                 entityInfo.getType().getName(),
                                  entityInfo.getAttributeNames());
                         throw (MappingException) mx.initCause(x);
                     }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -12,6 +12,11 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import static io.openliberty.data.internal.persistence.Util.SORT_PARAM_TYPES;
+import static io.openliberty.data.internal.persistence.Util.lifeCycleReturnTypes;
+import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
+import static jakarta.data.repository.By.ID;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Animals.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Animals.java
@@ -12,7 +12,11 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
+import java.util.stream.Stream;
+
 import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Repository;
 
 import test.jakarta.data.web.Animal.ScientificName;
@@ -26,4 +30,8 @@ public interface Animals extends CrudRepository<Animal, ScientificName> {
     long countByIdNotNull();
 
     boolean existsById(ScientificName id);
+
+    @Find
+    @OrderBy("id.species")
+    Stream<ScientificName> ofGenus(String id_genus);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Animals.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Animals.java
@@ -15,8 +15,8 @@ package test.jakarta.data.web;
 import java.util.stream.Stream;
 
 import jakarta.data.repository.CrudRepository;
-import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
 import test.jakarta.data.web.Animal.ScientificName;
@@ -31,7 +31,9 @@ public interface Animals extends CrudRepository<Animal, ScientificName> {
 
     boolean existsById(ScientificName id);
 
-    @Find
+    // Using @Find here would require @Select(ID),
+    // which is not available in Data 1.0 // TODO move to 1.1 tests
+    @Query("SELECT id WHERE id.genus = ?1")
     @OrderBy("id.species")
     Stream<ScientificName> ofGenus(String id_genus);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2045,6 +2045,12 @@ public class DataTestServlet extends FATServlet {
         assertEquals(1, foxSquirrel.version());
 
         // TODO enable once #29460 is fixed
+        //assertEquals(List.of("Sciurus carolinensis",
+        //                     "Sciurus niger"),
+        //             animals.ofGenus("Sciurus")
+        //                             .map(n -> n.genus() + ' ' + n.species())
+        //                             .collect(Collectors.toList()));
+
         //ScientificName grayFoxId = new ScientificName("Urocyon", "cinereoargenteus");
         //grayFox = animals.findById(grayFoxId).orElseThrow();
         //assertEquals("gray fox", grayFox.commonName());
@@ -4544,6 +4550,10 @@ public class DataTestServlet extends FATServlet {
                          Participant.of("Samantha", "TestRecordAsEmbeddable", 4));
 
         assertEquals("Simon", participants.getFirstName(3).orElseThrow());
+
+        // TODO enable once #29460 is fixed
+        //assertEquals(new Participant.Name("Samantha", "TestRecordAsEmbeddable"),
+        //             participants.findNameById(4).orElseThrow());
 
         // TODO enable once #29460 is fixed
         //assertEquals(List.of("Samantha", "Sarah", "Simon", "Steve"),

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -148,6 +148,9 @@ public class DataTestServlet extends FATServlet {
     Products products;
 
     @Inject
+    Purchases purchases;
+
+    @Inject
     Ratings ratings;
 
     @Inject
@@ -4582,6 +4585,31 @@ public class DataTestServlet extends FATServlet {
         assertEquals(17.29f, receipts.totalOf(2001L), 0.001f);
 
         assertEquals(2, receipts.removeIfTotalUnder(2000.0f));
+    }
+
+    /**
+     * Verify that a record return type (per spec) takes precedence over an
+     * entity attribute that is a record.
+     */
+    @Test
+    public void testRecordReturnTypePrecedence() {
+        purchases.clearAll();
+
+        Purchase p1 = new Purchase();
+        p1.total = 105.19f;
+        p1.customer = "TestRecordReturnTypePrecedence";
+        p1.purchaseId = 1L;
+        // the following does not match on purpose
+        p1.receipt = new Receipt(1001L, "Customer1", 1.99f);
+
+        purchases.buy(p1);
+
+        Receipt r1 = purchases.receiptFor(1L).orElseThrow();
+        assertEquals("TestRecordReturnTypePrecedence", r1.customer());
+        assertEquals(1L, r1.purchaseId());
+        assertEquals(105.19f, r1.total(), 0.001f);
+
+        purchases.clearAll();
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participants.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participants.java
@@ -24,6 +24,8 @@ import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
+import test.jakarta.data.web.Participant.Name;
+
 /**
  * Repository for an unannotated entity with a record attribute
  * that should be interpreted as an embeddable.
@@ -33,6 +35,8 @@ public interface Participants extends DataRepository<Participant, Integer> {
 
     @Insert
     void add(Participant... p);
+
+    Optional<Name> findNameById(int id);
 
     @Query("SELECT name.first WHERE id = ?1")
     Optional<String> getFirstName(int id);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participants.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participants.java
@@ -36,6 +36,9 @@ public interface Participants extends DataRepository<Participant, Integer> {
     @Insert
     void add(Participant... p);
 
+    // Using Query by Method Name would require @Select("name"),
+    // which is not available in Data 1.0 // TODO move to 1.1 tests
+    @Query("SELECT name WHERE id = ?1")
     Optional<Name> findNameById(int id);
 
     @Query("SELECT name.first WHERE id = ?1")

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Purchase.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Purchase.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+/**
+ * Entity where one of the attributes is a record that is in this case used as
+ * an embeddable, but elsewhere used as an entity.
+ */
+public class Purchase {
+    public String customer;
+
+    public long purchaseId;
+
+    public Receipt receipt;
+
+    public float total;
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Purchases.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Purchases.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import java.util.Optional;
+
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for an entity where one of the attributes is a record that is in
+ * this case used as an embeddable, but elsewhere used as an entity.
+ */
+@Repository
+public interface Purchases extends DataRepository<Purchase, Long> {
+
+    @Insert
+    void buy(Purchase purchase);
+
+    @Delete
+    void clearAll();
+
+    // Selects multiple entity attributes into a record, per the spec
+    @Find
+    Optional<Receipt> receiptFor(long purchaseId);
+
+}

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -52,6 +52,7 @@ import org.junit.Test;
 
 import componenttest.app.FATServlet;
 import junit.framework.AssertionFailedError;
+import test.jakarta.data.experimental.web.Shipment.Instructions;
 
 @SuppressWarnings("serial")
 @WebServlet("/*")
@@ -1375,6 +1376,44 @@ public class DataExperimentalServlet extends FATServlet {
                                      .collect(Collectors.toList()));
 
         reservations.deleteByHostNot("unused@example.org");
+    }
+
+    /**
+     * Find operation that returns an entity attribute that is a record.
+     */
+    @Test
+    public void testReturnRecordAttribute() {
+        shipments.removeEverything();
+
+        Shipment s1 = new Shipment();
+        s1.setDestination("2800 37th St NW, Rochester, MN 55901");
+        s1.setLocation("44.006349, -92.4665299");
+        s1.setId(10);
+        s1.setInstructions(new Instructions(//
+                        "Handle with care", //
+                        "Leave at door, send text alert", //
+                        false));
+        s1.setOrderedAt(OffsetDateTime.now());
+        s1.setStatus("SHIPPED");
+        shipments.save(s1);
+
+        Shipment s2 = new Shipment();
+        s2.setDestination("2800 37th St NW, Rochester, MN 55901");
+        s2.setLocation("44.006349,-92.4665299");
+        s2.setId(20);
+        s2.setOrderedAt(OffsetDateTime.now());
+        s2.setStatus("ORDER_RECEIVED");
+        shipments.save(s2);
+
+        // TODO enable once #29460 is fixed
+        //Instructions inst1 = shipments.getInstructions(10).orElseThrow();
+        //assertEquals("Handle with care", inst1.handlingRequirements());
+        //assertEquals("Leave at door, send text alert", inst1.deliveryRequirements());
+        //assertEquals(false, inst1.needsSignature());
+
+        //assertEquals(false, shipments.getInstructions(20).isPresent());
+
+        shipments.removeEverything();
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Shipment.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Shipment.java
@@ -19,9 +19,17 @@ import java.time.OffsetDateTime;
  */
 public class Shipment implements ScheduledShipment {
 
+    public record Instructions(
+                    String handlingRequirements,
+                    String deliveryRequirements,
+                    boolean needsSignature) {
+    }
+
     private long id;
 
     private String destination;
+
+    private Instructions instructions;
 
     private String location;
 
@@ -44,6 +52,10 @@ public class Shipment implements ScheduledShipment {
 
     public long getId() {
         return id;
+    }
+
+    public Instructions getInstructions() {
+        return instructions;
     }
 
     public String getLocation() {
@@ -78,6 +90,10 @@ public class Shipment implements ScheduledShipment {
 
     public void setId(long id) {
         this.id = id;
+    }
+
+    public void setInstructions(Instructions value) {
+        this.instructions = value;
     }
 
     public void setLocation(String location) {

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Shipments.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Shipments.java
@@ -13,8 +13,10 @@
 package test.jakarta.data.experimental.web;
 
 import static io.openliberty.data.repository.Is.Op.In;
+import static jakarta.data.repository.By.ID;
 
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -29,6 +31,7 @@ import jakarta.data.repository.Update;
 import io.openliberty.data.repository.Is;
 import io.openliberty.data.repository.Select;
 import io.openliberty.data.repository.update.Assign;
+import test.jakarta.data.experimental.web.Shipment.Instructions;
 
 /**
  *
@@ -59,6 +62,10 @@ public interface Shipments {
     @OrderBy("status")
     @OrderBy(value = "orderedAt", descending = true)
     Shipment[] getAll();
+
+    @Find
+    @Select("instructions")
+    Optional<Instructions> getInstructions(@By(ID) long id);
 
     @Find
     @Select("status")


### PR DESCRIPTION
Repository methods should be able to return the subsets of entity attributes via records, and should be able to do so without being confused by attributes of entities that are also records of the same type.
Add a correct implementation of entity attributes subsets as records, and write better error reporting that is specific to entity attributes/subsets rather than allowing less meaningful errors to flow back to the user, so that the user can figure out how to correct their application code, whether they intended the record result type for this purpose or for returning a single attribute that is a record.
This PR also aligns with behavior being standardized in the spec.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
