### PR TITLE
query information for introspector

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -9,12 +9,15 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import java.io.PrintWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -261,6 +264,94 @@ public class Util {
     }
 
     /**
+     * Print the string, adding indentation after end-of-line characters.
+     * Indentation is not added before the first line.
+     *
+     * @param s      string to print, which might have end-of-line characters.
+     * @param writer writer for output.
+     * @param indent indentation for lines.
+     */
+    @Trivial
+    private static void printIndented(String s, PrintWriter writer, String indent) {
+        int start = 0, eoln;
+        while ((eoln = s.indexOf(EOLN, start)) >= 0) {
+            writer.print(s.substring(start, eoln));
+            writer.println();
+            writer.print(indent);
+            start = eoln + EOLN.length();
+        }
+        writer.print(s.substring(start, s.length()));
+    }
+
+    /**
+     * Print the exception, its stack, and causes to the specified writer.
+     *
+     * @param x                 the exception or error.
+     * @param writer            writer for output.
+     * @param indent            indentation for lines.
+     * @param suppressedIgnores exceptions/errors already printed that should be
+     *                              ignored when printing a suppressed Throwable.
+     *                              Null if not printing a suppressed Throwable.
+     *                              This method adds to the set.
+     */
+    @Trivial
+    public static void printStackTrace(Throwable x,
+                                       PrintWriter writer,
+                                       String indent,
+                                       Set<Throwable> suppressedIgnores) {
+        Set<Throwable> alreadyPrinted = suppressedIgnores == null //
+                        ? new HashSet<>() //
+                        : suppressedIgnores;
+
+        for (Throwable cause = x; cause != null; cause = cause.getCause()) {
+            if (alreadyPrinted.add(cause)) {
+                writer.print(indent);
+                if (cause != x)
+                    writer.print("Caused by: ");
+                else if (suppressedIgnores != null)
+                    writer.print("Suppressed: ");
+
+                printIndented(cause.toString(), writer, indent + "  ");
+                writer.println();
+
+                for (StackTraceElement e : cause.getStackTrace())
+                    writer.println(indent + "  at " + e.toString());
+
+                for (Throwable suppressed : x.getSuppressed())
+                    printStackTrace(suppressed, writer, indent + "  ", alreadyPrinted);
+            } else {
+                writer.println(indent + "[CIRCULAR REFERENCE: " +
+                               cause.getClass().getName() + ']');
+            }
+        }
+    }
+
+    /**
+     * Returns a textual representation of the annotation, omitting parts
+     * that can be assumed. This helps make the introspector output more
+     * concise and less cluttered.
+     *
+     * @param anno annotation.
+     * @return a shortened textual representation of the annotation.
+     */
+    @Trivial
+    private static String toString(Annotation anno) {
+        String s = anno.toString();
+
+        int openParen = s.indexOf('(');
+        int dot = openParen > 0 ? s.lastIndexOf('.', openParen) : -1;
+        int end = s.length() - (s.endsWith("()") ? 2 : 0);
+
+        // omit jakarta data package names and any ending ()
+        if (dot > 0 && s.startsWith("@jakarta.data."))
+            s = '@' + s.substring(dot + 1, end);
+        else
+            s = s.substring(0, end);
+
+        return s;
+    }
+
+    /**
      * String representation of a class, for logging to trace or introspector output.
      *
      * @param c      generated entity class.
@@ -279,8 +370,39 @@ public class Util {
 
         StringBuilder s = new StringBuilder(1000);
         for (Annotation anno : c.getDeclaredAnnotations())
-            s.append(indent).append(anno).append(EOLN);
-        s.append(indent).append(c.toGenericString()).append(" {").append(EOLN);
+            s.append(indent).append(toString(anno)).append(EOLN);
+        s.append(indent).append(c.toGenericString());
+
+        RecordComponent[] components = c.getRecordComponents();
+        if (components != null) {
+            s.append('(');
+            for (int rc = 0; rc < components.length; rc++) {
+                if (rc > 0)
+                    s.append(", ");
+                s.append(shorten.apply(components[rc].getGenericType().getTypeName())) //
+                                .append(' ') //
+                                .append(components[rc].getName());
+            }
+            s.append(')');
+        }
+
+        Type supertype = c.getGenericSuperclass();
+        if (supertype != null)
+            s.append(" extends ").append(shorten.apply(supertype.getTypeName()));
+
+        Type[] interfaces = c.getGenericInterfaces();
+        if (interfaces != null && interfaces.length > 0) {
+            s.append(c.isInterface() ? " extends" : " implements");
+            for (int i = 0; i < interfaces.length; i++)
+                s.append(i == 0 ? " " : ", ") //
+                                .append(shorten.apply(interfaces[i].getTypeName()));
+        }
+
+        s.append(" {").append(EOLN);
+
+        // inner classes
+        for (Class<?> inner : c.getDeclaredClasses())
+            s.append(EOLN).append(toString(inner, indent + "  ")).append(EOLN);
 
         // fields
         TreeMap<String, Field> fields = new TreeMap<>();
@@ -289,7 +411,7 @@ public class Util {
         for (Field f : fields.values()) {
             s.append(EOLN);
             for (Annotation anno : f.getDeclaredAnnotations())
-                s.append(indent).append("  ").append(anno).append(EOLN);
+                s.append(indent).append("  ").append(toString(anno)).append(EOLN);
             s.append(indent).append("  ") //
                             .append(shorten.apply(f.toGenericString())) //
                             .append(';').append(EOLN);
@@ -335,7 +457,7 @@ public class Util {
                                        StringBuilder b) {
         // method or constructor annotations first:
         for (Annotation anno : m.getDeclaredAnnotations())
-            b.append(indent).append(anno).append(EOLN);
+            b.append(indent).append(toString(anno)).append(EOLN);
         String s = shorten.apply(m.toGenericString());
         // insert parameter annotations because they are absent from the above
         Annotation[][] paramAnnos = m.getParameterAnnotations();
@@ -346,7 +468,7 @@ public class Util {
             b.append(indent).append(s.substring(0, paramStart));
             for (int a = 0; a < paramAnnos.length; a++) {
                 for (Annotation anno : paramAnnos[a])
-                    b.append(anno).append(' ');
+                    b.append(toString(anno)).append(' ');
                 int paramNext = s.indexOf(',', paramStart);
                 paramNext = paramNext == -1 ? s.length() : paramNext + 1;
                 b.append(s.substring(paramStart, paramNext)).append(' ');

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -264,15 +264,19 @@ public class Util {
     }
 
     /**
-     * Print the string, adding indentation after end-of-line characters.
-     * Indentation is not added before the first line.
+     * Print the string, adding indentation after end-of-line characters that are
+     * within the string. Indentation is not added before the first line.
      *
      * @param s      string to print, which might have end-of-line characters.
      * @param writer writer for output.
      * @param indent indentation for lines.
      */
     @Trivial
-    private static void printIndented(String s, PrintWriter writer, String indent) {
+    public static void printlnIndented(String s, PrintWriter writer, String indent) {
+        if (s == null) {
+            writer.println("null");
+            return;
+        }
         int start = 0, eoln;
         while ((eoln = s.indexOf(EOLN, start)) >= 0) {
             writer.print(s.substring(start, eoln));
@@ -280,7 +284,7 @@ public class Util {
             writer.print(indent);
             start = eoln + EOLN.length();
         }
-        writer.print(s.substring(start, s.length()));
+        writer.println(s.substring(start, s.length()));
     }
 
     /**
@@ -311,8 +315,7 @@ public class Util {
                 else if (suppressedIgnores != null)
                     writer.print("Suppressed: ");
 
-                printIndented(cause.toString(), writer, indent + "  ");
-                writer.println();
+                printlnIndented(cause.toString(), writer, indent + "  ");
 
                 for (StackTraceElement e : cause.getStackTrace())
                     writer.println(indent + "  at " + e.toString());

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -50,6 +50,7 @@ import com.ibm.wsspi.persistence.DDLGenerationParticipant;
 
 import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.EntityManagerBuilder;
+import io.openliberty.data.internal.persistence.Util;
 import io.openliberty.data.internal.persistence.provider.PUnitEMBuilder;
 import io.openliberty.data.internal.persistence.service.DBStoreEMBuilder;
 import jakarta.data.exceptions.DataException;
@@ -699,7 +700,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                 writer.println("completed");
             } catch (Throwable x) {
                 writer.println("failed");
-                x.printStackTrace(writer);
+                Util.printStackTrace(x, writer, indent + "  ", null);
             }
         else
             writer.println("not completed");

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -16,6 +16,7 @@ import java.io.PrintWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -140,11 +141,12 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
      *
      * @param writer writes to the introspection file.
      * @param indent indentation for lines.
-     * @return Map of entity class to list of QueryInfo for the caller to log
-     *         after eliminating duplicates.
+     * @return list of QueryInfo for the caller to log.
      */
     @Trivial
-    public Map<Class<?>, List<QueryInfo>> introspect(PrintWriter writer, String indent) {
+    public List<QueryInfo> introspect(PrintWriter writer, String indent) {
+        List<QueryInfo> queryInfos = new ArrayList<>();
+
         writer.println(indent + "RepositoryProducer@" + Integer.toHexString(hashCode()));
         writer.println(indent + "  repository: " + repositoryInterface.getName());
         writer.println(indent + "  primary entity: " +
@@ -169,12 +171,14 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
                 writer.println(indent + "    " + qi.toString() //
                                 .replace('\r', ' ') // print on single line
                                 .replace('\n', ' '));
+
+            queryInfos.addAll(queries);
         });
 
         writer.println();
         futureEMBuilder.introspect(writer, "  " + indent);
 
-        return queriesPerEntityClass;
+        return queryInfos;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -157,7 +157,7 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
         queriesPerEntityClass.forEach((entityClass, queries) -> {
             writer.println();
             if (QueryInfo.ENTITY_TBD.equals(entityClass))
-                writer.println(indent + "  Queries for entity determined from Query value:");
+                writer.println(indent + "  Queries for entity to be determined:");
             else
                 writer.println(indent + "  Queries for entity " + entityClass.getName() + ':');
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/ClassDefiner.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/ClassDefiner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,20 +12,17 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence.service;
 
-import static io.openliberty.data.internal.persistence.Util.EOLN;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AllPermission;
 import java.security.Permissions;
 import java.security.ProtectionDomain;
-import java.util.TreeMap;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+
+import io.openliberty.data.internal.persistence.Util;
 
 /**
  * Initially copied from @nmittles pull #25248
@@ -135,7 +132,7 @@ class ClassDefiner {
                                                              svAllPermissionProtectionDomain);
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-                Tr.exit(tc, "defineClass", c);
+                Tr.exit(tc, "defineClass", Util.toString(c, ""));
 
             return c;
         } catch (IllegalAccessException ex) {
@@ -185,46 +182,5 @@ class ClassDefiner {
             Tr.exit(tc, "findLoadedOrDefineClass", klass);
 
         return klass;
-    }
-
-    /**
-     * String representation of a generated entity class, for logging to trace.
-     *
-     * @param c generated entity class.
-     * @return textual representation.
-     */
-    @Trivial
-    private static String toString(Class<?> c) {
-        StringBuilder s = new StringBuilder(500).append(EOLN);
-        s.append(c.toGenericString()).append(" {").append(EOLN);
-
-        // fields
-        TreeMap<String, Field> fields = new TreeMap<>();
-        for (Field f : c.getFields())
-            fields.put(f.getName(), f);
-        for (Field f : fields.values())
-            s.append("  ").append(f.toGenericString()).append(';').append(EOLN);
-
-        s.append(EOLN);
-
-        // constructors
-        TreeMap<String, Constructor<?>> ctors = new TreeMap<>();
-        for (Constructor<?> ctor : c.getConstructors())
-            ctors.put(ctor.getName(), ctor);
-        for (Constructor<?> ctor : ctors.values())
-            s.append("  ").append(ctor.toGenericString()).append(EOLN);
-
-        s.append(EOLN);
-
-        // methods
-        TreeMap<String, Method> methods = new TreeMap<>();
-        for (Method m : c.getMethods())
-            if (!Object.class.equals(m.getDeclaringClass()))
-                methods.put(m.getName(), m);
-        for (Method m : methods.values())
-            s.append("  ").append(m.toGenericString()).append(EOLN);
-
-        s.append('}');
-        return s.toString();
     }
 }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
@@ -38,6 +38,28 @@ public class DataIntrospectorTest extends FATServletClient {
     static final List<String> introspectorOutput = new ArrayList<>();
 
     /**
+     * Asserts that a line containing the expected substring is found
+     * within the Jakarta Data introspector output.
+     *
+     * @param expected the line to search for.
+     */
+    private static void assertLineContains(String expectedSubstring) {
+        if (introspectorOutput.isEmpty())
+            fail("JakartaDataIntrospector output not found. Unable to run test. " +
+                 "Check server logs for errors.");
+
+        for (String line : introspectorOutput)
+            if (line.contains(expectedSubstring))
+                return;
+
+        fail("Substring not found within introspector output. " +
+             "To view introspector output from the test results page, " +
+             "follow the System.out link and then search for " +
+             "testIntrospectorOutputObtained. Missing substring is: " +
+             expectedSubstring);
+    }
+
+    /**
      * Asserts that a line is found within the Jakarta Data introspector output.
      *
      * @param expected the line to search for.
@@ -171,7 +193,9 @@ public class DataIntrospectorTest extends FATServletClient {
      */
     @Test
     public void testOutputContainsRepositoryAnnotation() {
-        assertLineFound("      @Repository(dataStore=\"java:app/jdbc/DerbyDataSource\", provider=\"\")");
+        // fields of the annotation could be printed in any order
+        assertLineContains("      @Repository(");
+        assertLineContains("dataStore=\"java:app/jdbc/DerbyDataSource\"");
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
@@ -69,6 +69,15 @@ public class DataIntrospectorTest extends FATServletClient {
     }
 
     /**
+     * Verify that introspector output contains the entity class that is used
+     * by the repository.
+     */
+    @Test
+    public void testOutputContainsCauseOfException() {
+        assertLineFound("        Caused by: javax.naming.NameNotFoundException: AbsentFromConfig");
+    }
+
+    /**
      * Verify that introspector output contains the config display id of
      * databaseStore elements that are used by repositories.
      */
@@ -137,5 +146,24 @@ public class DataIntrospectorTest extends FATServletClient {
         assertLineFound("      repository: test.jakarta.data.errpaths.web.RepoWithoutDataStore");
         assertLineFound("      repository: test.jakarta.data.errpaths.web.Voters");
         assertLineFound("      repository: test.jakarta.data.errpaths.web.WrongPersistenceUnitRefRepo");
+    }
+
+    /**
+     * Verify that introspector output contains the Repository annotation.
+     */
+    @Test
+    public void testOutputContainsRepositoryAnnotation() {
+        assertLineFound("      @Repository(dataStore=\"java:app/jdbc/DerbyDataSource\", provider=\"\")");
+    }
+
+    /**
+     * Verify that introspector output contains the signature of repository methods.
+     */
+    @Test
+    public void testOutputContainsRepositoryMethodSignature() {
+        assertLineFound("        @Find");
+        assertLineFound("        public abstract java.util.List<Voter> livesAt(" +
+                        "@By(\"address\") java.lang.String, jakarta.data.Limit, " +
+                        "jakarta.data.Order<Voter>, jakarta.data.Limit) ");
     }
 }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
@@ -78,6 +78,16 @@ public class DataIntrospectorTest extends FATServletClient {
     }
 
     /**
+     * Verify the introspector output contains a count query that is used to
+     * find the number of total elements across all pages.
+     */
+    @Test
+    public void testOutputContainsCountQueryForPages() {
+        assertLineFound("    JPQL count query: " +
+                        "SELECT COUNT(o) FROM Voter o WHERE (o.address=?1)");
+    }
+
+    /**
      * Verify that introspector output contains the config display id of
      * databaseStore elements that are used by repositories.
      */
@@ -125,6 +135,14 @@ public class DataIntrospectorTest extends FATServletClient {
     }
 
     /**
+     * Verify that the introspector output contains the names of JPQL named parameters.
+     */
+    @Test
+    public void testOutputContainsJPQLNamedParameterNames() {
+        assertLineFound("    JPQL parameter names: [lname]");
+    }
+
+    /**
      * Verify that introspector output contains the name of the primary entity class.
      */
     @Test
@@ -154,6 +172,16 @@ public class DataIntrospectorTest extends FATServletClient {
     @Test
     public void testOutputContainsRepositoryAnnotation() {
         assertLineFound("      @Repository(dataStore=\"java:app/jdbc/DerbyDataSource\", provider=\"\")");
+    }
+
+    /**
+     * Verify that introspector output contains the result type of a repository method.
+     */
+    @Test
+    public void testOutputContainsRepositoryMethodResultType() {
+        assertLineFound("    return array type: test.jakarta.data.errpaths.web.Voter");
+        assertLineFound("    multiple result type: [Ltest.jakarta.data.errpaths.web.Voter;");
+        assertLineFound("    single result type: test.jakarta.data.errpaths.web.Voter");
     }
 
     /**


### PR DESCRIPTION
Include query information in the introspector output.
Also, correct the formatting of exception messages and stacks.
Also, restore the tracing of generated entities.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
