### PR TITLE
Query by Method Name applies Contains restriction to ElementCollection attribute

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1224,6 +1224,19 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Query-by-Method-Name query with a Contains restriction applied to an
+     * ElementCollection.
+     */
+    @Test
+    public void testElementCollectionContains() {
+        assertEquals(List.of(5L, 7L, 17L, 37L, 47L),
+                     primes.findByRomanNumeralSymbolsContainsAndNumberIdLessThan("V",
+                                                                                 50)
+                                     .map(prime -> prime.numberId)
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
      * Unannotated entity with an attribute that is an embeddable type.
      */
     @SkipIfSysProp(DB_Postgres) //Failing on Postgres due to eclipselink issue.  https://github.com/OpenLiberty/open-liberty/issues/28380

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -246,6 +246,10 @@ public interface Primes {
     @OrderBy("name")
     Page<Prime> findByRomanNumeralStartsWithAndNumberIdLessThan(String prefix, long max, PageRequest pagination);
 
+    @OrderBy(ID)
+    Stream<Prime> findByRomanNumeralSymbolsContainsAndNumberIdLessThan(String symbol,
+                                                                       long max);
+
     @Find
     Prime findFirst(Sort<Prime> sort, Limit limitOf1);
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -1004,6 +1004,80 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Attempt to supply a single NULL Sort to a repository method that retrieves
+     * results as CursoredPage.
+     */
+    @Test
+    public void testNullSortForCursoredPage() {
+        CursoredPage<Voter> page;
+        Cursor ssn0 = Cursor.forKey(0);
+        try {
+            page = voters.selectByAddress("4051 E River Rd NE, Rochester, MN 55906",
+                                          PageRequest.ofSize(5).afterCursor(ssn0),
+                                          new Sort<?>[] { null });
+            fail("Obtained a cursored page sorted by NULL: " + page);
+        } catch (IllegalArgumentException x) {
+            // expected
+        }
+    }
+
+    /**
+     * Attempt to supply a single NULL Sort to a repository method that retrieves
+     * results as a Page.
+     */
+    @Test
+    public void testNullSortForPage() {
+        Page<Voter> page;
+        try {
+            page = voters.selectAll(PageRequest.ofSize(6),
+                                    new Sort<?>[] { null });
+            fail("Obtained a page sorted by NULL: " + page);
+        } catch (IllegalArgumentException x) {
+            // expected
+        }
+    }
+
+    /**
+     * Attempt to supply multiple Sorts, with one of them NULL, to a
+     * repository method that retrieves results as CursoredPage.
+     */
+    @Test
+    public void testNullSortWithOtherSortsValidForCursoredPage() {
+        CursoredPage<Voter> page;
+        Cursor ssn0 = Cursor.forKey(0,
+                                    "Val",
+                                    "4051 E River Rd NE, Rochester, MN 55906");
+        try {
+            page = voters.selectByAddress("4051 E River Rd NE, Rochester, MN 55906",
+                                          PageRequest.ofSize(4).afterCursor(ssn0),
+                                          Sort.asc(ID),
+                                          null,
+                                          Sort.desc("address"));
+            fail("Obtained a cursored page sorted by NULL: " + page);
+        } catch (IllegalArgumentException x) {
+            // expected
+        }
+    }
+
+    /**
+     * Attempt to supply multiple Sorts, with one of them NULL, to a
+     * repository method that retrieves results as a Page.
+     */
+    @Test
+    public void testNullSortWithOtherSortsValidForPage() {
+        Page<Voter> page;
+        try {
+            page = voters.selectAll(PageRequest.ofSize(7),
+                                    Sort.asc(ID),
+                                    null,
+                                    Sort.desc("name"));
+            fail("Obtained a page sorted by NULL: " + page);
+        } catch (IllegalArgumentException x) {
+            // expected
+        }
+    }
+
+    /**
      * Supply a PageRequest that has a Cursor to a repository method that returns
      * an offset-based Page rather than a CursoredPage. Expect an error.
      */

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -332,6 +332,10 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                            @Param("street") String street,
                            String city, // extra, unused parameter
                            String stateCode); // extra, unused parameter
+
+    @Find
+    Page<Voter> selectAll(PageRequest req,
+                          Sort<?>... sorts);
 
     @Find
     CursoredPage<Voter> selectByAddress(@By("address") String homeAddress,


### PR DESCRIPTION
Add test coverage for a Contains restriction in Query by Method Name operating on an ElementCollection attribute to identify if the value is found within the collection.  This is one of the scenarios behind why ElementCollection is useful.

Also, add test coverage for:
Page/CursoredPage with only sort NULL
Page/CursoredPage with one sort NULL, other sorts valid

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
