### PR TITLE
Fix log checking in OpenAPI merge config test

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -119,8 +119,8 @@ public class MergeConfigServerXMLTest {
             // check that documentation includes only app 1
             OpenAPITestUtil.checkPaths(openapiNode, 1, "/test");
 
-            // Test that merging disabled message was output (at some point)
-            assertThat(server.findStringsInLogsUsingMark(" I CWWKO1663I:.*Combining OpenAPI documentation from multiple modules is disabled.", server.getDefaultLogFile()),
+            // Test that merging disabled message was output (at some point, can't guarantee it was during this test as the message is only emitted once)
+            assertThat(server.findStringsInLogs(" I CWWKO1663I:.*Combining OpenAPI documentation from multiple modules is disabled.", server.getDefaultLogFile()),
                        hasSize(1));
 
             // remove app 1
@@ -136,6 +136,7 @@ public class MergeConfigServerXMLTest {
             OpenAPITestUtil.checkPaths(openapiNode, 2, "/test1/test", "/test2/test");
 
             // Check there's no "first module only" message
+            // There are other tests that provoke this message, so we can only check it wasn't emitted during this test
             assertThat(server.findStringsInLogsUsingMark("CWWKO1663I", server.getDefaultLogFile()),
                        hasSize(0));
         }


### PR DESCRIPTION
Since I've now got this wrong twice, also improve the comments to explain why we need a mark in once place and not the other.

For RTC 303027
Problem was introduced in #30256

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".