### PR TITLE
Remove ssl feature from OpenAPITestServer

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -304,8 +304,7 @@ public class DeploymentTest {
 
     private void assertServerContextRoot(JsonNode model,
                                          String contextRoot) {
-        OpenAPITestUtil.checkServer(model, OpenAPITestUtil.getServerURLs(server, server.getHttpDefaultPort(),
-                                                                         server.getHttpDefaultSecurePort(), contextRoot));
+        OpenAPITestUtil.checkServer(model, OpenAPITestUtil.getServerURLs(server, server.getHttpDefaultPort(), -1, contextRoot));
     }
 
     /**

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPITestServer/server.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPITestServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@
 
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>ssl-1.0</feature>
     <feature>mpOpenAPI-2.0</feature>
     <feature>mpConfig-2.0</feature>
     <feature>jaxrs-2.1</feature> <!-- EE feature to ensure we get the expected EE version -->


### PR DESCRIPTION
Currently we're not waiting for SSL certificate generation to finish before shutting down the server. This can cause the cleanup of the server to fail on Windows systems where keytool still has the file locked.

Since we don't need SSL for these tests, we should remove it.

Usually we see failures in `ShutdownTest` since it shuts down the server very quickly so it's less likely that the keytool processes finishes first.

For RTC 302718

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
