### PR TITLE
Demonstrate inconsistency and wrong behavior of ElementCollection

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ECEntity.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ECEntity.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+
+/**
+ * Entity with and without ElementCollection attributes.
+ */
+@Entity
+public class ECEntity {
+
+    @Id
+    String id;
+
+    int[] intArray = new int[] {};
+
+    ArrayList<Long> longList = new ArrayList<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    ArrayList<Long> longListEC = new ArrayList<>();
+
+    Set<String> stringSet = new HashSet<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    Set<String> stringSetEC = new HashSet<>();
+
+    public String getId() {
+        return id;
+    }
+
+    public int[] getIntArray() {
+        return intArray;
+    }
+
+    public ArrayList<Long> getLongList() {
+        return longList;
+    }
+
+    public ArrayList<Long> getLongListEC() {
+        return longListEC;
+    }
+
+    public Set<String> getStringSet() {
+        return stringSet;
+    }
+
+    public Set<String> getStringSetEC() {
+        return stringSetEC;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setIntArray(int[] intArray) {
+        this.intArray = intArray;
+    }
+
+    public void setLongList(ArrayList<Long> longList) {
+        this.longList = longList;
+    }
+
+    public void setLongListEC(ArrayList<Long> longListEC) {
+        this.longListEC = longListEC;
+    }
+
+    public void setStringSet(Set<String> stringSet) {
+        this.stringSet = stringSet;
+    }
+
+    public void setStringSetEC(Set<String> stringSetEC) {
+        this.stringSetEC = stringSetEC;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ECRepo.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ECRepo.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+import jakarta.persistence.EntityManager;
+
+/**
+ * Repository with an entity that has ElementCollection attributes
+ * and non-ElementCollection attributes.
+ */
+@Repository
+public interface ECRepo extends DataRepository<ECEntity, String> {
+
+    EntityManager getEntityManager();
+
+    @Insert
+    void insert(ECEntity e);
+}


### PR DESCRIPTION
This demonstrates that EclipseLink is allowing ElementCollection attributes to be returned by JPQL queries, but with results that are both inconsistent with non-ElementCollection attributes of the same type, and are also incorrect.  Especially when returning multiple results which get erroneously combined together into a single collection!

Here is the output of this test. Entity attribute names ending in "EC" use ElementCollection. The others have the same types but don't use ElementCollection:
```
 SELECT intArray FROM ECEntity WHERE id=?1
 getResultList returned a java.util.Vector
     elements are of type int[]
             contents are [[14, 12, 1]]
 SELECT longList FROM ECEntity WHERE id=?1
 getResultList returned a java.util.Vector
     elements are of type java.util.ArrayList
             contents are [[14, 12, 1]]
 SELECT longListEC FROM ECEntity WHERE id=?1
 getResultList returned a java.util.Vector
     elements are of type java.lang.Long
             contents are [14, 12, 1]
 SELECT stringSet FROM ECEntity WHERE id=?1
 getResultList returned a java.util.Vector
     elements are of type java.util.ImmutableCollections$SetN
             contents are [[one, twelve, fourteen]]
 SELECT stringSetEC FROM ECEntity WHERE id=?1
 getResultList returned a java.util.Vector
     elements are of type java.lang.String
             contents are [one, twelve, fourteen]
 SELECT longList FROM ECEntity WHERE id LIKE ?1
 getResultList returned a java.util.Vector
     elements are of type java.util.ArrayList
             contents are [[14, 12, 1], [14, 12, 2]]
 SELECT longListEC FROM ECEntity WHERE id LIKE ?1
 getResultList returned a java.util.Vector
     elements are of type java.lang.Long
             contents are [14, 12, 1, 14, 12, 2]
 SELECT stringSet FROM ECEntity WHERE id LIKE ?1
 getResultList returned a java.util.Vector
     elements are of type java.util.ImmutableCollections$SetN
             contents are [[one, twelve, fourteen], [two, twelve, fourteen]]
 SELECT stringSetEC FROM ECEntity WHERE id LIKE ?1
 getResultList returned a java.util.Vector
     elements are of type java.lang.String
             contents are [one, twelve, fourteen, two, twelve, fourteen]
```

If EclipseLink wants to reject this outright because the Jakarta Persistence specification does not require element collections to be selected by JPQL queries, that would be perfectly fine.  But if EclipseLink doesn't reject it, it at least needs to get the behavior correct and return valid results.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
