### PR TITLE
delay logstashCollector server in featureStart before shutting down

### DIFF
--- a/dev/build.featureStart.base/src/com/ibm/ws/test/featurestart/FeaturesStartTestBase.java
+++ b/dev/build.featureStart.base/src/com/ibm/ws/test/featurestart/FeaturesStartTestBase.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.ToLongFunction;
+import java.lang.Thread;
 
 import org.junit.Assert;
 
@@ -305,6 +306,14 @@ public class FeaturesStartTestBase {
 
         try {
             if (server.isStarted()) {
+                if (shortName.equals("logstashCollector-1.0")) {
+                    try {
+                        Thread.sleep(10000); //wait 10 seconds for logstashCollector
+                    }
+                    catch (Exception e) {
+                        //ignore and continue;
+                    }
+                }
                 logInfo(m, "Stopping: " + description);
                 if (allowedErrors != null) {
                     logInfo(m, "Allowed errors [ " + Arrays.toString(allowedErrors) + " ]");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

The logstash collector test seems to fail fairly often. Delaying before stopping the server to give it time.