### PR TITLE
Update SymbolicNameTest to not fetch from maven

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/SymbolicNameTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/SymbolicNameTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020,2024 IBM Corporation and others.
+ * Copyright (c) 2020,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -139,7 +139,7 @@ public class SymbolicNameTest {
         }
         File workspaceDir = new File(System.getProperty("user.dir")).getAbsoluteFile().getParentFile();
 
-        Workspace bndWorkspace = new Workspace(workspaceDir);
+        Workspace bndWorkspace = new Workspace(workspaceDir, "com.ibm.websphere.appserver.features");
         Collection<Project> projects = bndWorkspace.getAllProjects();
         for (Project project : projects) {
             Collection<String> bsns = project.getBsns();


### PR DESCRIPTION
- Set the BndWorkspace to offline in order to avoid loading artifacts from maven.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
