### PR TITLE
transactional interceptor on repository interface

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -56,6 +56,15 @@ public class Util {
     public static final String EOLN = String.format("%n");
 
     /**
+     * Type of life cycle methods (by annotation name) that are capable of
+     * returning entities.
+     */
+    static final List<String> LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES = //
+                    List.of(Insert.class.getSimpleName(),
+                            Save.class.getSimpleName(),
+                            Update.class.getSimpleName());
+
+    /**
      * Commonly used result types that are not entities.
      */
     static final Set<Class<?>> NON_ENTITY_RESULT_TYPES = new HashSet<>();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,8 @@ import java.util.Set;
 
 import javax.sql.DataSource;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
@@ -33,6 +35,7 @@ import jakarta.persistence.PersistenceException;
  * This builder is used when a persistence unit reference JNDI name is configured as the repository dataStore.
  */
 public class PUnitEMBuilder extends EntityManagerBuilder {
+    private static final TraceComponent tc = Tr.register(PUnitEMBuilder.class);
 
     private final EntityManagerFactory emf;
 
@@ -66,8 +69,13 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
     }
 
     @Override
+    @Trivial
     public EntityManager createEntityManager() {
-        return emf.createEntityManager();
+        EntityManager em = emf.createEntityManager();
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "createEntityManager: " + em);
+        return em;
     }
 
     @FFDCIgnore(PersistenceException.class)

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -458,8 +458,13 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
     }
 
     @Override
+    @Trivial
     public EntityManager createEntityManager() {
-        return persistenceServiceUnit.createEntityManager();
+        EntityManager em = persistenceServiceUnit.createEntityManager();
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "createEntityManager: " + em);
+        return em;
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -139,7 +139,10 @@ public class DataTestServlet extends FATServlet {
     Personnel personnel;
 
     @Inject
-    PersonRepo persons;
+    PersonRepo personRepo;
+
+    @Inject
+    Persons persons;
 
     // Only add to this repository within the Servlet.init method so that all tests can rely on its data:
     @Inject
@@ -2238,7 +2241,7 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testFindMultiple() throws Exception {
-        assertEquals(Collections.EMPTY_LIST, persons.find("TestFindMultiple"));
+        assertEquals(Collections.EMPTY_LIST, personRepo.find("TestFindMultiple"));
 
         Person jane = new Person();
         jane.firstName = "Jane";
@@ -2257,8 +2260,8 @@ public class DataTestServlet extends FATServlet {
 
         tran.begin();
         try {
-            persons.save(List.of(jane, joe));
-            persons.save(List.of(jude));
+            personRepo.save(List.of(jane, joe));
+            personRepo.save(List.of(jude));
         } finally {
             if (tran.getStatus() == Status.STATUS_MARKED_ROLLBACK)
                 tran.rollback();
@@ -2266,7 +2269,7 @@ public class DataTestServlet extends FATServlet {
                 tran.commit();
         }
 
-        List<Person> found = persons.find("TestFindMultiple");
+        List<Person> found = personRepo.find("TestFindMultiple");
         assertNotNull(found);
         assertEquals(2, found.size());
 
@@ -2286,7 +2289,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(p2expected.firstName, p2.firstName);
         assertEquals(p2expected.ssn_id, p2.ssn_id);
 
-        found = persons.find("Test-FindMultiple");
+        found = personRepo.find("Test-FindMultiple");
         assertNotNull(found);
         assertEquals(1, found.size());
         assertEquals(jude.ssn_id, found.get(0).ssn_id);
@@ -2671,13 +2674,13 @@ public class DataTestServlet extends FATServlet {
         isabelle.ssn_id = 999009003;
 
         try {
-            persons.insertAll(List.of(ian, ike, isabelle));
+            personRepo.insertAll(List.of(ian, ike, isabelle));
             fail("Did not detect duplicate insert of id within collection.");
         } catch (EntityExistsException x) {
             // pass
         }
 
-        persons.insertAll(List.of(ian, isabelle));
+        personRepo.insertAll(List.of(ian, isabelle));
 
         // insert varargs array:
         Person irene = new Person();
@@ -2775,7 +2778,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(null, personnel.insertAll(david, daniel, dorothy, dianne, dominic).join());
 
         assertEquals(List.of("Daniel", "David", "Dianne", "Dominic", "Dorothy"),
-                     persons.findFirstNames("TestInsertAndDeleteMultiple"));
+                     personRepo.findFirstNames("TestInsertAndDeleteMultiple"));
 
         Person dennis = new Person();
         dennis.firstName = "Dennis";
@@ -2797,14 +2800,14 @@ public class DataTestServlet extends FATServlet {
         }
 
         assertEquals(List.of("Daniel", "David", "Dianne", "Dominic", "Dorothy"),
-                     persons.findFirstNames("TestInsertAndDeleteMultiple"));
+                     personRepo.findFirstNames("TestInsertAndDeleteMultiple"));
 
         // delete multiple entities at once
 
         assertEquals(null, personnel.deleteMultiple(daniel, david).join());
 
         assertEquals(List.of("Dianne", "Dominic", "Dorothy"),
-                     persons.findFirstNames("TestInsertAndDeleteMultiple"));
+                     personRepo.findFirstNames("TestInsertAndDeleteMultiple"));
 
         // attempt deletion where one is not found:
 
@@ -2821,14 +2824,14 @@ public class DataTestServlet extends FATServlet {
         }
 
         assertEquals(List.of("Dianne", "Dominic", "Dorothy"),
-                     persons.findFirstNames("TestInsertAndDeleteMultiple"));
+                     personRepo.findFirstNames("TestInsertAndDeleteMultiple"));
 
         // delete remaining:
 
         assertEquals(Integer.valueOf(3), personnel.deleteSeveral(Stream.of(dianne, dorothy, dominic)).join());
 
         assertEquals(List.of(),
-                     persons.findFirstNames("TestInsertAndDeleteMultiple"));
+                     personRepo.findFirstNames("TestInsertAndDeleteMultiple"));
     }
 
     /**
@@ -6059,60 +6062,60 @@ public class DataTestServlet extends FATServlet {
         p3.lastName = "TestTransactional";
         p3.ssn_id = 300201003;
 
-        persons.save(List.of(p1, p2, p3));
+        personRepo.save(List.of(p1, p2, p3));
 
         System.out.println("TxType.SUPPORTS in transaction");
 
         tran.begin();
         try {
-            assertEquals(true, persons.setFirstNameInCurrentTransaction(p3.ssn_id, "Ty")); // update with MANDATORY
-            assertEquals("Ty", persons.getPersonInCurrentOrNoTransaction(p3.ssn_id).firstName); // read value with SUPPORTS
+            assertEquals(true, personRepo.setFirstNameInCurrentTransaction(p3.ssn_id, "Ty")); // update with MANDATORY
+            assertEquals("Ty", personRepo.getPersonInCurrentOrNoTransaction(p3.ssn_id).firstName); // read value with SUPPORTS
         } finally {
             tran.rollback();
         }
 
         assertIterableEquals(List.of("Thomas", "Timothy", "Tyler"),
-                             persons.findFirstNames("TestTransactional"));
+                             personRepo.findFirstNames("TestTransactional"));
 
         System.out.println("TxType.SUPPORTS from no transaction");
 
-        assertEquals("Tyler", persons.getPersonInCurrentOrNoTransaction(p3.ssn_id).firstName);
+        assertEquals("Tyler", personRepo.getPersonInCurrentOrNoTransaction(p3.ssn_id).firstName);
 
         System.out.println("TxType.REQUIRED in transaction");
 
         tran.begin();
         try {
-            assertEquals(true, persons.setFirstNameInCurrentOrNewTransaction(p1.ssn_id, "Tommy"));
+            assertEquals(true, personRepo.setFirstNameInCurrentOrNewTransaction(p1.ssn_id, "Tommy"));
         } finally {
             tran.rollback();
         }
 
         assertIterableEquals(List.of("Thomas", "Timothy", "Tyler"),
-                             persons.findFirstNames("TestTransactional"));
+                             personRepo.findFirstNames("TestTransactional"));
 
         System.out.println("TxType.REQUIRED from no transaction");
 
-        assertEquals(true, persons.setFirstNameInCurrentOrNewTransaction(p1.ssn_id, "Tom"));
+        assertEquals(true, personRepo.setFirstNameInCurrentOrNewTransaction(p1.ssn_id, "Tom"));
 
         assertIterableEquals(List.of("Timothy", "Tom", "Tyler"),
-                             persons.findFirstNames("TestTransactional"));
+                             personRepo.findFirstNames("TestTransactional"));
 
         System.out.println("TxType.MANDATORY in transaction");
 
         tran.begin();
         try {
-            assertEquals(true, persons.setFirstNameInCurrentTransaction(p3.ssn_id, "Ty"));
+            assertEquals(true, personRepo.setFirstNameInCurrentTransaction(p3.ssn_id, "Ty"));
         } finally {
             tran.rollback();
         }
 
         assertIterableEquals(List.of("Timothy", "Tom", "Tyler"),
-                             persons.findFirstNames("TestTransactional"));
+                             personRepo.findFirstNames("TestTransactional"));
 
         System.out.println("TxType.MANDATORY from no transaction is an error");
 
         try {
-            boolean result = persons.setFirstNameInCurrentTransaction(p3.ssn_id, "Ty");
+            boolean result = personRepo.setFirstNameInCurrentTransaction(p3.ssn_id, "Ty");
             fail("Invoked TxType.MANDATORY operation with no transaction on thread. Result: " + result);
         } catch (TransactionalException x) {
             if (!(x.getCause() instanceof TransactionRequiredException))
@@ -6123,26 +6126,26 @@ public class DataTestServlet extends FATServlet {
 
         tran.begin();
         try {
-            assertEquals(true, persons.setFirstNameInNewTransaction(p2.ssn_id, "Timmy"));
+            assertEquals(true, personRepo.setFirstNameInNewTransaction(p2.ssn_id, "Timmy"));
         } finally {
             tran.rollback();
         }
 
         assertIterableEquals(List.of("Timmy", "Tom", "Tyler"),
-                             persons.findFirstNames("TestTransactional"));
+                             personRepo.findFirstNames("TestTransactional"));
 
         System.out.println("TxType.REQUIRES_NEW from no transaction");
 
-        assertEquals(true, persons.setFirstNameInCurrentOrNewTransaction(p2.ssn_id, "Tim"));
+        assertEquals(true, personRepo.setFirstNameInCurrentOrNewTransaction(p2.ssn_id, "Tim"));
 
         assertIterableEquals(List.of("Tim", "Tom", "Tyler"),
-                             persons.findFirstNames("TestTransactional"));
+                             personRepo.findFirstNames("TestTransactional"));
 
         System.out.println("TxType.NEVER in transaction");
 
         tran.begin();
         try {
-            boolean result = persons.setFirstNameWhenNoTransactionIsPresent(p3.ssn_id, "Ty");
+            boolean result = personRepo.setFirstNameWhenNoTransactionIsPresent(p3.ssn_id, "Ty");
             fail("Invoked TxType.NEVER operation with transaction on thread. Result: " + result);
         } catch (TransactionalException x) {
             if (!(x.getCause() instanceof InvalidTransactionException))
@@ -6152,32 +6155,96 @@ public class DataTestServlet extends FATServlet {
         }
 
         assertIterableEquals(List.of("Tim", "Tom", "Tyler"),
-                             persons.findFirstNames("TestTransactional"));
+                             personRepo.findFirstNames("TestTransactional"));
 
         System.out.println("TxType.NEVER from no transaction");
 
-        assertEquals(true, persons.setFirstNameWhenNoTransactionIsPresent(p3.ssn_id, "Ty"));
+        assertEquals(true, personRepo.setFirstNameWhenNoTransactionIsPresent(p3.ssn_id, "Ty"));
 
         assertIterableEquals(List.of("Tim", "Tom", "Ty"),
-                             persons.findFirstNames("TestTransactional"));
+                             personRepo.findFirstNames("TestTransactional"));
 
         System.out.println("TxType.NOT_SUPPORTED in transaction");
 
         tran.begin();
         try {
-            assertEquals(true, persons.setFirstNameWithCurrentTransactionSuspended(p3.ssn_id, "Tyler"));
+            assertEquals(true, personRepo.setFirstNameWithCurrentTransactionSuspended(p3.ssn_id, "Tyler"));
         } finally {
             tran.rollback();
         }
 
         assertIterableEquals(List.of("Tim", "Tom", "Tyler"),
-                             persons.findFirstNames("TestTransactional"));
+                             personRepo.findFirstNames("TestTransactional"));
 
         System.out.println("TxType.NOT_SUPPORTED from no transaction");
 
-        assertEquals("Tyler", persons.getPersonInCurrentOrNoTransaction(p3.ssn_id).firstName);
+        assertEquals("Tyler", personRepo.getPersonInCurrentOrNoTransaction(p3.ssn_id).firstName);
 
         personnel.removeAll().get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+    }
+
+    /**
+     * Test that a repository interface can be annotated as Transactional, and the
+     * methods honor the specified transaction type of REQUIRES_NEW.
+     */
+    @Test
+    public void testTransactionalRepository() throws Exception {
+        people.deleteBySSN_IdBetween(0L, 999999999L);
+
+        Person p1 = new Person();
+        p1.firstName = "Tabitha";
+        p1.lastName = "TestTransactionalRepository";
+        p1.ssn_id = 555331111;
+
+        Person p2 = new Person();
+        p2.firstName = "Todd";
+        p2.lastName = "TestTransactionalRepository";
+        p2.ssn_id = 444332222;
+
+        Person p3 = new Person();
+        p3.firstName = "Ted";
+        p3.lastName = "TestTransactionalRepository";
+        p3.ssn_id = 111223333;
+
+        tran.begin();
+        try {
+            persons.insert(p1); // runs in current transaction
+
+            persons.insertAll(p2, p3); // runs in its own transaction
+        } finally {
+            tran.rollback();
+        }
+
+        // insert again, because the previous should have rolled back
+        persons.insert(p1);
+
+        tran.begin();
+        try {
+            p1.lastName = "Test-TransactionalRepository";
+            assertEquals(true, persons.updateOne(p1));
+
+            p2.lastName = "TestTransactional-Repository";
+            p3.firstName = "Theodore";
+            assertEquals(2L, persons.updateSome(p2, p3));
+        } finally {
+            // The above must run in their own separate transactions,
+            // so they must not roll back along with the following:
+            tran.rollback();
+        }
+
+        p1 = personRepo.getPersonInCurrentOrNoTransaction(p1.ssn_id);
+        assertEquals("Tabitha", p1.firstName);
+        assertEquals("Test-TransactionalRepository", p1.lastName);
+
+        p2 = personRepo.getPersonInCurrentOrNoTransaction(p2.ssn_id);
+        assertEquals("Todd", p2.firstName);
+        assertEquals("TestTransactional-Repository", p2.lastName);
+
+        p3 = personRepo.getPersonInCurrentOrNoTransaction(p3.ssn_id);
+        assertEquals("Theodore", p3.firstName);
+        assertEquals("TestTransactionalRepository", p3.lastName);
+
+        assertEquals(3L, people.deleteBySSN_IdBetween(0L, 999999999L));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
-import jakarta.data.repository.Update;
 import jakarta.transaction.Transactional;
 import jakarta.transaction.Transactional.TxType;
 
@@ -39,12 +38,6 @@ public interface PersonRepo {
     @Query("SELECT firstName WHERE lastName=:lastName")
     @OrderBy("firstName")
     List<String> findFirstNames(@Param("lastName") String surname);
-
-    @Insert
-    void insert(Person p);
-
-    @Insert
-    void insertAll(Person... p);
 
     @Insert
     void insertAll(Iterable<Person> p);
@@ -80,10 +73,4 @@ public interface PersonRepo {
     @Transactional(TxType.NOT_SUPPORTED)
     boolean setFirstNameWithCurrentTransactionSuspended(Long id,
                                                         String newFirstName);
-
-    @Update
-    boolean updateOne(Person person);
-
-    @Update
-    long updateSome(Person... people);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Persons.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Persons.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.Update;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
+
+/**
+ * A repository that is annotated with Transactional and sets the REQUIRES_NEW
+ * transaction type so that by default, all repository operations will run in a
+ * transaction of their own instead of a transaction that was already on the thread.
+ */
+@Repository
+@Transactional(TxType.REQUIRES_NEW)
+public interface Persons {
+
+    @Insert
+    @Transactional(TxType.SUPPORTS)
+    void insert(Person person);
+
+    @Insert
+    void insertAll(Person... people);
+
+    @Update
+    boolean updateOne(Person person);
+
+    @Update
+    long updateSome(Person... people);
+}


### PR DESCRIPTION
Test coverage for Transactional interceptor being placed on a repository method (first commit).
Also contains a commit with refactoring to complete the move of RepositoryImpl methods to QueryInfo.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
