### PR TITLE
changing Jakarta Validation 3.1 feature and bundle to use the 3.1.1 v…

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1584,7 +1584,7 @@
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
-      <version>3.1.0</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>jakarta.websocket</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -312,7 +312,7 @@ jakarta.servlet:jakarta.servlet-api:6.1.0
 jakarta.transaction:jakarta.transaction-api:1.3.3
 jakarta.transaction:jakarta.transaction-api:2.0.1
 jakarta.validation:jakarta.validation-api:3.0.2
-jakarta.validation:jakarta.validation-api:3.1.0
+jakarta.validation:jakarta.validation-api:3.1.1
 jakarta.websocket:jakarta.websocket-api:2.0.0
 jakarta.websocket:jakarta.websocket-api:2.1.1
 jakarta.websocket:jakarta.websocket-api:2.2.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.validation-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.validation-3.1.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.jakarta.validation-3.1
 visibility=private
 singleton=true
 -features=com.ibm.websphere.appserver.eeCompatible-11.0
--bundles=io.openliberty.jakarta.validation.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.validation:jakarta.validation-api:3.1.0"
+-bundles=io.openliberty.jakarta.validation.3.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.validation:jakarta.validation-api:3.1.1"
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.jakarta/validation.3.1.bnd
+++ b/dev/io.openliberty.jakarta/validation.3.1.bnd
@@ -20,7 +20,7 @@ Bundle-SymbolicName: io.openliberty.jakarta.validation.3.1; singleton:=true
 Export-Package: jakarta.validation.*;version="3.1.0"
 
 -includeresource: \
-  @${repo;jakarta.validation:jakarta.validation-api;3.1.0;EXACT}!/!(META-INF/maven/*|module-info.class)
+  @${repo;jakarta.validation:jakarta.validation-api;3.1.1;EXACT}!/!(META-INF/maven/*|module-info.class)
 
 -maven-dependencies: \
-   dep1;groupId=jakarta.validation;artifactId=jakarta.validation-api;version=3.1.0;scope=runtime
+   dep1;groupId=jakarta.validation;artifactId=jakarta.validation-api;version=3.1.1;scope=runtime

--- a/dev/io.openliberty.jakarta/validation.3.1.bnd
+++ b/dev/io.openliberty.jakarta/validation.3.1.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


Jakarta Validation 3.1.1 released.  https://github.com/jakartaee/validation/releases/tag/3.1.1
Hence changing Jakarta Validation 3.1 feature and bundle to use the 3.1.1 version.
