### PR TITLE
Update Gzip jaxws test to not fail sometimes

### DIFF
--- a/dev/io.openliberty.jaxws.config_fat/fat/src/io/openliberty/jaxws/config/fat/GzipInterceptorsTest.java
+++ b/dev/io.openliberty.jaxws.config_fat/fat/src/io/openliberty/jaxws/config/fat/GzipInterceptorsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -102,8 +102,8 @@ public class GzipInterceptorsTest {
 			response.contains("Hello, AddedElement"));
 
         // Test default behavior - gzip interceptors should not be enabled
-	String findStr1 = gzipServer.waitForStringInTrace(GZIPOUT_INTERCEPTOR_INVOKED);
-	String findStr2 = gzipServer.waitForStringInTrace(GZIPIN_INTERCEPTOR_INVOKED);
+	String findStr1 = gzipServer.waitForStringInTrace(GZIPOUT_INTERCEPTOR_INVOKED, 15000);
+	String findStr2 = gzipServer.waitForStringInTrace(GZIPIN_INTERCEPTOR_INVOKED, 15000);
 	assertTrue("Unexpeced output [" + GZIPOUT_INTERCEPTOR_INVOKED + "]  found in the server log", findStr1 == null);
 	assertTrue("Unexpeced output [" + GZIPIN_INTERCEPTOR_INVOKED + "]  found in the server log", findStr2 == null);
 
@@ -124,8 +124,8 @@ public class GzipInterceptorsTest {
 	assertTrue("Expected successful response 2, but response was " + response,
 			response.contains("Hello, AddedElement"));
 
-	findStr1 = gzipServer.waitForStringInTrace(GZIPOUT_INTERCEPTOR_INVOKED);
-	findStr2 = gzipServer.waitForStringInTrace(GZIPIN_INTERCEPTOR_INVOKED);
+	findStr1 = gzipServer.waitForStringInTrace(GZIPOUT_INTERCEPTOR_INVOKED, 15000);
+	findStr2 = gzipServer.waitForStringInTrace(GZIPIN_INTERCEPTOR_INVOKED, 15000);
 
 	assertTrue("Unable to find the output [" + GZIPOUT_INTERCEPTOR_INVOKED + "]  in the server log", findStr1 != null);
 	assertTrue("Unable to find the output [" + GZIPIN_INTERCEPTOR_INVOKED + "]  in the server log", findStr2 != null);
@@ -164,8 +164,8 @@ public class GzipInterceptorsTest {
 	assertTrue("Expected successful response, but response was " + response,
 			response.contains("Hello, AddedElement"));
 
-	String findStr1 = gzipServer.waitForStringInTrace(GZIPOUT_INTERCEPTOR_INVOKED);
-	String findStr2 = gzipServer.waitForStringInTrace(GZIPIN_INTERCEPTOR_INVOKED);
+	String findStr1 = gzipServer.waitForStringInTrace(GZIPOUT_INTERCEPTOR_INVOKED, 15000);
+	String findStr2 = gzipServer.waitForStringInTrace(GZIPIN_INTERCEPTOR_INVOKED, 15000);
 	assertTrue("Unexpeced output [" + GZIPOUT_INTERCEPTOR_INVOKED + "]  found in the server log", findStr1 == null);
 	assertTrue("Unexpeced output [" + GZIPIN_INTERCEPTOR_INVOKED + "]  found in the server log", findStr2 == null);
 
@@ -178,15 +178,18 @@ public class GzipInterceptorsTest {
 	assertTrue("Expected successful response 2, but response was " + response,
 			response.contains("Hello, AddedElement"));
 
-	findStr1 = gzipServer.waitForStringInTrace(GZIPOUT_INTERCEPTOR_INVOKED);
-	findStr2 = gzipServer.waitForStringInTrace(GZIPIN_INTERCEPTOR_INVOKED);
+	findStr1 = gzipServer.waitForStringInTrace(GZIPOUT_INTERCEPTOR_INVOKED, 15000);
+	findStr2 = gzipServer.waitForStringInTrace(GZIPIN_INTERCEPTOR_INVOKED, 15000);
 
 	assertTrue("Unable to find the output [" + GZIPOUT_INTERCEPTOR_INVOKED + "]  in the server log", findStr1 != null);
 	assertTrue("Unable to find the output [" + GZIPIN_INTERCEPTOR_INVOKED + "]  in the server log", findStr2 != null);
 
     }
 
-    private String runTest(LibertyServer server, String pathAndParams) throws ProtocolException, IOException {
+    private String runTest(LibertyServer server, String pathAndParams) throws Exception {
+        // Set the mark to end of log before running test so searching the trace log doesn't get the trace messages from the previous test
+        gzipServer.setTraceMarkToEndOfDefaultTrace();
+
         URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + pathAndParams);
         Log.info(this.getClass(), "assertResponseNotNull", "Calling Application with URL=" + url.toString());
 


### PR DESCRIPTION
- Update test case to set the trace log mark to the end of the file before executing the test on the server so that if the tests are run in the opposite order as written in the file, the test can still work
- Add timeouts to 15 seconds for the log checking so that we aren't waiting for 2 minute each time for logs that we are expecting not to be found.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
