### PR TITLE
Typo in metatype description of soLinger attribute

### DIFF
--- a/dev/com.ibm.ws.channelfw/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.channelfw/resources/OSGI-INF/l10n/metatype.properties
@@ -68,4 +68,4 @@ tcp.portOpenRetries=Port open retries
 tcp.portOpenRetries.desc=Number of retries to open a TCP/IP port during server startup.  There will be a one second delay between retries, until the opening is successful or the port open retry number is reached. 
 
 tcp.soLinger=SoLinger
-tcp.soLinger.desc=This parameter sets the delay for the connection while data is being transmitted before closing the socket, after a close request has been received. Set the value in the range of 0 to 65,536 to specify the delay period in seconds.Use -1 to disable this.
+tcp.soLinger.desc=This parameter sets the delay before closing the socket after a close request is received while data is transmitting. Set the value between 0 to 65,536 to specify the delay period in seconds. To disable this setting, set the value to -1.

--- a/dev/com.ibm.ws.channelfw/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.channelfw/resources/OSGI-INF/l10n/metatype.properties
@@ -68,4 +68,4 @@ tcp.portOpenRetries=Port open retries
 tcp.portOpenRetries.desc=Number of retries to open a TCP/IP port during server startup.  There will be a one second delay between retries, until the opening is successful or the port open retry number is reached. 
 
 tcp.soLinger=SoLinger
-tcp.soLinger.desc=This parameter sets the delay before closing the socket after a close request is received while data is transmitting. Set the value between 0 to 65,536 to specify the delay period in seconds. To disable this setting, set the value to -1.
+tcp.soLinger.desc=This parameter sets the delay before closing the socket after a close request is received while data is transmitting. Set the value between 0 and 65,536 to specify the delay period in seconds. To disable this setting, set the value to -1.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).

Fixes #30605 
