### PR TITLE
Get JSON-P/B TCKs running on z/OS again

### DIFF
--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/fat/src/io/openliberty/jakarta/jsonb/tck/JsonbTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/fat/src/io/openliberty/jakarta/jsonb/tck/JsonbTckLauncher.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package io.openliberty.jakarta.jsonb.tck;
 
-import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,7 +25,6 @@ import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
@@ -44,15 +41,6 @@ import componenttest.topology.utils.tck.TCKRunner;
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 11)
 @MaximumJavaLevel(javaLevel = 21) //Fails on Java 23 due to updates to CLDR https://jdk.java.net/23/release-notes#JDK-8319990
-/*
- * Tests run on client JVM and each test requires a new JVM fork because the TCK itself has a provider
- * which needs to be discovered in some tests, and ignored in other tests. When this fork is created on
- * z/OS the maven-surefire-plugin fails with:
- * - Corrupted channel by directly writing to native stream in forked JVM 1.
- * - The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
- * This seems to be a bug in the maven-surefire-plugin, which will hopefully be fixed in a future release
- */
-@SkipIfSysProp(OS_ZOS)
 public class JsonbTckLauncher {
 
     final static Map<String, String> additionalProps = new HashMap<>();

--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -171,7 +171,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.2</version>
+				<version>3.5.2</version>
 				<configuration>
 					<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBytes(). -->
 					<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->

--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -174,6 +174,7 @@
 				<version>3.1.2</version>
 				<configuration>
 					<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBytes(). -->
+					<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
 					<trimStackTrace>false</trimStackTrace>
 					<failIfNoTests>true</failIfNoTests>
 					<dependenciesToScan>${jakarta.jsonb.tck.groupId}:jakarta.json.bind-tck</dependenciesToScan>

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/fat/src/io/openliberty/jakarta/jsonp/tck/JsonpTckLauncher.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package io.openliberty.jakarta.jsonp.tck;
 
-import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +24,6 @@ import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.PrivHelper;
@@ -43,15 +40,6 @@ import componenttest.topology.utils.tck.TCKRunner;
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 11)
 @MaximumJavaLevel(javaLevel = 21) //Possibility to fail on Java 23 due to CLDR updates https://jdk.java.net/23/release-notes#JDK-8319990
-/*
- * Tests run on client JVM and each test requires a new JVM fork because the TCK itself has a provider
- * which needs to be discovered in some tests, and ignored in other tests. When this fork is created on
- * z/OS the maven-surefire-plugin fails with:
- * - Corrupted channel by directly writing to native stream in forked JVM 1.
- * - The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
- * This seems to be a bug in the maven-surefire-plugin, which will hopefully be fixed in a future release
- */
-@SkipIfSysProp(OS_ZOS)
 public class JsonpTckLauncher {
 
     //This is a standalone test no server needed

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -81,6 +81,7 @@
 						<version>3.1.2</version>
 						<configuration>
 							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). -->
+							<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
 							<trimStackTrace>false</trimStackTrace>
 							<failIfNoTests>true</failIfNoTests>
 							<!-- Required configuration - each test requires a new JVM because the TCK itself has a provider
@@ -126,6 +127,7 @@
 						<version>3.1.2</version>
 						<configuration>
 							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBytes(). -->
+							<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
 							<trimStackTrace>false</trimStackTrace>
 							<failIfNoTests>true</failIfNoTests>
 							<!-- Required configuration - each test requires a new JVM because the TCK itself has a provider

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -78,7 +78,7 @@
 		        <plugins>
 			        <plugin>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.1.2</version>
+						<version>3.5.2</version>
 						<configuration>
 							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). -->
 							<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
@@ -124,7 +124,7 @@
 		        <plugins>
 			        <plugin>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>3.1.2</version>
+						<version>3.5.2</version>
 						<configuration>
 							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBytes(). -->
 							<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->


### PR DESCRIPTION
The newer SurefireForkNodeFactory uses sockets for inter-process communication, which avoids issues with z/OS auto-charset translation when communicating via stdin/out.

This is the same fix that I made in #30606 that I think might work here too.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
