### PR TITLE
Fully read heartbeat stream in RESTMBeanServerConnection

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/client/rest/internal/RESTMBeanServerConnection.java
+++ b/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/client/rest/internal/RESTMBeanServerConnection.java
@@ -2379,12 +2379,12 @@ class RESTMBeanServerConnection implements MBeanServerConnection {
                                 } else {
                                     //no-op for failover polling, just break into the sleep segment
                                     // Server sends a string back that needs to be consumed to close the connection
-                                    InputStream is = connection.getInputStream();
-                                    int data = is.read();
-                                    while (data != -1) {
-                                        data = is.read();
+                                    try (InputStream is = connection.getInputStream()) {
+                                        int data = is.read();
+                                        while (data != -1) {
+                                            data = is.read();
+                                        }
                                     }
-                                    is.close();
                                 }
                                 break;
                             } catch (ClassNotFoundException cnf) {

--- a/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/client/rest/internal/RESTMBeanServerConnection.java
+++ b/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/client/rest/internal/RESTMBeanServerConnection.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.jmx.connector.client.rest.internal;
 
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.ConnectException;
@@ -2377,6 +2378,13 @@ class RESTMBeanServerConnection implements MBeanServerConnection {
                                     }
                                 } else {
                                     //no-op for failover polling, just break into the sleep segment
+                                    // Server sends a string back that needs to be consumed to close the connection
+                                    InputStream is = connection.getInputStream();
+                                    int data = is.read();
+                                    while (data != -1) {
+                                        data = is.read();
+                                    }
+                                    is.close();
                                 }
                                 break;
                             } catch (ClassNotFoundException cnf) {


### PR DESCRIPTION
The server response to the heartbeat/notification request is the class name string 'com.ibm.ws.kernel.boot.jmx.internal.PlatformMBeanServer'. This needs to be read, and the stream closed, to allow the HTTPURLConnection to be properly pooled/reused. Not reading the stream was causing dangling sockets in close_wait state

fixes #30758


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

