### PR TITLE
Rework async send tests part1

### DIFF
--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
@@ -192,6 +192,8 @@ public class JMS1AsyncSend extends ClientMain {
     	  BasicCompletionListener completionListener = new BasicCompletionListener();
           Queue queue = queueSession.createTemporaryQueue();
           
+          queueConnection.start();
+          
           try {
               MessageProducer producer = queueSession.createProducer(null);
 
@@ -433,6 +435,8 @@ public class JMS1AsyncSend extends ClientMain {
             TextMessage sentMessage = session.createTextMessage(methodName() + " at " + new Date());
             MessageProducer producer = session.createProducer(null);
             
+            queueConnection.start();
+            
             BasicCompletionListener completionListener = new BasicCompletionListener();
             try {
             	Util.TRACE("Sending message to null Destination. Expected to fail");
@@ -473,6 +477,8 @@ public class JMS1AsyncSend extends ClientMain {
             TextMessage sentMessage = session.createTextMessage(methodName() + " at " + new Date());
             MessageProducer producer = session.createProducer(queue);
             
+            queueConnection.start();
+            
             try {
             	Util.LOG("Sending message with null CompletionListener");
                 producer.send(sentMessage, null);
@@ -506,6 +512,8 @@ public class JMS1AsyncSend extends ClientMain {
             MessageProducer producer = session.createProducer(null);
             BasicCompletionListener completionListener = new BasicCompletionListener();
 
+            queueConnection.start();
+            
             try {
             	Util.LOG("Test no destination method 1");
                 producer.send(sentMessage, completionListener);

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
@@ -448,20 +448,31 @@ public class JMS1AsyncSend extends ClientMain {
     @ClientTest
     public void testJMS1AsyncSendNullListener() throws JMSException, TestException {
         
+    	Util.CODEPATH();
+    	
         try (QueueConnection queueConnection = queueConnectionFactory_.createQueueConnection();
         	 QueueSession session = queueConnection.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {
 
+        	Util.TRACE("Creating test objects");
+        	
         	Queue queue = session.createTemporaryQueue();
             TextMessage sentMessage = session.createTextMessage(methodName() + " at " + new Date());
             MessageProducer producer = session.createProducer(queue);
             
             try {
+            	Util.LOG("Sending message with null CompletionListener");
                 producer.send(sentMessage, null);
                 throw new TestException("IllegalArgumentException not thrown.");
             } catch (IllegalArgumentException e) {
                 // Expected Exception.
                 Util.TRACE(e);
             }
+        }
+        catch (JMSException | TestException e) {
+        	
+        	Util.LOG("Exception thrown during test", e);
+        	throw e;
+        	
         }
         
         reportSuccess();

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
@@ -182,16 +182,23 @@ public class JMS1AsyncSend extends ClientMain {
   public void testJMS1AsyncSendException() throws JMSException, TestException {
       //Util.setLevel(Level.FINEST);
 	  
+	  Util.CODEPATH();
 
       try ( QueueConnection connection = queueConnectionFactory_.createQueueConnection();
     		QueueSession queueSession = queueConnection_.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {  
           
+    	  Util.TRACE("Getting Test objects");
+    	  
     	  BasicCompletionListener completionListener = new BasicCompletionListener();
           Queue queue = queueSession.createTemporaryQueue();
           
           try {
               MessageProducer producer = queueSession.createProducer(null);
+
+              Util.TRACE("Sending null Message. Expected to fail");
               producer.send(queue, null, completionListener);
+              
+              Util.LOG("Send message did not throw expected Exception");
               throw new TestException("Expected MessageFormatException not thrown, completionListener state="+completionListener.formattedState());
           } catch (MessageFormatException e) {
               if (completionListener.completionCount_ != 0 )
@@ -201,7 +208,7 @@ public class JMS1AsyncSend extends ClientMain {
           }       
       }
       catch ( JMSException | TestException e) {
-    	  Util.LOG("TestException thrown during test", e);
+    	  Util.LOG("Exception thrown during test", e);
     	  throw e;
       }
 

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
@@ -424,7 +424,9 @@ public class JMS1AsyncSend extends ClientMain {
     @ClientTest
     public void testJMS1AsyncSendUnidentifiedProducerUnidentifiedDestination() throws JMSException, InterruptedException, TestException {
 
-        try (QueueSession session = queueConnection_.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {
+        try ( QueueConnection queueConnection = queueConnectionFactory_.createQueueConnection();
+        	  QueueSession session = queueConnection.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {
+        	
             TextMessage sentMessage = session.createTextMessage(methodName() + " at " + new Date());
             MessageProducer producer = session.createProducer(null);
             

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
@@ -184,8 +184,8 @@ public class JMS1AsyncSend extends ClientMain {
 	  
 	  Util.CODEPATH();
 
-      try ( QueueConnection connection = queueConnectionFactory_.createQueueConnection();
-    		QueueSession queueSession = queueConnection_.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {  
+      try ( QueueConnection queueConnection = queueConnectionFactory_.createQueueConnection();
+    		QueueSession queueSession = queueConnection.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {  
           
     	  Util.TRACE("Getting Test objects");
     	  

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
@@ -467,15 +467,20 @@ public class JMS1AsyncSend extends ClientMain {
 
     @ClientTest
     public void testJMS1AsyncSendNoDestination() throws JMSException, TestException {
+    	
+    	Util.CODEPATH();
 
         try (QueueConnection queueConnection = queueConnectionFactory_.createQueueConnection();
         	 QueueSession session = queueConnection.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {
         	
+        	Util.TRACE("Creating test objects");
+        	
             TextMessage sentMessage = session.createTextMessage(methodName() + " at " + new Date());
             MessageProducer producer = session.createProducer(null);
-
             BasicCompletionListener completionListener = new BasicCompletionListener();
+
             try {
+            	Util.LOG("Test no destination method 1");
                 producer.send(sentMessage, completionListener);
                 throw new TestException("UnsupportedOperationException 1 not thrown");
             } catch (UnsupportedOperationException e) {
@@ -483,6 +488,7 @@ public class JMS1AsyncSend extends ClientMain {
                 Util.TRACE(e);
             }
             try {
+            	Util.LOG("Test null destination method 1");
                 producer.send(null, sentMessage, completionListener);
                 throw new TestException("InvalidDestinationException 1 not thrown");
             } catch (InvalidDestinationException e) {
@@ -490,6 +496,7 @@ public class JMS1AsyncSend extends ClientMain {
                 Util.TRACE(e);
             }
             try {
+            	Util.LOG("Test no destination method 2");
                 producer.send(sentMessage, DeliveryMode.PERSISTENT, 0, 10000, completionListener);
                 throw new TestException("UnsupportedOperationException 2 not thrown");
             } catch (UnsupportedOperationException e) {
@@ -497,12 +504,19 @@ public class JMS1AsyncSend extends ClientMain {
                 Util.TRACE(e);
             }
             try {
+            	Util.LOG("Test null destination method 2");
                 producer.send(null, sentMessage, DeliveryMode.PERSISTENT, 0, 10000, completionListener);
                 throw new TestException("InvalidDestinationException 2 not thrown");
             } catch (InvalidDestinationException e) {
                 // Expected Exception.
                 Util.TRACE(e);
             }
+        }
+        catch (JMSException | TestException e) {
+        	
+        	Util.LOG("Exception thrown during test", e);
+        	throw e;
+        	
         }
 
         reportSuccess();

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
@@ -424,15 +424,21 @@ public class JMS1AsyncSend extends ClientMain {
     @ClientTest
     public void testJMS1AsyncSendUnidentifiedProducerUnidentifiedDestination() throws JMSException, InterruptedException, TestException {
 
+    	Util.CODEPATH();
+    	
         try ( QueueConnection queueConnection = queueConnectionFactory_.createQueueConnection();
         	  QueueSession session = queueConnection.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {
         	
+        	Util.TRACE("Getting Test objects");
             TextMessage sentMessage = session.createTextMessage(methodName() + " at " + new Date());
             MessageProducer producer = session.createProducer(null);
             
             BasicCompletionListener completionListener = new BasicCompletionListener();
             try {
+            	Util.TRACE("Sending message to null Destination. Expected to fail");
                 producer.send(null, sentMessage, completionListener);
+                
+                Util.LOG("Send message did not throw expected Exception");
                 throw new TestException("InvalidDestinationException not thrown");
             } catch (InvalidDestinationException e) {
                 // Expected Exception.
@@ -442,6 +448,12 @@ public class JMS1AsyncSend extends ClientMain {
             Util.TRACE(completionListener.formattedState());
             if (!completionListener.waitFor(0, 0))
                 throw new TestException("Unexpected completion notification received, completionListener.formattedState:" + completionListener.formattedState());
+        }
+        catch (JMSException | TestException e) {
+        	
+        	Util.LOG("Exception thrown during test", e);
+        	throw e;
+        	
         }
 
         reportSuccess();

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
@@ -448,9 +448,13 @@ public class JMS1AsyncSend extends ClientMain {
     @ClientTest
     public void testJMS1AsyncSendNullListener() throws JMSException, TestException {
         
-        try (QueueSession session = queueConnection_.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {
+        try (QueueConnection queueConnection = queueConnectionFactory_.createQueueConnection();
+        	 QueueSession session = queueConnection.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {
+
+        	Queue queue = session.createTemporaryQueue();
             TextMessage sentMessage = session.createTextMessage(methodName() + " at " + new Date());
-            MessageProducer producer = session.createProducer(queueOne_);
+            MessageProducer producer = session.createProducer(queue);
+            
             try {
                 producer.send(sentMessage, null);
                 throw new TestException("IllegalArgumentException not thrown.");
@@ -458,8 +462,6 @@ public class JMS1AsyncSend extends ClientMain {
                 // Expected Exception.
                 Util.TRACE(e);
             }
-        } finally {
-            clearQueue(queueOne_, methodName(), 0);
         }
         
         reportSuccess();

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/test-applications/JMS1AsyncSendClient.jar/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSend.java
@@ -468,7 +468,9 @@ public class JMS1AsyncSend extends ClientMain {
     @ClientTest
     public void testJMS1AsyncSendNoDestination() throws JMSException, TestException {
 
-        try (QueueSession session = queueConnection_.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {
+        try (QueueConnection queueConnection = queueConnectionFactory_.createQueueConnection();
+        	 QueueSession session = queueConnection.createQueueSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE)) {
+        	
             TextMessage sentMessage = session.createTextMessage(methodName() + " at " + new Date());
             MessageProducer producer = session.createProducer(null);
 


### PR DESCRIPTION
- [ x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
################################################################################################

For #30510

Reworking first set of tests in JMS1AsyncSend. Includes:
 - testJMS1AsyncSendException
 - testJMS1AsyncSendNoDestination
 - testJMS1AsyncSendNullListener
 - testJMS1AsyncSendUnidentifiedProducerUnidentifiedDestination