### PR TITLE
Improve handling of UnknownHostException in JMX client

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/client/rest/internal/RESTMBeanServerConnection.java
+++ b/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/client/rest/internal/RESTMBeanServerConnection.java
@@ -17,6 +17,7 @@ import java.io.OutputStream;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.UnknownHostException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.channels.ClosedByInterruptException;
@@ -2179,8 +2180,9 @@ class RESTMBeanServerConnection implements MBeanServerConnection {
         }
 
         //Try to connect to the simple URL
+        HttpsURLConnection connection = null;
         try {
-            HttpsURLConnection connection = getBasicConnection(testURL, HttpMethod.GET);
+            connection = getBasicConnection(testURL, HttpMethod.GET);
             final int responseCode = connection.getResponseCode();
             if (responseCode == HttpURLConnection.HTTP_OK) {
                 if (logger.isLoggable(Level.FINER)) {
@@ -2197,6 +2199,9 @@ class RESTMBeanServerConnection implements MBeanServerConnection {
         } catch (IOException e) {
             if (logger.isLoggable(Level.FINER)) {
                 logger.logp(Level.FINER, logger.getName(), "testConnection", "Failed connection attempt with exception:" + e.getMessage());
+            }
+            if (connection != null) {
+                connection.disconnect();
             }
             return false;
         }
@@ -2324,7 +2329,7 @@ class RESTMBeanServerConnection implements MBeanServerConnection {
                             logger.logp(Level.FINER, logger.getName(), sourceMethod, "Response code: " + responseCode);
                         }
 
-                    } catch (ConnectException ce) {
+                    } catch (ConnectException|UnknownHostException ce) {
                         logger.logp(Level.FINE, logger.getName(), sourceMethod, ce.getMessage(), ce);
                         recoverConnection(ce);
                         continue mainLoop;


### PR DESCRIPTION
In the JMX REST client, the handling of UnknownHostExceptions in RESTMBeanServerConnection may cause socket leaks/performance issues.
In the current state, the server polling loop will immediately retry to connect to the JMX server. As an UnknownHostException is unlikely to be a transient error, this is likely to cause a tight server polling loop, leading to leaking sockets/performance issues

Fixes #30711 
Fixes #PH65108

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


