### PR TITLE
JAX-WS: JAXB: backup with parent namespace test

### DIFF
--- a/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/FATSuite.java
@@ -12,26 +12,22 @@
  *******************************************************************************/
 package com.ibm.ws.jaxb.fat;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.rules.repeater.RepeatTests;
-
 @RunWith(Suite.class)
 @SuiteClasses({
                 LibertyJAXBTest.class,
+                LibertyJAXBSpecTest.class,
                 ThirdPartyJAXBFromJDKTest.class,
                 ThirdPartyJAXBFromAppTest.class,
                 JAXBToolsTest.class
 })
 
 public class FATSuite {
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new JakartaEE9Action())
-                    .andWith(new JakartaEE10Action());
+//    @ClassRule
+//    public static RepeatTests r = RepeatTests.withoutModification()
+//                    .andWith(new JakartaEE9Action())
+//                    .andWith(new JakartaEE10Action());
 }

--- a/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/FATSuite.java
@@ -12,9 +12,14 @@
  *******************************************************************************/
 package com.ibm.ws.jaxb.fat;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.rules.repeater.JakartaEE10Action;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -26,8 +31,8 @@ import org.junit.runners.Suite.SuiteClasses;
 })
 
 public class FATSuite {
-//    @ClassRule
-//    public static RepeatTests r = RepeatTests.withoutModification()
-//                    .andWith(new JakartaEE9Action())
-//                    .andWith(new JakartaEE10Action());
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(new JakartaEE9Action())
+                    .andWith(new JakartaEE10Action());
 }

--- a/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/LibertyJAXBSpecTest.java
+++ b/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/LibertyJAXBSpecTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/LibertyJAXBSpecTest.java
+++ b/dev/com.ibm.ws.jaxb_fat/fat/src/com/ibm/ws/jaxb/fat/LibertyJAXBSpecTest.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxb.fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Unmarshaller;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import junit.framework.Assert;
+
+@RunWith(FATRunner.class)
+public class LibertyJAXBSpecTest {
+
+    private static final String APP_NAME = "jaxbApp";
+
+    @Server("jaxbspec_fat")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, APP_NAME, "jaxb.web", "jaxb.xmlnsform.unqualified", "jaxb.xmlnsform.qualified");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    @After
+    public void afterTest() throws Exception {
+        server.stopServer();
+    }
+
+    @Test
+    public void testBackupWithParentNamespaceTrue() throws Exception {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("com.sun.xml.bind.backupWithParentNamespace", "true");
+//        server.setJvmOptions(map);
+        server.addBootstrapProperties(map);
+        server.startServer();
+
+        File personXml = new File(server.pathToAutoFVTTestFiles + "/Person.xml");
+        if (personXml.exists()) {
+            System.out.println("Person.xml path: " + personXml.getPath());
+        } else {
+            Assert.fail("Person.xml does not exist - " + personXml.getPath());
+        }
+
+        JAXBContext jaxbContextQualified = JAXBContext.newInstance(jaxb.xmlnsform.qualified.Person.class);
+        Unmarshaller unmarshallerQualified = jaxbContextQualified.createUnmarshaller();
+        jaxb.xmlnsform.qualified.Person qualifiedPerson = (jaxb.xmlnsform.qualified.Person) unmarshallerQualified.unmarshal(personXml);
+        System.out.println("~qualifiedPerson: " + qualifiedPerson);
+        assertNull("1", qualifiedPerson.getFirstNameWithPrefix());
+        assertNotNull("2", qualifiedPerson.getLastNameWithOutPrefix());
+
+        JAXBContext jaxbContextUnQualified = JAXBContext.newInstance(jaxb.xmlnsform.unqualified.Person.class);
+        Unmarshaller unmarshallerUnQualified = jaxbContextUnQualified.createUnmarshaller();
+        jaxb.xmlnsform.unqualified.Person unQualifiedPerson = (jaxb.xmlnsform.unqualified.Person) unmarshallerUnQualified.unmarshal(personXml);
+        System.out.println("~unQualifiedPerson: " + unQualifiedPerson);
+        assertNotNull("3", unQualifiedPerson.getFirstNameWithPrefix());
+        assertNull("4", unQualifiedPerson.getLastNameWithOutPrefix());
+    }
+
+    @Test
+    public void testBackupWithParentNamespaceFalse() throws Exception {
+//        server.setJvmOptions(new HashMap<String, String>());
+//        server.addBootstrapProperties(new HashMap<String, String>());
+        Map map = (Map) server.getBootstrapProperties().remove("com.sun.xml.bind.backupWithParentNamespace");
+
+        server.startServer();
+
+        File personXml = new File(server.pathToAutoFVTTestFiles + "/Person.xml");
+        if (personXml.exists()) {
+            System.out.println("Person.xml path: " + personXml.getPath());
+        } else {
+            Assert.fail("Person.xml does not exist - " + personXml.getPath());
+        }
+
+        JAXBContext jaxbContextQualified = JAXBContext.newInstance(jaxb.xmlnsform.qualified.Person.class);
+        Unmarshaller unmarshallerQualified = jaxbContextQualified.createUnmarshaller();
+        jaxb.xmlnsform.qualified.Person qualifiedPerson = (jaxb.xmlnsform.qualified.Person) unmarshallerQualified.unmarshal(personXml);
+        System.out.println("~qualifiedPerson: " + qualifiedPerson);
+        assertNotNull("Violation of JAXB spec, an element with a prefix from a XmlNsForm.QUALIFIED package should not be null", qualifiedPerson.getFirstNameWithPrefix());
+        assertNull("Violation of JAXB spec, an element with a prefix from a XmlNsForm.QUALIFIED package should not be null", qualifiedPerson.getLastNameWithOutPrefix());
+
+        JAXBContext jaxbContextUnQualified = JAXBContext.newInstance(jaxb.xmlnsform.unqualified.Person.class);
+        Unmarshaller unmarshallerUnQualified = jaxbContextUnQualified.createUnmarshaller();
+        jaxb.xmlnsform.unqualified.Person unQualifiedPerson = (jaxb.xmlnsform.unqualified.Person) unmarshallerUnQualified.unmarshal(personXml);
+        System.out.println("~unQualifiedPerson: " + unQualifiedPerson);
+        assertNull("Violation of JAXB spec, an element with a prefix from a XmlNsForm.UNQUALIFIED package should be null", unQualifiedPerson.getFirstNameWithPrefix());
+        assertNotNull("Violation of JAXB spec, an element with a prefix from a XmlNsForm.UNQUALIFIED package should not be null", unQualifiedPerson.getLastNameWithOutPrefix());
+    }
+}

--- a/dev/com.ibm.ws.jaxb_fat/publish/files/Person.xml
+++ b/dev/com.ibm.ws.jaxb_fat/publish/files/Person.xml
@@ -1,0 +1,4 @@
+<ns:Person xmlns:ns="http://a">
+    <ns:firstNameWithPrefix>John</ns:firstNameWithPrefix>
+    <LastNameWithOutPrefix>Doe</LastNameWithOutPrefix>
+</ns:Person>

--- a/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxbspec_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxbspec_fat/bootstrap.properties
@@ -1,16 +1,1 @@
-###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License 2.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
-###############################################################################
 bootstrap.include=../testports.properties
-# This server is exempt from j2sec because it only tests third-party/JDK usage of JAX-B
-# The only Liberty code involved is trivial server start and servlet GET logic
-websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxbspec_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxbspec_fat/bootstrap.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+# This server is exempt from j2sec because it only tests third-party/JDK usage of JAX-B
+# The only Liberty code involved is trivial server start and servlet GET logic
+websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxbspec_fat/server.xml
+++ b/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxbspec_fat/server.xml
@@ -1,15 +1,3 @@
-<!--
-    Copyright (c) 2018 IBM Corporation and others.
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License 2.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-2.0/
-    
-    SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
- -->
 <server>
     <featureManager>
         <feature>servlet-3.1</feature>

--- a/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxbspec_fat/server.xml
+++ b/dev/com.ibm.ws.jaxb_fat/publish/servers/jaxbspec_fat/server.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>jaxb-2.2</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+</server>

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/Person.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/Person.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/Person.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/Person.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package jaxb.xmlnsform.qualified;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/Person.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/Person.java
@@ -1,0 +1,37 @@
+package jaxb.xmlnsform.qualified;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "Person", namespace = "http://a")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Person {
+    @XmlElement
+    private String firstNameWithPrefix;
+
+    @XmlElement
+    private String LastNameWithOutPrefix;
+
+    public String getFirstNameWithPrefix() {
+        return firstNameWithPrefix;
+    }
+
+    public void setFirstNameWithPrefix(String firstNameWithPrefix) {
+        this.firstNameWithPrefix = firstNameWithPrefix;
+    }
+
+    public String getLastNameWithOutPrefix() {
+        return LastNameWithOutPrefix;
+    }
+
+    public void setLastNameWithOutPrefix(String lastNameWithOutPrefix) {
+        LastNameWithOutPrefix = lastNameWithOutPrefix;
+    }
+
+    @Override
+    public String toString() {
+        return "Person{nameWithPrefix='" + firstNameWithPrefix + "', nameWithOutPrefix=" + LastNameWithOutPrefix + '}';
+    }
+}

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/package-info.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/package-info.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/package-info.java
@@ -1,0 +1,2 @@
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://a", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package jaxb.xmlnsform.qualified;

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/package-info.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/qualified/package-info.java
@@ -1,2 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://a", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package jaxb.xmlnsform.qualified;

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/servlet/JaxbSpecTestServlet.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/servlet/JaxbSpecTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/servlet/JaxbSpecTestServlet.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/servlet/JaxbSpecTestServlet.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package jaxb.xmlnsform.servlet;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Unmarshaller;
+
+/**
+ *
+ */
+@WebServlet("/JaxbSpecTest")
+public class JaxbSpecTestServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        doWorker(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        doWorker(req, resp);
+    }
+
+    private void doWorker(HttpServletRequest req, HttpServletResponse resp) {
+        PrintWriter writer = null;
+        try {
+            writer = resp.getWriter();
+            File personXml = new File("Person.xml");
+
+            if (!personXml.exists()) {
+                writer.write("XML not found");
+                return;
+            }
+            JAXBContext jaxbContextQualified = JAXBContext.newInstance(jaxb.xmlnsform.qualified.Person.class);
+            Unmarshaller unmarshallerQualified = jaxbContextQualified.createUnmarshaller();
+            jaxb.xmlnsform.qualified.Person qualifiedPerson = (jaxb.xmlnsform.qualified.Person) unmarshallerQualified.unmarshal(personXml);
+            writeNullStatus(writer, "qpwp", qualifiedPerson.getFirstNameWithPrefix()); // qpwp: Qualified Person With Prefix
+            writeNullStatus(writer, "qpnp", qualifiedPerson.getLastNameWithOutPrefix()); // qpnp: Qualified Person No Prefix
+
+            JAXBContext jaxbContextUnQualified = JAXBContext.newInstance(jaxb.xmlnsform.unqualified.Person.class);
+            Unmarshaller unmarshallerUnQualified = jaxbContextUnQualified.createUnmarshaller();
+            jaxb.xmlnsform.unqualified.Person unQualifiedPerson = (jaxb.xmlnsform.unqualified.Person) unmarshallerUnQualified.unmarshal(personXml);
+            writeNullStatus(writer, "upwp", unQualifiedPerson.getFirstNameWithPrefix()); // upwp: Unqualified Person With Prefix
+            writeNullStatus(writer, "upnp", unQualifiedPerson.getLastNameWithOutPrefix()); // upnp: Unqualified Person No Prefix
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     *
+     * @param key   key to mark which assertion it's related to
+     * @param value value to test if it's null
+     * @return
+     */
+    private void writeNullStatus(PrintWriter writer, String key, String value) {
+        writer.write(key + (value == null ? ":null |" : ":value |"));
+    }
+
+}

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/Person.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/Person.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/Person.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/Person.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package jaxb.xmlnsform.unqualified;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/Person.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/Person.java
@@ -1,0 +1,37 @@
+package jaxb.xmlnsform.unqualified;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "Person", namespace = "http://a")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Person {
+    @XmlElement
+    private String firstNameWithPrefix;
+
+    @XmlElement
+    private String LastNameWithOutPrefix;
+
+    public String getFirstNameWithPrefix() {
+        return firstNameWithPrefix;
+    }
+
+    public void setFirstNameWithPrefix(String firstNameWithPrefix) {
+        this.firstNameWithPrefix = firstNameWithPrefix;
+    }
+
+    public String getLastNameWithOutPrefix() {
+        return LastNameWithOutPrefix;
+    }
+
+    public void setLastNameWithOutPrefix(String lastNameWithOutPrefix) {
+        LastNameWithOutPrefix = lastNameWithOutPrefix;
+    }
+
+    @Override
+    public String toString() {
+        return "Person{nameWithPrefix='" + firstNameWithPrefix + "', nameWithOutPrefix=" + LastNameWithOutPrefix + '}';
+    }
+}

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/package-info.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/package-info.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/package-info.java
@@ -1,0 +1,2 @@
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://a")
+package jaxb.xmlnsform.unqualified;

--- a/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/package-info.java
+++ b/dev/com.ibm.ws.jaxb_fat/test-applications/jaxbApp/src/jaxb/xmlnsform/unqualified/package-info.java
@@ -1,2 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://a")
 package jaxb.xmlnsform.unqualified;


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

JAXB provides `com.sun.xml.bind.backupWithParentNamespace` property to support old JAXB behavior. Tests are added to check the behavior. 