### PR TITLE
Update JACC tests to repeat with the right features

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/FATSuite.java
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,9 +51,9 @@ import componenttest.rules.repeater.RepeatTests;
                 PureAnnMergeConflictXMLBindingsTest.class, //Modified not to run the PureAnnTestBase and also removed from the lite bucket
 })
 public class FATSuite {
-    public static final Set<String> EE78_FEATURES;
-    private static final String[] EE78_FEATURES_ARRAY = {
-                                                          "appSecurity-1.0",
+    public static final Set<String> EE8_FEATURES;
+    private static final String[] EE8_FEATURES_ARRAY = {
+                                                          "appSecurity-3.0",
                                                           "usr:jaccTestProvider-1.0"
     };
 
@@ -73,7 +73,7 @@ public class FATSuite {
     };
 
     static {
-        EE78_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE78_FEATURES_ARRAY)));
+        EE8_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE8_FEATURES_ARRAY)));
         EE9_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE9_FEATURES_ARRAY)));
         EE10_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE10_FEATURES_ARRAY)));
         EE11_FEATURES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE11_FEATURES_ARRAY)));
@@ -83,7 +83,7 @@ public class FATSuite {
      * Run EE9 tests in LITE mode if Java 8, EE10 tests in LITE mode if >= Java 11, EE11 tests in LITE mode if >= Java 17 and run all tests in FULL mode.
      */
     public static RepeatTests defaultRepeat(String serverName) {
-        return RepeatTests.with(ee78Action(serverName, false).fullFATOnly())
+        return RepeatTests.with(ee8Action(serverName, false).fullFATOnly())
                         .andWith(ee9Action(serverName, false).conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
                         .andWith(ee10Action(serverName, false).conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
                         .andWith(ee11Action(serverName, false));
@@ -91,30 +91,30 @@ public class FATSuite {
 
     public static RepeatTests defaultAndCheckpointRepeat(String serverName) {
         return defaultRepeat(serverName)
-                        .andWith(ee78Action(serverName, true).fullFATOnly())
+                        .andWith(ee8Action(serverName, true).fullFATOnly())
                         .andWith(ee9Action(serverName, true).fullFATOnly())
                         .andWith(ee10Action(serverName, true).fullFATOnly())
                         .andWith(ee11Action(serverName, true));
     }
 
-    public static FeatureReplacementAction ee78Action(String serverName, boolean checkpointRepeat) {
+    public static FeatureReplacementAction ee8Action(String serverName, boolean checkpointRepeat) {
         FeatureReplacementAction action = checkpointRepeat ? new CheckpointEE8Action() : new EE8FeatureReplacementAction();
-        return action.forServers(serverName).removeFeatures(EE9_FEATURES).removeFeatures(EE10_FEATURES).removeFeatures(EE11_FEATURES).addFeatures(EE78_FEATURES);
+        return action.forServers(serverName).removeFeatures(EE9_FEATURES).removeFeatures(EE10_FEATURES).removeFeatures(EE11_FEATURES).addFeatures(EE8_FEATURES);
     }
 
     public static FeatureReplacementAction ee9Action(String serverName, boolean checkpointRepeat) {
         FeatureReplacementAction action = checkpointRepeat ? new CheckpointEE9Action() : new JakartaEE9Action();
-        return action.forServers(serverName).removeFeatures(EE78_FEATURES).removeFeatures(EE10_FEATURES).removeFeatures(EE11_FEATURES).addFeatures(EE9_FEATURES);
+        return action.forServers(serverName).removeFeatures(EE8_FEATURES).removeFeatures(EE10_FEATURES).removeFeatures(EE11_FEATURES).addFeatures(EE9_FEATURES);
     }
 
     public static FeatureReplacementAction ee10Action(String serverName, boolean checkpointRepeat) {
         FeatureReplacementAction action = checkpointRepeat ? new CheckpointEE10Action() : new JakartaEE10Action();
-        return action.forServers(serverName).removeFeatures(EE78_FEATURES).removeFeatures(EE9_FEATURES).removeFeatures(EE11_FEATURES).addFeatures(EE10_FEATURES);
+        return action.forServers(serverName).removeFeatures(EE8_FEATURES).removeFeatures(EE9_FEATURES).removeFeatures(EE11_FEATURES).addFeatures(EE10_FEATURES);
     }
 
     public static FeatureReplacementAction ee11Action(String serverName, boolean checkpointRepeat) {
         FeatureReplacementAction action = checkpointRepeat ? new CheckpointEE11Action() : FeatureReplacementAction.EE11_FEATURES();
-        return action.forServers(serverName).removeFeatures(EE78_FEATURES).removeFeatures(EE9_FEATURES).removeFeatures(EE10_FEATURES).addFeatures(EE11_FEATURES);
+        return action.forServers(serverName).removeFeatures(EE8_FEATURES).removeFeatures(EE9_FEATURES).removeFeatures(EE10_FEATURES).addFeatures(EE11_FEATURES);
     }
 
 }

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/FATSuite.java
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/FATSuite.java
@@ -53,7 +53,6 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     public static final Set<String> EE8_FEATURES;
     private static final String[] EE8_FEATURES_ARRAY = {
-                                                          "appSecurity-3.0",
                                                           "usr:jaccTestProvider-1.0"
     };
 

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat.bindings/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat.bindings/server.xml
@@ -1,12 +1,12 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
  -->
@@ -15,6 +15,7 @@
 	<featureManager>
 		<feature>servlet-3.1</feature>
 		<feature>ejbLite-3.2</feature>
+		<feature>appSecurity-2.0</feature>
 		<feature>usr:jaccTestProvider-1.0</feature>
 	</featureManager>
 	

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat.mergebindings/configs/pureAnn.mergebindings.server.org.xml
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat.mergebindings/configs/pureAnn.mergebindings.server.org.xml
@@ -1,19 +1,19 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
  -->
 <server description="EJB security FAT configuration">
 
 	<featureManager>
-		<feature>appSecurity-1.0</feature>
+		<feature>appSecurity-2.0</feature>
         	<feature>ejbLite-3.2</feature>
 		<feature>usr:jaccTestProvider-1.0</feature>
 	</featureManager>

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat.mergebindings/configs/pureAnn.mergeconflict.xml
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat.mergebindings/configs/pureAnn.mergeconflict.xml
@@ -1,19 +1,19 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
  -->
 <server description="EJB security FAT configuration">
 
 	<featureManager>
-		<feature>appSecurity-1.0</feature>
+		<feature>appSecurity-2.0</feature>
 		<feature>ejbLite-3.2</feature>
 		<feature>usr:jaccTestProvider-1.0</feature>
 	</featureManager>

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat.mergebindings/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat.mergebindings/server.xml
@@ -1,19 +1,19 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
  -->
 <server description="EJB security FAT configuration">
 
 	<featureManager>
-		<feature>appSecurity-1.0</feature>
+		<feature>appSecurity-2.0</feature>
 		<feature>ejbLite-3.2</feature>
 		<feature>usr:jaccTestProvider-1.0</feature>
 	</featureManager>

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat/configs/pureAnn.mergebindings.server.org.xml
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat/configs/pureAnn.mergebindings.server.org.xml
@@ -1,19 +1,19 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
  -->
 <server description="EJB security FAT configuration">
 
 	<featureManager>
-		<feature>appSecurity-1.0</feature>
+		<feature>appSecurity-2.0</feature>
 		<feature>ejbLite-3.2</feature>
 		<feature>usr:jaccTestProvider-1.0</feature>
 	</featureManager>

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/publish/servers/com.ibm.ws.ejbcontainer.security.jacc_fat/server.xml
@@ -1,12 +1,12 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
  -->
@@ -15,6 +15,7 @@
 	<featureManager>
 		<feature>servlet-3.1</feature>
 	        <feature>ejbLite-3.2</feature>
+	        <feature>appSecurity-2.0</feature>
 		<feature>usr:jaccTestProvider-1.0</feature>
 	</featureManager>
 	

--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/audit/BasicAuthAuditAUTHZTest.java
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/audit/BasicAuthAuditAUTHZTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -90,7 +90,9 @@ public class BasicAuthAuditAUTHZTest {
      * Need the first repeat to make sure that audit-2.0 from a previous repeat gets put back to audit-1.0
      */
     @ClassRule
-    public static RepeatTests auditRepeat = RepeatTests.with(new FeatureReplacementAction("audit-2.0", "audit-1.0").forServers("com.ibm.ws.webcontainer.security.fat.basicauth.audit").fullFATOnly()).andWith(new FeatureReplacementAction("audit-1.0", "audit-2.0").forServers("com.ibm.ws.webcontainer.security.fat.basicauth.audit"));
+    public static RepeatTests auditRepeat = RepeatTests.with(new FeatureReplacementAction("audit-2.0", "audit-1.0").forServerConfigPaths("publish/files/"
+                                                                                                                                         + DEFAULT_CONFIG_FILE).fullFATOnly()).andWith(new FeatureReplacementAction("audit-1.0", "audit-2.0").forServerConfigPaths("publish/files/"
+                                                                                                                                                                                                                                                                   + DEFAULT_CONFIG_FILE));
 
     @Rule
     public TestName name = _name;

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3509,14 +3509,6 @@ public class LibertyServer implements LogMonitorClient {
     private static final String[] EXEMPT_SERVERS = {
                                                      "cdi20EEServer", //com.ibm.ws.cdi.1.0_fat_EE
 
-                                                     "com.ibm.ws.security.authorization.jacc.dynamic_fat", //com.ibm.ws.ejbcontainer.security.jacc_fat.2
-                                                     "com.ibm.ws.ejbcontainer.security.jacc_fat.ejbjar.mergebindings", //com.ibm.ws.ejbcontainer.security.jacc_fat.2
-                                                     "com.ibm.ws.ejbcontainer.security.jacc_fat.ejbjar.inwar", //com.ibm.ws.ejbcontainer.security.jacc_fat.2
-                                                     "com.ibm.ws.ejbcontainer.security.jacc_fat.ejbjar.mc", //com.ibm.ws.ejbcontainer.security.jacc_fat.2
-                                                     "com.ibm.ws.ejbcontainer.security.jacc_fat", //com.ibm.ws.ejbcontainer.security.jacc_fat.2
-                                                     "com.ibm.ws.ejbcontainer.security.jacc_fat.bindings", //com.ibm.ws.ejbcontainer.security.jacc_fat.2
-                                                     "com.ibm.ws.ejbcontainer.security.jacc_fat.mergebindings", //com.ibm.ws.ejbcontainer.security.jacc_fat.2
-
                                                      "EclipseLinkServer", //com.ibm.ws.jpa.tests.eclipselink_jpa_2.1_fat
 
                                                      "com.ibm.ws.jpa.el.defaultds.fat.server", //com.ibm.ws.jpa.tests.jpa_fat
@@ -3575,8 +3567,6 @@ public class LibertyServer implements LogMonitorClient {
                                                      "com.ibm.ws.scaling.member.fat.controller1", //com.ibm.ws.scaling.member_fat
 
                                                      "com.ibm.ws.ui.fat", //com.ibm.ws.ui_rest_fat
-
-                                                     "com.ibm.ws.webcontainer.security.fat.basicauth.audit", //com.ibm.ws.webcontainer.security.jacc.1.5_fat
 
                                                      "com.ibm.ws.jaxrs.fat.exceptionMappingWithOT", //com.ibm.ws.jaxrs.2.0_fat
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Update repeat logic in ejb jacc FATSuite to reference EE 8 only
- Update server xml files to have appSecurity-2.0 in them instead of appSecurity-1.0
- Add appSecurity-2.0 to server.xml files that do not have appSecurity feature included, but jacc-1.5 is included which prefers 2.0 and tolerates 3.0 so it will use 2.0 even with EE 8 features since 2.0 works with EE 8 features
- Switch to `forServerConfigPaths` from `forServers` when repeating test in webcontainer jacc fat since we use a config path instead of the default server config
- Remove jacc fat servers from the exempt list now that these fixes are in