### PR TITLE
Address extra byte on testPriorityFrameLength4

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
@@ -2829,7 +2829,7 @@ public class H2FATDriverServlet extends FATServlet {
         setupDefaultUpgradedConnection(h2Client, HEADERS_ONLY_URI);
 
         //length: 4, which is invalid
-        String priorityString = "0000040200000000037fffffffff";
+        String priorityString = "0000040200000000037fffffff";
         byte[] b = parseHexBinary(priorityString);
         h2Client.sendBytes(b);
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

### Description of Issue

This test is using a priority frame set to `"0000040200000000037fffffffff"` for the purpose of confirming that the server recognizes it as invalid, as the frame would typically contain 5 octets. Therefore, the intended format for the frame should be:
First 3 bytes `00 00 04` -> Indicates the payload to be of length 4. 
Next byte `02` -> Indicates frame type to be PRIORITY
Next byte `00` -> Indicates no flags are set
Next 4 bytes `00 00 00 03` -> Indicates the stream ID

Herein lies the issue, there are 5 remaining bytes `ff ff ff ff ff`. However, the length bytes indicated that only 4 bytes would be sent over. When this test fails, the server reads in the 4 bytes it was told to and the remaining is treated as a new frame. This results in a frame that vastly exceeds the window size. 

As such, this test will be uploaded to contain 4 bytes in the payload as opposed to 5. 