### PR TITLE
properly obtain interceptor binding annotation

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadFactoryService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadFactoryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013,2024 IBM Corporation and others.
+ * Copyright (c) 2013,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -347,8 +347,6 @@ public class ManagedThreadFactoryService implements ResourceFactory, Application
                     accessor.beginContext(cData);
                     restoreMetadata = true;
                 }
-
-                // TODO look into a shortcut to avoid push/recapture and instead supply directly to the context service
             }
 
             if (appName == null) {

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -13,6 +13,7 @@
 package com.ibm.ws.concurrent.cdi.fat;
 
 import jakarta.enterprise.concurrent.spi.ThreadContextProvider;
+import jakarta.enterprise.inject.spi.Extension;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -56,8 +57,18 @@ public class ConcurrentCDITest extends FATServletClient {
                                               "concurrent.cdi.context.location.LocationContextProvider");
         ShrinkHelper.exportToServer(server, "lib", locationContextProviderJar);
 
-        WebArchive concurrentCDIWeb = ShrinkHelper.buildDefaultApp("concurrentCDIWeb", "concurrent.cdi.web");
-        ShrinkHelper.addDirectory(concurrentCDIWeb, "test-applications/concurrentCDIWeb/resources");
+        JavaArchive cdiExtensionJar = ShrinkWrap
+                        .create(JavaArchive.class, "cdi-extension.jar")
+                        .addPackage("concurrent.cdi.ext")
+                        .addAsServiceProvider(Extension.class.getName(),
+                                              "concurrent.cdi.ext.ConcurrentCDIExtension");
+
+        WebArchive concurrentCDIWeb = ShrinkHelper
+                        .buildDefaultApp("concurrentCDIWeb",
+                                         "concurrent.cdi.web")
+                        .addAsLibrary(cdiExtensionJar);
+        ShrinkHelper.addDirectory(concurrentCDIWeb,
+                                  "test-applications/concurrentCDIWeb/resources");
 
         JavaArchive concurrentCDIEJB = ShrinkHelper.buildJavaArchive("concurrentCDIEJB", "concurrent.cdi.ejb");
         ShrinkHelper.addDirectory(concurrentCDIEJB, "test-applications/concurrentCDIEJB/resources");
@@ -90,6 +101,11 @@ public class ConcurrentCDITest extends FATServletClient {
 
     @Test
     public void testEJBSelectContextServiceQualifiedFromAppDD() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testExtensionAddsAsynchronous() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ext/ConcurrentCDIExtension.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ext/ConcurrentCDIExtension.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.ext;
+
+import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.concurrent.Schedule;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
+import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
+import jakarta.enterprise.util.AnnotationLiteral;
+
+/**
+ * A CDI extension provided by the application that adds an Asynchronous method
+ * without annotating it.
+ */
+public class ConcurrentCDIExtension implements Extension {
+    /**
+     * Programmatically defined literal instance of the Asynchronous annotation.
+     */
+    public static final class AsyncLiteral extends AnnotationLiteral<Asynchronous> //
+                    implements Asynchronous {
+        public static final AsyncLiteral INSTANCE = new AsyncLiteral();
+
+        private static final long serialVersionUID = 1L;
+
+        private AsyncLiteral() {
+        }
+
+        @Override
+        public String executor() {
+            return "java:comp/DefaultManagedExecutorService";
+        }
+
+        @Override
+        public Schedule[] runAt() {
+            return new Schedule[] {};
+        }
+    }
+
+    /**
+     * Observer method that makes a bean method that is named "asyncByExtension"
+     * into an Asynchronous method.
+     */
+    public <T> void processAnnotatedType(@Observes ProcessAnnotatedType<T> event) {
+        AnnotatedTypeConfigurator<T> typeConfigurator = //
+                        event.configureAnnotatedType();
+
+        typeConfigurator.methods()
+                        .stream()
+                        .filter(methodConfigurator -> methodConfigurator
+                                        .getAnnotated()
+                                        .getJavaMember()
+                                        .getName()
+                                        .equals("asyncByExtension"))
+                        .forEach(methodConfigurator -> {
+                            System.out.println("CDI extension found: " +
+                                               methodConfigurator.getAnnotated());
+                            methodConfigurator.add(AsyncLiteral.INSTANCE);
+                            System.out.println("  added literal Asynchronous");
+                        });
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/TestBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/TestBean.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * A bean that has a method with a signature that looks like it could be
+ * an Asynchronous method, but doesn't have the annotation. A CDI extension
+ * adds Asynchronous to it instead.
+ */
+@ApplicationScoped
+public class TestBean {
+    /**
+     * Do not put @Asynchronous on this method.
+     * We want to test that a CDI extension can do it.
+     */
+    public CompletableFuture<Thread> asyncByExtension() {
+        return Asynchronous.Result.complete(Thread.currentThread());
+    }
+}


### PR DESCRIPTION
Obtain interceptor binding annotations from the invocation context of the asynchronous method.
Write a test case and test CDI extension where the CDI extension programmatically adds Asynchronous to a method that otherwise resembles an asynchronous method.  Verify that the method behaves as an asynchronous method when invoked on the bean.
Also, this addressed a couple of other TODOs in Concurrency code. One of which was removed because the improvement would have only been a negligible improvement to the ManagedThreadFactory creation path, which shouldn't be very frequent.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

