### PR TITLE
fix: docker image builder for pipelines

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/containers/substitution/LibertyImageNameSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/substitution/LibertyImageNameSubstitutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -73,10 +73,17 @@ public class LibertyImageNameSubstitutor extends ImageNameSubstitutor {
             // This is now handled directly by the ArtifactoryRegistry
 
             // Priority 6: If mirror registry is available use it to avoid rate limits on other registries
-            if (ArtifactoryRegistry.instance().isRegistryAvailable() || InternalRegistry.instance().isRegistryAvailable()) {
+            if (ArtifactoryRegistry.instance().isRegistryAvailable() && ArtifactoryRegistry.instance().supportsRegistry(original)) {
                 ImageVerifier.collectImage(original);
                 result = REGISTRY.apply(MIRROR.apply(original));
-                reason = "Artifactory was available.";
+                reason = "Artifactory registry was available and supports " + original.getRegistry();
+                break;
+            }
+
+            if (InternalRegistry.instance().isRegistryAvailable() && InternalRegistry.instance().supportsRegistry(original)) {
+                ImageVerifier.collectImage(original);
+                result = REGISTRY.apply(MIRROR.apply(original));
+                reason = "Internal registry was available and supports " + original.getRegistry();
                 break;
             }
 

--- a/dev/io.openliberty.org.testcontainers/build.gradle
+++ b/dev/io.openliberty.org.testcontainers/build.gradle
@@ -49,13 +49,13 @@ task assembleTestContainerData(type: JavaExec) {
 task generateCustomImages(type: JavaExec) {
     // If artifactory is available then use it for BASE_NAME substitution
     if ( gradle.userProps.containsKey("artifactory.docker.server") ) {
-        environment "TESTCONTAINERS_IMAGE_SUBSTITUTOR", "componenttest.containers.ArtifactoryMirrorSubstitutor"
-        environment "ARTIFACTORY_REGISTRY", gradle.userProps.getProperty("artifactory.docker.server")
+        environment "TESTCONTAINERS_IMAGE_SUBSTITUTOR", "componenttest.containers.substitution.LibertyImageNameSubstitutor"
+        environment "ARTIFACTORY_DOCKER_SERVER", gradle.userProps.getProperty("artifactory.docker.server")
     }
     
     // If internal registry is available then use it for caching image
     if ( gradle.userProps.containsKey("docker_registry.server") ) {
-        environment "INTERNAL_REGISTRY", gradle.userProps.getProperty("docker_registry.server")
+        environment "DOCKER_REGISTRY_SERVER", gradle.userProps.getProperty("docker_registry.server")
     }
     
     // Run main method of CustomImages class

--- a/dev/io.openliberty.org.testcontainers/resources/openliberty/testcontainers/db2-krb5/12.1.0.0/Dockerfile
+++ b/dev/io.openliberty.org.testcontainers/resources/openliberty/testcontainers/db2-krb5/12.1.0.0/Dockerfile
@@ -5,8 +5,6 @@ ARG BASE_IMAGE="icr.io/db2_community/db2:12.1.0.0"
 
 FROM ${BASE_IMAGE}
 
-RUN yum -y update
-
 # TODO 'krb5-auth-dialog' is no longer available from package managers
 # that are configured on DB2 image. If needed download directly.
 RUN yum -y install krb5-workstation krb5-libs

--- a/dev/io.openliberty.org.testcontainers/src/io/openliberty/org/testcontainers/generate/CustomImages.java
+++ b/dev/io.openliberty.org.testcontainers/src/io/openliberty/org/testcontainers/generate/CustomImages.java
@@ -37,6 +37,16 @@ public class CustomImages {
 
         // Get data from calling script
         String projectPath = args[0];
+        
+        if (System.getenv().containsKey("ARTIFACTORY_DOCKER_SERVER")) {
+            System.out.println("Setting fat.test.artifactory.docker.server=" + System.getenv().get("ARTIFACTORY_DOCKER_SERVER"));
+            System.setProperty("fat.test.artifactory.docker.server", System.getenv().get("ARTIFACTORY_DOCKER_SERVER"));
+        }
+        
+        if (System.getenv().containsKey("DOCKER_REGISTRY_SERVER")) {
+            System.out.println("Setting fat.test.docker.registry.server=" + System.getenv().get("DOCKER_REGISTRY_SERVER"));
+            System.setProperty("fat.test.docker.registry.server", System.getenv().get("DOCKER_REGISTRY_SERVER"));
+        }
 
         // Where to find instructions to build images
         Path commonPath = Paths.get(projectPath, "resources", "openliberty", "testcontainers");
@@ -44,6 +54,7 @@ public class CustomImages {
         // Find all dockerfiles and attempt to build their corresponding images
         Dockerfile.findDockerfiles(commonPath).stream()
                 .map(location -> new Dockerfile(location))
+                .sorted() //Sort in case images end up depending on each other
                 .forEach(dockerfile -> {
                     // Find or build all images
                     if(dockerfile.isCached()) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Switch to using LibertyImageNameSubstitutor for the generateCustomImages gradle task
- modify LibertyImageNameSubstitutor logic to be more strict on when to use Artifactory or Internal registries
- modify db2 krb5 dockerfile to not perform yum update (takes 30 minutes and bad practice in a dockerfile)
- simplify docker image builder logic