### PR TITLE
Updated regex for toString changes in Java 23

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -725,9 +725,17 @@ public class AcmeCaRestHandlerTest extends TestContainerSuite {
     private static String getLeafSerialFromHtml(String htmlCertChain) {
         String serial = null;
 
-        Matcher m = Pattern.compile(".*SerialNumber:\\s+\\[\\s*(.*)\\].*").matcher(htmlCertChain);
+        Matcher m = Pattern.compile(".*SerialNumber:\\s+\\s*(.*).*").matcher(htmlCertChain);
         if (m.find()) {
             serial = m.group(1);
+            // Before Java 23, the format was SerialNumber: [number].  Starting in Java 23, the brackets are not used.
+            // The regex above was adjusted to remove the brackets, so we need to strip off the brackets now.
+            if (serial.startsWith("[")) {
+                serial = serial.substring(1);
+            }
+            if (serial.endsWith("]")) {
+                serial= serial.substring(0, serial.length()  -1);
+            }
         }
 
         Log.info(AcmeCaRestHandlerTest.class, "getLeafSerialFromHtml(String)", serial);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

The format of the SerialNumber output from the certificate changed in Java 23 it appears from `SerialNumber: [number]` to just `SerialNumber: number`.  This PR handles both of the formats of the output.