### PR TITLE
Fix up grammar and wording in WebContainer's metatype.properties file

### DIFF
--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -18,7 +18,7 @@ web.container.app.name=Web Container
 web.container.app.desc=Configuration for the web container.
 
 mimeTypes.name=MIME types
-mimeTypes.desc=A list of mappings between a file types and MIME types to use when loading files from this application, for instance, txt=text/plain.
+mimeTypes.desc=A list of mappings of file types and MIME types to use when loading files from the application, for instance, txt=text/plain. 
 
 listeners.name=Listeners
 listeners.desc=A comma-separated list of listener classes.
@@ -42,7 +42,7 @@ disallowServeServletsByClassName.name=Disallow serve servlet by class name
 disallowServeServletsByClassName.desc=Disallows the use of serveServletsByClassnameEnabled on the application server level. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.disallowserveservletsbyclassname.
 
 doNotServeByClassName.name=Do not serve by class name
-doNotServeByClassName.desc=A semi-colon delimited list of classes to be completely disallowed from being served by class name. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.donotservebyclassname.
+doNotServeByClassName.desc=A semicolon-separated list of classes by class name that are prohibited from being served. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.donotservebyclassname.
 
 trustHostHeaderPort.name=Trust host header port
 trustHostHeaderPort.desc=Set this property to true and the com.ibm.ws.webcontainer.extractHostHeaderPort custom property to true to return the port number from the request host header first.
@@ -57,13 +57,13 @@ httpsIndicatorHeader.name=HTTPS indicator header
 httpsIndicatorHeader.desc=For SSL offloading, set to the name of the HTTP header variable inserted by the SSL accelerator/proxy/load balancer.
 
 exposeWebInfOnDispatch.name=Expose web info on dispatch
-exposeWebInfOnDispatch.desc=When this property is true, a servlet can access static files in the WEB-INF directory. When this property is set to false, the default, servlets cannot access static files in the WEB-INF directory.
+exposeWebInfOnDispatch.desc=When this property is set to true, a servlet can access static files in the WEB-INF directory. When this property is set to false, which is the default, servlets cannot access static files in the WEB-INF directory.
 
 decodeUrlPlusSign.name=Decode url plus sign
 decodeUrlPlusSign.desc=Decode the plus sign when it is part of the URL. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.decodeurlplussign. For servlet-5.0 and newer Servlet features, the default value is false.
 
 fileWrapperEvents.name=File wrapper events
-fileWrapperEvents.desc=Web container will generate SMF and PMI data when serving the static files. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.fileWrapperEvents.
+fileWrapperEvents.desc=The web container generates SMF and PMI data when it serves static files. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.fileWrapperEvents.
 
 defaultTraceRequestBehavior.name=Allow the HTTP TRACE request method to be invoked
 defaultTraceRequestBehavior.desc=Restore HTTP TRACE processing. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.DefaultTraceRequestBehavior.
@@ -103,7 +103,7 @@ enableDefaultIsElIgnoredInTag.name=Evaluate isELIgnored behavior in JSP tag file
 enableDefaultIsElIgnoredInTag.desc=Always evaluate whether to ignore EL expressions in tag files. If parent JSP files have different isELIgnored settings, the setting will be re-evaluated in the tag file. The equivalent custom property in the full profile application server is com.ibm.ws.jsp.enabledefaultiselignoredintag.
 
 parseUtf8PostData.name=Parse UTF-8 post data
-parseUtf8PostData.desc=Web container will detect non-URL encoded UTF-8 post data and include it in the parameter values. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.parseutf8postdata.
+parseUtf8PostData.desc=The web container detects non-URL encoded UTF-8 post data and includes it in the parameter values. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.parseutf8postdata.
 
 logServletContainerInitializerClassLoadingErrors.name=Warn on ServletContainerIntializer errors
 logServletContainerInitializerClassLoadingErrors.desc=Log servlet container class loading errors as warnings rather than logging them only when debug is enabled. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.logservletcontainerinitializerclassloadingerrors.
@@ -133,7 +133,7 @@ asyncPurgeInterval.name=Async servlet purge interval
 asyncPurgeInterval.desc=Time interval to wait between each required purge of the canceled task pool. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.asyncpurgeinterval.
 
 asyncTimeoutDefault.name=Default async timeout
-asyncTimeoutDefault.desc=Async servlet timeout value used when a timeout value has not been explicitly specified. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.asynctimeoutdefault.
+asyncTimeoutDefault.desc=Async servlet timeout value that is used when a timeout value is not explicitly specified. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.asynctimeoutdefault.
 
 asyncTimerThreads.name=Async timer threads
 asyncTimerThreads.desc=Maximum number of threads to use for async servlet timeout processing. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.asynctimerthreads.
@@ -145,10 +145,10 @@ emptyServletMappings.name=Return empty servlet mappings
 emptyServletMappings.desc=Toggle if you want to return an empty collection, instead of null, when no servlet mappings are added. The default value is false. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.emptyservletmappings.
 
 deferServletRequestListenerDestroyOnError.name=Defer servlet request listener destroy
-deferServletRequestListenerDestroyOnError.desc=Toggle if you want to defer ServletRequestListener destroy when there is an error serving the request. The default value is false but is true for servlet 5.0 and later. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.deferServletRequestListenerDestroyOnError.
+deferServletRequestListenerDestroyOnError.desc=Enable this property to defer the ServletRequestListener destroy method call when there is an error serving the request. In servlet-5.0 and later, the default value is true. In servlet-4.0 and earlier, the default is false. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.deferServletRequestListenerDestroyOnError.
 
 allowExpressionFactoryPerApp.name=Allow expression factory per application
-allowExpressionFactoryPerApp.desc=Toggle to load the ExpressionFactory that is set by the application. Enable this custom property if you use a custom EL implementation (for example, JUEL) that needs to set its own ExpressionFactory.
+allowExpressionFactoryPerApp.desc=Enable this property to load the ExpressionFactory that is set by the application. Enable this custom property if you use a custom EL implementation (for example, JUEL) that needs to set its own ExpressionFactory.
 
 ignoreSemiColonOnRedirectToWelcomePage.name=Ignore semicolon on redirect to the welcome page
 ignoreSemiColonOnRedirectToWelcomePage.desc=Toggle to ignore the trailing semicolon when redirecting to the welcome page. The default value is false. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.ignoreSemiColonOnRedirectToWelcomePage.
@@ -162,7 +162,7 @@ servletDestroyWaitTime.desc=Wait time in seconds for an active request to comple
 servletPathForDefaultMapping.name=Set the servlet path value for a default mapping
 servletPathForDefaultMapping.desc=Set the servlet path value to the request URI minus the context path. The path information is null when a servlet is used as a default mapping. The default value is true for version 4.0 or later of the servlet feature. It is false for other servlet features. When mapping is to the /* pattern, the servlet path is empty and the path information starts with a leading slash (/).
 
-throwExceptionWhenUnableToCompleteOrDispatch.name=Throw exception for not complete or dispatch async
+throwExceptionWhenUnableToCompleteOrDispatch.name=Throw an exception for an incomplete or dispatched async request
 throwExceptionWhenUnableToCompleteOrDispatch.desc=Throw an illegal state exception when an asynchronous request cannot be completed or dispatched. The default is true. If the asynchronous request must complete or the dispatch method must return, even if the call does not succeed, set the property to false.
 
 getRealPathReturnsQualifiedPath.name=Always return a non-null path from getRealPath
@@ -178,10 +178,10 @@ addStrictTransportSecurityHeader.name=Add the HTTP strict transport security hea
 addStrictTransportSecurityHeader.desc=Enables the HTTP Strict Transport Security (HSTS) header for HTTPS responses and allows a value to be set for that header, for example: "max-age=31536000;includeSubDomains". HSTS can also be configured in the web.xml file by setting the "com.ibm.ws.webcontainer.ADD_STS_HEADER_WEBAPP" context parameter.
 
 allowQueryParamWithNoEqual.name=Allow query parameters with no value
-allowQueryParamWithNoEqual.desc=When this property is set to true, if the query parameter in a URL contains only the string name, the server returns an empty string as the value for the request.getParameter(name) query. When this property is set to false, the server returns null as the value for the request.getParameter(name) query. The default value is false but is true for servlet 5.0 and higher.
+allowQueryParamWithNoEqual.desc=This property determines how the server responds when the query parameter in a URL contains only the string name. When it is set to true, the server returns an empty string as the value for the request.getParameter(name) query. When it is set to false, the server returns null as the value for the request.getParameter(name) query. In servlet-5.0 and later, the default value is true. In servlet-4.0 and earlier, the default is false.
 
 setHtmlContentTypeOnError.name=Disable text/html content type on error responses
-setHtmlContentTypeOnError.desc=When this property is false, the webcontainer will not set the response's content-type header during the error handling process. An application is responsible for setting the response's content type. The default value (true) sets the content type to "text/html".
+setHtmlContentTypeOnError.desc=When this property is false, the web container does not set the response content-type header during the error handling process. An application is responsible for setting the response content type. The default value (true) sets the content type to "text/html".
 
 excludeAllHandledTypesClasses.name=Disable returning handlesTypes parameters
 excludeAllHandledTypesClasses.desc=When this property is set to true, during startup, ServletContainerInitializer implementors that use the HandlesTypes annotation do not receive classes that are specified as HandlesTypes parameters.
@@ -193,10 +193,10 @@ maxFileCount.name=The maximum uploaded files in a single request
 maxFileCount.desc=The maximum number of files that can be uploaded by a multipart/form-data request. The default value is 5000. For unlimited file upload, set the value to -1.
 
 donotCloseOutputOnForwardForServletError.name=Do not close output on forwarded servlet error 
-donotCloseOutputOnForwardForServletError.desc=When this property is set to true, if a servlet called from dispatch forward throws an exception other than IOException and ServletException, the output is not automatically closed.
+donotCloseOutputOnForwardForServletError.desc=When this property is set to true, the output is not automatically closed if a servlet called from dispatch forward throws an exception other than IOException and ServletException, 
 
 set400SCOnTooManyParentDirs.name=Set 400 for invalid path traversal request
 set400SCOnTooManyParentDirs.desc=When this property is set to true, a request with an invalid path traversal is returned with a 400 status code instead of 500. The default is false. You can use this property with servlet-5.0 and earlier. For servlet-6.0 and later, the 400 response code is returned by default and this property has no effect.
 
 allowAbsoluteFileNameForPartWrite.name=Write part files to absolute file locations
-allowAbsoluteFileNameForPartWrite.desc=When this property is set to true, the runtime treats the filename argument on the part.write method call as an absolute location, rather than saving the filename argument under the temporary location. In servlet-6.0 and earlier, the default value is false. In servlet-6.1 and later, the default value is true.
+allowAbsoluteFileNameForPartWrite.desc=When this property is set to true, the runtime treats the filename argument on the part.write method call as an absolute location, rather than saving the filename argument under the temporary location. In servlet-6.1 and later, the default value is true. In servlet-6.0 and earlier, the default value is false. 

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -18,10 +18,10 @@ web.container.app.name=Web Container
 web.container.app.desc=Configuration for the web container.
 
 mimeTypes.name=MIME types
-mimeTypes.desc=A list of mappings between a file types and MIME types to use when loading files from this application, for instance txt=text/plain.
+mimeTypes.desc=A list of mappings between a file types and MIME types to use when loading files from this application, for instance, txt=text/plain.
 
 listeners.name=Listeners
-listeners.desc=A comma separated list of listener classes.
+listeners.desc=A comma-separated list of listener classes.
 
 decodeUrlAsUtf8.name=Decode URLs using UTF-8 encoding
 decodeUrlAsUtf8.desc=Decode URLs using an encoding setting of UTF-8.
@@ -42,7 +42,7 @@ disallowServeServletsByClassName.name=Disallow serve servlet by class name
 disallowServeServletsByClassName.desc=Disallows the use of serveServletsByClassnameEnabled on the application server level. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.disallowserveservletsbyclassname.
 
 doNotServeByClassName.name=Do not serve by class name
-doNotServeByClassName.desc=A semi-colon delimited list of classes to be completely disallowed from being served by classname. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.donotservebyclassname.
+doNotServeByClassName.desc=A semi-colon delimited list of classes to be completely disallowed from being served by class name. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.donotservebyclassname.
 
 trustHostHeaderPort.name=Trust host header port
 trustHostHeaderPort.desc=Set this property to true and the com.ibm.ws.webcontainer.extractHostHeaderPort custom property to true to return the port number from the request host header first.
@@ -57,13 +57,13 @@ httpsIndicatorHeader.name=HTTPS indicator header
 httpsIndicatorHeader.desc=For SSL offloading, set to the name of the HTTP header variable inserted by the SSL accelerator/proxy/load balancer.
 
 exposeWebInfOnDispatch.name=Expose web info on dispatch
-exposeWebInfOnDispatch.desc=When this property is set to true, a servlet can access static files in the WEB-INF directory. When this property is set to false, which is the default, a servlet cannot access static files in the WEB-INF directory.
+exposeWebInfOnDispatch.desc=When this property is true, a servlet can access static files in the WEB-INF directory. When this property is set to false, the default, servlets cannot access static files in the WEB-INF directory.
 
 decodeUrlPlusSign.name=Decode url plus sign
 decodeUrlPlusSign.desc=Decode the plus sign when it is part of the URL. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.decodeurlplussign. For servlet-5.0 and newer Servlet features, the default value is false.
 
 fileWrapperEvents.name=File wrapper events
-fileWrapperEvents.desc=Web container will generate SMF and PMI data when  serving the static files. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.fileWrapperEvents.
+fileWrapperEvents.desc=Web container will generate SMF and PMI data when serving the static files. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.fileWrapperEvents.
 
 defaultTraceRequestBehavior.name=Allow the HTTP TRACE request method to be invoked
 defaultTraceRequestBehavior.desc=Restore HTTP TRACE processing. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.DefaultTraceRequestBehavior.
@@ -72,7 +72,7 @@ defaultHeadRequestBehavior.name=Allow the HTTP HEAD request method to be invoked
 defaultHeadRequestBehavior.desc=Restore the behavior where the HEAD request is not subject to the security constraint defined for the GET method. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.DefaultHeadRequestBehavior.
 
 tolerateSymbolicLinks.name=Tolerate symbolic links
-tolerateSymbolicLinks.desc=Enables the web container to support the use of  symbolic links. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.TolerateSymbolicLinks.
+tolerateSymbolicLinks.desc=Enables the web container to support the use of symbolic links. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.TolerateSymbolicLinks.
 
 symbolicLinksCacheSize.name=Symbolic link cache size
 symbolicLinksCacheSize.desc=Initial size of the symbolic link cache. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.SymbolicLinksCacheSize.
@@ -103,7 +103,7 @@ enableDefaultIsElIgnoredInTag.name=Evaluate isELIgnored behavior in JSP tag file
 enableDefaultIsElIgnoredInTag.desc=Always evaluate whether to ignore EL expressions in tag files. If parent JSP files have different isELIgnored settings, the setting will be re-evaluated in the tag file. The equivalent custom property in the full profile application server is com.ibm.ws.jsp.enabledefaultiselignoredintag.
 
 parseUtf8PostData.name=Parse UTF-8 post data
-parseUtf8PostData.desc=Web container will detect non URL encoded UTF-8 post data and include it in the parameter values. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.parseutf8postdata.
+parseUtf8PostData.desc=Web container will detect non-URL encoded UTF-8 post data and include it in the parameter values. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.parseutf8postdata.
 
 logServletContainerInitializerClassLoadingErrors.name=Warn on ServletContainerIntializer errors
 logServletContainerInitializerClassLoadingErrors.desc=Log servlet container class loading errors as warnings rather than logging them only when debug is enabled. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.logservletcontainerinitializerclassloadingerrors.
@@ -130,10 +130,10 @@ asyncMaxSizeTaskPool.name=Async servlet maximum pool size
 asyncMaxSizeTaskPool.desc=Maximum size of tasks in the Async task pool before automatically purging canceled tasks. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.asyncmaxsizetaskpool.
 
 asyncPurgeInterval.name=Async servlet purge interval
-asyncPurgeInterval.desc=Time interval to wait between each required purge of the cancelled task pool. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.asyncpurgeinterval.
+asyncPurgeInterval.desc=Time interval to wait between each required purge of the canceled task pool. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.asyncpurgeinterval.
 
 asyncTimeoutDefault.name=Default async timeout
-asyncTimeoutDefault.desc=Async servlet timeout value used when a timeout value has not been explcitly specified. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.asynctimeoutdefault.
+asyncTimeoutDefault.desc=Async servlet timeout value used when a timeout value has not been explicitly specified. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.asynctimeoutdefault.
 
 asyncTimerThreads.name=Async timer threads
 asyncTimerThreads.desc=Maximum number of threads to use for async servlet timeout processing. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.asynctimerthreads.
@@ -145,12 +145,12 @@ emptyServletMappings.name=Return empty servlet mappings
 emptyServletMappings.desc=Toggle if you want to return an empty collection, instead of null, when no servlet mappings are added. The default value is false. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.emptyservletmappings.
 
 deferServletRequestListenerDestroyOnError.name=Defer servlet request listener destroy
-deferServletRequestListenerDestroyOnError.desc=Toggle if you want to defer ServletRequestListener destroy when there is an error serving the request. The default value is false, but is true for servlet 5.0 and later. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.deferServletRequestListenerDestroyOnError.
+deferServletRequestListenerDestroyOnError.desc=Toggle if you want to defer ServletRequestListener destroy when there is an error serving the request. The default value is false but is true for servlet 5.0 and later. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.deferServletRequestListenerDestroyOnError.
 
 allowExpressionFactoryPerApp.name=Allow expression factory per application
-allowExpressionFactoryPerApp.desc=Toggle to load the ExpressionFactory that is set by the application. Enable this custom property if you are using a custom EL implementation (for example, JUEL) that needs to set its own ExpressionFactory.
+allowExpressionFactoryPerApp.desc=Toggle to load the ExpressionFactory that is set by the application. Enable this custom property if you use a custom EL implementation (for example, JUEL) that needs to set its own ExpressionFactory.
 
-ignoreSemiColonOnRedirectToWelcomePage.name=Ignore semicolon on redirect to welcome page
+ignoreSemiColonOnRedirectToWelcomePage.name=Ignore semicolon on redirect to the welcome page
 ignoreSemiColonOnRedirectToWelcomePage.desc=Toggle to ignore the trailing semicolon when redirecting to the welcome page. The default value is false. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.ignoreSemiColonOnRedirectToWelcomePage.
 
 useSemiColonAsDelimiterInURI.name=Use semicolon as delimiter in URI
@@ -162,7 +162,7 @@ servletDestroyWaitTime.desc=Wait time in seconds for an active request to comple
 servletPathForDefaultMapping.name=Set the servlet path value for a default mapping
 servletPathForDefaultMapping.desc=Set the servlet path value to the request URI minus the context path. The path information is null when a servlet is used as a default mapping. The default value is true for version 4.0 or later of the servlet feature. It is false for other servlet features. When mapping is to the /* pattern, the servlet path is empty and the path information starts with a leading slash (/).
 
-throwExceptionWhenUnableToCompleteOrDispatch.name=Throw exception for not complete or dispatch asyn
+throwExceptionWhenUnableToCompleteOrDispatch.name=Throw exception for not complete or dispatch async
 throwExceptionWhenUnableToCompleteOrDispatch.desc=Throw an illegal state exception when an asynchronous request cannot be completed or dispatched. The default is true. If the asynchronous request must complete or the dispatch method must return, even if the call does not succeed, set the property to false.
 
 getRealPathReturnsQualifiedPath.name=Always return a non-null path from getRealPath
@@ -172,22 +172,22 @@ stopAppStartUponListenerException.name=Stop application for unhandled listener e
 stopAppStartUponListenerException.desc=Some web applications depend on context listeners for setup before the web application starts. When this property is set to true, the application stops starting up when an unhandled exception is thrown from the context listeners. For servlet-5.0 and newer Servlet features, the default value is true. 
 
 redirectToRelativeUrl.name=Send redirect response to a relative URL location
-redirectToRelativeUrl.desc=Send redirect response to a relative URL location without processing it. Set this property to true to send redirect response without converting the URL to an absolute location. 
+redirectToRelativeUrl.desc=Send redirect response to a relative URL location without processing it. Set this property to true to send a redirect response without converting the URL to an absolute location. 
 
 addStrictTransportSecurityHeader.name=Add the HTTP strict transport security header
 addStrictTransportSecurityHeader.desc=Enables the HTTP Strict Transport Security (HSTS) header for HTTPS responses and allows a value to be set for that header, for example: "max-age=31536000;includeSubDomains". HSTS can also be configured in the web.xml file by setting the "com.ibm.ws.webcontainer.ADD_STS_HEADER_WEBAPP" context parameter.
 
 allowQueryParamWithNoEqual.name=Allow query parameters with no value
-allowQueryParamWithNoEqual.desc=When this property is set to true, if the query parameter in a URL contains only the string name, the server returns an empty string as the value for the request.getParameter(name) query. When this property is set to false, the server returns null as the value for the request.getParameter(name) query. The default value is false, but is true for servlet 5.0 and higher.
+allowQueryParamWithNoEqual.desc=When this property is set to true, if the query parameter in a URL contains only the string name, the server returns an empty string as the value for the request.getParameter(name) query. When this property is set to false, the server returns null as the value for the request.getParameter(name) query. The default value is false but is true for servlet 5.0 and higher.
 
 setHtmlContentTypeOnError.name=Disable text/html content type on error responses
-setHtmlContentTypeOnError.desc=When this property is false, the webcontainer will not set the response's content type header during the error handling process. An application is responsible to set the response's content type. The default value (true) sets the content type to "text/html".
+setHtmlContentTypeOnError.desc=When this property is false, the webcontainer will not set the response's content-type header during the error handling process. An application is responsible for setting the response's content type. The default value (true) sets the content type to "text/html".
 
 excludeAllHandledTypesClasses.name=Disable returning handlesTypes parameters
 excludeAllHandledTypesClasses.desc=When this property is set to true, during startup, ServletContainerInitializer implementors that use the HandlesTypes annotation do not receive classes that are specified as HandlesTypes parameters.
 
 skipEncodedCharVerification.name=Skip verification of encoded characters in URI
-skipEncodedCharVerification.desc=A request is rejected if the request URI contains the %23, %2E, %2F, or %5C encoded characters. When this property is set to true, the request URI is not checked for these encoded characters. This property is available starting in servlet 6.0, and default value is false.
+skipEncodedCharVerification.desc=A request is rejected if the request URI contains the %23, %2E, %2F, or %5C encoded characters. When this property is set to true, the request URI is not checked for these encoded characters. This property is available starting in servlet 6.0, and the default value is false.
 
 maxFileCount.name=The maximum uploaded files in a single request
 maxFileCount.desc=The maximum number of files that can be uploaded by a multipart/form-data request. The default value is 5000. For unlimited file upload, set the value to -1.
@@ -199,4 +199,4 @@ set400SCOnTooManyParentDirs.name=Set 400 for invalid path traversal request
 set400SCOnTooManyParentDirs.desc=When this property is set to true, a request with an invalid path traversal is returned with a 400 status code instead of 500. The default is false. You can use this property with servlet-5.0 and earlier. For servlet-6.0 and later, the 400 response code is returned by default and this property has no effect.
 
 allowAbsoluteFileNameForPartWrite.name=Write part files to absolute file locations
-allowAbsoluteFileNameForPartWrite.desc=When this property is set to true, the runtime treats the filename argument on the part.write method call as an absolute location, rather than saving the filename arguement under the temporary location. In servlet-6.0 and earlier, the default value is false. In servlet-6.1 and later, the default value is true.
+allowAbsoluteFileNameForPartWrite.desc=When this property is set to true, the runtime treats the filename argument on the part.write method call as an absolute location, rather than saving the filename argument under the temporary location. In servlet-6.0 and earlier, the default value is false. In servlet-6.1 and later, the default value is true.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


Small improvements, grammar and clarity, to these property descriptions. 