### PR TITLE
@Version attribute of type LocalDateTime

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1502,12 +1502,12 @@ public class DataTestServlet extends FATServlet {
                              houses.findKitchenLengthAndKitchenWidthAndGarageAreaAndAreaByAreaLessThan(2000)
                                              .map(Arrays::toString)
                                              .collect(Collectors.toList()));
-        
+
         /*
          * Update embeddable attributes
          * TODO enable once #30789 is fixed
          */
-        
+
         //assertEquals(true, houses.updateByParcelIdSetGarageAddAreaAddKitchenLengthSetNumBedrooms("TestEmbeddable-304-3655-30", null, 180, 2, 4));
 
         //h = houses.findById("TestEmbeddable-304-3655-30");
@@ -1520,7 +1520,7 @@ public class DataTestServlet extends FATServlet {
         // SQL:  UPDATE WLPHouse SET NUMBEDROOMS = 4, AREA = (AREA + 180), GARAGEAREA = NULL, KITCHENLENGTH = (KITCHENLENGTH + 2) WHERE (PARCELID = 'TestEmbeddable-304-3655-30')
         // This causes the following assertion to fail:
         // assertEquals(null, h.garage);
-        // TODO re-enable the above if fixed
+        // TODO re-enable the above if EclipseLink bug #24926 is fixed
         //assertNotNull(h.kitchen);
         //assertEquals(16, h.kitchen.length);
         //assertEquals(12, h.kitchen.width);
@@ -1529,7 +1529,7 @@ public class DataTestServlet extends FATServlet {
         //assertEquals(153000f, h.purchasePrice, 0.001f);
         //assertEquals(Year.of(2018), h.sold);
 
-        //assertEquals(2, houses.dropAll());
+        assertEquals(2, houses.dropAll());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -36,9 +36,7 @@ import javax.naming.InitialContext;
 @Repository
 public interface Counties {
 
-    boolean deleteByNameAndLastUpdated(String name, Long version);
-    // TODO switch to the following once EclipseLink bug #30534 is fixed
-    // boolean deleteByNameAndLastUpdated(String name, LocalDateTime version);
+    boolean deleteByNameAndLastUpdated(String name, LocalDateTime version);
 
     int deleteByNameIn(List<String> names);
 
@@ -53,9 +51,7 @@ public interface Counties {
     @OrderBy("name")
     List<Set<CityId>> findCitiesByNameStartsWith(String beginning);
 
-    Long findLastUpdatedByName(String name);
-    // TODO switch to the following once EclipseLink bug #30534 is fixed
-    //LocalDateTime findLastUpdatedByName(String name);
+    LocalDateTime findLastUpdatedByName(String name);
 
     @Query("SELECT zipcodes WHERE name = ?1")
     Optional<int[]> findZipCodesByName(String name);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/County.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/County.java
@@ -26,9 +26,7 @@ public class County {
     public Set<CityId> cities;
 
     @Version
-    public Long lastUpdated;
-    // TODO switch to the following once EclipseLink bug #30534 is fixed
-    //public LocalDateTime lastUpdated;
+    public LocalDateTime lastUpdated;
 
     @Id
     public String name;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2082,9 +2082,17 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(Integer.valueOf(1983), camry.getYearIntroduced());
         assertEquals("Toyota", camry.getManufacturer().getName());
 
-        corolla = models.findById(corollaId).orElseThrow();
-
-        assertEquals("Corolla", corolla.getName());
+        // TODO enable once EclipseLink bug #28813 is fixed
+        //Instant corollaLastMod;
+        Long corollaLastMod;
+        corollaLastMod = models.lastModified(corollaId).orElseThrow();
+        List<Model> found = models.modifiedAt(corollaLastMod);
+        assertEquals(false, found.isEmpty());
+        corolla = null;
+        for (Model model : found)
+            if ("Corolla".equals(model.getName()))
+                corolla = model;
+        assertNotNull(corolla);
         assertEquals(Integer.valueOf(1966), corolla.getYearIntroduced());
         assertEquals("Toyota", corolla.getManufacturer().getName());
 
@@ -4334,9 +4342,7 @@ public class DataJPATestServlet extends FATServlet {
         }
 
         // Update the version/LocalDateTime and retry:
-        Long lastUpdate;
-        // TODO switch to the following once EclipseLink bug #30534 is fixed
-        //LocalDateTime lastUpdate;
+        LocalDateTime lastUpdate;
         lastUpdate = dodge.lastUpdated = counties.findLastUpdatedByName("Dodge");
         dodge.population = 20981;
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -270,6 +270,8 @@ public class DataJPATestServlet extends FATServlet {
 
         // TODO remove this workaround for intermittent issue triggered by test ordering once 28078 is fixed
         testLiteralDouble();
+        // To quickly try reproducing the issue, remove the above line and add the following line to tearDown,
+        // runTest(server, "DataJPATestApp", "testLiteralDouble");
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Model.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Model.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Version;
 
 /**
  * This entity has a ManyToOne relationship with Manufacturer.
@@ -34,6 +35,12 @@ public class Model {
 
     @Column(name = "name")
     private String name;
+
+    @Column(name = "updated_at")
+    @Version
+    // TODO enable once EclipseLink bug #28813 is fixed
+    //Instant updatedAt;
+    Long updatedAt;
 
     @Column(name = "intro_year")
     private Integer yearIntroduced;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Models.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Models.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,13 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Repository;
 
 /**
@@ -22,4 +26,13 @@ import jakarta.data.repository.Repository;
  */
 @Repository
 public interface Models extends CrudRepository<Model, UUID> {
+    @Find
+    // TODO enable once EclipseLink bug #28813 is fixed
+    //Optional<Instant> lastModified(UUID id);
+    Optional<Long> lastModified(UUID id);
+
+    @Find
+    // TODO enable once EclipseLink bug #28813 is fixed
+    //List<Model> modifiedAt(Instant updatedAt);
+    List<Model> modifiedAt(Long updatedAt);
 }


### PR DESCRIPTION
Tests for LocalDateTime attribute being a `@Version` (enabled) and Instant attribute being a `@Version` (disabled due to being blocked by another EclipseLink issue).

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
