### PR TITLE
Disable Netty on H2 tests

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpEndpointImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpEndpointImpl.java
@@ -306,7 +306,7 @@ public class HttpEndpointImpl implements RuntimeUpdateListener, PauseableCompone
         useNetty = ProductInfo.getBetaEdition() &&
                    MetatypeUtils.parseBoolean(config, NettyConstants.USE_NETTY, config.get(NettyConstants.USE_NETTY), true);
     
-
+        useNetty=false;
 
         initializeChains();
 

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
@@ -92,7 +92,7 @@ public class H2FATDriverServlet extends FATServlet {
         if (LOGGER.isLoggable(Level.INFO)) {
             LOGGER.logp(Level.INFO, this.getClass().getName(), "setUsingNetty", "Setting Netty Usage for tests!!");
         }
-        USING_NETTY = true;
+        USING_NETTY = false;
     }
 
     public void testUpgradeHeader(HttpServletRequest request, HttpServletResponse response) throws InterruptedException, Exception {


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Test Legacy with Netty Branch but Netty disabled.