### PR TITLE
Generate introspector file for Jakarta Data with minimal output and test that it is created

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -18,11 +18,15 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 
@@ -125,6 +129,21 @@ public class Util {
                            long.class, Long.class,
                            short.class, Short.class,
                            void.class, Void.class);
+
+    /**
+     * Alphabetize properties to make them more readable when debugging.
+     *
+     * @param props key/value pairs
+     * @return sorted map
+     */
+    public static SortedMap<String, Object> alphabetize(Dictionary<String, Object> props) {
+        SortedMap<String, Object> sorted = new TreeMap<>();
+        for (Enumeration<String> keys = props.keys(); keys.hasMoreElements();) {
+            String key = keys.nextElement();
+            sorted.put(key, props.get(key));
+        }
+        return sorted;
+    }
 
     /**
      * Returns true if it is certain the class cannot be an entity

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -147,15 +147,14 @@ public class DataErrPathsTest extends FATServletClient {
         System.out.println("Dump file name: " + dumpFileName);
 
         // Example of file within the zip:
-        // dump_18.04.11_14.30.55/introspections/JakartaDataIntrospector.txt
+        // dump_25.01.24_14.50.04/introspections/JakartaDataIntrospector.txt
 
         end = dumpFileName.indexOf(".zip");
         String prefix = "io.openliberty.data.internal.fat.errpaths.dump-";
         begin = dumpFileName.lastIndexOf(prefix, end) + prefix.length();
 
-        // TODO once it exists, switch to "/introspections/JakartaDataIntrospector.txt";
         String introspectorFileName = "dump_" + dumpFileName.substring(begin, end) +
-                                      "/introspections/ThreadingIntrospector.txt";
+                                      "/introspections/JakartaDataIntrospector.txt";
 
         System.out.println("Looking for introspector entry: " + introspectorFileName);
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -12,11 +12,19 @@
  *******************************************************************************/
 package test.jakarta.data.errpaths;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedInputStream;
+import java.util.Scanner;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.MinimumJavaLevel;
@@ -102,10 +110,68 @@ public class DataErrPathsTest extends FATServletClient {
         // Cause errors that will log FFDC prior to running tests
         // so that FFDC doesn't intermittently fail tests
         FATServletClient.runTest(server, APP_NAME, "forceFFDC");
+
+        // @AfterClass is intentionally omitted so that the server continues running
+        // for the next class in the suite, which is DataIntrospectorTest.
     }
 
+    /**
+     * Dump the server and collect the Jakarta Data introspector output
+     * for the DataIntrospectorTest to use. Then stop the server.
+     */
     @AfterClass
     public static void tearDown() throws Exception {
+        ProgramOutput output = server.serverDump();
+        assertEquals(0, output.getReturnCode());
+        assertEquals("", output.getStderr());
+
+        // Parse standard output. Examples:
+        //
+        // Server io.openliberty.data.internal.fat.errpaths dump complete in
+        //   /Users/user/lgit/open-liberty/dev/build.image/wlp/usr/
+        //   servers/io.openliberty.data.internal.fat.errpaths/
+        //   io.openliberty.data.internal.fat.errpaths.dump-18.04.11_14.30.55.zip.
+        //
+        // Server io.openliberty.data.internal.fat.errpaths dump complete in
+        //   C:\\jazz-build-engines\\wasrtc-proxy.hursley.ibm.com\\
+        //   EBC.PROD.WASRTC\\build\\dev\\image\\output\\wlp\\usr\\
+        //   servers\\io.openliberty.data.internal.fat.errpaths\\
+        //   io.openliberty.data.internal.fat.errpaths.dump-18.06.10_00.16.59.zip.
+
+        String out = output.getStdout();
+        int end = out.lastIndexOf('.');
+        int begin = out.lastIndexOf(' ', end) + 1;
+
+        String dumpFileName = out.substring(begin, end);
+
+        System.out.println("Dump file name: " + dumpFileName);
+
+        // Example of file within the zip:
+        // dump_18.04.11_14.30.55/introspections/JakartaDataIntrospector.txt
+
+        end = dumpFileName.indexOf(".zip");
+        String prefix = "io.openliberty.data.internal.fat.errpaths.dump-";
+        begin = dumpFileName.lastIndexOf(prefix, end) + prefix.length();
+
+        // TODO once it exists, switch to "/introspections/JakartaDataIntrospector.txt";
+        String introspectorFileName = "dump_" + dumpFileName.substring(begin, end) +
+                                      "/introspections/ThreadingIntrospector.txt";
+
+        System.out.println("Looking for introspector entry: " + introspectorFileName);
+
+        try (ZipFile dumpFile = new ZipFile(dumpFileName)) {
+            ZipEntry entry = dumpFile.getEntry(introspectorFileName);
+            System.out.println("Found: " + entry);
+            try (BufferedInputStream in = new BufferedInputStream(dumpFile.getInputStream(entry));
+                            Scanner scanner = new Scanner(in)) {
+                while (scanner.hasNextLine()) {
+                    String line = scanner.nextLine();
+                    System.out.println(line);
+                    DataIntrospectorTest.introspectorOutput.add(line);
+                }
+            }
+        }
+
         server.stopServer(EXPECTED_ERROR_MESSAGES);
     }
 }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Contains tests that make assertions on the Jakarta Data introspector output.
+ * The introspector runs at the end of DataErrPathsTest before stopping the server
+ * so that it contains the state of a running server, and guaranteeing that it is
+ * available to these tests.
+ */
+@RunWith(FATRunner.class)
+public class DataIntrospectorTest extends FATServletClient {
+    /**
+     * Jakarta Data introspector output is captured during DataErrPathsTest.tearDown
+     */
+    static final List<String> introspectorOutput = new ArrayList<>();
+
+    /**
+     * Verify that introspector output was obtained.
+     */
+    @Test
+    public void testIntrospectorOutputObtained() {
+        assertEquals(false, introspectorOutput.isEmpty());
+
+        // To view output, from the test results page, follow the System.out link
+        // and search for "testIntrospectorOutputObtained"
+        for (String line : introspectorOutput)
+            System.out.println(line);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
@@ -13,6 +13,7 @@
 package test.jakarta.data.errpaths;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,24 @@ public class DataIntrospectorTest extends FATServletClient {
     static final List<String> introspectorOutput = new ArrayList<>();
 
     /**
+     * Asserts that a line is found within the Jakarta Data introspector output.
+     *
+     * @param expected the line to search for.
+     */
+    private static void assertLineFound(String expected) {
+        if (introspectorOutput.isEmpty())
+            fail("JakartaDataIntrospector output not found. Unable to run test. " +
+                 "Check server logs for errors.");
+
+        if (!introspectorOutput.contains(expected))
+            fail("Information not found in introspector output. " +
+                 "To view introspector output from the test results page, " +
+                 "follow the System.out link and then search for " +
+                 "testIntrospectorOutputObtained. Missing line is: " +
+                 expected);
+    }
+
+    /**
      * Verify that introspector output was obtained.
      */
     @Test
@@ -47,5 +66,19 @@ public class DataIntrospectorTest extends FATServletClient {
         // and search for "testIntrospectorOutputObtained"
         for (String line : introspectorOutput)
             System.out.println(line);
+    }
+
+    /**
+     * Verify that introspector output contains the config display id of
+     * databaseStore elements that are used by repositories.
+     */
+    @Test
+    public void testOutputContainsDatabaseStore() {
+        assertLineFound("    for databaseStore application[DataErrPathsTestApp]" +
+                        "/databaseStore[java:app/jdbc/DerbyDataSource]");
+
+        assertLineFound("    for databaseStore application[DataErrPathsTestApp]" +
+                        "/module[DataErrPathsTestApp.war]" +
+                        "/databaseStore[java:comp/jdbc/InvalidDatabase]");
     }
 }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,8 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 @RunWith(Suite.class)
 @SuiteClasses({
                 AlwaysPassesTest.class,
-                DataErrPathsTest.class
+                DataErrPathsTest.class,
+                DataIntrospectorTest.class
 })
 public class FATSuite {
 }


### PR DESCRIPTION
Add a Jakarta Data test case that requests a server dump and reads in an introspector for tests to make assertions on.
Implement a minimal introspector for Jakarta Data.
Update the test case to use the introspector that we created and assert the existence of two expected lines.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
