### PR TITLE
Improve handling of UnknownHostException in JMX client

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/client/rest/internal/RESTMBeanServerConnection.java
+++ b/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/client/rest/internal/RESTMBeanServerConnection.java
@@ -2330,6 +2330,16 @@ class RESTMBeanServerConnection implements MBeanServerConnection {
                         continue mainLoop;
                     } catch (IOException io) {
                         logger.logp(Level.FINE, logger.getName(), sourceMethod, io.getMessage(), io);
+                        connection.disconnect();
+                        try {
+                            synchronized (waitFlag) {
+                                waitFlag.wait(connector.getServerStatusPollingInterval());
+                            }
+                        } catch (InterruptedException e) {
+                            if (logger.isLoggable(Level.FINE)) {
+                                logger.logp(Level.FINE, logger.getName(), sourceMethod, "Interrupted sleep in thread: " + getCustomId());
+                            }
+                        }
                         continue mainLoop;
                     }
 


### PR DESCRIPTION
In the JMX REST client, the handling of UnknownHostExceptions in RESTMBeanServerConnection may cause socket leaks/performance issues.
In the current state, the server polling loop will immediately retry to connect to the JMX server if a an UnknownHostException is caught. As an UnknownHostException is unlikely to be a transient error, this is likely to cause a tight server polling loop, leading to leaking sockets/performance issues

Fixes #30711 
Fixes #PH65108

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".