### PR TITLE
Updates to make things compile cleanly in eclipse

### DIFF
--- a/dev/com.ibm.ws.messaging.comms.server/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.comms.server/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -59,9 +59,9 @@ instrument.disabled: true
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.websphere.security;version=latest,\
 	io.openliberty.io.netty;version=latest,\
+	io.openliberty.io.netty.ssl;version=latest,\
 	io.openliberty.netty.internal;version=latest,\
 	io.openliberty.netty.internal.impl;version=latest,\
-	io.netty.handler,\
 	io.openliberty.endpoint,\
 	com.ibm.ws.kernel.boot.core,\
 	com.ibm.ws.kernel.boot.common,\

--- a/dev/com.ibm.ws.sipcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.sipcontainer/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2024 IBM Corporation and others.
+# Copyright (c) 2019, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -122,5 +122,4 @@ instrument.disabled: true
 	io.openliberty.endpoint,\
 	io.openliberty.io.netty,\
 	io.openliberty.netty.internal,\
-	io.openliberty.io.netty.ssl,\
-	io.netty.handler
+	io.openliberty.io.netty.ssl


### PR DESCRIPTION
- Remove non existent io.netty.handler bundle from buildpath
- Add io.openliberty.io.netty.ssl to fix indirect reference compile failure in eclipse.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
