### PR TITLE
workarounds for selecting ElementCollection attributes

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1016,3 +1016,25 @@ CWWKD1101.attr.subset.mismatch.explanation=When Java records are used to \
 CWWKD1101.attr.subset.mismatch.useraction=Rename the record components to \
  match valid entity attribute names, or use the Select annotation to explicitly \
  request entity attributes by their name.
+
+CWWKD1102.incompat.query.result=CWWKD1102E: The {0} method of the {1} repository \
+ has the {2} return type, but the Jakarta Persistence provider performed a \
+ query with results of the {3} type. Check if the Jakarta Persistence provider \
+ allows querying for the types of entity attributes that are selected by the \
+ {0} method.
+CWWKD1102.incompat.query.result.explanation=Jakarta Persistence providers might \
+ not allow returning all types of entity attributes.
+CWWKD1102.incompat.query.result.useraction=Modify the query to retrieve the whole \
+ entity or a different set of entity attributes that are allowed by the Jakarta \
+ Persistence provider.
+
+CWWKD1103.incompat.query.result=CWWKD1103E: The {0} method of the {1} repository \
+ has the {2} return type, but the Jakarta Persistence provider performed a \
+ {3} query with results of the {4} type. Check if the Jakarta Persistence provider \
+ allows querying for the types of entity attributes that are selected by the \
+ {0} method.
+CWWKD1103.incompat.query.result.explanation=Jakarta Persistence providers might \
+ not allow returning all types of entity attributes.
+CWWKD1103.incompat.query.result.useraction=Modify the query to retrieve the whole \
+ entity or a different set of entity attributes that are allowed by the Jakarta \
+ Persistence provider.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1019,22 +1019,34 @@ CWWKD1101.attr.subset.mismatch.useraction=Rename the record components to \
 
 CWWKD1102.incompat.query.result=CWWKD1102E: The {0} method of the {1} repository \
  has the {2} return type, but the Jakarta Persistence provider performed a \
- query with results of the {3} type. Check if the Jakarta Persistence provider \
- allows querying for the types of entity attributes that are selected by the \
- {0} method.
-CWWKD1102.incompat.query.result.explanation=Jakarta Persistence providers might \
- not allow returning all types of entity attributes.
-CWWKD1102.incompat.query.result.useraction=Modify the query to retrieve the whole \
- entity or a different set of entity attributes that are allowed by the Jakarta \
- Persistence provider.
+ query with results of the {3} type. Check whether the Jakarta Persistence \
+ provider allows querying for the types of entity attributes that the {0} method \
+ selects. Check for other causes of incompatibility if the Jakarta provider does \
+ allow querying for the types of entity attributes that the {0} method selects.
+CWWKD1102.incompat.query.result.explanation=Jakarta Persistence providers do not \
+ allow returning all types of entity attributes. If the Jakarta provider does \
+ return the type of entity attributes that the method selected, another cause \
+ of incompatibility exists. For example, the Jakarta Persistence provider might \
+ have a bug or the repository method signature might have an error.
+CWWKD1102.incompat.query.result.useraction=If the type of entity attributes that \
+ the method selects is not allowed, modify the query to retrieve the whole entity \
+ or a different set of entity attributes that the Jakarta Persistence provider \
+ allows. If the type of entity attributes that the method selects is allowed, \
+ check for other causes of incompatibility.
 
 CWWKD1103.incompat.query.result=CWWKD1103E: The {0} method of the {1} repository \
  has the {2} return type, but the Jakarta Persistence provider performed a \
- {3} query with results of the {4} type. Check if the Jakarta Persistence provider \
- allows querying for the types of entity attributes that are selected by the \
- {0} method.
-CWWKD1103.incompat.query.result.explanation=Jakarta Persistence providers might \
- not allow returning all types of entity attributes.
-CWWKD1103.incompat.query.result.useraction=Modify the query to retrieve the whole \
- entity or a different set of entity attributes that are allowed by the Jakarta \
- Persistence provider.
+ {3} query with results of the {4} type. Check whether the Jakarta Persistence \
+ provider allows querying for the types of entity attributes that the {0} method \
+ selects. Check for other causes of incompatibility if the Jakarta provider does \
+ allow querying for the types of entity attributes that the {0} method selects.
+CWWKD1103.incompat.query.result.explanation=Jakarta Persistence providers do not \
+ allow returning all types of entity attributes. If the Jakarta provider does \
+ return the type of entity attributes that the method selected, another cause \
+ of incompatibility exists. For example, the Jakarta Persistence provider might \
+ have a bug or the repository method signature might have an error.
+CWWKD1103.incompat.query.result.useraction=If the type of entity attributes that \
+ the method selects is not allowed, modify the query to retrieve the whole entity \
+ or a different set of entity attributes that the Jakarta Persistence provider \
+ allows. If the type of entity attributes that the method selects is allowed, \
+ check for other causes of incompatibility.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -850,12 +850,14 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                     returnValue = oneResult(queryInfo, results);
                                 } else if (multiType != null &&
                                            multiType.isInstance(results) &&
-                                           (results.isEmpty() || !(results.get(0) instanceof Object[]))) {
+                                           (results.isEmpty() || singleType.isInstance(results.get(0)) &&
+                                                                 !(results.get(0) instanceof Object[]))) {
                                     returnValue = results;
                                 } else if (multiType != null && Iterable.class.isAssignableFrom(multiType)) {
                                     returnValue = queryInfo.convertToIterable(results,
+                                                                              multiType,
                                                                               singleType,
-                                                                              multiType);
+                                                                              query);
                                 } else if (Iterator.class.equals(multiType)) {
                                     returnValue = results.iterator();
                                 } else if (queryInfo.returnArrayType != null) {

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -63,7 +63,11 @@ public class DataTest extends FATServletClient {
                                    "CWWKD1054E.*findAsLongBetween",
                                    "CWWKD1054E.*findByNumberIdBetween",
                                    "CWWKD1075E.*Apartment2",
-                                   "CWWKD1075E.*Apartment3"
+                                   "CWWKD1075E.*Apartment3",
+                                   // work around to prevent bad behavior from EclipseLink (see #30575)
+                                   "CWWKD1103E.*romanNumeralSymbolsAsListOfArrayList",
+                                   // work around to prevent bad behavior from EclipseLink (see #30575)
+                                   "CWWKD1103E.*romanNumeralSymbolsAsSetOfArrayList"
                     };
 
     @ClassRule

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -36,6 +36,7 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -4381,6 +4382,52 @@ public class DataTestServlet extends FATServlet {
     public void testQueryReturnsArrayListAttributeAsCollection() {
         assertEquals(List.of("X", "X", "X", "V", "I", "I"),
                      primes.romanNumeralSymbolsAsCollection(37).orElseThrow());
+    }
+
+    /**
+     * Repository Query method that selects and returns a multiple results of an
+     * ArrayList attribute
+     */
+    @Test
+    public void testQueryReturnsArrayListAttributeAsListOfArrayList() {
+        List<ArrayList<String>> results;
+        try {
+            results = primes.romanNumeralSymbolsAsListOfArrayList("XL%");
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage().startsWith("CWWKD1103E"))
+                // work around for bad behavior from EclipseLink when selecting
+                // ElementCollection attributes (see #30575)
+                return;
+            else
+                throw x;
+        }
+        assertEquals(List.of(new ArrayList<String>(List.of("X", "L", "I")),
+                             new ArrayList<String>(List.of("X", "L", "I", "I", "I")),
+                             new ArrayList<String>(List.of("X", "L", "V", "I", "I"))),
+                     results);
+    }
+
+    /**
+     * Repository Query method that selects and returns a multiple results of an
+     * ArrayList attribute as a Set.
+     */
+    @Test
+    public void testQueryReturnsArrayListAttributeAsSetOfArrayList() {
+        LinkedHashSet<ArrayList<String>> results;
+        try {
+            results = primes.romanNumeralSymbolsAsSetOfArrayList("XL%");
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage().startsWith("CWWKD1103E"))
+                // work around for bad behavior from EclipseLink when selecting
+                // ElementCollection attributes (see #30575)
+                return;
+            else
+                throw x;
+        }
+        assertEquals(Set.of(new ArrayList<String>(List.of("X", "L", "I")),
+                            new ArrayList<String>(List.of("X", "L", "I", "I", "I")),
+                            new ArrayList<String>(List.of("X", "L", "V", "I", "I"))),
+                     results);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4365,6 +4365,25 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Repository Query method that selects and returns a single ArrayList attribute
+     */
+    @Test
+    public void testQueryReturnsArrayListAttribute() {
+        assertEquals(new ArrayList<String>(List.of("X", "L", "I")),
+                     primes.romanNumeralSymbolsAsArrayList(41).orElseThrow());
+    }
+
+    /**
+     * Repository Query method that selects a single attribute of type ArrayList
+     * and returns it as a Collection.
+     */
+    @Test
+    public void testQueryReturnsArrayListAttributeAsCollection() {
+        assertEquals(List.of("X", "X", "X", "V", "I", "I"),
+                     primes.romanNumeralSymbolsAsCollection(37).orElseThrow());
+    }
+
+    /**
      * Use a Repository method that has the Query annotation and has a return type
      * that uses a Java record indicating to select a subset of entity attributes.
      */

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -427,6 +427,12 @@ public interface Primes {
                                      long min2, long max2,
                                      PageRequest pageRequest);
 
+    @Query("SELECT romanNumeralSymbols WHERE numberId = ?1")
+    Optional<ArrayList<String>> romanNumeralSymbolsAsArrayList(long num);
+
+    @Query("SELECT romanNumeralSymbols WHERE numberId = ?1")
+    Optional<Collection<String>> romanNumeralSymbolsAsCollection(long num);
+
     @Query("SELECT hex WHERE numberId=:id")
     Optional<Character> singleHexDigit(long id);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -432,6 +433,14 @@ public interface Primes {
 
     @Query("SELECT romanNumeralSymbols WHERE numberId = ?1")
     Optional<Collection<String>> romanNumeralSymbolsAsCollection(long num);
+
+    @Query("SELECT romanNumeralSymbols WHERE romanNumeral LIKE ?1")
+    @OrderBy(ID)
+    List<ArrayList<String>> romanNumeralSymbolsAsListOfArrayList(String pattern);
+
+    @Query("SELECT romanNumeralSymbols WHERE romanNumeral LIKE ?1")
+    @OrderBy(ID)
+    LinkedHashSet<ArrayList<String>> romanNumeralSymbolsAsSetOfArrayList(String pattern);
 
     @Query("SELECT hex WHERE numberId=:id")
     Optional<Character> singleHexDigit(long id);

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -54,7 +54,10 @@ public class DataJPATest extends FATServletClient {
                                    "CWWKD1054E.*findByIsControlTrueAndNumericValueBetween",
                                    "CWWKD1075E.*Apartment2",
                                    "CWWKD1075E.*Apartment3",
-                                   "CWWKD1091E.*countBySurgePriceGreaterThanEqual"
+                                   "CWWKD1091E.*countBySurgePriceGreaterThanEqual",
+                                   // work around to prevent bad behavior from EclipseLink (see #30575)
+                                   "CWWKD1103E.*findBankAccountsByFilingStatus"
+
                     };
 
     @ClassRule

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/City.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/City.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,8 @@ import jakarta.persistence.Version;
 @Entity
 @IdClass(CityId.class)
 public class City {
-    // TODO uncomment to reproduce EclipseLink bug with selecting an attribute that is a collection type.
+    // TODO uncomment to reproduce EclipseLink bugs #28589, #29475
+    // that select an attribute that is a collection type.
     //@ElementCollection(fetch = FetchType.EAGER)
     public Set<Integer> areaCodes;
 


### PR DESCRIPTION
EclipseLink has wrong behavior when ElementCollection attributes are selected, as shown by #30575
This PR puts in place the following workarounds, to the degree that we are able,

When a single result of a selected ElementCollection is returned, we can sometimes implement a workaround to identify the mismatch and generate the correct type of collection, populated with the results.

When multiple results of a selected ElementCollection are returned, EclipseLink combines the values into a single vector where it is impossible to split them back out into the separate results that they are. We attempt to detect this scenario and raise our own UnsupportedOperationException in order to spare the user from unexpected wrong behavior.

There are also some improvements in this area to type conversions.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
