### PR TITLE
Prevent http route resolution for requests made directly to server with 4xx response codes.

### DIFF
--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpServerStatsMonitor.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpServerStatsMonitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -137,13 +137,18 @@ public class HttpServerStatsMonitor extends StatisticActions {
 		tl_startNanos.set(System.nanoTime());
 		HttpStatAttributes.Builder builder = HttpStatAttributes.builder();
 
+		
+		boolean is4xxCode = false;
+		
 		/*
 		 *  Get Status Code (and Exception if it exists)
 		 */
 		if (myargs.length > 0) {
 			if (myargs[0] != null && myargs[0] instanceof StatusCodes) {
 				StatusCodes statCode = (StatusCodes) myargs[0];
+				
 				builder.withResponseStatus(statCode.getIntCode());
+				is4xxCode = (statCode.getIntCode() % 400 <= 99 ) ? true : false;
 			}
 
 			if (myargs[2] != null && myargs[2] instanceof Exception) {
@@ -165,8 +170,10 @@ public class HttpServerStatsMonitor extends StatisticActions {
 			 try {
 
 					HttpRequest httpRequest = httpDispatcherLink.getRequest();
+					if (!is4xxCode) {
+						builder.withHttpRoute(httpRequest.getURI());
+					}
 					
-					builder.withHttpRoute(httpRequest.getURI());
 					builder.withRequestMethod(httpRequest.getMethod());
 					builder.withScheme(httpRequest.getScheme());
 					resolveNetworkProtocolInfo(httpRequest.getVersion(), builder);

--- a/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpServerStatsMonitor.java
+++ b/dev/io.openliberty.http.monitor/src/io/openliberty/http/monitor/HttpServerStatsMonitor.java
@@ -172,6 +172,12 @@ public class HttpServerStatsMonitor extends StatisticActions {
 					HttpRequest httpRequest = httpDispatcherLink.getRequest();
 					if (!is4xxCode) {
 						builder.withHttpRoute(httpRequest.getURI());
+					} else {
+						/*
+						 * For 4xx response codes,
+						 *  set HTTP route to "/"
+						 */
+						builder.withHttpRoute("/");
 					}
 					
 					builder.withRequestMethod(httpRequest.getMethod());

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -259,14 +259,14 @@ public abstract class BaseTestClass {
                                   + "\",http_request_method=\""
                                   + requestMethod
                                   + "\",http_response_status_code=\"" + responseStatus
-                                  + "\",http_route=\"" + route
+                                  + ((route != null) ? ("\",http_route=\"" + route) : "\",http_route=\"")
                                   + "\",mp_scope=\"vendor\",network_protocol_version=\"1\\.[01]\",server_address=\"localhost\",server_port=\"[0-9]+\",url_scheme=\"http\",\\} ";
 
         String sumMatchString = "http_server_request_duration_seconds_sum\\{error_type=\"" + errorType
                                 + "\",http_request_method=\""
                                 + requestMethod
                                 + "\",http_response_status_code=\"" + responseStatus
-                                + "\",http_route=\"" + route
+                                + ((route != null) ? ("\",http_route=\"" + route) : "\",http_route=\"")
                                 + "\",mp_scope=\"vendor\",network_protocol_version=\"1\\.[01]\",server_address=\"localhost\",server_port=\"[0-9]+\",url_scheme=\"http\",\\} ";
 
         return validatePrometheusHTTPMetricCount(vendorMetricsOutput, route, responseStatus, requestMethod, errorType, expectedCount, countMatchString) &&
@@ -325,7 +325,7 @@ public abstract class BaseTestClass {
             countMatchString = "http_server_request_duration_seconds_count\\{http_request_method=\""
                                + requestMethod
                                + "\",http_response_status_code=\"" + responseStatus
-                               + "\",http_route=\"" + route
+                               + ((route != null) ? ("\",http_route=\"" + route) : "")
                                + "\",instance=\"[a-zA-Z0-9-]*\""
                                + ",job=\"" + appName
                                + "\",network_protocol_version=\"1\\.[01]\",server_address=\"localhost\",server_port=\"[0-9]+\",url_scheme=\"http\"\\} ";
@@ -333,7 +333,7 @@ public abstract class BaseTestClass {
             sumMatchString = "http_server_request_duration_seconds_sum\\{http_request_method=\""
                              + requestMethod
                              + "\",http_response_status_code=\"" + responseStatus
-                             + "\",http_route=\"" + route
+                             + ((route != null) ? ("\",http_route=\"" + route) : "")
                              + "\",instance=\"[a-zA-Z0-9-]*\""
                              + ",job=\"" + appName
                              + "\",network_protocol_version=\"1\\.[01]\",server_address=\"localhost\",server_port=\"[0-9]+\",url_scheme=\"http\"\\} ";
@@ -342,7 +342,7 @@ public abstract class BaseTestClass {
                                + "\",http_request_method=\""
                                + requestMethod
                                + "\",http_response_status_code=\"" + responseStatus
-                               + "\",http_route=\"" + route
+                               + ((route != null) ? ("\",http_route=\"" + route) : "")
                                + "\",instance=\"[a-zA-Z0-9-]*\""
                                + ",job=\"" + appName
                                + "\",network_protocol_version=\"1\\.[01]\",server_address=\"localhost\",server_port=\"[0-9]+\",url_scheme=\"http\"\\} ";
@@ -351,7 +351,7 @@ public abstract class BaseTestClass {
                              + "\",http_request_method=\""
                              + requestMethod
                              + "\",http_response_status_code=\"" + responseStatus
-                             + "\",http_route=\"" + route
+                             + ((route != null) ? ("\",http_route=\"" + route) : "")
                              + "\",instance=\"[a-zA-Z0-9-]*\""
                              + ",job=\"" + appName
                              + "\",network_protocol_version=\"1\\.[01]\",server_address=\"localhost\",server_port=\"[0-9]+\",url_scheme=\"http\"\\} ";

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerNoAppTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerNoAppTest.java
@@ -97,17 +97,20 @@ public class ContainerNoAppTest extends BaseTestClass {
         String route = "/madeThisUp";
         String requestMethod = HttpMethod.GET;
         String responseStatus = "404";
+        String expectedRoute = "/";
 
         String res = requestHttpServlet(route, server, requestMethod);
 
         //Allow time for the collector to receive and expose metrics
-        assertTrueRetryWithTimeout(() -> validateMpTelemetryHttp(Constants.OTEL_SERVICE_NOT_SET, getContainerCollectorMetrics(container), null, responseStatus, requestMethod));
+        assertTrueRetryWithTimeout(() -> validateMpTelemetryHttp(Constants.OTEL_SERVICE_NOT_SET, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
+                                                                 requestMethod));
 
         String route2 = "/anotherMadeThisUp";
         String res2 = requestHttpServlet(route, server, requestMethod);
 
         //Allow time for the collector to receive and expose metrics
-        assertTrueRetryWithTimeout(() -> validateMpTelemetryHttp(Constants.OTEL_SERVICE_NOT_SET, getContainerCollectorMetrics(container), null, responseStatus, requestMethod, null,
+        assertTrueRetryWithTimeout(() -> validateMpTelemetryHttp(Constants.OTEL_SERVICE_NOT_SET, getContainerCollectorMetrics(container), expectedRoute, responseStatus,
+                                                                 requestMethod, null,
                                                                  ">1", null));
 
     }

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerNoAppTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerNoAppTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -86,6 +86,29 @@ public class ContainerNoAppTest extends BaseTestClass {
         String res = requestHttpServlet(route, server, requestMethod);
         //Allow time for the collector to receive and expose metrics
         assertTrueRetryWithTimeout(() -> validateMpTelemetryHttp(Constants.OTEL_SERVICE_NOT_SET, getContainerCollectorMetrics(container), route, responseStatus, requestMethod));
+
+    }
+
+    @Test
+    public void c_noApp_nonExistent() throws Exception {
+
+        assertTrue(server.isStarted());
+
+        String route = "/madeThisUp";
+        String requestMethod = HttpMethod.GET;
+        String responseStatus = "404";
+
+        String res = requestHttpServlet(route, server, requestMethod);
+
+        //Allow time for the collector to receive and expose metrics
+        assertTrueRetryWithTimeout(() -> validateMpTelemetryHttp(Constants.OTEL_SERVICE_NOT_SET, getContainerCollectorMetrics(container), null, responseStatus, requestMethod));
+
+        String route2 = "/anotherMadeThisUp";
+        String res2 = requestHttpServlet(route, server, requestMethod);
+
+        //Allow time for the collector to receive and expose metrics
+        assertTrueRetryWithTimeout(() -> validateMpTelemetryHttp(Constants.OTEL_SERVICE_NOT_SET, getContainerCollectorMetrics(container), null, responseStatus, requestMethod, null,
+                                                                 ">1", null));
 
     }
 

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/NoAppTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/NoAppTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -81,6 +81,26 @@ public class NoAppTest extends BaseTestClass {
         String res = requestHttpServlet(route, server, requestMethod);
 
         assertTrue(validateMpMetricsHttp(getVendorMetrics(server), route, responseStatus, requestMethod));
+
+    }
+
+    @Test
+    public void noApp_nonExistent() throws Exception {
+
+        assertTrue(server.isStarted());
+
+        String route = "/madeThisUp";
+        String requestMethod = HttpMethod.GET;
+        String responseStatus = "404";
+
+        String res = requestHttpServlet(route, server, requestMethod);
+
+        assertTrue(validateMpMetricsHttp(getVendorMetrics(server), null, responseStatus, requestMethod));
+
+        String route2 = "/anotherMadeThisUp";
+        String res2 = requestHttpServlet(route, server, requestMethod);
+
+        assertTrue(validateMpMetricsHttp(getVendorMetrics(server), null, responseStatus, requestMethod, null, ">1", null));
 
     }
 

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/NoAppTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/NoAppTest.java
@@ -92,15 +92,16 @@ public class NoAppTest extends BaseTestClass {
         String route = "/madeThisUp";
         String requestMethod = HttpMethod.GET;
         String responseStatus = "404";
+        String expectedRoute = "/";
 
         String res = requestHttpServlet(route, server, requestMethod);
 
-        assertTrue(validateMpMetricsHttp(getVendorMetrics(server), null, responseStatus, requestMethod));
+        assertTrue(validateMpMetricsHttp(getVendorMetrics(server), expectedRoute, responseStatus, requestMethod));
 
         String route2 = "/anotherMadeThisUp";
         String res2 = requestHttpServlet(route, server, requestMethod);
 
-        assertTrue(validateMpMetricsHttp(getVendorMetrics(server), null, responseStatus, requestMethod, null, ">1", null));
+        assertTrue(validateMpMetricsHttp(getVendorMetrics(server), expectedRoute, responseStatus, requestMethod, null, ">1", null));
 
     }
 


### PR DESCRIPTION
When the server is handling requests made to the server itself (i.e., not through a deployed application) and a 4xx response code is encountered, the HTTP route is resolved to "/".

Test methods also updated to accept `null` and interpret it as "no http route". (This is not used for this PR change, but can be used in the future).



- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
fixes #30567 