### PR TITLE
SecurityUtility only prints Exception name without errorstack

### DIFF
--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/AESKeyManager.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/AESKeyManager.java
@@ -31,7 +31,8 @@ import com.ibm.wsspi.security.crypto.KeyStringResolver;
  */
 public class AESKeyManager {
     private static final AtomicReference<KeyStringResolver> _resolver = new AtomicReference<KeyStringResolver>();
-
+    private static final boolean DEBUG = Boolean.getBoolean("enableDebug");  // Used exclusively for debugging securityUtility
+    
     public static enum KeyVersion {
         AES_V0("PBKDF2WithHmacSHA1", 84756, 128, new byte[] { -89, -94, -125, 57, 76, 90, -77, 79, 50, 21, 10, -98, 47, 23, 17, 56, -61, 46, 125, -128 }),
         AES_V1("PBKDF2WithHmacSHA512", 300000, 256, new byte[] { -89, -63, 22, 15, -121, 11, 102, 75, -91, 68, -94, -89, 96, 83, -21, -69, -45, 29, 26, 106, -18, 69, 60, -6,
@@ -47,7 +48,9 @@ public class AESKeyManager {
         private final int iterations;
         private final int keyLength;
         private final byte[] salt;
+	
 
+	
         private KeyVersion(String alg, int iterations, int keyLength, byte[] salt) {
             this.alg = alg;
             this.iterations = iterations;
@@ -67,8 +70,14 @@ public class AESKeyManager {
                     // Still use this holder for returns even if I do not end up caching it.
                     holder = holder2;
                 } catch (InvalidKeySpecException e) {
+		    if (Boolean.getBoolean("enableDebug")) {
+			securityUtilDebug("InvalidKeySpecException received. Returning null", e); 
+		    }
                     return null;
                 } catch (NoSuchAlgorithmException e) {
+		    if (Boolean.getBoolean("enableDebug")) {
+			securityUtilDebug("InvalidKeySpecException received. Returning null", e); 			
+		    }		    
                     return null;
                 }
 
@@ -77,6 +86,14 @@ public class AESKeyManager {
             return holder;
         }
     }
+
+    // Used exclusively for debugging securityUtility
+    private static void securityUtilDebug(String message, Throwable throwable) {
+        if (DEBUG) {
+            System.out.println("[DEBUG] " + message);
+            throwable.printStackTrace(System.out);  // Prints the exception stack trace
+        }
+    }    
 
     private static class KeyHolder {
         private final char[] keyChars;

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/AESKeyManager.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/AESKeyManager.java
@@ -70,12 +70,12 @@ public class AESKeyManager {
                     // Still use this holder for returns even if I do not end up caching it.
                     holder = holder2;
                 } catch (InvalidKeySpecException e) {
-		    if (Boolean.getBoolean("enableDebug")) {
+		    if (DEBUG) {
 			securityUtilDebug("InvalidKeySpecException received. Returning null", e); 
 		    }
                     return null;
                 } catch (NoSuchAlgorithmException e) {
-		    if (Boolean.getBoolean("enableDebug")) {
+		    if (DEBUG) {
 			securityUtilDebug("InvalidKeySpecException received. Returning null", e); 			
 		    }		    
                     return null;

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/AESKeyManager.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/AESKeyManager.java
@@ -89,10 +89,8 @@ public class AESKeyManager {
 
     // Used exclusively for debugging securityUtility
     private static void securityUtilDebug(String message, Throwable throwable) {
-        if (DEBUG) {
-            System.out.println("[DEBUG] " + message);
-            throwable.printStackTrace(System.out);  // Prints the exception stack trace
-        }
+        System.out.println("[DEBUG] " + message);
+        throwable.printStackTrace(System.out);  // Prints the exception stack trace
     }    
 
     private static class KeyHolder {

--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/SecurityUtility.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/SecurityUtility.java
@@ -136,11 +136,13 @@ public class SecurityUtility extends UtilityTemplate {
                 stderr.println("");
                 stderr.println(CommandUtils.getMessage("error", e.getMessage()));
                 stderr.println(help.getTaskUsage(task));
+		e.printStackTrace(stderr);		
                 return SecurityUtilityReturnCodes.ERR_GENERIC;
             } catch (Exception e) {
                 stderr.println("");
                 stderr.println(CommandUtils.getMessage("error", e.toString()));
                 stderr.println(help.getTaskUsage(task));
+		e.printStackTrace(stderr);
                 return SecurityUtilityReturnCodes.ERR_GENERIC;
             }
         }

--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/SecurityUtility.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/SecurityUtility.java
@@ -136,7 +136,6 @@ public class SecurityUtility extends UtilityTemplate {
                 stderr.println("");
                 stderr.println(CommandUtils.getMessage("error", e.getMessage()));
                 stderr.println(help.getTaskUsage(task));
-		e.printStackTrace(stderr);		
                 return SecurityUtilityReturnCodes.ERR_GENERIC;
             } catch (Exception e) {
                 stderr.println("");

--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/SecurityUtility.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/SecurityUtility.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves 

This PR enhances the serviceability of the `securityUtility` command. By adding a single line of code to each catch block, we enabled the printing of debug information, as reported by the user. This additional detail has proven invaluable in furthering our investigation.  Resolving this issue took over a month, but these changes should significantly improve troubleshooting efficiency moving forward. 

**BEFORE**
> $ wlp/bin/securityUtility encode --encoding=aes Welcome1 
> Error: java.lang.NullPointerException
> Usage:
> securityUtility encode [options]
> Description:
> Encode the provided text.

**AFTER** 

> $ securityUtility encode --encoding=aes Welcome1" 
> DEBUG: Exception received. Below is a debug message
> java.lang.NullPointerException
>        at com.ibm.ws.crypto.util.AESKeyManager.getKey(AESKeyManager.java:123)
>        at com.ibm.ws.crypto.util.PasswordCipherUtil.aesEncipherV0(PasswordCipherUtil.java:528)
>        at com.ibm.ws.crypto.util.PasswordCipherUtil.encipher_internal(PasswordCipherUtil.java:368)
>        at com.ibm.websphere.crypto.PasswordUtil.encode_password(PasswordUtil.java:705)
>        at com.ibm.websphere.crypto.PasswordUtil.encode(PasswordUtil.java:265)
>        at com.ibm.ws.security.utility.tasks.EncodeTask.encode(EncodeTask.java:110)
>        at com.ibm.ws.security.utility.tasks.EncodeTask.handleTask(EncodeTask.java:144)
>        at com.ibm.ws.security.utility.SecurityUtility.runProgram(SecurityUtility.java:145)
>        at com.ibm.ws.security.utility.SecurityUtility.main(SecurityUtility.java:187)
>        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
>        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
>        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
>        at java.lang.reflect.Method.invoke(Method.java:498)
>        at com.ibm.ws.kernel.boot.cmdline.UtilityMain.internal_main(UtilityMain.java:175)
>        at com.ibm.ws.kernel.boot.cmdline.UtilityMain.main(UtilityMain.java:55)
>        at com.ibm.ws.kernel.boot.cmdline.Main.main(Main.java:54)
 
The above information let me to add code in AESKeyManager. It finally found that PBKDF2WithHmacSHA1 was disabled in their environment.  

> [DEBUG] Creating the new holder with alg=PBKDF2WithHmacSHA1 salt=[B@4b6995df iterations=84756 keyLength=128
> [DEBUG] NoSuchAlgorithmException received. Returning null
> java.security.NoSuchAlgorithmException: PBKDF2WithHmacSHA1 SecretKeyFactory not available
> 	at javax.crypto.SecretKeyFactory.<init>(SecretKeyFactory.java:122)
> 	at javax.crypto.SecretKeyFactory.getInstance(SecretKeyFactory.java:160)
> 	at com.ibm.ws.crypto.util.AESKeyManager$KeyVersion.get(AESKeyManager.java:72)
> 	at com.ibm.ws.crypto.util.AESKeyManager$KeyVersion.access$400(AESKeyManager.java:38)
> 	at com.ibm.ws.crypto.util.AESKeyManager.getHolder(AESKeyManager.java:186)
> 	at com.ibm.ws.crypto.util.AESKeyManager.getKey(AESKeyManager.java:155)
> 	at com.ibm.ws.crypto.util.PasswordCipherUtil.aesEncipherV0(PasswordCipherUtil.java:528)
> 	at com.ibm.ws.crypto.util.PasswordCipherUtil.encipher_internal(PasswordCipherUtil.java:368)
> 	at com.ibm.websphere.crypto.PasswordUtil.encode_password(PasswordUtil.java:705)
> 	at com.ibm.websphere.crypto.PasswordUtil.encode(PasswordUtil.java:265)

The user recently migrated from IBM Java 8 to Semeru 11, which disables PBKDF2WithHmacSHA1 in FIPS mode. 
Workaround: https://www.ibm.com/support/pages/fips-certified-cryptography-ibm-semeru-runtimes