### PR TITLE
Reenable ignored classloader package tests

### DIFF
--- a/dev/com.ibm.ws.classloading_test/test-resources/PackageDefineTestResources/MANIFEST.MF
+++ b/dev/com.ibm.ws.classloading_test/test-resources/PackageDefineTestResources/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 
 Name: test/
-Specification-Title: Classloading Test Resources 
+Specification-Title: Classloading Test Resources
 Specification-Version: 1.0
 Specification-Vendor: IBM
-Implementation-Title: test 
+Implementation-Title: test
 Implementation-Version: foo1
 Implementation-Vendor: IBM
 Sealed: true

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/PackageDefinitionsTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/PackageDefinitionsTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 import java.lang.instrument.ClassFileTransformer;
 import java.security.ProtectionDomain;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -38,7 +37,6 @@ public class PackageDefinitionsTest {
     /**
      * Test to make sure that the package is defined after calling loadClass when there is no transformer registered
      */
-    @Ignore
     @Test
     public void testPackageDeclaration() throws Exception {
         AppClassLoader loader = createAppClassloader(this.getClass().getName() + ".jar-loader", getTestJarURL(), true);
@@ -48,7 +46,6 @@ public class PackageDefinitionsTest {
     /**
      * Test to make sure that the package is defined after calling loadClass when there is a transformer defined when using a class in a jar
      */
-    @Ignore
     @Test
     public void testPackageDeclarationWithTransformerOnJar() throws Exception {
         AppClassLoader loader = createAppClassloader(this.getClass().getName() + ".jar-loader-transform", getTestJarURL(), true);
@@ -82,7 +79,6 @@ public class PackageDefinitionsTest {
     /**
      * This test makes sure that when shadowing a directory the package is correctly defined by having any properties set on it from the manifest
      */
-    @Ignore
     @Test
     public void testPackageDefinitionsFromShadowLoaderOnJar() throws Exception {
         AppClassLoader loader = createAppClassloader(this.getClass().getName() + ".shadowed-jar", getTestJarURL(), true);


### PR DESCRIPTION
It is unclear why the tests were igored.  These tests were failing when enabled because the test MANIFEST.MF has some trailing spaces that caused the tests to fail on comparing the package attributes.


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

