### PR TITLE
test case for inherited interceptor binding

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2024 IBM Corporation and others.
+# Copyright (c) 2017,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -32,5 +32,6 @@ fat.project: true
 	io.openliberty.jakarta.cdi.4.1;version=latest,\
 	io.openliberty.jakarta.concurrency.3.1;version=latest,\
 	io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\
+	io.openliberty.jakarta.interceptor.2.1;version=latest,\
 	io.openliberty.jakarta.servlet.6.1;version=latest,\
 	io.openliberty.jakarta.transaction.2.0;version=latest

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -110,6 +110,11 @@ public class ConcurrentCDITest extends FATServletClient {
     }
 
     @Test
+    public void testInheritAsynchronous() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
     public void testInjectContextServiceDefaultInstance() throws Exception {
         runTest(server, APP_NAME, testName);
     }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -369,6 +369,22 @@ public class ConcurrentCDIServlet extends HttpServlet {
     }
 
     /**
+     * Test that an application-defined interceptor can be annotated with
+     * Asynchronous, causing the interceptor binding annotation to make
+     * methods into asynchronous methods.
+     */
+    public void testInheritAsynchronous() throws Exception {
+        // Use separate completable future to avoid causing the asynchronous
+        // method to complete inline on the requester thread.
+        CompletableFuture<Thread> cf = new CompletableFuture<>();
+
+        testBean.inheritAsync().thenAccept(cf::complete);
+
+        Thread thread = cf.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertNotSame(Thread.currentThread(), thread);
+    }
+
+    /**
      * Inject default instance of ContextService and use it.
      */
     public void testInjectContextServiceDefaultInstance() throws Exception {

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/MyAsync.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/MyAsync.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi.web;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.interceptor.InterceptorBinding;
+
+/**
+ * Tests if CDI bean method with Observes Startup can access an injected
+ * Concurrency resource.
+ */
+@Asynchronous
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+public @interface MyAsync {
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/TestBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/TestBean.java
@@ -13,6 +13,7 @@
 package concurrent.cdi.web;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -29,6 +30,15 @@ public class TestBean {
      * We want to test that a CDI extension can do it.
      */
     public CompletableFuture<Thread> asyncByExtension() {
+        return Asynchronous.Result.complete(Thread.currentThread());
+    }
+
+    /**
+     * Do not put @Asynchronous on this method.
+     * We want to test that it is inherited from @MyAsync.
+     */
+    @MyAsync
+    public CompletionStage<Thread> inheritAsync() {
         return Asynchronous.Result.complete(Thread.currentThread());
     }
 }


### PR DESCRIPTION
Write an automated test to cover the other scenario from #28978 
The application adds an interceptor of its own, which is annotated with Asynchronous.  Bean methods that are annotated with the interceptor binding annotation from the application must inherit Asynchronous from that.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".