### PR TITLE
Remove scarf from SwaggerUI dependencies

### DIFF
--- a/dev/com.ibm.ws.openapi.ui/swagger-ui/package-lock.json
+++ b/dev/com.ibm.ws.openapi.ui/swagger-ui/package-lock.json
@@ -3138,10 +3138,11 @@
       }
     },
     "node_modules/@scarf/scarf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
-      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-      "hasInstallScript": true
+      "name": "dry-uninstall",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dry-uninstall/-/dry-uninstall-0.3.0.tgz",
+      "integrity": "sha512-b8h94RVpETWkVV59x62NsY++79bM7Si6Dxq7a4iVxRcJU3ZJJ4vaiC7wUZwM8WDK0ySRL+i+T/1SMAzbJLejYA==",
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",

--- a/dev/com.ibm.ws.openapi.ui/swagger-ui/package.json
+++ b/dev/com.ibm.ws.openapi.ui/swagger-ui/package.json
@@ -42,6 +42,7 @@
   "overrides": {
     "axios": "npm:dry-uninstall",
     "prismjs": "npm:dry-uninstall",
+    "@scarf/scarf": "npm:dry-uninstall",
     "dompurify": "^3.2.3"
   },
   "browserslist": [


### PR DESCRIPTION
Note this does not change the built js or css files, scarf is only used at npm install time.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
