### PR TITLE
fips140-3: don't cache iv in audit crypto

### DIFF
--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/encryption/AuditCrypto.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/encryption/AuditCrypto.java
@@ -2118,14 +2118,10 @@ final class AuditCrypto {
 
         if (cipher.indexOf("ECB") == -1) {
             if (cipher.indexOf("AES") != -1) {
-                if (ivs16 == null) {
-                    setIVS16(key);
-                }
+                setIVS16(key);
                 ci.init(cipherMode, sKey, ivs16);
             } else {
-                if (ivs8 == null) {
-                    setIVS8(key);
-                }
+                setIVS8(key);
                 ci.init(cipherMode, sKey, ivs8);
             }
         } else {
@@ -2225,21 +2221,18 @@ final class AuditCrypto {
         if (tc.isEntryEnabled())
             Tr.entry(tc, "setIVS8");
 
-        if (ivs8 == null) // only set it once
-        {
-            try {
-                byte[] iv8 = new byte[8];
-                for (int i = 0; i < 8; i++) {
-                    iv8[i] = key[i];
-                }
-                ivs8 = new IvParameterSpec(iv8);
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "setIVS8: ivs8 successfully set");
-            } catch (Exception e) {
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "setIVS8 unxepected exception setting initialization vector", new Object[] { e });
-                com.ibm.ws.ffdc.FFDCFilter.processException(e, "com.ibm.ws.security.ltpa.LTPAToken2Factory.initialize", "2539");
+        try {
+            byte[] iv8 = new byte[8];
+            for (int i = 0; i < 8; i++) {
+                iv8[i] = key[i];
             }
+            ivs8 = new IvParameterSpec(iv8);
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "setIVS8: ivs8 successfully set");
+        } catch (Exception e) {
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "setIVS8 unxepected exception setting initialization vector", new Object[] { e });
+            com.ibm.ws.ffdc.FFDCFilter.processException(e, "com.ibm.ws.security.ltpa.LTPAToken2Factory.initialize", "2539");
         }
     }
 
@@ -2250,21 +2243,18 @@ final class AuditCrypto {
         if (tc.isEntryEnabled())
             Tr.entry(tc, "setIVS16");
 
-        if (ivs16 == null) // only set it once
-        {
-            try {
-                byte[] iv16 = new byte[16];
-                for (int i = 0; i < 16; i++) {
-                    iv16[i] = key[i];
-                }
-                ivs16 = new IvParameterSpec(iv16);
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "setIVS16: ivs16 successfully set");
-            } catch (Exception e) {
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "setIVS16 unxepected exception setting initialization vector", new Object[] { e });
-                com.ibm.ws.ffdc.FFDCFilter.processException(e, "com.ibm.ws.security.ltpa.LTPAToken2Factory.initialize", "2568");
+        try {
+            byte[] iv16 = new byte[16];
+            for (int i = 0; i < 16; i++) {
+                iv16[i] = key[i];
             }
+            ivs16 = new IvParameterSpec(iv16);
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "setIVS16: ivs16 successfully set");
+        } catch (Exception e) {
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "setIVS16 unxepected exception setting initialization vector", new Object[] { e });
+            com.ibm.ws.ffdc.FFDCFilter.processException(e, "com.ibm.ws.security.ltpa.LTPAToken2Factory.initialize", "2568");
         }
     }
 }


### PR DESCRIPTION
we are currently cacheing the initialization vector in audit crypto for aes which is leading to issues because the iv should be derived per the encryption key and we have two encryption keys in audit (1 for signing and 1 for encrypting). thus, whichever operation is done first determines the iv that is used for both operations. this is incorrect as we should be using an iv that corresponds to the encryption key being used, and not the same iv for both keys.