### PR TITLE
disabling CRYPTO_INSECURE messages

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -146,14 +146,16 @@ public class CryptoUtils {
 
     public static void logInsecureAlgorithmReplaced(String configProperty, String insecureAlgorithm, String secureAlgorithm) {
         // TODO remove beta check
-        if (isRunningBetaMode()) {
+        // TODO disabling CRYPTO_INSECURE warnings until full FIPS 140-3 support on Semeru is complete
+        if (false && isRunningBetaMode()) {
             Tr.warning(tc, "CRYPTO_INSECURE_REPLACED", configProperty, insecureAlgorithm, secureAlgorithm);
         }
     }
 
     public static void logInsecureProvider(String provider, String insecureAlgorithm) {
         // TODO remove beta check
-        if (isRunningBetaMode()) {
+        // TODO disabling CRYPTO_INSECURE warnings until full FIPS 140-3 support on Semeru is complete
+        if (false && isRunningBetaMode()) {
             Tr.warning(tc, "CRYPTO_INSECURE_PROVIDER", provider, insecureAlgorithm);
         }
     }

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -138,7 +138,8 @@ public class CryptoUtils {
 
     public static void logInsecureAlgorithm(String configProperty, String insecureAlgorithm) {
         // TODO remove beta check
-        if (isRunningBetaMode()) {
+        // TODO disabling CRYPTO_INSECURE warnings until full FIPS 140-3 support on Semeru is complete
+        if (false && isRunningBetaMode()) {
             Tr.warning(tc, "CRYPTO_INSECURE", configProperty, insecureAlgorithm);
         }
     }


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


Disabling CRYPTO_WARNING messages until full FIPS 140-3 on Semeru is completed. These warnings are causing test failures that we need to filter out in order to declare Java 8 support for 140-3