### PR TITLE
 Concurrency resource accessed from PostConstruct and Observes Startup

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -169,6 +169,11 @@ public class ConcurrentCDITest extends FATServletClient {
     }
 
     @Test
+    public void testObserveStartup() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
     public void testOverrideContextServiceQualifiersViaDD() throws Exception {
         runTest(server, APP_NAME, testName);
     }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2024 IBM Corporation and others.
+ * Copyright (c) 2017,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -185,6 +185,11 @@ public class ConcurrentCDITest extends FATServletClient {
 
     @Test
     public void testOverrideManagedThreadFactoryQualifiersViaWebDD() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testPostConstruct() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2024 IBM Corporation and others.
+ * Copyright (c) 2017,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -161,6 +161,9 @@ public class ConcurrentCDIServlet extends HttpServlet {
     @WithoutLocationContext
     @WithoutTransactionContext
     ManagedExecutorService executorWithoutLocationAndTxContext;
+
+    @Inject
+    OnConstruct onConstruct;
 
     @Inject
     @WithAppContext
@@ -1035,6 +1038,14 @@ public class ConcurrentCDIServlet extends HttpServlet {
         thread.start();
         assertEquals(3, thread.getPriority());
         assertEquals(thread, future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Tests using an injected ManagedScheduledExecutorService from PostConstruct.
+     */
+    public void testPostConstruct() throws Exception {
+        assertEquals("SUCCESS",
+                     onConstruct.getResult(TIMEOUT_NS, TimeUnit.NANOSECONDS));
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -166,6 +166,9 @@ public class ConcurrentCDIServlet extends HttpServlet {
     OnConstruct onConstruct;
 
     @Inject
+    OnStartup onStartup;
+
+    @Inject
     @WithAppContext
     ManagedScheduledExecutorService scheduledExecutorWithAppContext;
 
@@ -845,6 +848,14 @@ public class ConcurrentCDIServlet extends HttpServlet {
         } finally {
             Location.clear();
         }
+    }
+
+    /**
+     * Tests using an injected ManagedScheduledExecutorService from Observes Startup.
+     */
+    public void testObserveStartup() throws Exception {
+        assertEquals("SUCCESS",
+                     onStartup.getResult(TIMEOUT_NS, TimeUnit.NANOSECONDS));
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/OnConstruct.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/OnConstruct.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Tests it PostConstruct can access an injected Concurrency resource.
+ */
+@ApplicationScoped
+public class OnConstruct {
+    private final CompletableFuture<String> result = new CompletableFuture<>();
+
+    @Inject
+    private ManagedScheduledExecutorService scheduler;
+
+    private void complete() {
+        result.complete("SUCCESS");
+    }
+
+    String getResult(long timeout, TimeUnit unit) throws ExecutionException, //
+                    InterruptedException, TimeoutException {
+        return result.get(timeout, unit);
+    }
+
+    /**
+     * This does not run until the bean is constructed, which does not happen
+     * until a method is invoked on it.
+     */
+    @PostConstruct
+    public void init() {
+        System.out.println("Scheduling to run 3 seconds from now");
+        try {
+            ScheduledFuture<?> future = scheduler.schedule(this::complete,
+                                                           3,
+                                                           TimeUnit.SECONDS);
+            System.out.println("Scheduled: " + future);
+        } catch (RuntimeException | Error x) {
+            x.printStackTrace(System.out);
+            throw x;
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/OnStartup.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/OnStartup.java
@@ -18,16 +18,18 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Startup;
 import jakarta.inject.Inject;
 
 /**
- * Tests if PostConstruct can access an injected Concurrency resource.
+ * Tests if CDI bean method with Observes Startup can access an injected
+ * Concurrency resource.
  */
 @ApplicationScoped
-public class OnConstruct {
+public class OnStartup {
     private final CompletableFuture<String> result = new CompletableFuture<>();
 
     @Inject
@@ -42,16 +44,11 @@ public class OnConstruct {
         return result.get(timeout, unit);
     }
 
-    /**
-     * This does not run until the bean is constructed, which does not happen
-     * until a method is invoked on it.
-     */
-    @PostConstruct
-    public void init() {
-        System.out.println("PostConstruct: scheduling to run 1 second from now");
+    public void init(@Observes Startup event) {
+        System.out.println("Startup: scheduling to run 3 seconds from now");
         try {
             ScheduledFuture<?> future = scheduler.schedule(this::complete,
-                                                           1,
+                                                           3,
                                                            TimeUnit.SECONDS);
             System.out.println("scheduled " + future);
         } catch (RuntimeException | Error x) {


### PR DESCRIPTION
Scenarios where an injected Concurrency resource is accessed from PostConstruct and Observes Startup

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
