### PR TITLE
LTPA Key security provider might be different than the default one

### DIFF
--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/KeyEncryptor.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/KeyEncryptor.java
@@ -74,6 +74,16 @@ public class KeyEncryptor {
 	 * @return The encrypted key
 	 */
 	public byte[] encrypt(byte[] key) throws Exception {
-		return LTPACrypto.encrypt(key, this.key, CIPHER);
+		return encrypt(key, null);
+	}
+
+    	/**
+	 * Encrypt the key
+	 *
+	 * @param key The key
+	 * @return The encrypted key
+	 */
+	public byte[] encrypt(byte[] key, String userJdkProvider) throws Exception {
+		return LTPACrypto.encrypt(key, this.key, CIPHER, userJdkProvider);
 	}
 }

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/KeyEncryptor.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/KeyEncryptor.java
@@ -45,14 +45,26 @@ public class KeyEncryptor {
 		}
 	}
 
-	/**
+    /**
 	 * Decrypt the key.
 	 *
 	 * @param encryptedKey The encrypted key
 	 * @return The decrypted key
 	 */
 	public byte[] decrypt(byte[] encryptedKey) throws Exception {
-		return LTPACrypto.decrypt(encryptedKey, key, CIPHER);
+        return decrypt(encryptedKey, null);
+    }
+
+    /**
+	 * Decrypt the key.
+	 *
+	 * @param encryptedKey   The encrypted key
+     * @param userJdkProvider The JDK Provider to use to decrypt the LTPA key
+	 * @return The decrypted key
+	 */
+
+	public byte[] decrypt(byte[] encryptedKey, String userJdkProvider) throws Exception {
+		return LTPACrypto.decrypt(encryptedKey, key, CIPHER, userJdkProvider);
 	}
 
 	/**

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/KeyEncryptor.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/KeyEncryptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2024 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -695,8 +695,22 @@ final class LTPACrypto {
      */
     @Trivial
     protected static final byte[] encrypt(byte[] data, byte[] key, String cipher) throws Exception {
-        SecretKey sKey = constructSecretKey(key, cipher);
-        Cipher ci = createCipher(Cipher.ENCRYPT_MODE, key, cipher, sKey);
+        return encrypt(data, key, cipher, null);
+    }
+
+    /**
+     * Encrypt the data.
+     *
+     * @param data   The byte representation of the data
+     * @param key    The key used to encrypt the data
+     * @param cipher The cipher algorithm
+     * @param userJdkProvider    The JDK provider to be used to decrypt the LTPA key
+     * @return The encrypted data (ciphertext)
+     */
+    @Trivial
+    protected static final byte[] encrypt(byte[] data, byte[] key, String cipher, String userJdkProvider) throws Exception {
+        SecretKey sKey = constructSecretKey(key,cipher, userJdkProvider);
+        Cipher ci = createCipher(Cipher.ENCRYPT_MODE, key, cipher, sKey, userJdkProvider);
         return ci.doFinal(data);
     }
 
@@ -707,7 +721,6 @@ final class LTPACrypto {
      * @param msg              The byte representation of the data
      * @param key              The key used to decrypt the data
      * @param cipher            The cipher algorithm
-     * @param userJdkProvider    The JDK provider to be used to decrypt the LTPA key
      * @return The decrypted data (plaintext)
      */
     @Trivial

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -593,6 +593,20 @@ final class LTPACrypto {
     @Trivial
     private static SecretKey constructSecretKey(byte[] key, String cipher)
             throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException, NoSuchProviderException {
+                return constructSecretKey(key, cipher, null);
+    }
+    /**
+     * @param key
+     * @param cipher
+     * @param userJdkProvider
+     * @return
+     * @throws InvalidKeyException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     */
+    @Trivial
+    private static SecretKey constructSecretKey(byte[] key, String cipher, String userJdkProvider)
+            throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException, NoSuchProviderException {
         SecretKey sKey = null;
         if (cipher.indexOf("AES") != -1) {
             // 16 bytes = 128 bit key
@@ -600,16 +614,20 @@ final class LTPACrypto {
         } else {
             DESedeKeySpec kSpec = new DESedeKeySpec(key);
             SecretKeyFactory kFact = null;
-
-            kFact = (provider == null) ? SecretKeyFactory.getInstance(encryptAlgorithm)
-                    : SecretKeyFactory.getInstance(encryptAlgorithm, provider);
+            if (userJdkProvider == null){
+                kFact = (provider == null) ? SecretKeyFactory.getInstance(encryptAlgorithm)
+                : SecretKeyFactory.getInstance(encryptAlgorithm, provider);
+            }
+            else{
+                kFact = SecretKeyFactory.getInstance(encryptAlgorithm, userJdkProvider);
+            }
 
             sKey = kFact.generateSecret(kSpec);
         }
         return sKey;
     }
 
-    /**
+        /**
      * @param key
      * @param cipher
      * @param sKey
@@ -623,9 +641,31 @@ final class LTPACrypto {
     private static Cipher createCipher(int cipherMode, byte[] key, String cipher, SecretKey sKey)
             throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException,
             InvalidAlgorithmParameterException, NoSuchProviderException {
+                return createCipher(cipherMode,  key, cipher,sKey, null);
+    }
+
+    /**
+     * @param key
+     * @param cipher
+     * @param sKey
+     * @return
+     * @throws NoSuchAlgorithmException
+     * @throws NoSuchPaddingException
+     * @throws InvalidKeyException
+     * @throws InvalidAlgorithmParameterException
+     */
+    @Trivial
+    private static Cipher createCipher(int cipherMode, byte[] key, String cipher, SecretKey sKey, String userJdkProvider)
+            throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException,
+            InvalidAlgorithmParameterException, NoSuchProviderException {
 
         Cipher ci = null;
-        ci = (provider == null) ? Cipher.getInstance(cipher) : Cipher.getInstance(cipher, provider);
+
+        if (userJdkProvider == null){
+            ci = (provider == null) ? Cipher.getInstance(cipher) : Cipher.getInstance(cipher, provider);
+        }else{
+            ci = Cipher.getInstance(cipher, userJdkProvider);
+        }
 
         if (cipher.indexOf("ECB") == -1) {
             if (cipher.indexOf("AES") != -1) {
@@ -660,18 +700,34 @@ final class LTPACrypto {
         return ci.doFinal(data);
     }
 
-    /**
+
+      /**
      * Decrypt the specified msg.
      *
-     * @param msg    The byte representation of the data
-     * @param key    The key used to decrypt the data
-     * @param cipher The cipher algorithm
+     * @param msg              The byte representation of the data
+     * @param key              The key used to decrypt the data
+     * @param cipher            The cipher algorithm
+     * @param userJdkProvider    The JDK provider to be used to decrypt the LTPA key
      * @return The decrypted data (plaintext)
      */
     @Trivial
     protected static final byte[] decrypt(byte[] msg, byte[] key, String cipher) throws Exception {
-        SecretKey sKey = constructSecretKey(key, cipher);
-        Cipher ci = createCipher(Cipher.DECRYPT_MODE, key, cipher, sKey);
+        return decrypt(msg, key, cipher, null);
+    }
+
+    /**
+     * Decrypt the specified msg.
+     *
+     * @param msg              The byte representation of the data
+     * @param key              The key used to decrypt the data
+     * @param cipher            The cipher algorithm
+     * @param userJdkProvider    The JDK provider to be used to decrypt the LTPA key
+     * @return The decrypted data (plaintext)
+     */
+    @Trivial
+    protected static final byte[] decrypt(byte[] msg, byte[] key, String cipher, String userJdkProvider) throws Exception {
+        SecretKey sKey = constructSecretKey(key, cipher, userJdkProvider);
+        Cipher ci = createCipher(Cipher.DECRYPT_MODE, key, cipher, sKey, userJdkProvider);
         return ci.doFinal(msg);
     }
 

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -619,6 +619,7 @@ final class LTPACrypto {
                 : SecretKeyFactory.getInstance(encryptAlgorithm, provider);
             }
             else{
+                System.out.println("UserJDK Provider specified"+ userJdkProvider);
                 kFact = SecretKeyFactory.getInstance(encryptAlgorithm, userJdkProvider);
             }
 
@@ -664,6 +665,7 @@ final class LTPACrypto {
         if (userJdkProvider == null){
             ci = (provider == null) ? Cipher.getInstance(cipher) : Cipher.getInstance(cipher, provider);
         }else{
+            System.out.println("UserJDK Provider specified"+ userJdkProvider);
             ci = Cipher.getInstance(cipher, userJdkProvider);
         }
 

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyFileUtilityImpl.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPAKeyFileUtilityImpl.java
@@ -36,7 +36,7 @@ public class LTPAKeyFileUtilityImpl implements LTPAKeyFileUtility {
         return ltpaProps;
     }
 
-    /**
+       /**
      * Generates the LTPA keys and stores them into a Properties object.
      *
      * @param keyPasswordBytes
@@ -45,6 +45,18 @@ public class LTPAKeyFileUtilityImpl implements LTPAKeyFileUtility {
      * @throws Exception
      */
     protected final Properties generateLTPAKeys(byte[] keyPasswordBytes, final String realm) throws Exception {
+        return generateLTPAKeys(keyPasswordBytes, realm, null);
+    }
+
+    /**
+     * Generates the LTPA keys and stores them into a Properties object.
+     *
+     * @param keyPasswordBytes
+     * @param realm
+     * @return
+     * @throws Exception
+     */
+    protected final Properties generateLTPAKeys(byte[] keyPasswordBytes, final String realm, String userJdkProvider) throws Exception {
         Properties expProps = null;
 
         try {

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -8,6 +8,7 @@
 * SPDX-License-Identifier: EPL-2.0
 *******************************************************************************/
 package com.ibm.ws.common.crypto;
+
 import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -40,10 +40,17 @@ public class CryptoUtils {
     public static boolean ibmJCEPlusFIPSAvailable = false;
     public static boolean openJCEPlusAvailable = false;
     public static boolean openJCEPlusFIPSAvailable = false;
+    //Alternative
+    public static boolean ibmJCECCAAvailable = false;
+    public static boolean ibmJCEHYBRIDAvailable = false;
+    
     public static boolean ibmJCEProviderChecked = false;
     public static boolean ibmJCEPlusFIPSProviderChecked = false;
     public static boolean openJCEPlusProviderChecked = false;
     public static boolean openJCEPlusFIPSProviderChecked = false;
+    //Alternative
+    public static boolean ibmJCECCAProviderChecked = false;
+    public static boolean ibmJCEHYBRIDProviderChecked = false;
 
     public static boolean unitTest = false;
     public static boolean fipsChecked = false;
@@ -62,11 +69,18 @@ public class CryptoUtils {
     public static String IBMJCE_PLUS_FIPS_PROVIDER = "com.ibm.crypto.plus.provider.IBMJCEPlusFIPS";
     public static String OPENJCE_PLUS_PROVIDER = "com.ibm.crypto.plus.provider.OpenJCEPlus";
     public static String OPENJCE_PLUS_FIPS_PROVIDER = "com.ibm.crypto.plus.provider.OpenJCEPlusFIPS";
+    //Alternative
+    //jdk 8 and semeru 17
+    public static String IBMJCEHYBRID_PROVIDER = "com.ibm.crypto.ibmjcehybrid.provider";
+    public static String IBMJCECCA_PROVIDER = "com.ibm.crypto.hdwrCCA.provider";
 
     public static final String IBMJCE_NAME = "IBMJCE";
     public static final String IBMJCE_PLUS_FIPS_NAME = "IBMJCEPlusFIPS";
     public static final String OPENJCE_PLUS_NAME = "OpenJCEPlus";
     public static final String OPENJCE_PLUS_FIPS_NAME = "OpenJCEPlusFIPS";
+    //Alternative
+    private static final String HW_PROVIDER = "IBMJCECCA";
+    private static final String HW_HYBRID_PROVIDER = "IBMJCEHYBRID";
 
     public static final String USE_FIPS_PROVIDER = "com.ibm.jsse2.usefipsprovider";
     public static final String USE_FIPS_PROVIDER_NAME = "com.ibm.jsse2.usefipsProviderName";
@@ -203,6 +217,27 @@ public class CryptoUtils {
         }
     }
 
+    //Alternative
+    public static boolean isIBMJCECCAAvailable() {
+        if (ibmJCECCAProviderChecked) {
+            return ibmJCECCAAvailable;
+        } else {
+            ibmJCECCAAvailable = JavaInfo.isSystemClassAvailable(IBMJCECCA_PROVIDER);
+            ibmJCECCAProviderChecked = true;
+            return ibmJCECCAAvailable;
+        }
+    }
+
+    public static boolean isIBMJCEHybridAvailable() {
+        if (ibmJCEHYBRIDProviderChecked) {
+            return ibmJCEHYBRIDAvailable;
+        } else {
+            ibmJCEHYBRIDAvailable = JavaInfo.isSystemClassAvailable(IBMJCEHYBRID_PROVIDER);
+            ibmJCEHYBRIDProviderChecked = true;
+            return ibmJCEHYBRIDAvailable;
+        }
+    }
+
     public static boolean isOpenJCEPlusFIPSAvailable() {
         if (openJCEPlusFIPSProviderChecked) {
             return openJCEPlusFIPSAvailable;
@@ -273,6 +308,25 @@ public class CryptoUtils {
             provider = OPENJCE_PLUS_NAME;
         } else if (isIBMJCEAvailable()) {
             provider = IBMJCE_NAME;
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            if (provider != null) {
+                Tr.debug(tc, "Provider configured is " + provider);
+            } else {
+                Tr.debug(tc, "Provider configured by JDK is " + (Security.getProviders() != null ? Security.getProviders()[0].getName() : "NULL"));
+            }
+        }
+        return provider;
+    }
+
+    //Alternative
+    public static String getHyridHardwareProvider() {
+        String provider = null;
+         if (isIBMJCECCAAvailable()) {
+            provider = HW_PROVIDER;
+        } else if (isIBMJCEHybridAvailable()) {
+            provider = HW_HYBRID_PROVIDER;
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -8,7 +8,6 @@
 * SPDX-License-Identifier: EPL-2.0
 *******************************************************************************/
 package com.ibm.ws.common.crypto;
-
 import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2023 IBM Corporation and others.
+# Copyright (c) 2011, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/l10n/metatype.properties
@@ -46,6 +46,9 @@ authFilterRef=Authentication Filter Reference
 authFilterRef$Ref=Authentication filter reference
 authFilterRef.desc=Specifies the authentication filter reference. 
 
+useJdkProvider=Use JDK provider for managing the LTPA keys
+useJdkProvider.desc=Specifies if the JDK Provider will be used for managing the LTPA keys. 
+
 validationKeys=LTPA Validation Keys
 validationKeys.desc=The LTPA keys that are used only for validating existing LTPA tokens, not for creating new LTPA tokens.
 

--- a/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/l10n/metatype.properties
@@ -46,8 +46,8 @@ authFilterRef=Authentication Filter Reference
 authFilterRef$Ref=Authentication filter reference
 authFilterRef.desc=Specifies the authentication filter reference. 
 
-useJdkProvider=Use JDK provider for managing the LTPA keys
-useJdkProvider.desc=Specifies if the JDK Provider will be used for managing the LTPA keys. 
+provider=The JDK provider to be used to manage the LTPA Keys.
+provider.desc=Specifies the JDK provider to be used to manage the LTPA Keys. 
 
 validationKeys=LTPA Validation Keys
 validationKeys.desc=The LTPA keys that are used only for validating existing LTPA tokens, not for creating new LTPA tokens.

--- a/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/l10n/metatype.properties
@@ -46,7 +46,7 @@ authFilterRef=Authentication Filter Reference
 authFilterRef$Ref=Authentication filter reference
 authFilterRef.desc=Specifies the authentication filter reference. 
 
-provider=The JDK provider to be used to manage the LTPA Keys.
+provider=The JDK provider to be used to manage the LTPA Keys
 provider.desc=Specifies the JDK provider to be used to manage the LTPA Keys. 
 
 validationKeys=LTPA Validation Keys

--- a/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/metatype/metatype.xml
@@ -48,6 +48,8 @@
         <AD id="expirationDifferenceAllowed" name="internal" description="internal use only"
             required="false" type="String" ibm:type="duration(ms)" 
             default="3000ms" /> 
+        <AD id="useJdkProvider" name="%useJdkProvider" description="%useJdkProvider.desc"
+            required="false" type="String" default="" />
         <AD id="validationKeys" ibm:type="pid" ibm:reference="com.ibm.ws.security.token.ltpa.validationKeys" 
            	required="false" type="String" 
             ibm:flat="true" cardinality="2147483647"/>        

--- a/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/metatype/metatype.xml
@@ -48,7 +48,7 @@
         <AD id="expirationDifferenceAllowed" name="internal" description="internal use only"
             required="false" type="String" ibm:type="duration(ms)" 
             default="3000ms" /> 
-        <AD id="useJdkProvider" name="%useJdkProvider" description="%useJdkProvider.desc"
+        <AD id="provider" name="%provider" description="%provider.desc"
             required="false" type="String" default="" />
         <AD id="validationKeys" ibm:type="pid" ibm:reference="com.ibm.ws.security.token.ltpa.validationKeys" 
            	required="false" type="String" 

--- a/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.token.ltpa/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2023 IBM Corporation and others.
+    Copyright (c) 2011, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAConfiguration.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -127,5 +127,9 @@ public interface LTPAConfiguration {
      * @return validation Keys
      */
     List<Properties> getValidationKeys();
-    
+
+    /**
+     * @return string for
+     */
+    public String getUserJdkProvider();
 }

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAKeyInfoManager.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAKeyInfoManager.java
@@ -121,8 +121,24 @@ public class LTPAKeyInfoManager {
     @SuppressWarnings("deprecation")
     public synchronized final void prepareLTPAKeyInfo(WsLocationAdmin locService, String primaryKeyImportFile, @Sensitive byte[] primaryKeyPassword,
                                                       @Sensitive List<Properties> validationKeys) throws Exception {
+     prepareLTPAKeyInfo(locService, primaryKeyImportFile, primaryKeyPassword, validationKeys);
+    }
+
+        /**
+     * Loads the contents of the primary/validation LTPA key import file if necessary.
+     *
+     * @param primaryKeyImportFile The URL of the key import file. If it's not the URL, it is assumed as a relative path from
+     *                                 ${app.root}/config
+     * @param primaryKeyPassword   The password of the LTPA keys
+     * @param validationKeys       The validationKeys
+     * @param userJdkProvider       The JDK provider to be used to decrypt the LTPA key
+     * @throws IOException
+     */
+    @SuppressWarnings("deprecation")
+    public synchronized final void prepareLTPAKeyInfo(WsLocationAdmin locService, String primaryKeyImportFile, @Sensitive byte[] primaryKeyPassword,
+                                                      @Sensitive List<Properties> validationKeys, String userJdkProvider) throws Exception {
         if (!this.importFileCache.contains(primaryKeyImportFile)) {
-            loadLtpaKeysFile(locService, primaryKeyImportFile, primaryKeyPassword, false, null);
+            loadLtpaKeysFile(locService, primaryKeyImportFile, primaryKeyPassword, false, null, userJdkProvider);
         }
         if (validationKeys != null && !validationKeys.isEmpty()) {
             ltpaValidationKeysInfos.clear();
@@ -147,7 +163,7 @@ public class LTPAKeyInfoManager {
                     }
 
                     byte[] password = getKeyPasswordBytes(vKeys);
-                    loadLtpaKeysFile(locService, filename, password, true, validUntilDateOdt);
+                    loadLtpaKeysFile(locService, filename, password, true, validUntilDateOdt, userJdkProvider);
                 }
             }
         }
@@ -202,7 +218,7 @@ public class LTPAKeyInfoManager {
      * @throws Exception
      */
     private void loadLtpaKeysFile(WsLocationAdmin locService, String keyImportFile, byte[] keyPassword, boolean validationKey,
-                                  OffsetDateTime validUntilDateOdt) throws IOException, Exception {
+                                  OffsetDateTime validUntilDateOdt, String userJdkProvider) throws IOException, Exception {
         // Need to load the key import file
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(this, tc, "Loading LTPA " + (validationKey == true ? "validation" : "primary") + "Keys file: " + keyImportFile);
@@ -244,7 +260,12 @@ public class LTPAKeyInfoManager {
                 throw new IllegalArgumentException(formattedMessage);
             } else {
                 byte[] keyEncoded = Base64Coder.base64DecodeString(secretKeyStr);
-                secretKey = encryptor.decrypt(keyEncoded);
+                if (userJdkProvider != null){
+                    secretKey = encryptor.decrypt(keyEncoded, userJdkProvider);
+                }
+                else{
+                    secretKey = encryptor.decrypt(keyEncoded);
+                }
             }
             // Private key
             if ((privateKeyStr == null) || (privateKeyStr.length() == 0)) {
@@ -253,7 +274,12 @@ public class LTPAKeyInfoManager {
                 throw new IllegalArgumentException(formattedMessage);
             } else {
                 byte[] keyEncoded = Base64Coder.base64DecodeString(privateKeyStr);
+                if (userJdkProvider != null){
+                    privateKey = encryptor.decrypt(keyEncoded, userJdkProvider);
+                }
+                else{
                 privateKey = encryptor.decrypt(keyEncoded);
+                }
             }
             // Public key
             if ((publicKeyStr == null) || (publicKeyStr.length() == 0)) {

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAKeyInfoManager.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAKeyInfoManager.java
@@ -237,6 +237,9 @@ public class LTPAKeyInfoManager {
             Tr.info(tc, "LTPA_CREATE_KEYS_START");
 
             LTPAKeyFileCreator creator = new LTPAKeyFileCreatorImpl();
+            if(userJdkProvider!=null){
+                props = creator.createLTPAKeysFile(locService, keyImportFile, keyPassword, userJdkProvider);
+            }
             props = creator.createLTPAKeysFile(locService, keyImportFile, keyPassword);
 
             Tr.audit(tc, "LTPA_CREATE_KEYS_COMPLETE", TimestampUtils.getElapsedTime(start), keyImportFile);

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAKeyInfoManager.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/LTPAKeyInfoManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -121,7 +121,7 @@ public class LTPAKeyInfoManager {
     @SuppressWarnings("deprecation")
     public synchronized final void prepareLTPAKeyInfo(WsLocationAdmin locService, String primaryKeyImportFile, @Sensitive byte[] primaryKeyPassword,
                                                       @Sensitive List<Properties> validationKeys) throws Exception {
-     prepareLTPAKeyInfo(locService, primaryKeyImportFile, primaryKeyPassword, validationKeys);
+        prepareLTPAKeyInfo(locService, primaryKeyImportFile, primaryKeyPassword, validationKeys, null);
     }
 
         /**

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -754,7 +754,7 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
 
     /** {@inheritDoc} */
     @Override
-    public String getuserJdkProvider() {
+    public String getUserJdkProvider() {
         return userJdkProvider;
     }
 

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
@@ -73,6 +73,7 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
     static final String DEFAULT_OUTPUT_LOCATION = "${server.output.dir}/resources/security/ltpa.keys";
     static final String KEY_AUTH_FILTER_REF = "authFilterRef";
     static final String KEY_EXP_DIFF_ALLOWED = "expirationDifferenceAllowed";
+    static final String USE_JDK_PROVIDER ="useJdkProvider";
     static protected final String KEY_SERVICE_PID = "service.pid";
     private final AtomicServiceReference<WsLocationAdmin> locationService = new AtomicServiceReference<WsLocationAdmin>(KEY_LOCATION_SERVICE);
     private final AtomicServiceReference<ExecutorService> executorService = new AtomicServiceReference<ExecutorService>(KEY_EXECUTOR_SERVICE);
@@ -96,6 +97,7 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
     private String authFilterRef;
     private long expirationDifferenceAllowed;
     private boolean monitorValidationKeysDir;
+    private boolean useJDKProvider;
     private String updateTrigger;
     private final List<Properties> validationKeys = new ArrayList<Properties>();
     // configValidationKeys are specified in the server xml configuration
@@ -196,6 +198,7 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
         // expirationDifferenceAllowed is set to 3 seconds (3000ms) by default.
         // If expirationDifferenceAllowed is set to less than 0, then the two expiration values will not be compared in the LTPAToken2.decrypt() method.
         expirationDifferenceAllowed = (Long) props.get(KEY_EXP_DIFF_ALLOWED);
+        useJDKProvider = (Boolean) props.get(USE_JDK_PROVIDER);
         monitorValidationKeysDir = (Boolean) props.get(CFG_KEY_MONITOR_VALIDATION_KEYS_DIR);
         updateTrigger = (String) props.get(CFG_KEY_UPDATE_TRIGGER);
 
@@ -747,6 +750,12 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
     @Override
     public long getExpirationDifferenceAllowed() {
         return expirationDifferenceAllowed;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean getUseJDKProvider() {
+        return useJDKProvider;
     }
 
     /**

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAConfigurationImpl.java
@@ -73,7 +73,7 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
     static final String DEFAULT_OUTPUT_LOCATION = "${server.output.dir}/resources/security/ltpa.keys";
     static final String KEY_AUTH_FILTER_REF = "authFilterRef";
     static final String KEY_EXP_DIFF_ALLOWED = "expirationDifferenceAllowed";
-    static final String USE_JDK_PROVIDER ="useJdkProvider";
+    static final String USER_JDK_PROVIDER ="provider";
     static protected final String KEY_SERVICE_PID = "service.pid";
     private final AtomicServiceReference<WsLocationAdmin> locationService = new AtomicServiceReference<WsLocationAdmin>(KEY_LOCATION_SERVICE);
     private final AtomicServiceReference<ExecutorService> executorService = new AtomicServiceReference<ExecutorService>(KEY_EXECUTOR_SERVICE);
@@ -97,7 +97,7 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
     private String authFilterRef;
     private long expirationDifferenceAllowed;
     private boolean monitorValidationKeysDir;
-    private boolean useJDKProvider;
+    private String userJdkProvider;
     private String updateTrigger;
     private final List<Properties> validationKeys = new ArrayList<Properties>();
     // configValidationKeys are specified in the server xml configuration
@@ -198,7 +198,7 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
         // expirationDifferenceAllowed is set to 3 seconds (3000ms) by default.
         // If expirationDifferenceAllowed is set to less than 0, then the two expiration values will not be compared in the LTPAToken2.decrypt() method.
         expirationDifferenceAllowed = (Long) props.get(KEY_EXP_DIFF_ALLOWED);
-        useJDKProvider = (Boolean) props.get(USE_JDK_PROVIDER);
+        userJdkProvider = (String) props.get(USER_JDK_PROVIDER);
         monitorValidationKeysDir = (Boolean) props.get(CFG_KEY_MONITOR_VALIDATION_KEYS_DIR);
         updateTrigger = (String) props.get(CFG_KEY_UPDATE_TRIGGER);
 
@@ -754,8 +754,8 @@ public class LTPAConfigurationImpl implements LTPAConfiguration, FileBasedAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean getUseJDKProvider() {
-        return useJDKProvider;
+    public String getuserJdkProvider() {
+        return userJdkProvider;
     }
 
     /**

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAKeyCreateTask.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAKeyCreateTask.java
@@ -54,9 +54,16 @@ class LTPAKeyCreateTask implements Runnable {
 
     private LTPAKeyInfoManager getPreparedLtpaKeyInfoManager() throws Exception {
         LTPAKeyInfoManager keyInfoManager = new LTPAKeyInfoManager();
+        if (config.getuserJdkProvider().isEmpty()){
         keyInfoManager.prepareLTPAKeyInfo(locService,
                                           config.getPrimaryKeyFile(),
                                           getKeyPasswordBytes(), config.getValidationKeys());
+        }
+        else{
+            keyInfoManager.prepareLTPAKeyInfo(locService,
+            config.getPrimaryKeyFile(),
+            getKeyPasswordBytes(), config.getValidationKeys(), config.getuserJdkProvider());
+        }
         return keyInfoManager;
     }
 

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAKeyCreateTask.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAKeyCreateTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -54,7 +54,7 @@ class LTPAKeyCreateTask implements Runnable {
 
     private LTPAKeyInfoManager getPreparedLtpaKeyInfoManager() throws Exception {
         LTPAKeyInfoManager keyInfoManager = new LTPAKeyInfoManager();
-        if (config.getuserJdkProvider().isEmpty()){
+        if (config.getUserJdkProvider().isEmpty()){
         keyInfoManager.prepareLTPAKeyInfo(locService,
                                           config.getPrimaryKeyFile(),
                                           getKeyPasswordBytes(), config.getValidationKeys());
@@ -62,7 +62,7 @@ class LTPAKeyCreateTask implements Runnable {
         else{
             keyInfoManager.prepareLTPAKeyInfo(locService,
             config.getPrimaryKeyFile(),
-            getKeyPasswordBytes(), config.getValidationKeys(), config.getuserJdkProvider());
+            getKeyPasswordBytes(), config.getValidationKeys(), config.getUserJdkProvider());
         }
         return keyInfoManager;
     }

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAKeyFileCreator.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAKeyFileCreator.java
@@ -36,5 +36,19 @@ public interface LTPAKeyFileCreator extends LTPAKeyFileUtility {
      * @throws Exception
      */
     public Properties createLTPAKeysFile(WsLocationAdmin locService, String keyFile, @Sensitive byte[] keyPasswordBytes) throws Exception;
+    /**
+     * Create the LTPA keys file at the specified location using
+     * the specified password bytes.
+     * <p>
+     * Access the keyFile using the WsLocationAdmin
+     *
+     * @param locService
+     * @param keyFile
+     * @param keyPasswordBytes
+     * @param userJdkProvider
+     * @return A Properties object containing the various attributes created for the LTPA keys
+     * @throws Exception
+     */
+    public Properties createLTPAKeysFile(WsLocationAdmin locService, String keyFile, @Sensitive byte[] keyPasswordBytes, String userJdkProvider) throws Exception;
 
 }

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAKeyFileCreatorImpl.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAKeyFileCreatorImpl.java
@@ -61,7 +61,13 @@ public class LTPAKeyFileCreatorImpl extends LTPAKeyFileUtilityImpl implements LT
     /** {@inheritDoc} */
     @Override
     public Properties createLTPAKeysFile(WsLocationAdmin locService, String keyFile, @Sensitive byte[] keyPasswordBytes) throws Exception {
-        Properties ltpaProps = generateLTPAKeys(keyPasswordBytes, getRealmName());
+        return createLTPAKeysFile(locService,keyFile,keyPasswordBytes,null );
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Properties createLTPAKeysFile(WsLocationAdmin locService, String keyFile, @Sensitive byte[] keyPasswordBytes, String userJdkProvider) throws Exception {
+        Properties ltpaProps = (userJdkProvider != null)? generateLTPAKeys(keyPasswordBytes, getRealmName(),userJdkProvider):generateLTPAKeys(keyPasswordBytes, getRealmName());
         addLTPAKeysToFile(getOutputStream(locService, keyFile), ltpaProps);
         return ltpaProps;
     }

--- a/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/FATTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/FATTest.java
@@ -65,6 +65,7 @@ public class FATTest {
     private static String ALTERNATE_SERVER_XML = "alternate/server.xml";
     private static String ALTERNATE_SERVER_XML_BAD_PROVIDER = "alternate/serverWithBadProvider.xml";
     private static String ALTERNATE_SERVER_XML_FIPS = "alternateFIPS/server.xml";
+    private static String ALTERNATE_SERVER_XML_WITH_JCE_PROVIDER = "alternate/serverWithJCEProvider.xml";
     private static String ALTERNATE_SERVER_XML_FIPS_BAD_PROVIDER = "alternateFIPS/serverWithBadProvider.xml";
     private static String ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR = "alternate/serverWithLTPAFileMonitor.xml";
     private static String ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR_FIPS = "alternateFIPS/serverWithLTPAFileMonitor.xml";
@@ -167,6 +168,19 @@ public class FATTest {
         assertFileWasCreated(DEFAULT_KEY_PATH);
     }
 
+        /**
+     * Validate that the LTPA service will generate a default LTPA key file
+     * if the LTPA key file does not exist.
+     */
+    @CheckForLeakedPasswords({ PWD_DEFAULT, PWD_DEFAULT_ENCODED })
+    @Test
+    public void genDefaultLTPAKeyFileWithJCEProvider() throws Exception {
+        startServerWithConfigFileAndLog(ALTERNATE_SERVER_XML_WITH_JCE_PROVIDER, "genDefaultLTPAKeyFile.log");
+        assertFeatureCompleteWithKeysGeneratedAndTestApp(DEFAULT_KEY_PATH);
+        assertTokenCanBeCreated();
+        assertFileWasCreated(DEFAULT_KEY_PATH);
+    }
+
     /**
      * Validate that the LTPA service will generate a default LTPA key file
      * if the LTPA key file does not exist.
@@ -215,6 +229,27 @@ public class FATTest {
     }
 
     /**
+     * Validate that the LTPA service will generate the LTPA key file
+     * if the LTPA key file does not exist (and it is not the default
+     * key file name).
+     */
+    @CheckForLeakedPasswords({ PWD_DEFAULT, PWD_DEFAULT_ENCODED })
+    @Test
+    public void genAlternateLTPAKeyFileWithoutRestartWithJCEProvider() throws Exception {
+        startServerWithConfigFileAndLog(ALTERNATE_SERVER_XML_WITH_JCE_PROVIDER, "genAlternateLTPAKeyFile.log");
+        assertFeatureCompleteWithKeysGeneratedAndTestApp(DEFAULT_KEY_PATH);
+        assertTokenCanBeCreated();
+        assertFileWasCreated(DEFAULT_KEY_PATH);
+
+        // NOW change to the alternate file
+        server.setMarkToEndOfLog();
+        server.setServerConfigurationFile(ALTERNATE_SERVER_XML);
+        assertKeysGenerated(ALTERNATE_KEY_PATH);
+
+        // Check to see if the file has been regenerated
+        assertFileWasCreated(ALTERNATE_KEY_PATH);
+    }
+    /**
      * Validate that the LTPA keys are reloaded after modifying the LTPA keys file.
      */
     @CheckForLeakedPasswords({ PWD_DEFAULT, PWD_ANOTHER, PWD_ANY_ENCODED })
@@ -222,6 +257,28 @@ public class FATTest {
     public void validateKeysReloadedAfterModification() throws Exception {
         try {
             startServerWithConfigFileAndLog(DEFAULT_SERVER_XML, "validateKeysReloadedAfterModification.log");
+            assertFeatureCompleteWithLTPAConfigAndTestApp();
+            assertTokenCanBeCreated();
+            replaceLTPAKeysFile(ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR, REPLACEMENT_LTPA_KEYS_PATH);
+            assertLTPAConfigurationReady();
+            assertAppDoesNotRestart();
+
+            // Assert token can be created with new keys
+            assertTokenCanBeCreated();
+        } finally {
+            // Clean up
+            replaceLTPAKeysFile(DEFAULT_SERVER_XML, REPLACEMENT_LTPA_KEYS_PATH);
+        }
+    }
+
+    /**
+     * Validate that the LTPA keys are reloaded after modifying the LTPA keys file.
+     */
+    @CheckForLeakedPasswords({ PWD_DEFAULT, PWD_ANOTHER, PWD_ANY_ENCODED })
+    @Test
+    public void validateKeysReloadedAfterModificationWithJCEProvider() throws Exception {
+        try {
+            startServerWithConfigFileAndLog(ALTERNATE_SERVER_XML_WITH_JCE_PROVIDER, "validateKeysReloadedAfterModification.log");
             assertFeatureCompleteWithLTPAConfigAndTestApp();
             assertTokenCanBeCreated();
             replaceLTPAKeysFile(ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR, REPLACEMENT_LTPA_KEYS_PATH);

--- a/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/FATTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/FATTest.java
@@ -63,8 +63,9 @@ public class FATTest {
     private static final String CORRUPTED_LTPA_KEYS_PATH = "corrupted/ltpa.keys";
     private static final String DEFAULT_SERVER_XML = "server.xml";
     private static String ALTERNATE_SERVER_XML = "alternate/server.xml";
-    private static final String ALTERNATE_SERVER_XML_BAD_PROVIDER = "alternate/serverWithBadProvider.xml";
+    private static String ALTERNATE_SERVER_XML_BAD_PROVIDER = "alternate/serverWithBadProvider.xml";
     private static String ALTERNATE_SERVER_XML_FIPS = "alternateFIPS/server.xml";
+    private static String ALTERNATE_SERVER_XML_FIPS_BAD_PROVIDER = "alternateFIPS/serverWithBadProvider.xml";
     private static String ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR = "alternate/serverWithLTPAFileMonitor.xml";
     private static String ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR_FIPS = "alternateFIPS/serverWithLTPAFileMonitor.xml";
     private static String ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR_AND_WRONG_PASSWORD = "alternate/serverWithLTPAFileMonitorAndWrongPassword.xml";
@@ -104,6 +105,7 @@ public class FATTest {
             ALTERNATE_KEY_PATH = ALTERNATE_KEY_PATH_FIPS;
             REPLACEMENT_LTPA_KEYS_PATH = REPLACEMENT_FIPS_LTPA_KEYS_PATH;
             ALTERNATE_SERVER_XML = ALTERNATE_SERVER_XML_FIPS;
+            ALTERNATE_SERVER_XML_BAD_PROVIDER = ALTERNATE_SERVER_XML_FIPS_BAD_PROVIDER;
             ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR = ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR_FIPS;
             ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR_AND_WRONG_PASSWORD = ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR_AND_WRONG_PASSWORD_FIPS;
         }

--- a/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/FATTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/FATTest.java
@@ -63,6 +63,7 @@ public class FATTest {
     private static final String CORRUPTED_LTPA_KEYS_PATH = "corrupted/ltpa.keys";
     private static final String DEFAULT_SERVER_XML = "server.xml";
     private static String ALTERNATE_SERVER_XML = "alternate/server.xml";
+    private static final String ALTERNATE_SERVER_XML_BAD_PROVIDER = "alternate/serverWithBadProvider.xml";
     private static String ALTERNATE_SERVER_XML_FIPS = "alternateFIPS/server.xml";
     private static String ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR = "alternate/serverWithLTPAFileMonitor.xml";
     private static String ALTERNATE_SERVER_XML_WITH_LTPA_FILE_MONITOR_FIPS = "alternateFIPS/serverWithLTPAFileMonitor.xml";
@@ -162,6 +163,17 @@ public class FATTest {
         assertFeatureCompleteWithKeysGeneratedAndTestApp(DEFAULT_KEY_PATH);
         assertTokenCanBeCreated();
         assertFileWasCreated(DEFAULT_KEY_PATH);
+    }
+
+    /**
+     * Validate that the LTPA service will generate a default LTPA key file
+     * if the LTPA key file does not exist.
+     */
+    @CheckForLeakedPasswords({ PWD_DEFAULT, PWD_DEFAULT_ENCODED })
+    @ExpectedFFDC("java.security.NoSuchProviderException")
+    @Test
+    public void genDefaultLTPAKeyFileBadProvider() throws Exception {
+        startServerWithConfigFileAndLogBadProvider(ALTERNATE_SERVER_XML_BAD_PROVIDER, "genDefaultLTPAKeyFileBadProvider.log");
     }
 
     /**
@@ -432,6 +444,20 @@ public class FATTest {
         // Wait for the LTPA configuration to be ready
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
                       server.waitForStringInLog("CWWKS4105I"));
+    }
+
+    private void startServerWithConfigFileAndLogBadProvider(String configFile, String logFileName) throws Exception {
+        server.setServerConfigurationFile(configFile);
+
+        server.startServer(logFileName);
+
+        assertNotNull("Featurevalid did not report update was complete",
+                      server.waitForStringInLog("CWWKF0008I"));
+        assertNotNull("The application did not report is was started",
+                      server.waitForStringInLog("CWWKZ0001I"));
+        // Wait for the LTPA configuration to be ready
+        assertNotNull("The LTPA configuration must not be reloaded.",
+        server.waitForStringInLog("CWWKS4106E:.*"));
     }
 
     /**

--- a/dev/com.ibm.ws.security.token.ltpa_fat/publish/files/alternate/serverWithBadProvider.xml
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/publish/files/alternate/serverWithBadProvider.xml
@@ -1,0 +1,36 @@
+<server>
+
+    <!-- Enable features -->
+	<featureManager>
+        <feature>appSecurity-2.0</feature>
+        <feature>jsp-2.2</feature>
+		<feature>ltpafattestlibertyinternals-1.0</feature>
+		<feature>servlet-3.1</feature>
+    </featureManager>
+    
+    <ltpa provider="BAD_PROVIDER" keysFileName="${server.config.dir}/resources/security/alternate/testLtpa.keys"/>
+
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
+
+    <basicRegistry id="basic" realm="BasicRealm">
+        <user name="user1" password="user1pwd" />
+        <group name="group1">
+            <member name="user1"/>
+        </group>
+    </basicRegistry>
+
+	<application type="war" id="ltpaTest" name="ltpaTest" location="${server.config.dir}/apps/ltpaTest.war"/>
+
+	<include optional="true" location="../fatTestPorts.xml"/>
+
+    <authentication id="Basic" cacheEnabled="false" />
+    <javaPermission className="javax.security.auth.AuthPermission" name="createLoginContext.system.WEB_INBOUND"/>
+    <javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getCallerSubject"/>
+    <javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getRunAsSubject"/>
+    <javaPermission className="javax.security.auth.PrivateCredentialPermission" signedBy="com.ibm.ws.security.token.internal.SingleSignonTokenImpl" principalType="com.ibm.ws.security.authentication.principals.WSPrincipal" principalName="*" actions="read"/>
+
+    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
+    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+
+</server>

--- a/dev/com.ibm.ws.security.token.ltpa_fat/publish/files/alternate/serverWithJCEProvider.xml
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/publish/files/alternate/serverWithJCEProvider.xml
@@ -1,0 +1,36 @@
+<server>
+
+    <!-- Enable features -->
+	<featureManager>
+        <feature>appSecurity-2.0</feature>
+        <feature>jsp-2.2</feature>
+		<feature>ltpafattestlibertyinternals-1.0</feature>
+		<feature>servlet-3.1</feature>
+    </featureManager>
+    
+    <ltpa provider = "SunJCE"/>
+
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
+
+    <basicRegistry id="basic" realm="BasicRealm">
+        <user name="user1" password="user1pwd" />
+        <group name="group1">
+            <member name="user1"/>
+        </group>
+    </basicRegistry>
+
+	<application type="war" id="ltpaTest" name="ltpaTest" location="${server.config.dir}/apps/ltpaTest.war"/>
+
+	<include optional="true" location="../fatTestPorts.xml"/>
+
+    <authentication id="Basic" cacheEnabled="false" />
+    <javaPermission className="javax.security.auth.AuthPermission" name="createLoginContext.system.WEB_INBOUND"/>
+    <javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getCallerSubject"/>
+    <javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getRunAsSubject"/>
+    <javaPermission className="javax.security.auth.PrivateCredentialPermission" signedBy="com.ibm.ws.security.token.internal.SingleSignonTokenImpl" principalType="com.ibm.ws.security.authentication.principals.WSPrincipal" principalName="*" actions="read"/>
+
+    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
+    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+
+</server>

--- a/dev/com.ibm.ws.security.token.ltpa_fat/publish/files/alternateFIPS/serverWithBadProvider.xml
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/publish/files/alternateFIPS/serverWithBadProvider.xml
@@ -1,0 +1,40 @@
+<server>
+
+    <!-- Enable features -->
+	<featureManager>
+        <feature>appSecurity-2.0</feature>
+        <feature>jsp-2.2</feature>
+		<feature>ltpafattestlibertyinternals-1.0</feature>
+		<feature>servlet-3.1</feature>
+    </featureManager>
+    
+    <ltpa provider="BAD_PROVIDER" keysFileName="${server.config.dir}/resources/security/alternateFIPS/testLtpa.keys"/>
+
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
+
+    <basicRegistry id="basic" realm="BasicRealm">
+        <user name="user1" password="user1pwd" />
+        <group name="group1">
+            <member name="user1"/>
+        </group>
+    </basicRegistry>
+
+	<application type="war" id="ltpaTest" name="ltpaTest" location="${server.config.dir}/apps/ltpaTest.war"/>
+
+	<include optional="true" location="../fatTestPorts.xml"/>
+
+    <ltpa monitorInterval = "10" monitorValidationKeysDir="true" expiration="10m" updateTrigger="polled" keysFileName="${server.config.dir}/resources/security/ltpa.keys" keysPassword="{xor}CDo9Hgw=">
+        <validationKeys fileName="configuredValidation1.keys" password="{xor}CDo9Hgw=" validUntilDate="2099-01-01T00:00:00Z"/>
+    </ltpa>
+    
+    <authentication id="Basic" cacheEnabled="false" />
+    <javaPermission className="javax.security.auth.AuthPermission" name="createLoginContext.system.WEB_INBOUND"/>
+    <javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getCallerSubject"/>
+    <javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getRunAsSubject"/>
+    <javaPermission className="javax.security.auth.PrivateCredentialPermission" signedBy="com.ibm.ws.security.token.internal.SingleSignonTokenImpl" principalType="com.ibm.ws.security.authentication.principals.WSPrincipal" principalName="*" actions="read"/>
+
+    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
+    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+
+</server>


### PR DESCRIPTION
Sometimes the LTPA key security provider might be Hardware related. This investigation is looking to see if it's possible to update the provider being used.


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
