### PR TITLE
Ending dot in dns name on Ubuntu platform prevents Liberty make SSL port available 

### DIFF
--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2024 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1812,7 +1812,7 @@ public class WSKeyStore extends Properties {
             if (hostname != null && !hostname.isEmpty()) {
                 if (hostname.equalsIgnoreCase("localhost")) {
                     String host = InetAddress.getLocalHost().getCanonicalHostName();
-                    san.add("dns:" + host);
+                    san.add("dns:" + removeDots(host));
                 }
                 InetAddress addr;
                 // get the InetAddress if there is one
@@ -1820,11 +1820,11 @@ public class WSKeyStore extends Properties {
                 if (addr != null && addr.toString().startsWith("/"))
                     san.add("ip:" + hostname);
                 else {
-                    san.add("dns:" + hostname);
+                    san.add("dns:" + removeDots(hostname));
                 }
             } else {
                 String host = InetAddress.getLocalHost().getCanonicalHostName();
-                san.add("dns:" + host);
+                san.add("dns:" + removeDots(host));
             }
             String ipAddresses = DefaultSubjectDN.buildSanIpStringFromNetworkInterface();
             if (ipAddresses != null)
@@ -1851,6 +1851,15 @@ public class WSKeyStore extends Properties {
 
     }
 
+    /**
+    * Removes leading and trailing dots from a DNS string.
+    * @param dnsString the DNS string to be processed
+    * @return the DNS string with leading and trailing dots removed
+    */
+    String removeDots(String dnsString) {
+        return dnsString.replaceAll("^\\.", "").replaceAll("\\.$", "");
+    }
+    
     /**
      * @param hostname
      * @return


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

According to the SSL trace, `createCertSANInfo` method shows the hostname with ending doc, as the error message suggests. 
```
createCertSANInfo: SAN=dns:IBM-PW05G4LL.,dns:localhost,ip:172.21.46.155,ip:10.255.255.254,ip:127.0.0.1 Exit
```

With the test patch created by the proposed code, the successful certificate creation message appears. 
```
[1/16/25 10:47:56:212 EST] 00000027 id=00000000 com.ibm.ws.ssl.config.WSKeyStore                             < createCertSANInfo: SAN=dns:IBM-PW05G4LL,dns:localhost,ip:172.21.46.155,ip:10.255.255.254,ip:127.0.0.1 Exit

[1/16/25 10:47:56:993 EST] 00000027 id=00000000 com.ibm.ws.ssl.config.WSKeyStore 
A CWPKI0803A: SSL certificate created in 0.798 seconds. SSL key file: /home/hiroko/myGit/liberty-
formlogin/build/wlp/usr/servers/defaultServer/resources/security/key.p12
```