### PR TITLE
Set OIDC Client ID in Thread AccesTokenAuthenticator

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/AccessTokenAuthenticator.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/AccessTokenAuthenticator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -70,6 +70,7 @@ public class AccessTokenAuthenticator {
     private static final String JWT_SEGMENTS = "-segments";
     private static final String JWT_SEGMENT_INDEX = "-";
     private static final String BEARER_SCHEME = "Bearer ";
+    public static ThreadLocal<String> threadClientID = new ThreadLocal<String>();
 
     OidcClientUtil oidcClientUtil = new OidcClientUtil();
     SSLSupport sslSupport = null;
@@ -105,6 +106,9 @@ public class AccessTokenAuthenticator {
         oidcClientRequest.setTokenType(OidcClientRequest.TYPE_ACCESS_TOKEN);
         ProviderAuthenticationResult oidcResult = new ProviderAuthenticationResult(AuthResult.FAILURE, HttpServletResponse.SC_UNAUTHORIZED);
         String accessToken = null;
+
+        setThreadClientId(clientConfig.getClientId());
+
         if (clientConfig.getAccessTokenInLtpaCookie()) {
             accessToken = getAccessTokenFromReqAsAttribute(req, true);
         }
@@ -1103,5 +1107,12 @@ public class AccessTokenAuthenticator {
                 Tr.debug(tc, "Not setting new RS fail message since one was already found: " + existingFailMsg);
             }
         }
+    }
+    private void setThreadClientId(String clientID) {
+        threadClientID.set(clientID);
+    }
+
+    public static String getThreadClientId() {
+        return threadClientID.get();
     }
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
@@ -466,7 +466,6 @@ public class OIDCClientAuthenticatorUtil {
     public static String getIssuerIdentifier(ConvergedClientConfig clientConfig) {
         String issuer = null;
         issuer = clientConfig.getIssuerIdentifier();
-        setThreadClientId(clientConfig.getClientId());
         if (issuer == null || issuer.isEmpty()) {
             issuer = extractIssuerFromTokenEndpointUrl(clientConfig);
         }
@@ -490,7 +489,7 @@ public class OIDCClientAuthenticatorUtil {
         return issuer;
     }
 
-    private static void setThreadClientId(String clientID) {
+    private void setThreadClientId(String clientID) {
         threadClientID.set(clientID);
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
@@ -466,6 +466,7 @@ public class OIDCClientAuthenticatorUtil {
     public static String getIssuerIdentifier(ConvergedClientConfig clientConfig) {
         String issuer = null;
         issuer = clientConfig.getIssuerIdentifier();
+        setThreadClientId(clientConfig.getClientId());
         if (issuer == null || issuer.isEmpty()) {
             issuer = extractIssuerFromTokenEndpointUrl(clientConfig);
         }
@@ -489,7 +490,7 @@ public class OIDCClientAuthenticatorUtil {
         return issuer;
     }
 
-    private void setThreadClientId(String clientID) {
+    private static void setThreadClientId(String clientID) {
         threadClientID.set(clientID);
     }
 


### PR DESCRIPTION
Currently, we are setting the clientID in the thread only when there is no inbound propagation. However we also need it when inbound propagation happens.

Fixes #PH61850

- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".