### PR TITLE
use spec-defined terminology for entity attributes

### DIFF
--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -138,9 +138,9 @@ public class Data_1_1 implements DataVersionCompatibility {
             if (ignoreCase ||
                 baseOp != Is.Op.Equal) // TODO also have an operation for collection containing?
                 throw new UnsupportedOperationException("The " + comparison.name() +
-                                                        " comparison that is applied to entity property " +
+                                                        " comparison that is applied to entity attribute " +
                                                         attrName +
-                                                        " is not supported for collection properties."); // TODO NLS (future)
+                                                        " is not supported for collection attributes."); // TODO NLS (future)
 
         switch (baseOp) {
             case Equal:

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -126,12 +126,12 @@ CWWKD1009.lifecycle.param.err.explanation=Lifecycle methods must have a single \
 CWWKD1009.lifecycle.param.err.useraction=Update the repository method to have a \
  single parameter that is an entity or an array of List of the entity.
 
-CWWKD1010.unknown.entity.prop=CWWKD1010E: An entity attribute named {0} is \
+CWWKD1010.unknown.entity.attr=CWWKD1010E: An entity attribute named {0} is \
  not found on the {1} entity class for the {2} method of the {3} repository \
  interface. Valid attribute names for the entity are: {4}.
-CWWKD1010.unknown.entity.prop.explanation=The repository method is attempting \
+CWWKD1010.unknown.entity.attr.explanation=The repository method is attempting \
  to use an entity attribute that does not exist.
-CWWKD1010.unknown.entity.prop.useraction=Update the repository method to match \
+CWWKD1010.unknown.entity.attr.useraction=Update the repository method to match \
  a valid attribute that is defined by the entity.
 
 CWWKD1011.unknown.method.pattern=CWWKD1011E: The {0} method of the {1} repository \
@@ -268,21 +268,21 @@ CWWKD1023.extra.param.explanation=Query conditions that define \
 CWWKD1023.extra.param.useraction=Update the repository method signature \
  to remove extra parameters that do not correspond to declared conditions.
 
-CWWKD1024.missing.entity.prop=CWWKD1024E: The {0} method of the {1} repository \
+CWWKD1024.missing.entity.attr=CWWKD1024E: The {0} method of the {1} repository \
  interface is missing an entity attribute name or was supplied with a parameter \
  that lacks an entity attribute name. Valid attribute names for the {2} entity \
  class are: {3}.
-CWWKD1024.missing.entity.prop.explanation=The query conditions and sort criteria \
+CWWKD1024.missing.entity.attr.explanation=The query conditions and sort criteria \
  for a repository method must include an entity attribute name.
-CWWKD1024.missing.entity.prop.useraction=Inspect the declaration and usage of \
+CWWKD1024.missing.entity.attr.useraction=Inspect the declaration and usage of \
  the repository method to ensure that an entity attribute name is supplied for \
  each query condition and sort criterion.
 
-CWWKD1025.missing.id.prop=CWWKD1025E: The {0} entity class that is used by the \
+CWWKD1025.missing.id.attr=CWWKD1025E: The {0} entity class that is used by the \
  {1} method of the {2} repository interface does not have an ID attribute.
-CWWKD1025.missing.id.prop.explanation=Repository methods that delete and return \
+CWWKD1025.missing.id.attr.explanation=Repository methods that delete and return \
  an entity must have an ID attribute.
-CWWKD1025.missing.id.prop.useraction=If the entity does not have a single \
+CWWKD1025.missing.id.attr.useraction=If the entity does not have a single \
  attribute for the ID, define separate repository methods that query for the \
  entity and delete the entity.
 
@@ -296,14 +296,14 @@ CWWKD1026.ignore.case.not.text.useraction=Ensure the sort criteria is applied \
  to the correct entity attribute and remove the instruction to ignore case if the \
  entity attribute does not represent text.
 
-CWWKD1027.anno.missing.prop.name=CWWKD1027E: Parameter {0} of the {1} method of \
+CWWKD1027.anno.missing.attr.name=CWWKD1027E: Parameter {0} of the {1} method of \
  the {2} repository interface is annotated with an {3} annotation that does not \
  specify an entity attribute name as its value. The annotation must either specify \
  the entity attribute name as its value, or the -parameters compile option must be \
  enabled and the parameter must have the same name as the entity attribute.
-CWWKD1027.anno.missing.prop.name.explanation=Parameters of repository update \
+CWWKD1027.anno.missing.attr.name.explanation=Parameters of repository update \
  methods must correspond to entity attributes.
-CWWKD1027.anno.missing.prop.name.useraction=Update the repository method to \
+CWWKD1027.anno.missing.attr.name.useraction=Update the repository method to \
  indicate the entity attribute to which the parameter pertains.
 
 CWWKD1028.first.exceeds.max=CWWKD1028E: The {0} method of the {1} repository \
@@ -554,14 +554,14 @@ CWWKD1054.non.unique.result.useraction=Update the repository method to either us
  a return type that supports multiple results or update the repository method \
  to return no more than a single result.
 
-CWWKD1055.unsupported.entity.prop=CWWKD1055E: The {0} attribute of the {1} entity \
+CWWKD1055.unsupported.entity.attr=CWWKD1055E: The {0} attribute of the {1} entity \
  has an unsupported type: {2}. Jakarta Data supports Java enumeration types, \
  the {3} temporal types, and the following basic types: {4}. The built-in \
  Jakarta Data provider also supports some Jakarta Persistence types, such as \
  embeddables.
-CWWKD1055.unsupported.entity.prop.explanation=Jakarta Data does not support the \
+CWWKD1055.unsupported.entity.attr.explanation=Jakarta Data does not support the \
  type used by the entity attribute.
-CWWKD1055.unsupported.entity.prop.useraction=Update the entity attribute to use \
+CWWKD1055.unsupported.entity.attr.useraction=Update the entity attribute to use \
  one of the supported types.
 
 CWWKD1056.unsupported.keyword=CWWKD1056E: The {0} method of the {1} repository \
@@ -590,12 +590,12 @@ CWWKD1058.no.args.constr.err.explanation=The public constructor without paramete
 CWWKD1058.no.args.constr.err.useraction=Fix the error in the constructor, or \
  update the repository method to use a different return type.
 
-CWWKD1059.prop.cast.err=CWWKD1059E: The {0} method of the {1} repository \
+CWWKD1059.attr.cast.err=CWWKD1059E: The {0} method of the {1} repository \
  interface cannot access the {2} attribute of the {3} entity because the \
  {4} field or method of the {5} class is incompatible with a {6} value.
-CWWKD1059.prop.cast.err.explanation=An entity attribute or a related attribute from \
+CWWKD1059.attr.cast.err.explanation=An entity attribute or a related attribute from \
  its hierarchy is not compatible with the expected type.
-CWWKD1059.prop.cast.err.useraction=Review the entity model and verify that the \
+CWWKD1059.attr.cast.err.useraction=Review the entity model and verify that the \
  correct types are used for each attribute.
 
 CWWKD1060.name.out.of.scope=CWWKD1060E: The {0} repository interface in the \
@@ -727,12 +727,12 @@ CWWKD1074.qbmn.incompat.keywords.explanation=The specified Query by Method Name 
 CWWKD1074.qbmn.incompat.keywords.useraction=Rename the method to not combine \
  the keywords on the same condition.
 
-CWWKD1075.entity.prop.conflict=CWWKD1075E: The {0} entity cannot have an attribute \
+CWWKD1075.entity.attr.conflict=CWWKD1075E: The {0} entity cannot have an attribute \
  named {1} and an attribute named {2} because the Jakarta Data specification \
  considers these names to be aliases for the same entity attribute.
-CWWKD1075.entity.prop.conflict.explanation=There is a collision between the \
+CWWKD1075.entity.attr.conflict.explanation=There is a collision between the \
  names of two entity attributes due to the underscore character.
-CWWKD1075.entity.prop.conflict.useraction=Do not use the underscore character \
+CWWKD1075.entity.attr.conflict.useraction=Do not use the underscore character \
  in entity attribute names.
 
 CWWKD1076.repo.disposed=CWWKD1076E: The {0} method of the {1} repository \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -71,8 +71,8 @@ CWWKD1004.general.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
 CWWKD1005.find.rtrn.err=CWWKD1005E: The {0} method of the {1} repository \
  interface is not valid. The method specifies a {2} return type that is \
  not convertible from the {3} entity type. The result type of a \
- find operation must be the entity type, a type of an entity property, \
- a Java record composed of entity properties, or a type constructed \
+ find operation must be the entity type, a type of an entity attribute, \
+ a Java record composed of entity attributes, or a type constructed \
  by the query that is supplied to the \
  Query annotation. The return type of the repository find method can be \
  the result type, an array of the result type, or any of the following types \
@@ -108,13 +108,13 @@ CWWKD1007.updel.rtrn.err.useraction=Update the repository method to use one \
 
 CWWKD1008.ambig.rtrn.err=CWWKD1008E: The {0} return type of the {1} method \
  of the {2} repository interface is ambiguous as a return type because it \
- corresponds to multiple entity properties: {3}. The repository method \
+ corresponds to multiple entity attributes: {3}. The repository method \
  must switch to the Query annotation and use a query with a \
- SELECT clause that specifies which entity property to return.
+ SELECT clause that specifies which entity attribute to return.
 CWWKD1008.ambig.rtrn.err.explanation=The return type of the method is not \
  one of the supported return types for a delete method.
 CWWKD1008.ambig.rtrn.err.useraction=Update the repository method to use the \
- Query annotation to select the entity property.
+ Query annotation to select the entity attribute.
 
 CWWKD1009.lifecycle.param.err=CWWKD1009E: The {0} method of the {1} repository \
  interface cannot have {2} parameters because the method is annotated with the \
@@ -126,13 +126,13 @@ CWWKD1009.lifecycle.param.err.explanation=Lifecycle methods must have a single \
 CWWKD1009.lifecycle.param.err.useraction=Update the repository method to have a \
  single parameter that is an entity or an array of List of the entity.
 
-CWWKD1010.unknown.entity.prop=CWWKD1010E: An entity property named {0} is \
+CWWKD1010.unknown.entity.prop=CWWKD1010E: An entity attribute named {0} is \
  not found on the {1} entity class for the {2} method of the {3} repository \
- interface. Valid property names for the entity are: {4}.
+ interface. Valid attribute names for the entity are: {4}.
 CWWKD1010.unknown.entity.prop.explanation=The repository method is attempting \
- to use an entity property that does not exist.
+ to use an entity attribute that does not exist.
 CWWKD1010.unknown.entity.prop.useraction=Update the repository method to match \
- a valid property that is defined by the entity.
+ a valid attribute that is defined by the entity.
 
 CWWKD1011.unknown.method.pattern=CWWKD1011E: The {0} method of the {1} repository \
  interface does not match any of the Jakarta Data defined patterns. \
@@ -149,43 +149,43 @@ CWWKD1011.unknown.method.pattern.useraction=Update the repository method to \
  adhere to one of the patterns from Jakarta Data.
 
 CWWKD1012.fd.missing.param.anno=CWWKD1012E: Parameter {0} of the {1} method of \
- the {2} repository interface does not match an entity property. Parameters that \
- do not match an entity property must be annotated with the By annotation or have \
+ the {2} repository interface does not match an entity attribute. Parameters that \
+ do not match an entity attribute must be annotated with the By annotation or have \
  one of the special parameter types: {3}. To define a condition for the \
  restriction of query results, the parameter must be annotated with the By \
  annotation and the value of the By annotation must be assigned to be the entity \
- property name. Alternatively, enable the -parameters compile option and give \
- the parameter the same name as the entity property.
+ attribute name. Alternatively, enable the -parameters compile option and give \
+ the parameter the same name as the entity attribute.
 CWWKD1012.fd.missing.param.anno.explanation=Parameters of repository find and \
- delete methods must correspond to entity properties or be special Jakarta Data \
+ delete methods must correspond to entity attributes or be special Jakarta Data \
  defined parameter types.
 CWWKD1012.fd.missing.param.anno.useraction=Update the repository method such \
- that all parameters correspond to entity properties or have one of the Jakarta \
+ that all parameters correspond to entity attributes or have one of the Jakarta \
  Data special parameter types.
 
 CWWKD1013.cde.missing.param.anno=CWWKD1013E: Parameter {0} of the {1} method of \
- the {2} repository interface does not match an entity property. Parameters \
- that do not match an entity property must be annotated with the By annotation and \
- the By annotation value must be assigned to be the entity property name. \
+ the {2} repository interface does not match an entity attribute. Parameters \
+ that do not match an entity attribute must be annotated with the By annotation and \
+ the By annotation value must be assigned to be the entity attribute name. \
  Alternatively, enable the -parameters compile option and give the parameter \
- the same name as the entity property.
+ the same name as the entity attribute.
 CWWKD1013.cde.missing.param.anno.explanation=Parameters of repository count, \
- delete, and exists methods must correspond to entity properties.
+ delete, and exists methods must correspond to entity attributes.
 CWWKD1013.cde.missing.param.anno.useraction=Update the repository method such \
- that all parameters correspond to entity properties.
+ that all parameters correspond to entity attributes.
 
 CWWKD1014.upd.missing.param.anno=CWWKD1014E: Parameter {0} of the {1} method of \
- the {2} repository interface does not match an entity property. Parameters that \
- do not match an entity property must have one of the parameter annotations: {3}. \
+ the {2} repository interface does not match an entity attribute. Parameters that \
+ do not match an entity attribute must have one of the parameter annotations: {3}. \
  To define a condition for the restriction of query results, the parameter must \
  be annotated with the By annotation and the By annotation value must be \
- assigned to be the entity property name. Alternatively, enable the \
+ assigned to be the entity attribute name. Alternatively, enable the \
  -parameters compile option and give the parameter the same name as the entity \
- property.
+ attribute.
 CWWKD1014.upd.missing.param.anno.explanation=Parameters of repository update \
- methods must correspond to entity properties.
+ methods must correspond to entity attributes.
 CWWKD1014.upd.missing.param.anno.useraction=Update the repository method such that \
- all parameters correspond to entity properties.
+ all parameters correspond to entity attributes.
 
 CWWKD1015.null.entity.param=CWWKD1015E: The {0} method of the {1} repository \
  interface cannot accept a null entity.
@@ -269,43 +269,42 @@ CWWKD1023.extra.param.useraction=Update the repository method signature \
  to remove extra parameters that do not correspond to declared conditions.
 
 CWWKD1024.missing.entity.prop=CWWKD1024E: The {0} method of the {1} repository \
- interface is missing an entity property name or was supplied with a parameter \
- that lacks an entity property name. Valid property names for the {2} entity \
+ interface is missing an entity attribute name or was supplied with a parameter \
+ that lacks an entity attribute name. Valid attribute names for the {2} entity \
  class are: {3}.
 CWWKD1024.missing.entity.prop.explanation=The query conditions and sort criteria \
- for a repository method must include an entity property name.
+ for a repository method must include an entity attribute name.
 CWWKD1024.missing.entity.prop.useraction=Inspect the declaration and usage of \
- the repository method to ensure that an entity property name is supplied for \
+ the repository method to ensure that an entity attribute name is supplied for \
  each query condition and sort criterion.
 
 CWWKD1025.missing.id.prop=CWWKD1025E: The {0} entity class that is used by the \
- {1} method of the {2} repository interface does not have an ID property or \
- accessor method.
+ {1} method of the {2} repository interface does not have an ID attribute.
 CWWKD1025.missing.id.prop.explanation=Repository methods that delete and return \
- an entity must have an ID property.
+ an entity must have an ID attribute.
 CWWKD1025.missing.id.prop.useraction=If the entity does not have a single \
- property for the ID, define separate repository methods that query for the \
+ attribute for the ID, define separate repository methods that query for the \
  entity and delete the entity.
 
-CWWKD1026.ignore.case.not.text=CWWKD1026E: The {0} property of the {1} entity is \
+CWWKD1026.ignore.case.not.text=CWWKD1026E: The {0} attribute of the {1} entity is \
  not a character or character sequence; therefore, the {2} sort criteria must not \
- specify to ignore case. The type of the property is {3}, and it was supplied to \
+ specify to ignore case. The type of the attribute is {3}, and it was supplied to \
  the {4} method of the {5} repository interface.
 CWWKD1026.ignore.case.not.text.explanation=Sorting with case ignored is only \
- possible with entity properties that represent text.
+ possible with entity attributes that represent text.
 CWWKD1026.ignore.case.not.text.useraction=Ensure the sort criteria is applied \
- to the correct entity property and remove the instruction to ignore case if the \
- entity property does not represent text.
+ to the correct entity attribute and remove the instruction to ignore case if the \
+ entity attribute does not represent text.
 
 CWWKD1027.anno.missing.prop.name=CWWKD1027E: Parameter {0} of the {1} method of \
  the {2} repository interface is annotated with an {3} annotation that does not \
- specify an entity property name as its value. The annotation must either specify \
- the entity property name as its value, or the -parameters compile option must be \
- enabled and the parameter must have the same name as the entity property.
+ specify an entity attribute name as its value. The annotation must either specify \
+ the entity attribute name as its value, or the -parameters compile option must be \
+ enabled and the parameter must have the same name as the entity attribute.
 CWWKD1027.anno.missing.prop.name.explanation=Parameters of repository update \
- methods must correspond to entity properties.
+ methods must correspond to entity attributes.
 CWWKD1027.anno.missing.prop.name.useraction=Update the repository method to \
- indicate the entity property to which the parameter pertains.
+ indicate the entity attribute to which the parameter pertains.
 
 CWWKD1028.first.exceeds.max=CWWKD1028E: The {0} method of the {1} repository \
  interface requests the first {2} results, which exceeds the maximum allowed \
@@ -504,7 +503,7 @@ CWWKD1049.count.convert.err.useraction=Adjust the return type of the repository 
  method to allow for the value to be returned.
 
 CWWKD1050.opt.lock.exc=CWWKD1050E: The {0} method of the {1} repository \
- interface did not find a {2} entity that matches the entity properties: {3}. \
+ interface did not find a {2} entity that matches the entity attributes: {3}. \
  Verify that the entity instance that is supplied to the \
  {0} method is based on the most recent version of the entity. The most recent \
  version of the entity can be obtained from a find method or from the result \
@@ -555,14 +554,14 @@ CWWKD1054.non.unique.result.useraction=Update the repository method to either us
  a return type that supports multiple results or update the repository method \
  to return no more than a single result.
 
-CWWKD1055.unsupported.entity.prop=CWWKD1055E: The {0} property of the {1} entity \
+CWWKD1055.unsupported.entity.prop=CWWKD1055E: The {0} attribute of the {1} entity \
  has an unsupported type: {2}. Jakarta Data supports Java enumeration types, \
  the {3} temporal types, and the following basic types: {4}. The built-in \
  Jakarta Data provider also supports some Jakarta Persistence types, such as \
  embeddables.
 CWWKD1055.unsupported.entity.prop.explanation=Jakarta Data does not support the \
- type used by the entity property.
-CWWKD1055.unsupported.entity.prop.useraction=Update the entity property to use \
+ type used by the entity attribute.
+CWWKD1055.unsupported.entity.prop.useraction=Update the entity attribute to use \
  one of the supported types.
 
 CWWKD1056.unsupported.keyword=CWWKD1056E: The {0} method of the {1} repository \
@@ -592,12 +591,12 @@ CWWKD1058.no.args.constr.err.useraction=Fix the error in the constructor, or \
  update the repository method to use a different return type.
 
 CWWKD1059.prop.cast.err=CWWKD1059E: The {0} method of the {1} repository \
- interface cannot access the {2} property of the {3} entity because the \
+ interface cannot access the {2} attribute of the {3} entity because the \
  {4} field or method of the {5} class is incompatible with a {6} value.
-CWWKD1059.prop.cast.err.explanation=An entity property or a related property from \
+CWWKD1059.prop.cast.err.explanation=An entity attribute or a related attribute from \
  its hierarchy is not compatible with the expected type.
 CWWKD1059.prop.cast.err.useraction=Review the entity model and verify that the \
- correct types are used for each property.
+ correct types are used for each attribute.
 
 CWWKD1060.name.out.of.scope=CWWKD1060E: The {0} repository interface in the \
  {1} application configures a {2} value for the {3} attribute, but {3} names \
@@ -706,8 +705,8 @@ CWWKD1071.record.with.type.var.useraction=Remove the type variables from the \
 CWWKD1072.record.comp.conflict=CWWKD1072E: The {0} record is used as an entity by \
  one or more of the repository interfaces ({1}) in the {2} application artifact, \
  but the record cannot be an entity because its {3} component and {4} component \
- both resolve to the same entity property name.
-CWWKD1072.record.comp.conflict.explanation=Entity property names must be \
+ both resolve to the same entity attribute name.
+CWWKD1072.record.comp.conflict.explanation=Entity attribute names must be \
  unique ignoring case.
 CWWKD1072.record.comp.conflict.useraction=Rename one of the record components \
  to avoid the conflict.
@@ -728,13 +727,13 @@ CWWKD1074.qbmn.incompat.keywords.explanation=The specified Query by Method Name 
 CWWKD1074.qbmn.incompat.keywords.useraction=Rename the method to not combine \
  the keywords on the same condition.
 
-CWWKD1075.entity.prop.conflict=CWWKD1075E: The {0} entity cannot have a property \
- named {1} and a property named {2} because the Jakarta Data specification \
- considers these names to be aliases for the same entity property.
+CWWKD1075.entity.prop.conflict=CWWKD1075E: The {0} entity cannot have an attribute \
+ named {1} and an attribute named {2} because the Jakarta Data specification \
+ considers these names to be aliases for the same entity attribute.
 CWWKD1075.entity.prop.conflict.explanation=There is a collision between the \
- names of two entity properties due to the underscore character.
+ names of two entity attributes due to the underscore character.
 CWWKD1075.entity.prop.conflict.useraction=Do not use the underscore character \
- in entity property names.
+ in entity attribute names.
 
 CWWKD1076.repo.disposed=CWWKD1076E: The {0} method of the {1} repository \
  interface cannot be invoked because the application that defines the repository \
@@ -910,11 +909,11 @@ CWWKD1090.orderby.conflict.explanation=The OrderBy annotation is not compatible 
 CWWKD1090.orderby.conflict.useraction=Use only the OrderBy annotation or the \
  OrderBy keyword.
 
-CWWKD1091.method.name.parse.err=CWWKD1091E: An entity property named {0} is \
+CWWKD1091.method.name.parse.err=CWWKD1091E: An entity attribute named {0} is \
  not found on the {1} entity class for the {2} method of the {3} repository \
  interface. Confirm that the repository method either has a name that conforms \
  to the Query by Method Name pattern or is annotated with one of: {4}. \
- Valid property names for the entity are: {5}.
+ Valid attribute names for the entity are: {5}.
 CWWKD1091.method.name.parse.err.explanation=The repository method name was parsed \
  according to the Query by Method Name pattern because the repository method \
  does not have a Jakarta Data annotation that indicates the type of operation.
@@ -932,10 +931,10 @@ CWWKD1092.lifecycle.arg.empty.useraction=Ensure that the array, List, or Stream 
 
 CWWKD1093.fn.not.applicable=CWWKD1093E: The {0} function cannot be evaluated \
  for the {1} entity that is used by the {2} method of the {3} repository \
- interface. The entity does not have a property that is annotated with {4} \
+ interface. The entity does not have an attribute that is annotated with {4} \
  or from which {0} can be inferred.
 CWWKD1093.fn.not.applicable.explanation=The function cannot be used on the entity \
- because the entity lacks an ID or version property.
+ because the entity lacks an ID or version attribute.
 CWWKD1093.fn.not.applicable.useraction=Do not use the function in query language \
  or parameters for the repository method.
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Condition.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Condition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -92,7 +92,7 @@ enum Condition {
         if (!supportsCollections || ignoreCase)
             throw new MappingException(new UnsupportedOperationException("Repository keyword " +
                                                                          (ignoreCase ? "IgnoreCase" : name()) +
-                                                                         " which is applied to entity property " + attributeName +
-                                                                         " is not supported for collection properties.")); // TODO
+                                                                         " which is applied to entity attribute " + attributeName +
+                                                                         " is not supported for collection attributes.")); // TODO
     }
 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -226,7 +226,7 @@ public class EntityInfo {
         for (Entry<String, Class<?>> attrType : attributeTypes.entrySet())
             if (Util.UNSUPPORTED_ATTR_TYPES.contains(attrType.getValue()))
                 throw exc(MappingException.class,
-                          "CWWKD1055.unsupported.entity.prop",
+                          "CWWKD1055.unsupported.entity.attr",
                           attrType.getKey(),
                           entityClass.getName(),
                           attrType.getValue().getName(),

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -257,7 +257,7 @@ public abstract class EntityManagerBuilder {
 
                             if (conflictingAttribute != null)
                                 throw exc(MappingException.class,
-                                          "CWWKD1075.entity.prop.conflict",
+                                          "CWWKD1075.entity.attr.conflict",
                                           userEntityClass.getName(),
                                           fullAttributeName,
                                           conflictingAttribute);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1991,7 +1991,7 @@ public class QueryInfo {
                                     attribute = params[p].getName();
                                 else
                                     throw exc(MappingException.class,
-                                              "CWWKD1027.anno.missing.prop.name",
+                                              "CWWKD1027.anno.missing.attr.name",
                                               p + 1,
                                               method.getName(),
                                               repositoryInterface.getName(),
@@ -2151,7 +2151,7 @@ public class QueryInfo {
             ("The " + method.getName() + " method of the " +
              repositoryInterface.getName() + " repository has a " +
              method.getGenericReturnType().getTypeName() + " return type and" +
-             " specifies to return the " + selections + " entity properties," +
+             " specifies to return the " + selections + " entity attributes," +
              " but delete operations can only return void, a deletion count," +
              " a boolean deletion indicator, or the removed entities.");
         } else {
@@ -2310,7 +2310,7 @@ public class QueryInfo {
 
     /**
      * Generates and appends JQPL to sort based on the specified entity attribute.
-     * For most properties, this will be of a form such as o.name or LOWER(o.name) DESC or ...
+     * For most attributes, this will be of a form such as o.name or LOWER(o.name) DESC or ...
      *
      * @param q             builder for the JPQL query.
      * @param Sort          sort criteria for a single attribute (name must already
@@ -2495,14 +2495,21 @@ public class QueryInfo {
     }
 
     /**
-     * Generates the JPQL WHERE clause for all findBy, deleteBy, or updateBy conditions such as MyColumn[IgnoreCase][Not]Like
+     * Generates the JPQL WHERE clause for all find/delete/count/exists/By
+     * conditions such as MyColumn[IgnoreCase][Not]Like
      */
-    private void generateWhereClause(String methodName, int start, int endBefore, StringBuilder q) {
+    private void generateWhereClause(String methodName,
+                                     int start,
+                                     int endBefore,
+                                     StringBuilder q) {
         hasWhere = true;
         q.append(" WHERE (");
-        for (int and = start, or = start, iNext = start, i = start; hasWhere && i >= start && iNext < endBefore; i = iNext) {
-            // The extra character (+1) below allows for entity property names that begin with Or or And.
-            // For example, findByOrg and findByPriceBetweenAndOrderNumber
+        for (int and = start, or = start, iNext = start, i = start; //
+             hasWhere && i >= start && iNext < endBefore; //
+             i = iNext) {
+            // The extra character (+1) below allows for entity attribute names
+            // that begin with Or or And. For example,
+            // findByOrg and findByPriceBetweenAndOrderNumber
             and = and == -1 || and > i + 1 ? and : methodName.indexOf("And", i + 1);
             or = or == -1 || or > i + 1 ? or : methodName.indexOf("Or", i + 1);
             iNext = Math.min(and, or);
@@ -2545,7 +2552,7 @@ public class QueryInfo {
                     value = ((Field) accessor).get(value);
             } else {
                 throw exc(MappingException.class,
-                          "CWWKD1059.prop.cast.err",
+                          "CWWKD1059.attr.cast.err",
                           method.getName(),
                           repositoryInterface.getName(),
                           attributeName,
@@ -2606,7 +2613,7 @@ public class QueryInfo {
                 }
             else
                 throw exc(MappingException.class,
-                          "CWWKD1010.unknown.entity.prop",
+                          "CWWKD1010.unknown.entity.attr",
                           name,
                           entityInfo.getType().getName(),
                           method.getName(),
@@ -2618,7 +2625,7 @@ public class QueryInfo {
             if (attributeName == null)
                 if (name.length() == 0) {
                     throw exc(MappingException.class,
-                              "CWWKD1024.missing.entity.prop",
+                              "CWWKD1024.missing.entity.attr",
                               method.getName(),
                               repositoryInterface.getName(),
                               entityInfo.getType().getName(),
@@ -2634,7 +2641,7 @@ public class QueryInfo {
                         if (attributeName == null && failIfNotFound) {
                             if (Util.hasOperationAnno(method))
                                 throw exc(MappingException.class,
-                                          "CWWKD1010.unknown.entity.prop",
+                                          "CWWKD1010.unknown.entity.attr",
                                           name,
                                           entityInfo.getType().getName(),
                                           method.getName(),
@@ -5009,7 +5016,8 @@ public class QueryInfo {
     }
 
     /**
-     * Validates that ignoreCase is only true if the type of the property being sort on is a String.
+     * Validates that ignoreCase is only true if the type of the attribute being
+     * sorted on is a String.
      *
      * @param sort the Jakarta Data Sort object being evaluated
      */

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -815,7 +815,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                                 List<Member> accessors = entityInfo.attributeAccessors.get(entityInfo.attributeNames.get(ID));
                                                 if (accessors == null || accessors.isEmpty())
                                                     throw exc(MappingException.class,
-                                                              "CWWKD1025.missing.id.prop",
+                                                              "CWWKD1025.missing.id.attr",
                                                               entityInfo.getType().getName(),
                                                               method.getName(),
                                                               repositoryInterface);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4953,7 +4953,7 @@ public class DataTestServlet extends FATServlet {
                                              .map(o -> o.a)
                                              .collect(Collectors.toList()));
 
-        // "Or" in middle of entity attribute name is possible to to use of @Query.
+        // "Or" in middle of entity attribute name is possible when using @Query.
         assertIterableEquals(List.of("Honeycrisp"),
                              things.forPurchaseOrder(20)
                                              .map(o -> o.brand)

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -4923,10 +4923,10 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Experiment with reserved keywords in entity property names.
+     * Experiment with reserved keywords in entity attribute names.
      */
     @Test
-    public void testReservedKeywordsInEntityPropertyNames() {
+    public void testReservedKeywordsInEntityAttributeNames() {
         // clear out old data before test
         things.deleteAll();
 
@@ -4940,7 +4940,7 @@ public class DataTestServlet extends FATServlet {
         Thing thing = things.findById(2);
         assertEquals("Haralson", thing.brand);
 
-        // "like" is allowed at end of entity property name because the capitalization differs.
+        // "like" is allowed at end of entity attribute name because the capitalization differs.
         assertIterableEquals(List.of("Fireside", "Haralson", "Honeycrisp", "Honeygold"),
                              things.findByAlike(true)
                                              .map(o -> o.brand)
@@ -4953,43 +4953,51 @@ public class DataTestServlet extends FATServlet {
                                              .map(o -> o.a)
                                              .collect(Collectors.toList()));
 
-        // "Or" in middle of entity property name is possible to to use of @Query.
+        // "Or" in middle of entity attribute name is possible to to use of @Query.
         assertIterableEquals(List.of("Honeycrisp"),
                              things.forPurchaseOrder(20)
                                              .map(o -> o.brand)
                                              .collect(Collectors.toList()));
 
-        // "Or" is allowed at the beginning of an entity property name because "find...By" immediately precedes it.
+        // "Or" is allowed at the beginning of an entity attribute name
+        // because "find...By" immediately precedes it.
         assertIterableEquals(List.of("Honeygold"),
                              things.findByOrderNumber(100201L)
                                              .map(o -> o.brand)
                                              .collect(Collectors.toList()));
 
-        // "And" is allowed at the beginning of an entity property name because "find...By" immediately precedes it.
+        // "And" is allowed at the beginning of an entity attribute name
+        // because "find...By" immediately precedes it.
         assertIterableEquals(List.of("android"),
                              things.findByAndroid(true)
                                              .map(o -> o.a)
                                              .collect(Collectors.toList()));
 
-        // "and" is allowed at end of entity property name "brand" because the capitalization differs.
-        // "Not" is allowed at the beginning of an entity property name "Notes" because the reserved word "Not" never appears prior to the property name.
-        // "And" is allowed at the beginning of an entity property name because "And" or "Or" immediately precedes it.
+        // "and" is allowed at end of entity attribute name "brand"
+        // because the capitalization differs.
+        // "Not" is allowed at the beginning of an entity attribute name "Notes"
+        // because the reserved word "Not" never appears prior to the attribute name.
+        // "And" is allowed at the beginning of an entity attribute name
+        // because "And" or "Or" immediately precedes it.
         assertIterableEquals(List.of(2L, 3L, 5L, 6L),
                              things.findByBrandOrNotesContainsOrAndroid("IBM", "October", true)
                                              .map(o -> o.thingId)
                                              .sorted()
                                              .collect(Collectors.toList()));
 
-        // "or" is allowed at end of entity property name "floor" because the capitalization differs.
-        // "In" is allowed at the beginning of an entity property name "Info" because the reserved word "In" never appears prior to the property name.
-        // "Or" is allowed at the beginning of an entity property name because "And" or "Or" immediately precedes it.
+        // "or" is allowed at end of entity attribute name "floor"
+        // because the capitalization differs.
+        // "In" is allowed at the beginning of an entity attribute name "Info"
+        // because the reserved word "In" never appears prior to the attribute name.
+        // "Or" is allowed at the beginning of an entity attribute name
+        // because "And" or "Or" immediately precedes it.
         assertIterableEquals(List.of("2nd floor conference room", "Golden Delicious x Haralson"),
                              things.findByFloorNotAndInfoLikeAndOrderNumberLessThan(3, "%o%", 300000L)
                                              .map(o -> o.info)
                                              .sorted()
                                              .collect(Collectors.toList()));
 
-        // TODO is "Desc" allowed in an entity property name in the OrderBy clause?
+        // TODO is "Desc" allowed in an entity attribute name in the OrderBy clause?
         assertIterableEquals(List.of("A101", "android", "apple"),
                              things.findByThingIdGreaterThan(3L)
                                              .map(o -> o.a)
@@ -5470,7 +5478,7 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Use the JDQL id(entityVar) function as the sort property to perform a
+     * Use the JDQL id(entityVar) function as the sort attribute to perform a
      * descending sort.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Thing.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Thing.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,11 +13,11 @@
 package test.jakarta.data.web;
 
 /**
- * For testing entity property names with reserved keywords in them.
+ * For testing entity attribute names with reserved keywords in them.
  */
 public class Thing {
 
-    // single character property name, for testing the difference between findByALike and findByAlike
+    // single character attribute name, for testing the difference between findByALike and findByAlike
     public String a;
 
     // ending with "like" does not conflict with reserved word "Like" due to case difference.
@@ -41,7 +41,7 @@ public class Thing {
     // starting with reserved word "Not" is okay
     public String notes;
 
-    // Due to reserved word "Or" within property name, this cannot be used in query by method name.
+    // Due to reserved word "Or" within attribute name, this cannot be used in query by method name.
     // Test with @Query instead.
     public int purchaseOrder;
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Things.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Things.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
 /**
- * For testing entity property names with reserved keywords in them.
+ * For testing entity attribute names with reserved keywords in them.
  */
 @Repository
 public interface Things {

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1568,14 +1568,16 @@ public class DataExperimentalServlet extends FATServlet {
         assertEquals(40.0f, item.price, 0.01f);
         assertEquals("Item 2 halved", item.description);
 
-        // subtract from price and append to description via Update method with property names inferred from parameters
+        // subtract from price and append to description via Update method
+        // with entity attribute names inferred from parameters
         assertEquals(true, items.shorten(item2.pk, 1.0f, " and reduced $1"));
 
         item = items.get(item2.pk);
         assertEquals(39.0f, item.price, 0.01f);
         assertEquals("Item 2 halved and reduced $1", item.description);
 
-        // subtract from price and append to description via Update method with annotatively specified property names
+        // subtract from price and append to description via Update method
+        // with annotatively specified entity attribute names
         items.shortenBy(2, " and then another $2", item2.pk);
 
         item = items.get(item2.pk);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -450,7 +450,7 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Comparison ignoring case on an entity property of type char.
+     * Comparison ignoring case on an entity attribute of type char.
      */
     @Test
     public void testCharIgnoreCase() {
@@ -1573,7 +1573,7 @@ public class DataJPATestServlet extends FATServlet {
         o5 = orders.create(o5);
         int o5_v1 = o5.versionNum;
 
-        // delete even though a property doesn't match
+        // delete even though an entity attribute doesn't match
         o4.total = 44.99f;
         orders.delete(o4);
 
@@ -3984,7 +3984,7 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Use the JPQL version(entityVar) function as the sort property to perform
+     * Use the JPQL version(entityVar) function as the sort attribute to perform
      * an ascending sort.
      */
     @Test
@@ -4119,7 +4119,8 @@ public class DataJPATestServlet extends FATServlet {
         of = Sort.of("population", Direction.DESC, true);
         try {
             cities.allSorted(of);
-            fail("Should not be able to applay a Sort with ignoreCase=true on a non-string property");
+            fail("Should not be able to applay a Sort with ignoreCase=true on a" +
+                 " non-string entity attribute");
         } catch (UnsupportedOperationException x) {
             // expected
         }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ public interface Employees {
 
     @OrderBy(value = "badge.accessLevel", ignoreCase = true)
     @OrderBy("empNum")
-    // The parameter would more naturally be char because the entity property
+    // The parameter would more naturally be char because the entity attribute
     // has type char, but JPA only allows String for LOWER(string_expression)
     Stream<Employee> findByBadgeAccessLevelIgnoreCaseGreaterThan(String exclusiveMin);
 


### PR DESCRIPTION
The Jakarta Data specification and Javadoc uses the term _entity attribute_ rather than entity property.  Our NLS messages and code should do likewise.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
