### PR TITLE
Query with record result in place of SELECT

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -785,9 +785,9 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testCountPagesWithNullValues() {
-        Page<String> page1 = primes.romanNumerals(30L, 49L,
-                                                  4000L, 4009L,
-                                                  PageRequest.ofSize(3));
+        Page<String> page1 = primes.romanNumeralsWithin(30L, 49L,
+                                                        4000L, 4009L,
+                                                        PageRequest.ofSize(3));
 
         assertEquals(8, page1.totalElements());
         assertEquals(3, page1.totalPages());
@@ -795,9 +795,9 @@ public class DataTestServlet extends FATServlet {
         assertEquals(List.of("XXXI", "XXXVII", "XLI"),
                      page1.content());
 
-        Page<String> page2 = primes.romanNumerals(30L, 49L,
-                                                  4000L, 4009L,
-                                                  page1.nextPageRequest());
+        Page<String> page2 = primes.romanNumeralsWithin(30L, 49L,
+                                                        4000L, 4009L,
+                                                        page1.nextPageRequest());
 
         assertEquals(8, page2.totalElements());
         assertEquals(3, page2.totalPages());
@@ -805,9 +805,9 @@ public class DataTestServlet extends FATServlet {
         assertEquals(Arrays.asList("XLIII", "XLVII", null),
                      page2.content());
 
-        Page<String> page3 = primes.romanNumerals(30L, 49L,
-                                                  4000L, 4009L,
-                                                  page2.nextPageRequest());
+        Page<String> page3 = primes.romanNumeralsWithin(30L, 49L,
+                                                        4000L, 4009L,
+                                                        page2.nextPageRequest());
 
         assertEquals(8, page3.totalElements());
         assertEquals(3, page3.totalPages());
@@ -4353,6 +4353,26 @@ public class DataTestServlet extends FATServlet {
         assertEquals(false, vehicles.existsAny());
         assertEquals(0L, vehicles.findAll().count());
         assertEquals(List.of(), vehicles.findAllOrderByPriceDescVinIdAsc());
+    }
+
+    /**
+     * Use a Repository method that has the Query annotation and has a return type
+     * that uses a Java record indicating to select a subset of entity attributes.
+     */
+    @Test
+    public void testQueryWithRecordResult() {
+        assertEquals(List.of("eleven XI ( X I )",
+                             "five V ( V )",
+                             "nineteen XIX ( X I X )",
+                             "seven VII ( V I I )",
+                             "seventeen XVII ( X V I I )",
+                             "thirteen XIII ( X I I I )",
+                             "three III ( I I I )",
+                             "two II ( I I )"),
+                     primes.romanNumeralsLessThanEq(20)
+                                     .stream()
+                                     .map(RomanNumeral::toString)
+                                     .collect(Collectors.toList()));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -404,17 +404,6 @@ public interface Primes {
     @Insert
     void persist(Prime... primes);
 
-    @Query("SELECT DISTINCT LENGTH(p.romanNumeral) FROM Prime p WHERE p.numberId <= ?1 ORDER BY LENGTH(p.romanNumeral) DESC")
-    Page<Integer> romanNumeralLengths(long maxNumber, PageRequest pagination);
-
-    @Query("SELECT romanNumeral" +
-           " WHERE (numberId BETWEEN ?1 AND ?2)" +
-           "    OR (numberId BETWEEN ?3 AND ?4)" +
-           " ORDER BY numberId ASC")
-    Page<String> romanNumerals(long min1, long max1,
-                               long min2, long max2,
-                               PageRequest pageRequest);
-
     @Query("SELECT DISTINCT(romanNumeral)" +
            " WHERE (numberId BETWEEN ?1 AND ?2)" +
            "    OR (numberId BETWEEN ?3 AND ?4)" +
@@ -422,6 +411,21 @@ public interface Primes {
     Page<String> romanNumeralsDistinct(long min1, long max1,
                                        long min2, long max2,
                                        PageRequest pageRequest);
+
+    @Query("SELECT DISTINCT LENGTH(p.romanNumeral) FROM Prime p WHERE p.numberId <= ?1 ORDER BY LENGTH(p.romanNumeral) DESC")
+    Page<Integer> romanNumeralLengths(long maxNumber, PageRequest pagination);
+
+    @Query("WHERE numberId <= ?1")
+    @OrderBy("name")
+    List<RomanNumeral> romanNumeralsLessThanEq(long max);
+
+    @Query("SELECT romanNumeral" +
+           " WHERE (numberId BETWEEN ?1 AND ?2)" +
+           "    OR (numberId BETWEEN ?3 AND ?4)" +
+           " ORDER BY numberId ASC")
+    Page<String> romanNumeralsWithin(long min1, long max1,
+                                     long min2, long max2,
+                                     PageRequest pageRequest);
 
     @Query("SELECT hex WHERE numberId=:id")
     Optional<Character> singleHexDigit(long id);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/RomanNumeral.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/RomanNumeral.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import java.util.ArrayList;
+
+/**
+ * A record to use as a result type for selecting attributes of the Prime entity.
+ */
+public record RomanNumeral(
+                String name,
+                String romanNumeral
+// , TODO enable once EclipseLink bug #30501 is fixed
+// ArrayList<String> romanNumeralSymbols
+) {
+
+    /**
+     * Format in an easy way for tests to compare results.
+     */
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder();
+        s.append(name).append(" ");
+        s.append(romanNumeral).append(" ( ");
+        for (char symbol : romanNumeral.toCharArray())
+        // TODO replace the above with the following once EclipseLink bug #30501 is fixed
+        //for (String symbol : romanNumeralSymbols)
+            s.append(symbol).append(' ');
+        s.append(")");
+        return s.toString();
+    }
+}


### PR DESCRIPTION
Ability for a Query method to use a Java record result to request a subset of entity attributes in place of a SELECT statement.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
