### PR TITLE
Remove TestName Rule from EJB FATSuite

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/PassivationTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/PassivationTest.java
@@ -19,9 +19,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -87,9 +85,6 @@ public class PassivationTest extends FATServletClient {
             Assert.assertTrue("Unexpected line: " + line, p.matcher(line).find());
         }
     }
-
-    @Rule
-    public final TestName testName = new TestName();
 
     @Test
     public void testPassivationCapable() throws Exception {


### PR DESCRIPTION
Presence of TestName Rule on test breaks use of same Rule on parent class
- remove rule on test class; not needed/used


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".