### PR TITLE
fix FIPS jvm settings from clearing existing jvm Options

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -36,7 +36,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.Charset;
-import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.security.AccessController;
@@ -7820,16 +7819,16 @@ public class LibertyServer implements LogMonitorClient {
         boolean isIBMJVM17 = (serverJavaInfo.majorVersion() == 17) && (serverJavaInfo.VENDOR == Vendor.IBM);
         if (logOutput && GLOBAL_FIPS_140_3) {
             Log.info(c, methodName, "Liberty server is running JDK version: " + serverJavaInfo.majorVersion()
-                    + " and vendor: " + serverJavaInfo.VENDOR);
+                                    + " and vendor: " + serverJavaInfo.VENDOR);
             if (isIBMJVM8) {
                 Log.info(c, methodName, "global build properties FIPS_140_3 is set for server " + getServerName() +
-                        " and IBM java 8 is available to run with FIPS 140-3 enabled.");
+                                        " and IBM java 8 is available to run with FIPS 140-3 enabled.");
             } else if (isIBMJVM17) {
                 Log.info(c, methodName, "global build properties FIPS_140_3 is set for server " + getServerName() +
-                        " and IBM java 17 is available to run with FIPS 140-3 enabled.");
+                                        " and IBM java 17 is available to run with FIPS 140-3 enabled.");
             } else {
                 Log.info(c, methodName, "The global build properties FIPS_140_3 is set for server " + getServerName() +
-                        ",  but no IBM java 8 or java 17 on liberty server to run with FIPS 140-3 enabled.");
+                                        ",  but no IBM java 8 or java 17 on liberty server to run with FIPS 140-3 enabled.");
             }
         }
         return GLOBAL_FIPS_140_3 && (isIBMJVM8 || isIBMJVM17);
@@ -7838,10 +7837,11 @@ public class LibertyServer implements LogMonitorClient {
     public boolean isFIPS140_3EnabledAndSupported() throws IOException {
         return isFIPS140_3EnabledAndSupported(JavaInfo.forServer(this), true);
     }
- 
-     public boolean isFIPS140_3EnabledAndSupported(JavaInfo info) throws IOException {
+
+    public boolean isFIPS140_3EnabledAndSupported(JavaInfo info) throws IOException {
         return isFIPS140_3EnabledAndSupported(info, true);
     }
+
     /**
      * No longer using bootstrap properties to update server config for database rotation.
      * Instead look at using the fattest.databases module
@@ -8049,14 +8049,14 @@ public class LibertyServer implements LogMonitorClient {
 
             if (!ltpaKeys.exists() && !fipsKeyExists) {
                 Log.info(this.getClass(), "configureLTPAKeys",
-                        "FIPS 140-3 global build properties are set for server " + serverName
-                                + ", but neither ltpa.keys nor ltpaFIPS.keys is found in " + serverSecurityDir);
+                         "FIPS 140-3 global build properties are set for server " + serverName
+                                                               + ", but neither ltpa.keys nor ltpaFIPS.keys is found in " + serverSecurityDir);
             } else {
                 Log.info(this.getClass(), "configureLTPAKeys",
-                        "FIPS 140-3 global build properties are set for server " + serverName
-                                + ", swapping ltpaFIPS.keys into ltpa.keys");
+                         "FIPS 140-3 global build properties are set for server " + serverName
+                                                               + ", swapping ltpaFIPS.keys into ltpa.keys");
             }
-            
+
             if (fipsKeyExists) {
                 Files.move(ltpaFIPSKeys.toPath(), ltpaKeys.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 // Log.info(this.getClass(), "configureLTPAKeys",
@@ -8071,25 +8071,25 @@ public class LibertyServer implements LogMonitorClient {
         }
     }
 
-    
     private void configureLTPAKeys() throws IOException, InterruptedException {
         configureLTPAKeys(JavaInfo.forServer(this));
     }
 
-    private Map<String, String> getFipsJvmOptions(JavaInfo info, boolean includeGlobalArgs) throws IOException {
+    private Map<String, String> getFipsJvmOptions(JavaInfo info, boolean includeGlobalArgs) throws Exception, IOException {
         Map<String, String> opts = new HashMap<>();
+        opts.putAll(this.getJvmOptionsAsMap()); //Add all current JVM option so we don't unintentionally clear any set by tests.
         if (isFIPS140_3EnabledAndSupported(info, false)) {
             if (info.majorVersion() == 17) {
                 Log.info(c, "getFipsJvmOptions",
-                        "FIPS 140-3 global build properties is set for server " + getServerName()
-                                + " with IBM Java 17, adding required JVM arguments to run with FIPS 140-3 enabled");
+                         "FIPS 140-3 global build properties is set for server " + getServerName()
+                                                 + " with IBM Java 17, adding required JVM arguments to run with FIPS 140-3 enabled");
                 opts.put("-Dsemeru.fips", "true");
                 opts.put("-Dsemeru.customprofile", "OpenJCEPlusFIPS.FIPS140-3-withPKCS12");
                 opts.put("-Dcom.ibm.fips.mode", "140-3");
             } else if (info.majorVersion() == 8) {
                 Log.info(c, "getFipsJvmOptions", "FIPS 140-3 global build properties is set for server "
-                        + getServerName()
-                        + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
+                                                 + getServerName()
+                                                 + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
                 opts.put("-Xenablefips140-3", null);
                 opts.put("-Dcom.ibm.jsse2.usefipsprovider", "true");
                 opts.put("-Dcom.ibm.jsse2.usefipsProviderName", "IBMJCEPlusFIPS");
@@ -8104,12 +8104,11 @@ public class LibertyServer implements LogMonitorClient {
         return opts;
     }
 
-    public void setKeysAndJVMOptsForFips() throws Exception
-    {
+    public void setKeysAndJVMOptsForFips() throws Exception {
         // Enable FIPS on members via jvm.options file. This way when the controller starts / joins members
-        // the appropriate FIPS jvm arguments will be configured. 
+        // the appropriate FIPS jvm arguments will be configured.
         JavaInfo info = JavaInfo.forServer(this);
-        if(isFIPS140_3EnabledAndSupported(info)){
+        if (isFIPS140_3EnabledAndSupported(info)) {
             this.configureLTPAKeys(info);
             Map<String, String> jvm_opts = this.getJvmOptionsAsMap();
             Map<String, String> combined = new HashMap(jvm_opts);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


Test would set the following
```LibertyServer                  setJvmOptions                  I jvm.options: [-Dcom.sun.xml.bind.backupWithParentNamespace=true]```

Which is now preserved by the `getFipsJvmOptions` call
```
LibertyServer                  startServerWithArgs            I Using additional env props: {JVM_ARGS=-Dcom.ibm.ws.beta.edition=true  -Dcom.ibm.fips.mode=140-3 -Dcom.sun.xml.bind.backupWithParentNamespace=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS -Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true, ...}
```