### PR TITLE
Fix enableExtensionFunctions in Java 24+

### DIFF
--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -725,6 +725,10 @@
 			<arg value="-Dbasedir=${basedir}" />
 			<arg value="-Ddir.log.html=${dir.log.html}" />
 			<arg value="-Ddir.log.xml=${dir.log.xml}" />
+			<!-- In Java 24, the default for 'jdk.xml.enableExtensionFunctions' was changed to false
+				 This broke our JUnit XML to HTML transformations for FAT output in junit.html
+				 Forcing value back to true - https://bugs.openjdk.org/browse/JDK-8343024 -->
+			<jvmarg line="-Djdk.xml.enableExtensionFunctions=true" />
 		</java>
 
 		<iff>


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #30526 

In Java 24, the default value for `jdk.xml.enableExtensionFunctions` was changed from `true` to `false` ([reference](https://bugs.openjdk.org/browse/JDK-8343024)).
This broke our JUnit XML to HTML transformations for FAT output in the junit.html directory.
Forcing the `jdk.xml.enableExtensionFunctions` value back to `true` resolves this issue.