### PR TITLE
Disallow deprecated entity attribute types

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -22,7 +22,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZonedDateTime;
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -224,18 +223,12 @@ public class EntityInfo {
     @Trivial
     private void validate() {
         for (Entry<String, Class<?>> attrType : attributeTypes.entrySet())
-            // ZonedDateTime is not one of the supported Temporal types
-            // Jakarta Data and Jakarta Persistence and does not behave
-            // correctly in EclipseLink where we have observed reading back
-            // a different value from the database than was persisted.
-            // If proper support is added for it in the future, then this
-            // can be removed.
-            if (ZonedDateTime.class.equals(attrType.getValue()))
+            if (Util.UNSUPPORTED_ATTR_TYPES.contains(attrType.getValue()))
                 throw exc(MappingException.class,
                           "CWWKD1055.unsupported.entity.prop",
                           attrType.getKey(),
                           entityClass.getName(),
-                          attrType.getValue(),
+                          attrType.getValue().getName(),
                           List.of(Instant.class.getSimpleName(),
                                   LocalDate.class.getSimpleName(),
                                   LocalDateTime.class.getSimpleName(),

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -70,6 +71,25 @@ public class Util {
      */
     static final Set<Class<?>> SORT_PARAM_TYPES = //
                     Set.of(Order.class, Sort.class, Sort[].class);
+
+    /**
+     * These types are never supported for entity attributes.
+     *
+     * ZonedDateTime is not one of the supported Temporal types of Jakarta Data
+     * or Jakarta Persistence, and it does not behave correctly in EclipseLink,
+     * where we have observed it reading back a different value from the database
+     * than was persisted. If proper support is added for it in the future,
+     * then this restriction against using it can be made version dependent.
+     */
+    static final Set<Class<?>> UNSUPPORTED_ATTR_TYPES = //
+                    Set.of(Byte[].class, // deprecated in JPA 3.2
+                           Character[].class, // deprecated in JPA 3.2
+                           java.sql.Date.class, // deprecated in JPA 3.2
+                           java.sql.Time.class, // deprecated in JPA 3.2
+                           java.sql.Timestamp.class, // deprecated in JPA 3.2
+                           java.util.Calendar.class, // deprecated in JPA 3.2
+                           java.util.Date.class, // deprecated in JPA 3.2
+                           ZonedDateTime.class); // would be useful if it worked
 
     /**
      * Valid types for when a repository method computes an update count

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -36,7 +36,9 @@ import javax.naming.InitialContext;
 @Repository
 public interface Counties {
 
-    boolean deleteByNameAndLastUpdated(String name, Timestamp version);
+    boolean deleteByNameAndLastUpdated(String name, Long version);
+    // TODO switch to the following once EclipseLink bug #30534 is fixed
+    // boolean deleteByNameAndLastUpdated(String name, LocalDateTime version);
 
     int deleteByNameIn(List<String> names);
 
@@ -51,7 +53,9 @@ public interface Counties {
     @OrderBy("name")
     List<Set<CityId>> findCitiesByNameStartsWith(String beginning);
 
-    Timestamp findLastUpdatedByName(String name);
+    Long findLastUpdatedByName(String name);
+    // TODO switch to the following once EclipseLink bug #30534 is fixed
+    //LocalDateTime findLastUpdatedByName(String name);
 
     @Query("SELECT zipcodes WHERE name = ?1")
     Optional<int[]> findZipCodesByName(String name);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/County.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/County.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -26,7 +26,9 @@ public class County {
     public Set<CityId> cities;
 
     @Version
-    public Timestamp lastUpdated;
+    public Long lastUpdated;
+    // TODO switch to the following once EclipseLink bug #30534 is fixed
+    //public LocalDateTime lastUpdated;
 
     @Id
     public String name;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Rebate.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Rebate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ public record Rebate(
                 LocalDate purchaseMadeOn,
                 Rebate.Status status,
                 LocalDateTime updatedAt,
-                Integer version) { // TODO rename to something other than version, and use @Version
+                Integer version) {
     public static enum Status {
         DENIED, SUBMITTED, VERIFIED, PAID
     }


### PR DESCRIPTION
It is best if Jakarta Data disallows the entity attributes that are deprecated by JPA 3.2 so that customers don't start using them only to later see them removed.

We had one test case that was using a deprecated type: java.sql.Timestamp
It was using it as a Version attribute, so I tried switching to java.time.LocalDateTime, which has a similar meaning and is listed as supported by JPA 3.2.  EclipseLink rejected it, so I reported that to the JPA team and placed a TODO comment in the code pointing to the tracking issue and temporarily using `Long` instead. 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
