### PR TITLE
adding block so windows doesn't run retrieveUninstallFileList twice

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
@@ -75,12 +75,14 @@ class UninstallDirector extends AbstractDirector {
     }
 
     void retrieveUninstallFileList(UninstallAsset uninstallAsset, boolean checkDependency) throws InstallException {
-        if (uninstallAsset.getType().equals(UninstallAssetType.feature) &&
-            uninstallAsset.getFeatureFileList().isEmpty()) {
-            uninstallAsset.setFeaturePath(ESAAdaptor.getFeaturePath(uninstallAsset.getProvisioningFeatureDefinition(),
-                                                                    engine.getBaseDir(uninstallAsset.getProvisioningFeatureDefinition())));
-            uninstallAsset.setFeatureFileList(ESAAdaptor.determineFilesToBeDeleted(uninstallAsset.getProvisioningFeatureDefinition(), product.getFeatureDefinitions(),
-                                                                                   engine.getBaseDir(uninstallAsset.getProvisioningFeatureDefinition()),
+        if (uninstallAsset.getType().equals(UninstallAssetType.feature) && uninstallAsset.getFeatureFileList().isEmpty()) {
+
+            ProvisioningFeatureDefinition featureDef = uninstallAsset.getProvisioningFeatureDefinition();
+            File baseDir = engine.getBaseDir(featureDef);
+            uninstallAsset.setFeaturePath(ESAAdaptor.getFeaturePath(featureDef, baseDir));
+            uninstallAsset.setFeatureFileList(ESAAdaptor.determineFilesToBeDeleted(featureDef,
+                                                                                   product.getFeatureDefinitions(),
+                                                                                   baseDir,
                                                                                    uninstallAsset.getFeaturePath(), checkDependency,
                                                                                    uninstallAsset.getFixUpdatesFeature()));
         }
@@ -123,7 +125,9 @@ class UninstallDirector extends AbstractDirector {
             fireProgressEvent(InstallProgressEvent.UNINSTALL, progress, Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("STATE_UNINSTALLING", uninstallAsset.getName()));
             progress += interval;
             try {
-                retrieveUninstallFileList(uninstallAsset, checkDependency);
+                if (!InstallUtils.isWindows) {
+                    retrieveUninstallFileList(uninstallAsset, checkDependency);
+                }
                 engine.uninstall(uninstallAsset, checkDependency, filesRestored);
                 log(Level.FINE, uninstallAsset.uninstalledLogMsg());
             } catch (IOException e) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Calling `retrieveUninstallFileList` once reduced the count of call from 2074 to 1037. It reduced the total time by from  3102403ms to 2858950ms, which is about 4 min reduction. 
