### PR TITLE
Add arquillian and appmgr trace for OpenAPI TCK

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/servers/FATServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/servers/FATServer/bootstrap.properties
@@ -1,17 +1,16 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:MPOPENAPI=debug:io.smallrye.openapi.*=all
+#com.ibm.ws.logging.trace.specification=*=info:MPOPENAPI=debug:io.smallrye.openapi.*=all
 #com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all=enabled:mpOpenAPI=debug=enabled
 #com.ibm.ws.logging.trace.specification=*=info:io.smallrye.openapi.*=all
 
+# Logging for RTC 302767 & 303413
+com.ibm.ws.logging.trace.specification=com.ibm.ws.app.manager.*=all

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/logging.properties
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/logging.properties
@@ -1,0 +1,21 @@
+handlers = com.ibm.ws.fat.util.GenericHandler
+
+# The GenericHandler will log all messages printed at any logging level
+com.ibm.ws.fat.util.GenericHandler.level=ALL
+com.ibm.ws.fat.util.GenericHandler.formatter=com.ibm.ws.fat.util.GenericFormatter
+com.ibm.ws.fat.util.GenericHandler.stream=system.out
+com.ibm.ws.fat.util.GenericHandler.flush=true
+
+com.ibm.ws.fat.util.GenericFormatter.class.full=false
+com.ibm.ws.fat.util.GenericFormatter.class.length=30
+com.ibm.ws.fat.util.GenericFormatter.class.log=true
+com.ibm.ws.fat.util.GenericFormatter.level.log=true
+com.ibm.ws.fat.util.GenericFormatter.method.length=30
+com.ibm.ws.fat.util.GenericFormatter.method.log=true
+com.ibm.ws.fat.util.GenericFormatter.thread.length=3
+com.ibm.ws.fat.util.GenericFormatter.thread.log=true
+com.ibm.ws.fat.util.GenericFormatter.time.format=[MM/dd/yyyy HH:mm:ss:SSS z]
+com.ibm.ws.fat.util.GenericFormatter.time.log=true
+
+# Enable logging for the arquillian container for RTC 302767 & 303413
+io.openliberty.arquillian.managed.level=FINER

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/pom.xml
@@ -57,6 +57,12 @@
                 <version>${surefire.version}</version>
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <systemProperties>
+                      <property>
+                        <name>java.util.logging.config.file</name>
+                        <value>logging.properties</value>
+                      </property>
+                    </systemProperties>
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>

--- a/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/publish/servers/FATServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/publish/servers/FATServer/bootstrap.properties
@@ -1,17 +1,16 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:MPOPENAPI=debug:io.smallrye.openapi.*=all
+#com.ibm.ws.logging.trace.specification=*=info:MPOPENAPI=debug:io.smallrye.openapi.*=all
 #com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all=enabled:mpOpenAPI=debug=enabled
 #com.ibm.ws.logging.trace.specification=*=info:io.smallrye.openapi.*=all
 
+# Logging for RTC 302767 & 303413
+com.ibm.ws.logging.trace.specification=com.ibm.ws.app.manager.*=all

--- a/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/publish/tckRunner/tck/logging.properties
+++ b/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/publish/tckRunner/tck/logging.properties
@@ -1,0 +1,21 @@
+handlers = com.ibm.ws.fat.util.GenericHandler
+
+# The GenericHandler will log all messages printed at any logging level
+com.ibm.ws.fat.util.GenericHandler.level=ALL
+com.ibm.ws.fat.util.GenericHandler.formatter=com.ibm.ws.fat.util.GenericFormatter
+com.ibm.ws.fat.util.GenericHandler.stream=system.out
+com.ibm.ws.fat.util.GenericHandler.flush=true
+
+com.ibm.ws.fat.util.GenericFormatter.class.full=false
+com.ibm.ws.fat.util.GenericFormatter.class.length=30
+com.ibm.ws.fat.util.GenericFormatter.class.log=true
+com.ibm.ws.fat.util.GenericFormatter.level.log=true
+com.ibm.ws.fat.util.GenericFormatter.method.length=30
+com.ibm.ws.fat.util.GenericFormatter.method.log=true
+com.ibm.ws.fat.util.GenericFormatter.thread.length=3
+com.ibm.ws.fat.util.GenericFormatter.thread.log=true
+com.ibm.ws.fat.util.GenericFormatter.time.format=[MM/dd/yyyy HH:mm:ss:SSS z]
+com.ibm.ws.fat.util.GenericFormatter.time.log=true
+
+# Enable logging for the arquillian container for RTC 302767 & 303413
+io.openliberty.arquillian.managed.level=FINER

--- a/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -59,7 +59,12 @@
                 <version>${surefire.version}</version>
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
-
+                    <systemProperties>
+                      <property>
+                        <name>java.util.logging.config.file</name>
+                        <value>logging.properties</value>
+                      </property>
+                    </systemProperties>
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/servers/FATServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/servers/FATServer/bootstrap.properties
@@ -1,17 +1,16 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:MPOPENAPI=debug:io.smallrye.openapi.*=all
+#com.ibm.ws.logging.trace.specification=*=info:MPOPENAPI=debug:io.smallrye.openapi.*=all
 #com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all=enabled:mpOpenAPI=debug=enabled
 #com.ibm.ws.logging.trace.specification=*=info:io.smallrye.openapi.*=all
 
+# Logging for RTC 302767 & 303413
+com.ibm.ws.logging.trace.specification=com.ibm.ws.app.manager.*=all

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/logging.properties
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/logging.properties
@@ -1,0 +1,21 @@
+handlers = com.ibm.ws.fat.util.GenericHandler
+
+# The GenericHandler will log all messages printed at any logging level
+com.ibm.ws.fat.util.GenericHandler.level=ALL
+com.ibm.ws.fat.util.GenericHandler.formatter=com.ibm.ws.fat.util.GenericFormatter
+com.ibm.ws.fat.util.GenericHandler.stream=system.out
+com.ibm.ws.fat.util.GenericHandler.flush=true
+
+com.ibm.ws.fat.util.GenericFormatter.class.full=false
+com.ibm.ws.fat.util.GenericFormatter.class.length=30
+com.ibm.ws.fat.util.GenericFormatter.class.log=true
+com.ibm.ws.fat.util.GenericFormatter.level.log=true
+com.ibm.ws.fat.util.GenericFormatter.method.length=30
+com.ibm.ws.fat.util.GenericFormatter.method.log=true
+com.ibm.ws.fat.util.GenericFormatter.thread.length=3
+com.ibm.ws.fat.util.GenericFormatter.thread.log=true
+com.ibm.ws.fat.util.GenericFormatter.time.format=[MM/dd/yyyy HH:mm:ss:SSS z]
+com.ibm.ws.fat.util.GenericFormatter.time.log=true
+
+# Enable logging for the arquillian container for RTC 302767 & 303413
+io.openliberty.arquillian.managed.level=FINER

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -67,7 +67,12 @@
                 <version>${surefire.version}</version>
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
-
+                    <systemProperties>
+                      <property>
+                        <name>java.util.logging.config.file</name>
+                        <value>logging.properties</value>
+                      </property>
+                    </systemProperties>
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>

--- a/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/publish/servers/FATServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/publish/servers/FATServer/bootstrap.properties
@@ -1,17 +1,16 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 #com.ibm.ws.logging.trace.specification=*=info:MPOPENAPI=debug:io.smallrye.openapi.*=all
 #com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all=enabled:mpOpenAPI=debug=enabled
 #com.ibm.ws.logging.trace.specification=*=info:io.smallrye.openapi.*=all
 
+# Logging for RTC 302767 & 303413
+com.ibm.ws.logging.trace.specification=com.ibm.ws.app.manager.*=all

--- a/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/publish/tckRunner/tck/logging.properties
+++ b/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/publish/tckRunner/tck/logging.properties
@@ -1,0 +1,21 @@
+handlers = com.ibm.ws.fat.util.GenericHandler
+
+# The GenericHandler will log all messages printed at any logging level
+com.ibm.ws.fat.util.GenericHandler.level=ALL
+com.ibm.ws.fat.util.GenericHandler.formatter=com.ibm.ws.fat.util.GenericFormatter
+com.ibm.ws.fat.util.GenericHandler.stream=system.out
+com.ibm.ws.fat.util.GenericHandler.flush=true
+
+com.ibm.ws.fat.util.GenericFormatter.class.full=false
+com.ibm.ws.fat.util.GenericFormatter.class.length=30
+com.ibm.ws.fat.util.GenericFormatter.class.log=true
+com.ibm.ws.fat.util.GenericFormatter.level.log=true
+com.ibm.ws.fat.util.GenericFormatter.method.length=30
+com.ibm.ws.fat.util.GenericFormatter.method.log=true
+com.ibm.ws.fat.util.GenericFormatter.thread.length=3
+com.ibm.ws.fat.util.GenericFormatter.thread.log=true
+com.ibm.ws.fat.util.GenericFormatter.time.format=[MM/dd/yyyy HH:mm:ss:SSS z]
+com.ibm.ws.fat.util.GenericFormatter.time.log=true
+
+# Enable logging for the arquillian container for RTC 302767 & 303413
+io.openliberty.arquillian.managed.level=FINER

--- a/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -67,7 +67,12 @@
                 <version>${surefire.version}</version>
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
-
+                    <systemProperties>
+                      <property>
+                        <name>java.util.logging.config.file</name>
+                        <value>logging.properties</value>
+                      </property>
+                    </systemProperties>
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>


### PR DESCRIPTION
Need this trace to debug occasional app-start errors logged in builds.

For RTC 302767 & 303413

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".