### PR TITLE
Try to make consul lookups more reliable

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestService.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestService.java
@@ -205,6 +205,7 @@ public class ExternalTestService {
                                 + "this message can be ignored.");
         }
 
+	// Add all the servers to the list twice, effectively giving us a retry so double the chance of working if consul is slow
         List<String> servers = Arrays.asList((consulServerList+","+consulServerList).split(","));
         return consulServers = servers;
     }

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestService.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/ExternalTestService.java
@@ -100,9 +100,9 @@ public class ExternalTestService {
         Exception firstEx = null;
         for (String consulServer : getConsulServers()) {
             try {
-                JsonArray propertiesJson = new HttpsRequest(consulServer + "/v1/kv/service/" + propertyName + "?recurse=true")
+                JsonArray propertiesJson = new HttpsRequest(consulServer + "/v1/kv/service/" + propertyName + "?recurse=true&stale")
                                 .allowInsecure()
-                                .timeout(10_000)
+                                .timeout(30000)
                                 .expectCode(HttpsURLConnection.HTTP_OK)
                                 .expectCode(HttpsURLConnection.HTTP_NOT_FOUND)
                                 .run(JsonArray.class);
@@ -205,8 +205,7 @@ public class ExternalTestService {
                                 + "this message can be ignored.");
         }
 
-        List<String> servers = Arrays.asList(consulServerList.split(","));
-        Collections.shuffle(servers);
+        List<String> servers = Arrays.asList((consulServerList+","+consulServerList).split(","));
         return consulServers = servers;
     }
 
@@ -248,8 +247,8 @@ public class ExternalTestService {
         for (String consulServer : getConsulServers()) {
             JsonArray instances;
             try {
-                HttpsRequest instancesRequest = new HttpsRequest(consulServer + "/v1/health/service/" + serviceName + "?passing=true");
-                instancesRequest.timeout(10000);
+                HttpsRequest instancesRequest = new HttpsRequest(consulServer + "/v1/health/service/" + serviceName + "?passing=true&stale");
+                instancesRequest.timeout(30000);
                 instancesRequest.allowInsecure();
                 instances = instancesRequest.run(JsonArray.class);
             } catch (Exception e) {
@@ -263,7 +262,7 @@ public class ExternalTestService {
 
             JsonArray propertiesJson;
             try {
-                HttpsRequest propsRequest = new HttpsRequest(consulServer + "/v1/kv/service/" + serviceName + "/?recurse=true");
+                HttpsRequest propsRequest = new HttpsRequest(consulServer + "/v1/kv/service/" + serviceName + "/?recurse=true&stale");
                 propsRequest.allowInsecure();
                 propsRequest.timeout(10000);
                 propsRequest.expectCode(HttpsURLConnection.HTTP_OK).expectCode(HttpsURLConnection.HTTP_NOT_FOUND);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This PR will:

- Increase the timeout on the more expensive consul api calls from 10s to 30s
- Try all of the listed consul servers twice
- NOT shuffle the list of consul servers, as they are now deliberately ordered by proximity in the surrounding automation
- Allow consul to return stale cached data in the event that it is overloaded
