### PR TITLE
Remove add exports for sun.security.action from our tool script template

### DIFF
--- a/dev/cnf/resources/bin/tool
+++ b/dev/cnf/resources/bin/tool
@@ -285,7 +285,7 @@ fi
 
 # If this is a Java 9 JDK, add some JDK 9 workarounds to the JVM_ARGS
 if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
-  JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/sun.security.action=ALL-UNNAMED ${JVM_ARGS}"
+  JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED ${JVM_ARGS}"
 fi
 
 # Prevent the Java invocation appearing as an application on a mac

--- a/dev/cnf/resources/bin/tool.bat
+++ b/dev/cnf/resources/bin/tool.bat
@@ -54,7 +54,7 @@ if NOT defined JAVA_HOME (
 )
 
 @REM If this is a Java 9 JDK, add some JDK 9 workarounds to the JVM_ARGS
-if exist "%JAVA_HOME%\lib\modules" set JVM_ARGS=--add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/sun.security.action=ALL-UNNAMED !JVM_ARGS!
+if exist "%JAVA_HOME%\lib\modules" set JVM_ARGS=--add-opens java.base/java.lang=ALL-UNNAMED !JVM_ARGS!
 
 set JVM_ARGS=-Djava.awt.headless=true !JVM_ARGS!
 set TOOL_JAVA_CMD_QUOTED=!JAVA_CMD_QUOTED! !JVM_ARGS! -jar "!WLP_INSTALL_DIR!\bin\@TOOL_JAR@"


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #30627 

Currently we are adding:
```
 --add-exports java.base/sun.security.action=ALL-UNNAMED
```
 to our automatic scripts, via the tool template, when running on any JVM that is version 9 or higher.

In Java 24, Oracle removed `sun.security.action` from the `java.base` module, so when we add the `--add-exports` above, it gives us a warning that `sun.security.action` is not in `java.base`, like this:

```
WARNING: package sun.security.action not in java.base
```

This message shows up in our console log and interferes with some of our testing.  Since Open Liberty does not require anything in `sun.security.action`, we are removing the above `--add-exports` from our tool script template.