### PR TITLE
Add EE Repeats for EJB V32 FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/RemoteTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/RemoteTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -276,7 +276,7 @@ public class RemoteTests extends AbstractTest {
         server.saveServerConfiguration();
         ServerConfiguration config = server.getServerConfiguration();
         EJBAsynchronousElement asynchronous = new EJBAsynchronousElement();
-        asynchronous.setMaxUnclaimedRemoteResults("1");
+        asynchronous.setMaxUnclaimedRemoteResults(1);
         config.getEJBContainer().setAsynchronous(asynchronous);
         try {
             updateServerConfiguration(config);

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/bnd.bnd
@@ -24,9 +24,15 @@ src: \
 fat.project: true
 
 tested.features: \
+	ejbLite-3.2,\
 	ejbHome-3.2,\
+	enterpriseBeansLite-4.0,\
+	enterpriseBeansHome-4.0,\
 	servlet-3.1,\
-	servlet-4.0
+	servlet-4.0,\
+	servlet-5.0,\
+	servlet-6.0,\
+	servlet-6.1
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/JavaGlobalInjectIntoServletTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/JavaGlobalInjectIntoServletTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -27,6 +28,8 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import io.openliberty.ejb32.javaglobal.web.BasicServlet;
@@ -36,6 +39,13 @@ public class JavaGlobalInjectIntoServletTest extends FATServletClient {
     @Server("com.ibm.ws.ejbcontainer.v32.fat.basic")
     @TestServlets({ @TestServlet(servlet = BasicServlet.class, contextRoot = "JavaGlobalInjectIntoServletTestApp") })
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE11_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic"));
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/PassivationTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/PassivationTest.java
@@ -19,6 +19,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -27,6 +28,8 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -38,6 +41,13 @@ public class PassivationTest extends FATServletClient {
     public static LibertyServer server;
 
     private static boolean checkLogsAfterServerStop;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17).forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
+                    .andWith(FeatureReplacementAction.EE11_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation"));
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/PassivationTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/PassivationTest.java
@@ -43,7 +43,7 @@ public class PassivationTest extends FATServletClient {
     private static boolean checkLogsAfterServerStop;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
                     .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
                     .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
                     .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17).forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/PassivationTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/PassivationTest.java
@@ -43,7 +43,7 @@ public class PassivationTest extends FATServletClient {
     private static boolean checkLogsAfterServerStop;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
                     .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
                     .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //
                     .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17).forServers("com.ibm.ws.ejbcontainer.v32.fat.passivation")) //

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/SingletonLifecycleTxTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/SingletonLifecycleTxTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ package com.ibm.ws.ejbcontainer.v32.fat.tests;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -25,6 +26,8 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -33,6 +36,13 @@ public class SingletonLifecycleTxTest extends FATServletClient {
     @Server("com.ibm.ws.ejbcontainer.v32.fat.basic")
     @TestServlets({ @TestServlet(servlet = SingletonLifecycleTxTestServlet.class, contextRoot = "SingletonLifecycleTx") })
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE11_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic"));
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/SingletonLifecycleTxTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/SingletonLifecycleTxTest.java
@@ -38,7 +38,7 @@ public class SingletonLifecycleTxTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/SingletonLifecycleTxTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/SingletonLifecycleTxTest.java
@@ -38,7 +38,7 @@ public class SingletonLifecycleTxTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/StatefulLifecycleTxTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/StatefulLifecycleTxTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ package com.ibm.ws.ejbcontainer.v32.fat.tests;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -25,6 +26,8 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -33,6 +36,13 @@ public class StatefulLifecycleTxTest extends FATServletClient {
     @Server("com.ibm.ws.ejbcontainer.v32.fat.basic")
     @TestServlets({ @TestServlet(servlet = StatefulLifecycleTxTestServlet.class, contextRoot = "StatefulLifecycleTx") })
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+                    .andWith(FeatureReplacementAction.EE11_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic"));
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/StatefulLifecycleTxTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/StatefulLifecycleTxTest.java
@@ -38,7 +38,7 @@ public class StatefulLifecycleTxTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //

--- a/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/StatefulLifecycleTxTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/v32/fat/tests/StatefulLifecycleTxTest.java
@@ -38,7 +38,7 @@ public class StatefulLifecycleTxTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //
                     .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17).forServers("com.ibm.ws.ejbcontainer.v32.fat.basic")) //

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/EJBAsynchronousElement.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/EJBAsynchronousElement.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,7 +21,7 @@ public class EJBAsynchronousElement extends ConfigElement {
 
     private String contextServiceRef;
     private String unclaimedRemoteResultTimeout;
-    private String maxUnclaimedRemoteResults;
+    private Integer maxUnclaimedRemoteResults;
 
     public String getContextServiceRef() {
         return contextServiceRef;
@@ -41,12 +41,12 @@ public class EJBAsynchronousElement extends ConfigElement {
         this.unclaimedRemoteResultTimeout = unclaimedRemoteResultTimeout;
     }
 
-    public String getMaxUnclaimedRemoteResults() {
+    public Integer getMaxUnclaimedRemoteResults() {
         return maxUnclaimedRemoteResults;
     }
 
     @XmlAttribute(name = "maxUnclaimedRemoteResults")
-    public void setMaxUnclaimedRemoteResults(String maxUnclaimedRemoteResults) {
+    public void setMaxUnclaimedRemoteResults(Integer maxUnclaimedRemoteResults) {
         this.maxUnclaimedRemoteResults = maxUnclaimedRemoteResults;
     }
 

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/EJBContainerElement.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/EJBContainerElement.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,8 +21,8 @@ import javax.xml.bind.annotation.XmlElement;
 public class EJBContainerElement extends ConfigElement {
 
     private Integer cacheSize;
-    private Long poolCleanupInterval;
-    private Long cacheCleanupInterval;
+    private String poolCleanupInterval;
+    private String cacheCleanupInterval;
     private Boolean startEJBsAtAppStart;
     private EJBAsynchronousElement asynchronous;
     private EJBTimerServiceElement timerService;
@@ -40,21 +40,21 @@ public class EJBContainerElement extends ConfigElement {
         this.cacheSize = cacheSize;
     }
 
-    public Long getPoolCleanupInterval() {
+    public String getPoolCleanupInterval() {
         return poolCleanupInterval;
     }
 
     @XmlAttribute(name = "poolCleanupInterval")
-    public void setPoolCleanupInterval(Long poolCleanupInterval) {
+    public void setPoolCleanupInterval(String poolCleanupInterval) {
         this.poolCleanupInterval = poolCleanupInterval;
     }
 
-    public Long getCacheCleanupInterval() {
+    public String getCacheCleanupInterval() {
         return cacheCleanupInterval;
     }
 
     @XmlAttribute(name = "cacheCleanupInterval")
-    public void setCacheCleanupInterval(Long cacheCleanupInterval) {
+    public void setCacheCleanupInterval(String cacheCleanupInterval) {
         this.cacheCleanupInterval = cacheCleanupInterval;
     }
 


### PR DESCRIPTION
- Add RepeatActions to EJB V32 FAT tests
- Fix EJB metadata types in Simplicity so RepeatActions may update server.xml
- Update other tests that were programmatically setting EJB attributes with incorrect types


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".