### PR TITLE
removing allowedProtocols check

### DIFF
--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/ProtocolHelper.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/ProtocolHelper.java
@@ -93,10 +93,11 @@ public class ProtocolHelper {
         } else {
             String protocol = protocols[0];
             if (!validatedProtocols.contains(protocol)) {
-                if (fips140_3Enabled && !allowedProtocols.contains(protocol)) {
-                    Tr.error(tc, "ssl.protocol.error.CWPKI0832E", protocol);
-                    throw new SSLException("Protocol provided is not appropriate for a protocol list.");
-                }
+//                 TODO: uncomment the following once SSL tests have been updated for FIPS 140-3
+//                if (fips140_3Enabled && !allowedProtocols.contains(protocol)) {
+//                    Tr.error(tc, "ssl.protocol.error.CWPKI0832E", protocol);
+//                    throw new SSLException("Protocol provided is not appropriate for a protocol list.");
+//                }
                 checkProtocol(protocol);
             }
         }


### PR DESCRIPTION
Our test buckets fail with FIPS 140-3 when we throw the SSLException in ProtocolHelper. We need to stabilize our test runs and update all tests which use protocols that are invalid with FIPS 140-3. 

In order to understand which tests fail due to the ProtocolHelper change we must first revert it to set a baseline and then re-enable it to record the failing test cases. 