### PR TITLE
Improve Windows performance during uninstall

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
@@ -519,9 +519,12 @@ public class ESAAdaptor extends ArchiveAdaptor {
     }
 
     // Determine there is another platform feature requires this resource
-    private static boolean requiredByPlatformFeature(File baseDir, File testFile) {
+    private static boolean requiredByPlatformFeature(File baseDir, File testFile, Map<String, ProvisioningFeatureDefinition> features) {
         try {
-            Map<String, ProvisioningFeatureDefinition> features = new Product(baseDir).getFeatureDefinitions();
+            if (features == null) {
+                features = new Product(baseDir).getFeatureDefinitions();
+            }
+
             for (ProvisioningFeatureDefinition fd : features.values()) {
                 if (fd.isKernel()) {
                     if (requiredByFile(fd, baseDir, testFile))
@@ -561,9 +564,6 @@ public class ESAAdaptor extends ArchiveAdaptor {
                     for (String loc : locs) {
                         File b = br.selectBundle(loc, fr.getSymbolicName(), fr.getVersionRange());
                         if (b != null && b.exists()) {
-//                            if (!checkDependency || !requiredByOtherFeature(br, features, b)) {
-//                                resourceMap.put(fr.getSymbolicName(), b);
-//                            }
                             if (checkDependency) {
                                 if (!requiredByOtherFeature(br, features, b)) {
                                     resourceMap.put(fr.getSymbolicName(), b);
@@ -588,15 +588,12 @@ public class ESAAdaptor extends ArchiveAdaptor {
                                 testFile = new File(baseDir, loc);
                             }
                             if (testFile.exists()) {
-//                                if (!checkDependency || !requiredByOtherFeature(features, baseDir, testFile)) {
-//                                    resourceMap.put(fr.getSymbolicName(), testFile);
-//                                }
                                 if (checkDependency) {
                                     if (!requiredByOtherFeature(features, baseDir, testFile)) {
                                         resourceMap.put(fr.getSymbolicName(), testFile);
                                     }
                                 } else {
-                                    if (targetFd.isKernel() || !requiredByPlatformFeature(baseDir, testFile)) {
+                                    if (targetFd.isKernel() || !requiredByPlatformFeature(baseDir, testFile, features)) {
                                         resourceMap.put(fr.getSymbolicName(), testFile);
                                     }
                                 }

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
@@ -359,6 +359,8 @@ public class ESAAdaptor extends ArchiveAdaptor {
     public static List<File> determineFilesToBeDeleted(ProvisioningFeatureDefinition targetFd, Map<String, ProvisioningFeatureDefinition> features, File baseDir,
                                                        String featurePath,
                                                        boolean checkDependency, Set<IFixInfo> uninstallFixInfo) {
+        // Set kernel features
+        initKernelFeatures(baseDir, features);
         // Determine the feature contents
         Map<String, File> featureContents = getUninstallFeatureContents(targetFd, features, baseDir, checkDependency);
         // Determine the bundles to remove according to the symbolic names of the uninstalling feature resources
@@ -457,12 +459,12 @@ public class ESAAdaptor extends ArchiveAdaptor {
     }
 
     /**
-     * Get list of kernel features from all features map
+     * Set list of kernel features from all features map
      *
      * @param baseDir
      * @param features
      */
-    private static ArrayList<ProvisioningFeatureDefinition> getKernelFeatures(File baseDir, Map<String, ProvisioningFeatureDefinition> features) {
+    private static void initKernelFeatures(File baseDir, Map<String, ProvisioningFeatureDefinition> features) {
         if (features == null) {
             features = new Product(baseDir).getFeatureDefinitions();
         }
@@ -471,7 +473,7 @@ public class ESAAdaptor extends ArchiveAdaptor {
             kernelFeatures = (ArrayList<ProvisioningFeatureDefinition>) features.values().stream().filter(ProvisioningFeatureDefinition::isKernel).collect(Collectors.toList());
         }
 
-        return kernelFeatures;
+        return;
 
     }
 

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -455,9 +455,26 @@ public class ESAAdaptor extends ArchiveAdaptor {
     }
 
     // Determine there is another platform feature requires this resource
-    private static boolean requiredByPlatformFeature(ContentBasedLocalBundleRepository br, File baseDir, File b) {
+//    private static boolean requiredByPlatformFeature(ContentBasedLocalBundleRepository br, File baseDir, File b) {
+//        try {
+//            Map<String, ProvisioningFeatureDefinition> features = new Product(baseDir).getFeatureDefinitions();
+//            for (ProvisioningFeatureDefinition fd : features.values()) {
+//                if (fd.isKernel()) {
+//                    if (requiredByJar(br, fd, b))
+//                        return true;
+//                }
+//            }
+//        } catch (Exception e) {
+//        }
+//        return false;
+//    }
+
+    private static boolean requiredByPlatformFeature(ContentBasedLocalBundleRepository br, File baseDir, File b, Map<String, ProvisioningFeatureDefinition> features) {
         try {
-            Map<String, ProvisioningFeatureDefinition> features = new Product(baseDir).getFeatureDefinitions();
+            if (features == null) {
+                features = new Product(baseDir).getFeatureDefinitions();
+            }
+
             for (ProvisioningFeatureDefinition fd : features.values()) {
                 if (fd.isKernel()) {
                     if (requiredByJar(br, fd, b))
@@ -552,7 +569,7 @@ public class ESAAdaptor extends ArchiveAdaptor {
                                     resourceMap.put(fr.getSymbolicName(), b);
                                 }
                             } else {
-                                if (targetFd.isKernel() || !requiredByPlatformFeature(br, baseDir, b)) {
+                                if (targetFd.isKernel() || !requiredByPlatformFeature(br, baseDir, b, features)) {
                                     resourceMap.put(fr.getSymbolicName(), b);
                                 }
                             }

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
@@ -469,7 +469,7 @@ public class ESAAdaptor extends ArchiveAdaptor {
             features = new Product(baseDir).getFeatureDefinitions();
         }
 
-        if (kernelFeatures == null) {
+        if (kernelFeatures == null || kernelFeatures.isEmpty()) {
             kernelFeatures = (ArrayList<ProvisioningFeatureDefinition>) features.values().stream().filter(ProvisioningFeatureDefinition::isKernel).collect(Collectors.toList());
         }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
1. Creating a new `features` object instead of using the existing object dropped performance in Windows machines due to high latency in File I/O operation. 
By fixing this issue, total time to run `retrieveUninstallFileList` method reduced from 2858950 ms (47 min) to 1270675 ms (21 min), which is about 26 min improvement.

2. Cache kernel features : minor improvement in  `requiredByPlatformFeature`