### PR TITLE
Allow HTTP transport to ignore writes after message is committed

### DIFF
--- a/dev/com.ibm.ws.transport.http/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.transport.http/resources/OSGI-INF/l10n/metatype.properties
@@ -149,8 +149,8 @@ http.incomingBodyBufferSize.desc=Specifies the size of each buffer used when rea
 http.throwIOEForInboundConnections=Throw I/O exception for inbound connections
 http.throwIOEForInboundConnections.desc=Specifies whether the HTTP channel creates an I/O exception when an inbound connection is closed while still in use by the servlet. The default value is set according to the configured servlet feature. Prior to Servlet 4.0, the default value is false; starting with Servlet 4.0, the default value is true.
 
-http.persistOnError=Persist on error
-http.persistOnError.desc=When this attribute is set to true, persistent Keep-Alive connections remain active during closure even if an error occurs. If it is set to false, which is the default, any closure error terminates the connection.
+http.ignoreWriteAfterCommit=Ignore write after commit
+http.ignoreWriteAfterCommit.desc=When this attribute is set to true, the HTTP channel ignores write attempts if the message is already committed. If it is set to false, which is the default, any attempt to write after the message is committed results in a MessageSentException exception.
 
 http2.connectionIdleTimeout=HTTP/2 connection idle timeout
 http2.connectionIdleTimeout.desc=Specifies the amount of time, in seconds, that an HTTP/2 connection will be allowed to remain idle between socket IO operations. If not specified, or set to a value of 0, there is no connection timeout set.

--- a/dev/com.ibm.ws.transport.http/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.transport.http/resources/OSGI-INF/l10n/metatype.properties
@@ -150,7 +150,7 @@ http.throwIOEForInboundConnections=Throw I/O exception for inbound connections
 http.throwIOEForInboundConnections.desc=Specifies whether the HTTP channel creates an I/O exception when an inbound connection is closed while still in use by the servlet. The default value is set according to the configured servlet feature. Prior to Servlet 4.0, the default value is false; starting with Servlet 4.0, the default value is true.
 
 http.persistOnError=Persist on error
-http.persistOnError.desc=When enabled, persistent (Keep-Alive) connections will remain active during closure even if an error occurs. Otherwise, any closure error will result in the connection being terminated.
+http.persistOnError.desc=When this attribute is set to true, persistent Keep-Alive connections remain active during closure even if an error occurs. If it is set to false, which is the default, any closure error terminates the connection.
 
 http2.connectionIdleTimeout=HTTP/2 connection idle timeout
 http2.connectionIdleTimeout.desc=Specifies the amount of time, in seconds, that an HTTP/2 connection will be allowed to remain idle between socket IO operations. If not specified, or set to a value of 0, there is no connection timeout set.

--- a/dev/com.ibm.ws.transport.http/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.transport.http/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2024 IBM Corporation and others.
+# Copyright (c) 2011, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -148,6 +148,9 @@ http.incomingBodyBufferSize.desc=Specifies the size of each buffer used when rea
 
 http.throwIOEForInboundConnections=Throw I/O exception for inbound connections
 http.throwIOEForInboundConnections.desc=Specifies whether the HTTP channel creates an I/O exception when an inbound connection is closed while still in use by the servlet. The default value is set according to the configured servlet feature. Prior to Servlet 4.0, the default value is false; starting with Servlet 4.0, the default value is true.
+
+http.persistOnError=Persist on error
+http.persistOnError.desc=When enabled, persistent (Keep-Alive) connections will remain active during closure even if an error occurs. Otherwise, any closure error will result in the connection being terminated.
 
 http2.connectionIdleTimeout=HTTP/2 connection idle timeout
 http2.connectionIdleTimeout.desc=Specifies the amount of time, in seconds, that an HTTP/2 connection will be allowed to remain idle between socket IO operations. If not specified, or set to a value of 0, there is no connection timeout set.

--- a/dev/com.ibm.ws.transport.http/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.transport.http/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2024 IBM Corporation and others.
+    Copyright (c) 2011, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -209,6 +209,9 @@
 
         <AD name="%http.decompressionTolerance" description="%http.decompressionTolerance.desc"
             id="decompressionTolerance" required="false" type="Integer" min="0" default="3" />
+
+        <AD name="%http.persistOnError" description="%http.persistOnError.desc"
+            id="persistOnError" required="false" type="Boolean" default="false" />
             
         <AD name="%http2.connectionIdleTimeout" description="%http2.connectionIdleTimeout.desc"
             id="http2ConnectionIdleTimeout" required="false" type="String" ibm:type="duration(s)" min="0" default="0" />

--- a/dev/com.ibm.ws.transport.http/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.transport.http/resources/OSGI-INF/metatype/metatype.xml
@@ -210,8 +210,8 @@
         <AD name="%http.decompressionTolerance" description="%http.decompressionTolerance.desc"
             id="decompressionTolerance" required="false" type="Integer" min="0" default="3" />
 
-        <AD name="%http.persistOnError" description="%http.persistOnError.desc"
-            id="persistOnError" required="false" type="Boolean" default="false" />
+        <AD name="%http.ignoreWriteAfterCommit" description="%http.ignoreWriteAfterCommit.desc"
+            id="ignoreWriteAfterCommit" required="false" type="Boolean" default="false" />
             
         <AD name="%http2.connectionIdleTimeout" description="%http2.connectionIdleTimeout.desc"
             id="http2ConnectionIdleTimeout" required="false" type="String" ibm:type="duration(s)" min="0" default="0" />

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpChannelConfig.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpChannelConfig.java
@@ -212,7 +212,7 @@ public class HttpChannelConfig {
     /** Tracks headers that have been configured erroneously **/
     private HashSet<String> configuredHeadersErrorSet = null;
     /** Identifies if a persist enabled connection should remain open even if there are errors at closure */
-    private boolean persistOnError = false;
+    private boolean persistOnError = true;
 
     /**
      * Constructor for an HTTP channel config object.

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpChannelConfig.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpChannelConfig.java
@@ -212,7 +212,7 @@ public class HttpChannelConfig {
     /** Tracks headers that have been configured erroneously **/
     private HashSet<String> configuredHeadersErrorSet = null;
     /** Identifies if a persist enabled connection should remain open even if there are errors at closure */
-    private boolean persistOnError = true;
+    private boolean persistOnError = false;
 
     /**
      * Constructor for an HTTP channel config object.

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpChannelConfig.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpChannelConfig.java
@@ -212,6 +212,8 @@ public class HttpChannelConfig {
     /** Tracks headers that have been configured erroneously **/
     private HashSet<String> configuredHeadersErrorSet = null;
 
+    private boolean forcePersist = false;
+
     /**
      * Constructor for an HTTP channel config object.
      *
@@ -527,6 +529,10 @@ public class HttpChannelConfig {
                 props.put(HttpConfigConstants.PROPNAME_RESPONSE_HEADERS_REMOVE, value);
             }
 
+            if (key.equalsIgnoreCase(HttpConfigConstants.PROPNAME_FORCE_PERSIST)){
+                props.put(HttpConfigConstants.PROPNAME_FORCE_PERSIST, value);
+            }
+
             props.put(key, value);
         }
 
@@ -592,6 +598,7 @@ public class HttpChannelConfig {
         parseCookiesSameSitePartitioned(props);
         initSameSiteCookiesPatterns();
         parseHeaders(props);
+        parseForcePersist(props);
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.exit(tc, "parseConfig");
@@ -611,6 +618,16 @@ public class HttpChannelConfig {
             value = (String) props.get(key.toLowerCase());
         }
         return (null != value) ? value.trim() : null;
+    }
+
+    private void parseForcePersist(Map<Object, Object> props){
+        Object value = props.get("forcePersist");
+        if(null != value){
+            forcePersist = convertBoolean(value);
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                Tr.event(tc, "Config: forcePersist is " + forcePersist());
+            }
+        }     
     }
 
     /**
@@ -3100,6 +3117,10 @@ public class HttpChannelConfig {
      */
     public Map<Integer, String> getConfiguredHeadersToRemove() {
         return this.configuredHeadersToRemove;
+    }
+
+    public boolean forcePersist(){
+        return this.forcePersist;
     }
 
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpChannelConfig.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpChannelConfig.java
@@ -211,8 +211,9 @@ public class HttpChannelConfig {
 
     /** Tracks headers that have been configured erroneously **/
     private HashSet<String> configuredHeadersErrorSet = null;
-    /** Identifies if a persist enabled connection should remain open even if there are errors at closure */
-    private boolean persistOnError = false;
+    /** Identifies if the transport will ignore writes if the message has been committed. When false, an exception 
+     * is expected to be thrown marking the invalid state. */
+    private boolean ignoreWriteAfterCommit = false;
 
     /**
      * Constructor for an HTTP channel config object.
@@ -529,8 +530,8 @@ public class HttpChannelConfig {
                 props.put(HttpConfigConstants.PROPNAME_RESPONSE_HEADERS_REMOVE, value);
             }
 
-            if (key.equalsIgnoreCase(HttpConfigConstants.PROPNAME_PERSIST_ON_ERROR)){
-                props.put(HttpConfigConstants.PROPNAME_PERSIST_ON_ERROR, value);
+            if (key.equalsIgnoreCase(HttpConfigConstants.PROPNAME_IGNORE_WRITE_AFTER_COMMIT)){
+                props.put(HttpConfigConstants.PROPNAME_IGNORE_WRITE_AFTER_COMMIT, value);
             }
 
             props.put(key, value);
@@ -598,6 +599,7 @@ public class HttpChannelConfig {
         parseCookiesSameSitePartitioned(props);
         initSameSiteCookiesPatterns();
         parseHeaders(props);
+        parseIgnoreWriteAfterCommit(props);
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.exit(tc, "parseConfig");
@@ -631,7 +633,6 @@ public class HttpChannelConfig {
         parseKeepAliveEnabled(props);
         if (isKeepAliveEnabled()) {
             parseMaxPersist(props);
-            parsePersistOnError(props);
         }
     }
 
@@ -639,12 +640,12 @@ public class HttpChannelConfig {
      * Method to determine if a keep-alive connection should be kept open even if
      * an error is found during closure.
      */
-    private void parsePersistOnError(Map<Object, Object> props) {
-        Object value = props.get(HttpConfigConstants.PROPNAME_PERSIST_ON_ERROR);
+    private void parseIgnoreWriteAfterCommit(Map<Object, Object> props) {
+        Object value = props.get(HttpConfigConstants.PROPNAME_IGNORE_WRITE_AFTER_COMMIT);
         if (null != value) {
-            persistOnError = convertBoolean(value);
+            ignoreWriteAfterCommit = convertBoolean(value);
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "Config: persistOnError is " + persistOnError());
+                Tr.event(tc, "Config: ignoreWriteAfterCommit is " + ignoreWriteAfterCommit());
             }
         }
     }
@@ -3129,8 +3130,8 @@ public class HttpChannelConfig {
      * Returns whether a connection should remain active even if an error occurs during 
      * closure.
      */
-    public boolean persistOnError(){
-        return this.persistOnError;
+    public boolean ignoreWriteAfterCommit(){
+        return this.ignoreWriteAfterCommit;
     }
 
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpConfigConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpConfigConstants.java
@@ -454,6 +454,8 @@ public class HttpConfigConstants {
 
     public static final String PROPNAME_RESPONSE_HEADERS_SET_IF_MISSING = "headersSetIfMissingInternal";
 
+    public static final String PROPNAME_FORCE_PERSIST = "forcePersist";
+
     public static enum SameSite {
         LAX("Lax"),
         NONE("None"),

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpConfigConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpConfigConstants.java
@@ -454,7 +454,7 @@ public class HttpConfigConstants {
 
     public static final String PROPNAME_RESPONSE_HEADERS_SET_IF_MISSING = "headersSetIfMissingInternal";
 
-    public static final String PROPNAME_PERSIST_ON_ERROR = "persistOnError";
+    public static final String PROPNAME_IGNORE_WRITE_AFTER_COMMIT = "ignoreWriteAfterCommit";
 
     public static enum SameSite {
         LAX("Lax"),

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpConfigConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpConfigConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2024 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -454,7 +454,7 @@ public class HttpConfigConstants {
 
     public static final String PROPNAME_RESPONSE_HEADERS_SET_IF_MISSING = "headersSetIfMissingInternal";
 
-    public static final String PROPNAME_FORCE_PERSIST = "forcePersist";
+    public static final String PROPNAME_PERSIST_ON_ERROR = "persistOnError";
 
     public static enum SameSite {
         LAX("Lax"),

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundLink.java
@@ -765,8 +765,8 @@ public class HttpInboundLink extends InboundProtocolLink implements InterChannel
         // now check to see if the connection should be kept open (unless
         // we are in an error state). Perform one last check against a channel
         // stop, close the socket if not running.
-
-        if (!errorState && sc.isPersistent() && getChannel().isRunning()) {
+        boolean forcePersist = (config.forcePersist() || !errorState);
+        if (forcePersist && sc.isPersistent() && getChannel().isRunning()) {
 
             if (config.getDebugLog().isEnabled(DebugLog.Level.DEBUG)) {
                 config.getDebugLog().log(DebugLog.Level.DEBUG, HttpMessages.MSG_READ_PERSISTENT, sc);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundLink.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -765,8 +765,8 @@ public class HttpInboundLink extends InboundProtocolLink implements InterChannel
         // now check to see if the connection should be kept open (unless
         // we are in an error state). Perform one last check against a channel
         // stop, close the socket if not running.
-        boolean forcePersist = (config.forcePersist() || !errorState);
-        if (forcePersist && sc.isPersistent() && getChannel().isRunning()) {
+        boolean persistOnError = (config.persistOnError() || !errorState);
+        if (persistOnError && sc.isPersistent() && getChannel().isRunning()) {
 
             if (config.getDebugLog().isEnabled(DebugLog.Level.DEBUG)) {
                 config.getDebugLog().log(DebugLog.Level.DEBUG, HttpMessages.MSG_READ_PERSISTENT, sc);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundLink.java
@@ -765,8 +765,8 @@ public class HttpInboundLink extends InboundProtocolLink implements InterChannel
         // now check to see if the connection should be kept open (unless
         // we are in an error state). Perform one last check against a channel
         // stop, close the socket if not running.
-        boolean persistOnError = (config.persistOnError() || !errorState);
-        if (persistOnError && sc.isPersistent() && getChannel().isRunning()) {
+        boolean ignoreWriteAfterCommit = (config.ignoreWriteAfterCommit() || !errorState);
+        if (ignoreWriteAfterCommit && sc.isPersistent() && getChannel().isRunning()) {
 
             if (config.getDebugLog().isEnabled(DebugLog.Level.DEBUG)) {
                 config.getDebugLog().log(DebugLog.Level.DEBUG, HttpMessages.MSG_READ_PERSISTENT, sc);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #30757

Sample configuration:

```
<httpEndpoint host="*" httpPort="9080" httpsPort="9443" id="HTTPS">
   <httpOptions ignoreWriteAfterCommit="true"/>
</httpEndpoint>
```