### PR TITLE
tests for insert and save of null record entity

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -4848,7 +4848,7 @@ public class QueryInfo {
 
         Object entity = o;
         Class<?> oClass = o.getClass();
-        if (o != null && oClass.isRecord())
+        if (oClass.isRecord())
             try {
                 Class<?> entityClass = oClass.getClassLoader() //
                                 .loadClass(oClass.getName() + "Entity");

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3921,7 +3921,6 @@ public class QueryInfo {
      *
      * @param writer writes to the introspection file.
      * @param indent indentation for lines.
-     * @return list of QueryInfo for the caller to log.
      */
     @Trivial
     public void introspect(PrintWriter writer, String indent) {
@@ -4836,11 +4835,19 @@ public class QueryInfo {
      *              or an entity that is already an entity and does not
      *              need conversion.
      * @return entity.
+     * @throws NullPointerException if the record is null, with a CWWKD1015 message
+     *                                  that is appropriate for life cycle operations
      */
     @Trivial
     final Object toEntity(Object o) {
+        if (o == null)
+            throw exc(NullPointerException.class,
+                      "CWWKD1015.null.entity.param",
+                      method.getName(),
+                      repositoryInterface.getName());
+
         Object entity = o;
-        Class<?> oClass = o == null ? null : o.getClass();
+        Class<?> oClass = o.getClass();
         if (o != null && oClass.isRecord())
             try {
                 Class<?> entityClass = oClass.getClassLoader() //

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -58,6 +58,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1009E.*storeNothing", // Save method without parameters
                                    "CWWKD1009E.*storeInDatabase", // Save method with multiple parameters
                                    "CWWKD1010E.*nameAndZipCode", // Record return type with invalid attribute name
+                                   "CWWKD1015E.*addPollingLocation", // insert null entity
+                                   "CWWKD1015E.*addOrUpdatePollingLocation", // save null entity
                                    "CWWKD1017E.*livesAt", // multiple Limit parameters
                                    "CWWKD1017E.*residesAt", // multiple PageRequest parameters
                                    "CWWKD1018E.*inhabiting", // intermixed Limit and PageRequest

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -16,6 +16,7 @@ import static jakarta.data.repository.By.ID;
 import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.List;
@@ -644,6 +645,23 @@ public class DataErrPathsTestServlet extends FATServlet {
                 !x.getMessage().startsWith("CWWKD1094E:") ||
                 !x.getMessage().contains("register") ||
                 !x.getMessage().contains("Voter[]"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an appropriate error is raised when attempting to insert a null
+     * record entity.
+     */
+    @Test
+    public void testInsertNullRecordEntity() {
+        try {
+            voters.addPollingLocation(null);
+            fail("Should not be able to insert a null entity.");
+        } catch (NullPointerException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1015E") ||
+                !x.getMessage().contains("addPollingLocation"))
                 throw x;
         }
     }
@@ -1359,6 +1377,26 @@ public class DataErrPathsTestServlet extends FATServlet {
                 x.getMessage().contains("Voters$NameAndZipCode"))
                 ; // expected
             else
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an appropriate error is raised when attempting to save a list of
+     * record entities in which one is null.
+     */
+    @Test
+    public void testSaveListWithNullRecordEntity() {
+        PollingLocation loc1 = PollingLocation
+                        .of(42, "201 4th St SE, Rochester, MN 55904", 4, 2, //
+                            LocalTime.of(7, 0), LocalTime.of(20, 0));
+        try {
+            voters.addOrUpdate(Arrays.asList(loc1, null));
+            fail("Should not be able to save a list containing a null entity.");
+        } catch (NullPointerException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1015E") ||
+                !x.getMessage().contains("addOrUpdate"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/PollingLocation.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/PollingLocation.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import java.time.LocalTime;
+
+/**
+ * A valid record entity.
+ */
+public record PollingLocation(
+                long id,
+                String address,
+                LocalTime closesAt,
+                LocalTime opensAt,
+                int precinct,
+                int ward) {
+
+    public static PollingLocation of(long id,
+                                     String address,
+                                     int ward,
+                                     int precinct,
+                                     LocalTime opensAt,
+                                     LocalTime closesAt) {
+        return new PollingLocation(id, address, closesAt, opensAt, precinct, ward);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -54,6 +54,12 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     @Insert
     Voter[] addNothing();
 
+    @Save
+    void addOrUpdate(List<PollingLocation> list);
+
+    @Insert
+    void addPollingLocation(PollingLocation loc);
+
     /**
      * Invalid method. A method with a life cycle annotation must have exactly
      * 1 parameter, not multiple.


### PR DESCRIPTION
Add tests for insert of a null record entity and save of a list of record entities containing a null entity.
Behavior should be a NullPointerException with a helpful message. We already have the NLS message written and used in other scenarios such as update or delete of null entity, but we are missing the code path for the other life cycle operations.
These test scenarios will also be helpful to get a record entity into the errorpaths bucket so that introspector output can be logged for it, although it will be a separate PR to implement that code path.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".