### PR TITLE
introspector information for repositories, part 1

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
@@ -535,19 +535,21 @@ public class DataProvider implements //
         writer.println("EntityManager builders for unstarted applications:");
         futureEMBuilders.forEach((appName, futureEMBuilders) -> {
             writer.println("  for application " + appName);
-            for (FutureEMBuilder futureEMBuilder : futureEMBuilders)
+            for (FutureEMBuilder futureEMBuilder : futureEMBuilders) {
                 futureEMBuilder.introspect(writer, "    ");
+                writer.println();
+            }
         });
 
         writer.println();
         writer.println("Repository Producers:");
         repositoryProducers.forEach((appName, producers) -> {
             writer.println("  for application " + appName);
-            for (RepositoryProducer<?> producer : producers)
+            for (RepositoryProducer<?> producer : producers) {
                 producer.introspect(writer, "    ");
+                writer.println();
+            }
         });
-
-        writer.println();
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
@@ -26,6 +26,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 
 import javax.sql.DataSource;
@@ -70,6 +71,7 @@ import io.openliberty.cdi.spi.CDIExtensionMetadata;
 import io.openliberty.checkpoint.spi.CheckpointPhase;
 import io.openliberty.data.internal.persistence.cdi.DataExtension;
 import io.openliberty.data.internal.persistence.cdi.FutureEMBuilder;
+import io.openliberty.data.internal.persistence.cdi.RepositoryProducer;
 import io.openliberty.data.internal.persistence.metadata.DataComponentMetaData;
 import io.openliberty.data.internal.persistence.metadata.DataModuleMetaData;
 import io.openliberty.data.internal.version.DataVersionCompatibility;
@@ -209,6 +211,13 @@ public class DataProvider implements //
                     new ConcurrentHashMap<>();
 
     /**
+     * Map of application name to list of producers of repository beans.
+     * Entries are removed when the application stops.
+     */
+    final Map<String, Queue<RepositoryProducer<?>>> repositoryProducers = //
+                    new ConcurrentHashMap<>();
+
+    /**
      * For creating resource references.
      */
     public final ResourceConfigFactory resourceConfigFactory;
@@ -309,6 +318,8 @@ public class DataProvider implements //
         // Try to order removals based on dependencies, so that we remove first
         // what might depend on the others.
 
+        repositoryProducers.remove(appName);
+
         Queue<ServiceRegistration<DDLGenerationParticipant>> ddlgenRegistrations = //
                         ddlgeneratorsAllApps.remove(appName);
         if (ddlgenRegistrations != null)
@@ -385,6 +396,8 @@ public class DataProvider implements //
     protected void deactivate(ComponentContext cc) {
         // Try to order removals based on dependencies, so that we remove first
         // what might depend on the others.
+
+        repositoryProducers.clear();
 
         // Remove and unregister ddl generation services that our extension generated.
         for (Iterator<Queue<ServiceRegistration<DDLGenerationParticipant>>> it = //
@@ -496,12 +509,16 @@ public class DataProvider implements //
 
     /**
      * Write to the introspection file for Jakarta Data.
+     *
+     * @param writer writes to the introspection file.
      */
     @Override
-    public void introspect(PrintWriter writer) throws Exception {
+    public void introspect(PrintWriter writer) {
+        writer.println("compatibility: " + compat.getClass().getSimpleName());
         writer.println("createTables? " + createTables);
         writer.println("dropTables? " + dropTables);
         writer.println("logValues for " + logValues);
+
         writer.println();
         writer.println("databaseStore config:");
         dbStoreConfigAllApps.forEach((appName, dbStoreToConfig) -> {
@@ -514,7 +531,23 @@ public class DataProvider implements //
             });
         });
 
-        // TODO more information
+        writer.println();
+        writer.println("EntityManager builders for unstarted applications:");
+        futureEMBuilders.forEach((appName, futureEMBuilders) -> {
+            writer.println("  for application " + appName);
+            for (FutureEMBuilder futureEMBuilder : futureEMBuilders)
+                futureEMBuilder.introspect(writer, "    ");
+        });
+
+        writer.println();
+        writer.println("Repository Producers:");
+        repositoryProducers.forEach((appName, producers) -> {
+            writer.println("  for application " + appName);
+            for (RepositoryProducer<?> producer : producers)
+                producer.introspect(writer, "    ");
+        });
+
+        writer.println();
     }
 
     /**
@@ -718,6 +751,25 @@ public class DataProvider implements //
         Collection<FutureEMBuilder> previous = futureEMBuilders.putIfAbsent(appName, builders);
         if (previous != null)
             previous.addAll(builders);
+    }
+
+    /**
+     * Receives notification that a RepositoryProducer was created.
+     * DataProvider keeps track of RepositoryProducer instances in order to log
+     * information to the introspector output.
+     *
+     * @param appName  application name.
+     * @param producer RepositoryProducer instance.
+     */
+    @Trivial
+    public void producerCreated(String appName, RepositoryProducer<?> producer) {
+        Queue<RepositoryProducer<?>> producers = repositoryProducers.get(appName);
+        if (producers == null) {
+            Queue<RepositoryProducer<?>> empty = new ConcurrentLinkedQueue<>();
+            if ((producers = repositoryProducers.putIfAbsent(appName, empty)) == null)
+                producers = empty;
+        }
+        producers.add(producer);
     }
 
     @Reference(service = ModuleMetaDataListener.class,

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -92,6 +92,12 @@ public class QueryInfo {
     }
 
     /**
+     * Placeholder that indicates the entity class needs to be determined
+     * based on the content of the Query value.
+     */
+    public static final Class<?> ENTITY_TBD = Query.class;
+
+    /**
      * Indicates the repository method has no Sort, Sort[], or Order parameters
      * for dynamic sort criteria and also does not define any static sort criteria.
      */

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -149,7 +149,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
         for (Entry<Class<?>, List<QueryInfo>> entry : queriesPerEntityClass.entrySet()) {
             Class<?> entityClass = entry.getKey();
 
-            if (Query.class.equals(entityClass)) {
+            if (QueryInfo.ENTITY_TBD.equals(entityClass)) {
                 entitylessQueryInfos = entry.getValue();
             } else {
                 CompletableFuture<EntityInfo> entityInfoFuture = //

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -157,7 +157,7 @@ public class DataExtension implements Extension {
                 }
 
                 for (Class<?> entityClass : queriesPerEntityClass.keySet())
-                    if (!Query.class.equals(entityClass))
+                    if (!QueryInfo.ENTITY_TBD.equals(entityClass))
                         futureEMBuilder.addEntity(entityClass);
 
                 RepositoryProducer<Object> producer = new RepositoryProducer<>( //

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence.cdi;
 
+import java.io.PrintWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
@@ -75,6 +76,7 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
         this.provider = provider;
         this.queriesPerEntityClass = queriesPerEntityClass;
         this.repositoryInterface = repositoryInterface;
+        provider.producerCreated(futureEMBuilder.moduleName.getApplication(), this);
     }
 
     @Override
@@ -128,6 +130,18 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
     @Trivial
     public Set<Type> getTypes() {
         return beanTypes;
+    }
+
+    /**
+     * Write information about this instance to the introspection file for
+     * Jakarta Data.
+     *
+     * @param writer writes to the introspection file.
+     * @param indent indentation for lines.
+     */
+    @Trivial
+    public void introspect(PrintWriter writer, String indent) {
+        writer.println(indent + toString()); // TODO more information
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -31,6 +31,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.QueryInfo;
 import io.openliberty.data.internal.persistence.RepositoryImpl;
+import io.openliberty.data.internal.persistence.Util;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.repository.Repository;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -149,6 +150,9 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
         writer.println(indent + "  primary entity: " +
                        (primaryEntityClass == null ? null : primaryEntityClass.getName()));
         writer.println(indent + "  intercepted: " + intercepted);
+
+        writer.println();
+        writer.println(Util.toString(repositoryInterface, indent + "  "));
 
         queriesPerEntityClass.forEach((entityClass, queries) -> {
             writer.println();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/ClassDefiner.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/ClassDefiner.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence.service;
 
+import static io.openliberty.data.internal.persistence.Util.EOLN;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -192,27 +194,27 @@ class ClassDefiner {
      * @return textual representation.
      */
     @Trivial
-    private String toString(Class<?> c) {
-        StringBuilder s = new StringBuilder(500).append(DBStoreEMBuilder.EOLN);
-        s.append(c.toGenericString()).append(" {").append(DBStoreEMBuilder.EOLN);
+    private static String toString(Class<?> c) {
+        StringBuilder s = new StringBuilder(500).append(EOLN);
+        s.append(c.toGenericString()).append(" {").append(EOLN);
 
         // fields
         TreeMap<String, Field> fields = new TreeMap<>();
         for (Field f : c.getFields())
             fields.put(f.getName(), f);
         for (Field f : fields.values())
-            s.append("  ").append(f.toGenericString()).append(';').append(DBStoreEMBuilder.EOLN);
+            s.append("  ").append(f.toGenericString()).append(';').append(EOLN);
 
-        s.append(DBStoreEMBuilder.EOLN);
+        s.append(EOLN);
 
         // constructors
         TreeMap<String, Constructor<?>> ctors = new TreeMap<>();
         for (Constructor<?> ctor : c.getConstructors())
             ctors.put(ctor.getName(), ctor);
         for (Constructor<?> ctor : ctors.values())
-            s.append("  ").append(ctor.toGenericString()).append(DBStoreEMBuilder.EOLN);
+            s.append("  ").append(ctor.toGenericString()).append(EOLN);
 
-        s.append(DBStoreEMBuilder.EOLN);
+        s.append(EOLN);
 
         // methods
         TreeMap<String, Method> methods = new TreeMap<>();
@@ -220,7 +222,7 @@ class ClassDefiner {
             if (!Object.class.equals(m.getDeclaringClass()))
                 methods.put(m.getName(), m);
         for (Method m : methods.values())
-            s.append("  ").append(m.toGenericString()).append(DBStoreEMBuilder.EOLN);
+            s.append("  ").append(m.toGenericString()).append(EOLN);
 
         s.append('}');
         return s.toString();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package io.openliberty.data.internal.persistence.service;
 
 import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
+import static io.openliberty.data.internal.persistence.Util.EOLN;
 
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
@@ -83,7 +84,6 @@ import jakarta.persistence.Table;
  * It creates entity managers from a PersistenceServiceUnit from the persistence service.
  */
 public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerationParticipant {
-    static final String EOLN = String.format("%n");
     private static final long MAX_WAIT_FOR_SERVICE_NS = TimeUnit.SECONDS.toNanos(60);
     private static final Entry<String, String> ID_AND_VERSION_NOT_SPECIFIED = //
                     new SimpleImmutableEntry<>(null, null);

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
@@ -81,4 +81,61 @@ public class DataIntrospectorTest extends FATServletClient {
                         "/module[DataErrPathsTestApp.war]" +
                         "/databaseStore[java:comp/jdbc/InvalidDatabase]");
     }
+
+    /**
+     * Verify that introspector output contains the dataStore value that is
+     * configured on the repository.
+     */
+    @Test
+    public void testOutputContainsDataStore() {
+        assertLineFound("        dataStore: AbsentFromConfig");
+        assertLineFound("        dataStore: java:app/env/WrongPersistenceUnitRef");
+        assertLineFound("        dataStore: java:app/jdbc/DerbyDataSource");
+        assertLineFound("        dataStore: java:comp/DefaultDataSource");
+        assertLineFound("        dataStore: java:comp/jdbc/InvalidDatabase");
+        assertLineFound("        dataStore: java:module/env/DoesNotExist");
+        assertLineFound("        dataStore: java:module/jdbc/DataSourceForInvalidEntity");
+    }
+
+    /**
+     * Verify that introspector output contains the name of the module or
+     * application that defines the repository.
+     */
+    @Test
+    public void testOutputContainsDefiningArtifact() {
+        assertLineFound("        defining artifact: DataErrPathsTestApp#DataErrPathsTestApp.war");
+    }
+
+    /**
+     * Verify that introspector output contains the entity class that is used
+     * by the repository.
+     */
+    @Test
+    public void testOutputContainsEntity() {
+        assertLineFound("        entity: test.jakarta.data.errpaths.web.Voter");
+    }
+
+    /**
+     * Verify that introspector output contains the name of the primary entity class.
+     */
+    @Test
+    public void testOutputContainsPrimaryEntity() {
+        assertLineFound("      primary entity: test.jakarta.data.errpaths.web.Invention");
+        assertLineFound("      primary entity: test.jakarta.data.errpaths.web.Volunteer");
+        assertLineFound("      primary entity: test.jakarta.data.errpaths.web.Voter");
+    }
+
+    /**
+     * Verify that introspector output contains the name of repository interfaces.
+     */
+    @Test
+    public void testOutputContainsRepository() {
+        assertLineFound("      repository: test.jakarta.data.errpaths.web.InvalidDatabaseRepo");
+        assertLineFound("      repository: test.jakarta.data.errpaths.web.InvalidJNDIRepo");
+        assertLineFound("      repository: test.jakarta.data.errpaths.web.InvalidNonJNDIRepo");
+        assertLineFound("      repository: test.jakarta.data.errpaths.web.Inventions");
+        assertLineFound("      repository: test.jakarta.data.errpaths.web.RepoWithoutDataStore");
+        assertLineFound("      repository: test.jakarta.data.errpaths.web.Voters");
+        assertLineFound("      repository: test.jakarta.data.errpaths.web.WrongPersistenceUnitRefRepo");
+    }
 }


### PR DESCRIPTION
Include basic information from the RepositoryProducer in the introspector output. This includes the repository interface, primary entity class, all entity classes used, a listing of QueryInfo (but without much detail on each yet), and approximate repository method signatures.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
