### PR TITLE
Process headers to ensure compatibility between legacy and netty validation

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -45,6 +45,7 @@ import com.ibm.wsspi.http.channel.values.TransferEncodingValues;
 import com.ibm.wsspi.http.channel.values.VersionValues;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -55,6 +56,8 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.HttpConversionUtil;
+import io.openliberty.http.netty.channel.utils.HeaderValidator;
+import io.openliberty.http.netty.channel.utils.HeaderValidator.FieldType;
 import io.openliberty.http.netty.cookie.CookieEncoder;
 
 /**
@@ -98,6 +101,10 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     public void update(HttpResponse response) {
+        Objects.requireNonNull(response, "HttpResponse must not be null.");
+        if( !(response instanceof DefaultHttpResponse)){
+            throw new IllegalArgumentException("Expected an HttpResponse, typing does not match for: " + response);
+        }
         this.nettyResponse = response;
         this.headers = response.headers();
     }
@@ -407,7 +414,10 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
 
     @Override
     public void appendHeader(String header, String value) {
-        headers.add(header, value);
+        String normalizedName = HeaderValidator.process(header, FieldType.NAME, config);
+        String normalizedValue = HeaderValidator.process(value, FieldType.VALUE, config);
+
+        headers.add(normalizedName, normalizedValue);
 
     }
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -101,10 +101,6 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     public void update(HttpResponse response) {
-        Objects.requireNonNull(response, "HttpResponse must not be null.");
-        if( !(response instanceof DefaultHttpResponse)){
-            throw new IllegalArgumentException("Expected an HttpResponse, typing does not match for: " + response);
-        }
         this.nettyResponse = response;
         this.headers = response.headers();
     }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
@@ -27,6 +27,8 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http2.HttpConversionUtil;
+import io.openliberty.http.netty.channel.utils.HeaderValidator;
+import io.openliberty.http.netty.channel.utils.HeaderValidator.FieldType;
 
 /**
  *
@@ -95,22 +97,31 @@ public class HeaderHandler {
 
         if (config.useHeadersConfiguration()) {
             //Add all headers configured through the ADD configuration option
+            String name;
+            String value;
+
             for (List<Map.Entry<String, String>> headersToAdd : config.getConfiguredHeadersToAdd().values()) {
                 for (Entry<String, String> header : headersToAdd) {
-                    headers.add(header.getKey(), header.getValue());
+                    name = HeaderValidator.process(header.getKey(), FieldType.NAME, config);
+                    value = HeaderValidator.process(header.getValue(), FieldType.VALUE, config);
+                    headers.add(name, value);
                 }
             }
 
             //Set all headers configured through the SET configuration option
             for (Entry<String, String> header : config.getConfiguredHeadersToSet().values()) {
-                headers.set(header.getKey(), header.getValue());
+                name = HeaderValidator.process(header.getKey(), FieldType.NAME, config);
+                value = HeaderValidator.process(header.getValue(), FieldType.VALUE, config);
+                headers.set(name, value);
             }
 
             //Set all headers configured through the SET_IF_MISSING configuration option
             for (Entry<String, String> header : config.getConfiguredHeadersToSetIfMissing().values()) {
                 //Only set if not present
                 if (!headers.contains(header.getKey())) {
-                    headers.set(header.getKey(), header.getValue());
+                    name = HeaderValidator.process(header.getKey(), FieldType.NAME, config);
+                    value = HeaderValidator.process(header.getValue(), FieldType.VALUE, config);
+                    headers.set(name, value);
                 }
             }
 
@@ -122,10 +133,6 @@ public class HeaderHandler {
             }
 
         }
-
-//        if (HttpUtil.isKeepAlive(response) && config.isKeepAliveEnabled()) {
-//            headers.remove(HttpHeaderKeys.HDR_CONNECTION.getName());
-//        }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.exit(tc, method);

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/utils/HeaderValidator.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/utils/HeaderValidator.java
@@ -25,7 +25,7 @@ public class HeaderValidator {
      * Defines a pattern for valid header names (token characters or "tchars") as specified in 
      * RFC 7230, Section 3.2.6, "Field Value Components".
      */
-    private static final Pattern TCHAR_PATTERN = Pattern.compile("^[!#$%&'*+\\\\-.^_`|~0-9a-zA-Z]+$");
+    private static final Pattern TCHAR_PATTERN = Pattern.compile("^[!#$%&'*+\\-\\.\\^_`|~0-9a-zA-Z]+$");
 
     public enum FieldType{NAME, VALUE}
 
@@ -35,8 +35,8 @@ public class HeaderValidator {
 
     public static String process(String token, FieldType type, HttpChannelConfig config){
 
-        if(type == FieldType.NAME){
-            Objects.requireNonNull(token, "Header name must not be null");
+        if(type == FieldType.NAME && token == null){
+            throw new IllegalArgumentException("Header name must not be null");
         }
         String normalized = (token == null) ? "": token.trim();
 
@@ -50,7 +50,7 @@ public class HeaderValidator {
 
     }
 
-    public static void validate(String token, FieldType type, HttpChannelConfig config){
+    private static void validate(String token, FieldType type, HttpChannelConfig config){
 
         final int MAX_FIELD_SIZE = config.getLimitOfFieldSize();
 

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/utils/HeaderValidator.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/utils/HeaderValidator.java
@@ -26,58 +26,62 @@ import com.ibm.ws.http.channel.internal.HttpChannelConfig;
  *          must be followed by a whitespace.
  *      Trailing CR of LF is disallowed. 
  * 
- * The class also normalizes header names (converting them to lowercase) and
- * trims leading/trailing whitespaces from both names and values.
+ * The class also normalizes header names by trimming leading/trailing
+ * whitespaces from both names and values.
  */
 public class HeaderValidator {
 
-    /**
-     * Defines a pattern for valid header names (token characters or "tchars") as specified in 
-     * RFC 7230, Section 3.2.6, "Field Value Components".
-     */
-    private static final Pattern TCHAR_PATTERN = Pattern.compile("^[!#$%&'*+\\-\\.\\^_`|~0-9a-zA-Z]+$");
-    private static final char CR = '\r';
-    private static final char LF = '\n';
-    private static final char TAB = '\t';
-    private static final char SPACE = ' ';
-
-    /** 
-     * Enumerates if the field token being processed is a header name or header value.
-    */
-    public enum FieldType{NAME, VALUE}
-
-    private HeaderValidator() {
-        //Utility Singleton
-    }
-
-
-    /**
-     * Peforms processing of a header field (name or value).
-     * 
-     * This method normalizes a header field:
-     *      Ensures a non-null input if field type is {@link FieldType#NAME}.
-     *      Trims the input if it is non-null.
-     *      Substitutes a null input with an empty string if the field type is
-     *          {@link FieldType#VALUE}.
-     *      Lowercases the token if the field type is {@link FieldType#NAME}
-     * 
-     * @param token a raw header field token; may be {@code null} for values, 
-     *      but not for names.
-     * @param type whether this token is a header name or value
-     * @param config the HTTP configuration object
-     * @return processed and possibly normalized header field, ensuring to 
-     *      comply with the configured validation requirements
-     * @throws IllegalArgumentException if the field is invalid (too long, 
-     *      contains illegal characters, or null name)
-     */
-    public static String process(String token, FieldType type, HttpChannelConfig config){
-
-        if(type == FieldType.NAME && token == null){
-            throw new IllegalArgumentException("Header name must not be null");
+    private static boolean disabledUntilRFE = true;
+    
+        /**
+         * Defines a pattern for valid header names (token characters or "tchars") as specified in 
+         * RFC 7230, Section 3.2.6, "Field Value Components".
+         */
+        private static final Pattern TCHAR_PATTERN = Pattern.compile("^[!#$%&'*+\\-\\.\\^_`|~0-9a-zA-Z]+$");
+        private static final char CR = '\r';
+        private static final char LF = '\n';
+        private static final char TAB = '\t';
+        private static final char SPACE = ' ';
+    
+        /** 
+         * Enumerates if the field token being processed is a header name or header value.
+        */
+        public enum FieldType{NAME, VALUE}
+    
+        private HeaderValidator() {
+            //Utility Singleton
         }
-        String normalized = (token == null) ? "": token.trim();
-
-        if(type == FieldType.NAME){
+    
+    
+        /**
+         * Peforms processing of a header field (name or value).
+         * 
+         * This method normalizes a header field:
+         *      Ensures a non-null input if field type is {@link FieldType#NAME}.
+         *      Trims the input if it is non-null.
+         *      Substitutes a null input with an empty string if the field type is
+         *          {@link FieldType#VALUE}.
+         *      
+         * NOTE -> Should seek approval for:
+         *  Lowercases the token if the field type is {@link FieldType#NAME}
+         * 
+         * @param token a raw header field token; may be {@code null} for values, 
+         *      but not for names.
+         * @param type whether this token is a header name or value
+         * @param config the HTTP configuration object
+         * @return processed and possibly normalized header field, ensuring to 
+         *      comply with the configured validation requirements
+         * @throws IllegalArgumentException if the field is invalid (too long, 
+         *      contains illegal characters, or null name)
+         */
+        public static String process(String token, FieldType type, HttpChannelConfig config){
+    
+            if(type == FieldType.NAME && token == null){
+                throw new IllegalArgumentException("Header name must not be null");
+            }
+            String normalized = (token == null) ? "": token.trim();
+    
+            if(!disabledUntilRFE && type == FieldType.NAME){
             normalized = normalized.toLowerCase();
         }
         

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/utils/HeaderValidator.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/utils/HeaderValidator.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.http.netty.channel.utils;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import com.ibm.ws.http.channel.internal.HttpChannelConfig;
+
+/**
+ * Processes and validates HTTP header names and values in compliance with 
+ * RFC 7230, "Hypertext Transfer Protocol (HTTP/1.1): Message Syntax 
+ * and Routing"
+ */
+public class HeaderValidator {
+
+    /**
+     * Defines a pattern for valid header names (token characters or "tchars") as specified in 
+     * RFC 7230, Section 3.2.6, "Field Value Components".
+     */
+    private static final Pattern TCHAR_PATTERN = Pattern.compile("^[!#$%&'*+\\\\-.^_`|~0-9a-zA-Z]+$");
+
+    public enum FieldType{NAME, VALUE}
+
+    private HeaderValidator() {
+        //Utility Singleton
+    }
+
+    public static String process(String token, FieldType type, HttpChannelConfig config){
+
+        if(type == FieldType.NAME){
+            Objects.requireNonNull(token, "Header name must not be null");
+        }
+        String normalized = (token == null) ? "": token.trim();
+
+        if(type == FieldType.NAME){
+            normalized = normalized.toLowerCase();
+        }
+
+        validate(normalized, type, config);
+
+        return normalized;
+
+    }
+
+    public static void validate(String token, FieldType type, HttpChannelConfig config){
+
+        final int MAX_FIELD_SIZE = config.getLimitOfFieldSize();
+
+        // Check for length limit
+        if (token.length() > MAX_FIELD_SIZE) {
+            throw new IllegalArgumentException(token +
+                                               " exceeds the maximum allowed length of " + MAX_FIELD_SIZE + " characters");
+        }
+
+        // Additional validation for header names
+        if (type == FieldType.NAME && !TCHAR_PATTERN.matcher(token).matches()) {
+            throw new IllegalArgumentException("Invalid header name: " + token);
+        }
+
+        // Validate header values for control characters and non-ASCII characters
+        for (int i = 0; i < token.length(); i++) {
+            char c = token.charAt(i);
+
+            // Reject control characters (0x00-0x1F, except horizontal tab (0x09)) and DEL (0x7F)
+            if (c == '\r' || c == '\n' || (c >= 0 && c < 32 && c != '\t') || c == 127) {
+                throw new IllegalArgumentException("Invalid control character in Field Token [" + type + "]: " + token);
+            }
+
+            // Reject non-ASCII characters (0x80 and above)
+            if (c > 127) {
+                throw new IllegalArgumentException("Non-ASCII character found in Field Token [" + type + ":] " + token);
+            }
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/utils/HeaderValidator.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/utils/HeaderValidator.java
@@ -9,15 +9,25 @@
  *******************************************************************************/
 package io.openliberty.http.netty.channel.utils;
 
-import java.util.Objects;
 import java.util.regex.Pattern;
-
 import com.ibm.ws.http.channel.internal.HttpChannelConfig;
 
 /**
  * Processes and validates HTTP header names and values in compliance with 
  * RFC 7230, "Hypertext Transfer Protocol (HTTP/1.1): Message Syntax 
  * and Routing"
+ * 
+ * This utility ensures:
+ *      Header names are composed of valid "tchar" characters.
+ *      Header names and values do not exceed a configured maximum field length.
+ *      Control characters (except for valid folding) and non-ASCII characters
+ *          are properly handled.
+ *      When following a folding sequence, CR must be followed by LF, and LF 
+ *          must be followed by a whitespace.
+ *      Trailing CR of LF is disallowed. 
+ * 
+ * The class also normalizes header names (converting them to lowercase) and
+ * trims leading/trailing whitespaces from both names and values.
  */
 public class HeaderValidator {
 
@@ -26,13 +36,40 @@ public class HeaderValidator {
      * RFC 7230, Section 3.2.6, "Field Value Components".
      */
     private static final Pattern TCHAR_PATTERN = Pattern.compile("^[!#$%&'*+\\-\\.\\^_`|~0-9a-zA-Z]+$");
+    private static final char CR = '\r';
+    private static final char LF = '\n';
+    private static final char TAB = '\t';
+    private static final char SPACE = ' ';
 
+    /** 
+     * Enumerates if the field token being processed is a header name or header value.
+    */
     public enum FieldType{NAME, VALUE}
 
     private HeaderValidator() {
         //Utility Singleton
     }
 
+
+    /**
+     * Peforms processing of a header field (name or value).
+     * 
+     * This method normalizes a header field:
+     *      Ensures a non-null input if field type is {@link FieldType#NAME}.
+     *      Trims the input if it is non-null.
+     *      Substitutes a null input with an empty string if the field type is
+     *          {@link FieldType#VALUE}.
+     *      Lowercases the token if the field type is {@link FieldType#NAME}
+     * 
+     * @param token a raw header field token; may be {@code null} for values, 
+     *      but not for names.
+     * @param type whether this token is a header name or value
+     * @param config the HTTP configuration object
+     * @return processed and possibly normalized header field, ensuring to 
+     *      comply with the configured validation requirements
+     * @throws IllegalArgumentException if the field is invalid (too long, 
+     *      contains illegal characters, or null name)
+     */
     public static String process(String token, FieldType type, HttpChannelConfig config){
 
         if(type == FieldType.NAME && token == null){
@@ -43,14 +80,28 @@ public class HeaderValidator {
         if(type == FieldType.NAME){
             normalized = normalized.toLowerCase();
         }
-
-        validate(normalized, type, config);
-
-        return normalized;
+        
+        return validate(normalized, type, config);
 
     }
 
-    private static void validate(String token, FieldType type, HttpChannelConfig config){
+    /**
+     * Validates and cleans a header field:
+     *  Enforces the maximum allowed length as specified by {@link HttpChannelConfig}
+     *  Returns token as-is if validation is disabled.
+     *  Checks that a header name token is complaint with the RFC "tchar" pattern.
+     *  Disallows trailing CR or LF characters.
+     *  Ensures that an inline CR is followed by LF, and LF is followed by space or tab.
+     *  Replaces valid CR or LF (folding sequence) with space character.
+     *  For character outside of the printable ASCII range, if the masked code point 
+     *      is CR or LF, it is replaced with '?'.
+     * @param token the header field test after it has been normalized
+     * @param type  whether this token is a header name or a header value
+     * @param config the HTTP configuration object
+     * @return the validated (and clean) header field
+     * @throws IllegalArgumentException if the field fails one of the checks
+     */
+    private static String validate(String token, FieldType type, HttpChannelConfig config){
 
         final int MAX_FIELD_SIZE = config.getLimitOfFieldSize();
 
@@ -60,25 +111,67 @@ public class HeaderValidator {
                                                " exceeds the maximum allowed length of " + MAX_FIELD_SIZE + " characters");
         }
 
-        // Additional validation for header names
+        if(!config.isHeaderValidationEnabled()){
+            return token;
+        }
         if (type == FieldType.NAME && !TCHAR_PATTERN.matcher(token).matches()) {
             throw new IllegalArgumentException("Invalid header name: " + token);
         }
 
-        // Validate header values for control characters and non-ASCII characters
+        if(!token.isEmpty()){
+            char lastChar = token.charAt(token.length()-1);
+            if(lastChar == CR || lastChar == LF){
+                throw new IllegalArgumentException("Illegal trailing EOL in header field: " + token);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder(token.length());
+        String error = null;
         for (int i = 0; i < token.length(); i++) {
             char c = token.charAt(i);
 
-            // Reject control characters (0x00-0x1F, except horizontal tab (0x09)) and DEL (0x7F)
-            if (c == '\r' || c == '\n' || (c >= 0 && c < 32 && c != '\t') || c == 127) {
-                throw new IllegalArgumentException("Invalid control character in Field Token [" + type + "]: " + token);
+            if (c == CR) {
+                if (i + 1 >= token.length() || token.charAt(i + 1) != LF) {
+                    error = "Invalid CR not followed by LF in header " + token;
+                }
             }
-
-            // Reject non-ASCII characters (0x80 and above)
-            if (c > 127) {
-                throw new IllegalArgumentException("Non-ASCII character found in Field Token [" + type + ":] " + token);
+            else if (c == LF) {
+                if (i + 1 < token.length()) {
+                    char next = token.charAt(i + 1);
+                    if (next != SPACE && next != TAB) {
+                        error = "Invalid LF not followed by whitespace in header " + token;
+                    }
+                }
+            }
+            if (c >= 32 && c < 127) {
+                sb.append(c);
+            } 
+            else if (c == CR || c == LF) {
+                sb.append(SPACE);
+            } 
+            else {
+                int maskedCode = c & 0xFF;
+                if (maskedCode == CR || maskedCode == LF) {
+                    sb.append('?');
+                } else {
+                    sb.append(c);
+                }
+            }
+            if (error != null) {
+                break;
             }
         }
+        if (error != null) {
+            throw new IllegalArgumentException(error);
+        }
+
+        String validated = sb.toString();
+        if (validated.length() > MAX_FIELD_SIZE) {
+            throw new IllegalArgumentException(validated +" (rewritten) exceeds the maximum allowed length of " + MAX_FIELD_SIZE + " characters");
+        }
+
+        return validated;
     }
 
+    
 }

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/utils/package-info.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/utils/package-info.java
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+@org.osgi.annotation.versioning.Version("1.0")
+package io.openliberty.http.netty.channel.utils;
+

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/netty/HeaderValidatorTests.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/netty/HeaderValidatorTests.java
@@ -61,7 +61,10 @@ public class HeaderValidatorTests {
     public void testProcessValidHeaderNameNormalized() {
         String token = "Content-Type";
         String result = HeaderValidator.process(token, NAME, config);
-        assertThat(result, is("content-type"));
+        assertThat(result, is(token));
+        
+        //TODO -> seek approval to make it case insensitive
+        //assertThat(result, is("content-type"));
     }
 
     
@@ -88,8 +91,10 @@ public class HeaderValidatorTests {
     public void testValidHeaderNameNormalization() {
         String token = " X-CUSTOM-HEADER ";
         String result = HeaderValidator.process(token, NAME, config);
-        assertThat(result, is("x-custom-header"));
+        assertThat(result, is(token.trim()));
+        //TODO -> Seek approval
         //Should trim and lowercase a header name during normalization
+        //assertThat(result, is("x-custom-header"));
     }
 
     @Test
@@ -132,7 +137,9 @@ public class HeaderValidatorTests {
         when(config.isHeaderValidationEnabled()).thenReturn(false);
         String token = "Invalid@Name";
         String result = HeaderValidator.process(token, NAME, config);
-        assertThat(result, is("invalid@name"));
+        assertThat(result, is(token));
+        //TODO -> Seek case insensitive name validation
+        //assertThat(result, is("invalid@name"));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/netty/HeaderValidatorTests.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/netty/HeaderValidatorTests.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.netty;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.beans.Transient;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.ws.http.channel.internal.HttpChannelConfig;
+
+import io.openliberty.http.netty.channel.utils.HeaderValidator;
+import io.openliberty.http.netty.channel.utils.HeaderValidator.FieldType;
+
+/**
+ * Unit tests for the {@link HeaderValidator} class.
+ * 
+ * This class verifies the behavior of the header validator across multiple
+ * scenarios and edge cases based on RFC 7230. Current testing coverage includes:
+ * 
+ * Validation of proper header names and values.
+ * Rejection of invalid characters in either header names or values (per RFC 7230).
+ * Handling of null, empty, and whitespace leading/trailing fields.
+ * Enforcement of a configurable header field size limit.
+ * Proper normalization of fields (lowercase or trimming when applicable).
+ */
+public class HeaderValidatorTests {
+
+    private HttpChannelConfig config;
+    private String boundary;
+
+    @Before
+    public void setup(){
+        config = mock(HttpChannelConfig.class);
+        when(config.getLimitOfFieldSize()).thenReturn(100);
+
+        char[] chars = new char[100];
+        Arrays.fill(chars, 'a');
+        boundary = new String(chars);
+    }
+
+    @Test
+    public void testProcessValidHeaderName() {
+        String token = "Content-Type";
+        String result = HeaderValidator.process(token, HeaderValidator.FieldType.NAME, config);
+        assertThat(result, is("content-type"));
+    }
+
+    
+
+    @Test
+    public void testValidHeaderValue() {
+        String token = "text/html; charset=UTF-8";
+        String result = HeaderValidator.process(token, HeaderValidator.FieldType.VALUE, config);
+        assertThat(result, is(token));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyNameToken(){
+        HeaderValidator.process("", HeaderValidator.FieldType.NAME, config);
+    }
+
+    @Test
+    public void testEmptyValueToken() {
+        String result = HeaderValidator.process(null, HeaderValidator.FieldType.VALUE, config);
+        assertThat(result, is(""));
+    }
+
+    @Test
+    public void testValidHeaderNameNormalization() {
+        String token = " X-CUSTOM-HEADER ";
+        String result = HeaderValidator.process(token, HeaderValidator.FieldType.NAME, config);
+        assertThat(result, is("x-custom-header"));
+        //Should trim and lowercase a header name during normalization
+    }
+
+    @Test
+    public void testValidHeaderValueNormalization() {
+        String token = " X-CUSTOM-VALUE ";
+        String result = HeaderValidator.process(token, HeaderValidator.FieldType.VALUE, config);
+        assertThat(result, is(token.trim()));
+        //Should trim but not lowercase a header value during normalization
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateHeaderNameExceedsMaxLength() {
+        String token = boundary+"1"; // Exceeds max length (100)
+        HeaderValidator.process(token, HeaderValidator.FieldType.NAME, config);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateHeaderValueExceedsMaxLength() {
+        String token = boundary+ "1"; // Exceeds max length (100)
+        HeaderValidator.process(token, HeaderValidator.FieldType.VALUE, config);
+    }
+
+    @Test 
+    public void testValidateTokenExceedsMaxLengthWithTrailingWhitespace(){
+        String token = boundary + " ";
+        String result = HeaderValidator.process(token, FieldType.NAME, config);
+        assertThat(result, is(boundary));
+        //No exception should be thrown since, after trimming, header field is not 
+        //larger than limit size.
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidHeaderNameCharacters() {
+        String token = "Invalid Header@Name!";
+        HeaderValidator.process(token, HeaderValidator.FieldType.NAME, config);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testControlCharactersInHeaderValue() {
+        String token = "Invalid\u0001Value"; // Contains control character (0x01)
+        HeaderValidator.process(token, HeaderValidator.FieldType.VALUE, config);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNonASCIICharactersInHeaderValue() {
+        String token = "NonASCIIValue\u00E9"; // Contains non-ASCII character (é)
+        HeaderValidator.process(token, HeaderValidator.FieldType.VALUE, config);
+    }
+
+    @Test
+    public void testHeaderValueWithValidControlCharacters() {
+        String token = "Valid\tHeaderValue"; // Contains horizontal tab (0x09), which is allowed
+        String result = HeaderValidator.process(token, HeaderValidator.FieldType.VALUE, config);
+        assertThat(result, is(token));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWithNullHeaderNameThrowsException() {
+        HeaderValidator.process(null, HeaderValidator.FieldType.NAME, config);
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This PR introduces a `HeaderValidator` utility class for validating HTTP header names and values. Validation is made to comply with [RFC 7230, Section 3.2](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2). This RFC refers to "HTTP/1.1 Message Syntax and Routing" and Section 3.2 covers "Header Fields". In addition to enforcing strict checks to ensure the header is compliant, the utility normalizes the tokens by stripping whitespace padding.

### Testing

The accompanying unit tests confirm expected behaviors on:

- Header name validation 
- Header value validation
- Length validation
- Null input handling
- Header field normalization 

### Usage

> String headerName = HeaderValidator.process("Content-Type", FieldType.NAME, config);
> String headerValue = HeaderValidator.process(" application/json ", FieldType.VALUE, config);
> // Normalized headerName: "content-type"
> // Normalized headerValue: "application/json"