### PR TITLE
Add additional logic to FeatureUtil.isTest method

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/util/FeatureUtil.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/util/FeatureUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -222,15 +222,14 @@ public class FeatureUtil {
      * <li>test.InterimFixesManagerTest-1.0.mf</li>
      * <li>test.TestFixManagerTest-1.0.mf</li>
      * <li>test.featurefixmanager-1.0.mf</li>
-     * <li>txtest-1.0.mf</li>
-     * <li>txtest-2.0.mf</li>
+     * <li>features with IBM-Test-Feature:true set</li>
      * </ul>
      *
      * @param featureName A feature name.
      *
      * @return True or false telling if the named feature is a test feature.
      */
-    public static boolean isTest(String featureName) {
-        return featureName.startsWith("test.") || featureName.startsWith("txtest-");
+    public static boolean isTest(String featureName, ProvisioningFeatureDefinition featureDef) {
+        return featureName.startsWith("test.") || "true".equals(featureDef.getHeader("IBM-Test-Feature"));
     }
 }

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/util/RepositoryUtil.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/util/RepositoryUtil.java
@@ -714,7 +714,7 @@ public class RepositoryUtil {
             for (ProvisioningFeatureDefinition featureDef : getFeatureDefs()) {
                 if (isPublic(featureDef)) {
                     String symbolicName = featureDef.getSymbolicName();
-                    if (!isTest(symbolicName)) {
+                    if (!isTest(symbolicName, featureDef)) {
                         usePublicFeatures.add(symbolicName);
                     }
                 }

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/repository.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/repository.xml
@@ -3379,42 +3379,6 @@
         </constituent>
     </feature>
     <feature>
-        <file>com.ibm.websphere.appserver.componenttest-1.0.mf</file>
-        <name>componenttest-1.0</name>
-        <symbolic-name>com.ibm.websphere.appserver.componenttest-1.0</symbolic-name>
-        <short-name>componenttest-1.0</short-name>
-        <version>1.0.0</version>
-        <ibm-version>2</ibm-version>
-        <supported-version/>
-        <visibility>PUBLIC</visibility>
-        <restart>NEVER</restart>
-        <constituent>
-            <symbolic-name>com.ibm.ws.componenttest</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.1.0)</version-range>
-        </constituent>
-    </feature>
-    <feature>
-        <file>com.ibm.websphere.appserver.componenttest-2.0.mf</file>
-        <name>componenttest-2.0</name>
-        <symbolic-name>com.ibm.websphere.appserver.componenttest-2.0</symbolic-name>
-        <short-name>componenttest-2.0</short-name>
-        <version>1.0.0</version>
-        <ibm-version>2</ibm-version>
-        <supported-version/>
-        <visibility>PUBLIC</visibility>
-        <restart>NEVER</restart>
-        <constituent>
-            <symbolic-name>com.ibm.ws.componenttest.2.0</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.1.0)</version-range>
-        </constituent>
-    </feature>
-    <feature>
         <file>com.ibm.websphere.appserver.concurrencyPolicy-1.0.mf</file>
         <name>com.ibm.websphere.appserver.concurrencyPolicy-1.0</name>
         <symbolic-name>com.ibm.websphere.appserver.concurrencyPolicy-1.0</symbolic-name>
@@ -5070,24 +5034,6 @@
             <start-level>12</start-level>
             <activation-type>PARALLEL</activation-type>
             <type>type=jar</type>
-            <version-range>[1.0.0,1.1.0)</version-range>
-        </constituent>
-    </feature>
-    <feature>
-        <file>com.ibm.websphere.appserver.http2clienttest-1.0.mf</file>
-        <name>http2clienttest-1.0</name>
-        <symbolic-name>com.ibm.websphere.appserver.http2clienttest-1.0</symbolic-name>
-        <short-name>http2clienttest-1.0</short-name>
-        <version>1.0.0</version>
-        <ibm-version>2</ibm-version>
-        <supported-version/>
-        <visibility>PUBLIC</visibility>
-        <restart>NEVER</restart>
-        <constituent>
-            <symbolic-name>com.ibm.ws.http2.client</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
             <version-range>[1.0.0,1.1.0)</version-range>
         </constituent>
     </feature>
@@ -24397,24 +24343,6 @@
         </constituent>
     </feature>
     <feature>
-        <file>com.ibm.websphere.appserver.timedexit-1.0.mf</file>
-        <name>timedexit-1.0</name>
-        <symbolic-name>com.ibm.websphere.appserver.timedexit-1.0</symbolic-name>
-        <short-name>timedexit-1.0</short-name>
-        <version>1.0.0</version>
-        <ibm-version>2</ibm-version>
-        <supported-version/>
-        <visibility>PUBLIC</visibility>
-        <restart>NEVER</restart>
-        <constituent>
-            <symbolic-name>com.ibm.ws.timedexit.internal</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.1.0)</version-range>
-        </constituent>
-    </feature>
-    <feature>
         <file>com.ibm.websphere.appserver.transaction-1.1.mf</file>
         <name>com.ibm.websphere.appserver.transaction-1.1</name>
         <symbolic-name>com.ibm.websphere.appserver.transaction-1.1</symbolic-name>
@@ -28002,65 +27930,6 @@
             <activation-type>PARALLEL</activation-type>
             <type>type=osgi.bundle</type>
             <version-range>[1.0.0,1.1.0)</version-range>
-        </constituent>
-    </feature>
-    <feature>
-        <file>arquillian-liberty-support.mf</file>
-        <name>arquillian-support-1.0</name>
-        <symbolic-name>io.openliberty.arquillian.arquillian-support-1.0</symbolic-name>
-        <short-name>arquillian-support-1.0</short-name>
-        <version>1.0.8</version>
-        <ibm-version>2</ibm-version>
-        <supported-version/>
-        <visibility>PUBLIC</visibility>
-        <restart>NEVER</restart>
-        <constituent>
-            <symbolic-name>arquillian-liberty-support</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>1.0.8</version-range>
-        </constituent>
-        <constituent>
-            <symbolic-name>com.ibm.wsspi.appserver.webBundle-1.0</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.subsystem.feature</type>
-            <version-range>0.0.0</version-range>
-        </constituent>
-        <constituent>
-            <symbolic-name>com.ibm.websphere.appserver.servlet-3.0</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.subsystem.feature</type>
-            <version-range>0.0.0</version-range>
-            <tolerate>3.1</tolerate>
-            <tolerate>4.0</tolerate>
-        </constituent>
-    </feature>
-    <feature>
-        <file>arquillian-liberty-support-jakarta-2.1.mf</file>
-        <name>arquillian-support-jakarta-2.1</name>
-        <symbolic-name>io.openliberty.arquillian.arquillian-support-jakarta-2.1</symbolic-name>
-        <short-name>arquillian-support-jakarta-2.1</short-name>
-        <version>2.1.1</version>
-        <ibm-version>2</ibm-version>
-        <supported-version/>
-        <visibility>PUBLIC</visibility>
-        <restart>NEVER</restart>
-        <constituent>
-            <symbolic-name>arquillian-liberty-support-jakarta</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>2.1.1</version-range>
-        </constituent>
-        <constituent>
-            <symbolic-name>com.ibm.websphere.appserver.localConnector-1.0</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.subsystem.feature</type>
-            <version-range>0.0.0</version-range>
         </constituent>
     </feature>
     <feature>
@@ -57710,72 +57579,6 @@
             <activation-type>PARALLEL</activation-type>
             <type>type=osgi.bundle</type>
             <version-range>[1.0.0,1.1.0)</version-range>
-        </constituent>
-    </feature>
-    <feature>
-        <file>txtest-1.0.mf</file>
-        <name>txtest-1.0</name>
-        <symbolic-name>txtest-1.0</symbolic-name>
-        <version>1.0.0</version>
-        <ibm-version>2</ibm-version>
-        <supported-version/>
-        <visibility>PUBLIC</visibility>
-        <restart>NEVER</restart>
-        <constituent>
-            <symbolic-name>com.ibm.ws.transaction.test.util</symbolic-name>
-            <location>lib/com.ibm.ws.transaction.test.util.jar</location>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.1.0)</version-range>
-        </constituent>
-        <constituent>
-            <symbolic-name>com.ibm.websphere.javaee.transaction.1.2</symbolic-name>
-            <location>dev/api/spec/,lib/</location>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.1.0)</version-range>
-        </constituent>
-        <constituent>
-            <symbolic-name>com.ibm.ws.tx.embeddable</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.2.0)</version-range>
-        </constituent>
-    </feature>
-    <feature>
-        <file>txtest-2.0.mf</file>
-        <name>txtest-2.0</name>
-        <symbolic-name>txtest-2.0</symbolic-name>
-        <version>1.0.0</version>
-        <ibm-version>2</ibm-version>
-        <supported-version/>
-        <visibility>PUBLIC</visibility>
-        <restart>NEVER</restart>
-        <constituent>
-            <symbolic-name>com.ibm.ws.transaction.test.util.jakarta</symbolic-name>
-            <location>lib/com.ibm.ws.transaction.test.util.jakarta.jar</location>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.1.0)</version-range>
-        </constituent>
-        <constituent>
-            <symbolic-name>io.openliberty.jakarta.transaction.2.0</symbolic-name>
-            <location>dev/api/spec/,lib/</location>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.1.0)</version-range>
-        </constituent>
-        <constituent>
-            <symbolic-name>com.ibm.ws.tx.embeddable.jakarta</symbolic-name>
-            <start-level>12</start-level>
-            <activation-type>SEQUENTIAL</activation-type>
-            <type>type=osgi.bundle</type>
-            <version-range>[1.0.0,1.2.0)</version-range>
         </constituent>
     </feature>
 </repository>

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_durations.txt
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_durations.txt
@@ -14,8 +14,6 @@ com.ibm.websphere.appserver.bells-1.0_SERVER 0.003554700 s
 com.ibm.websphere.appserver.cdi-1.2_SERVER 0.014690300 s
 com.ibm.websphere.appserver.cdi-2.0_SERVER 0.016625800 s
 com.ibm.websphere.appserver.cloudant-1.0_SERVER 0.004248800 s
-com.ibm.websphere.appserver.componenttest-1.0_SERVER 0.001112200 s
-com.ibm.websphere.appserver.componenttest-2.0_SERVER 0.000769100 s
 com.ibm.websphere.appserver.concurrent-1.0_SERVER 0.005101100 s
 com.ibm.websphere.appserver.constrainedDelegation-1.0_SERVER 0.014541900 s
 com.ibm.websphere.appserver.couchdb-1.0_SERVER 0.004244900 s
@@ -28,7 +26,6 @@ com.ibm.websphere.appserver.ejbRemote-3.2_SERVER 0.028295000 s
 com.ibm.websphere.appserver.el-3.0_SERVER 0.001529500 s
 com.ibm.websphere.appserver.eventLogging-1.0_SERVER 0.001598200 s
 com.ibm.websphere.appserver.federatedRegistry-1.0_SERVER 0.010026500 s
-com.ibm.websphere.appserver.http2clienttest-1.0_SERVER 0.000773500 s
 com.ibm.websphere.appserver.j2eeManagement-1.1_SERVER 0.012835400 s
 com.ibm.websphere.appserver.jacc-1.5_SERVER 0.017110100 s
 com.ibm.websphere.appserver.jakartaee-8.0_SERVER 1.837915700 s
@@ -165,7 +162,6 @@ com.ibm.websphere.appserver.spnego-1.0_SERVER 0.037485400 s
 com.ibm.websphere.appserver.springBoot-1.5_SERVER 0.003394900 s
 com.ibm.websphere.appserver.springBoot-2.0_SERVER 0.003195500 s
 com.ibm.websphere.appserver.ssl-1.0_SERVER 0.000693800 s
-com.ibm.websphere.appserver.timedexit-1.0_SERVER 0.000325700 s
 com.ibm.websphere.appserver.transportSecurity-1.0_SERVER 0.000859000 s
 com.ibm.websphere.appserver.wasJmsClient-2.0_SERVER 0.046254100 s
 com.ibm.websphere.appserver.wasJmsSecurity-1.0_SERVER 0.018065500 s
@@ -188,8 +184,6 @@ io.openliberty.appClientSupport-2.0_SERVER 0.013656700 s
 io.openliberty.appSecurity-4.0_SERVER 0.096785800 s
 io.openliberty.appSecurity-5.0_SERVER 0.129644000 s
 io.openliberty.appSecurity-6.0_SERVER 0.121950700 s
-io.openliberty.arquillian.arquillian-support-1.0_SERVER 0.016922000 s
-io.openliberty.arquillian.arquillian-support-jakarta-2.1_SERVER 0.000665300 s
 io.openliberty.batch-2.0_SERVER 0.244823600 s
 io.openliberty.batch-2.1_SERVER 0.504041000 s
 io.openliberty.beanValidation-3.0_SERVER 0.015285300 s
@@ -305,6 +299,5 @@ com.ibm.websphere.appserver.jaxb-2.2_CLIENT 0.002902300 s
 com.ibm.websphere.appserver.jndi-1.0_CLIENT 0.002547300 s
 com.ibm.websphere.appserver.osgiConsole-1.0_CLIENT 0.000348300 s
 com.ibm.websphere.appserver.ssl-1.0_CLIENT 0.000655700 s
-com.ibm.websphere.appserver.timedexit-1.0_CLIENT 0.000680800 s
 io.openliberty.xmlBinding-3.0_CLIENT 0.003295800 s
 io.openliberty.xmlBinding-4.0_CLIENT 0.004895400 s

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_durations_WL.txt
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_durations_WL.txt
@@ -23,11 +23,9 @@ com.ibm.websphere.appserver.osgi.jpa-1.0 0.050935064 s
 com.ibm.websphere.appserver.acmeCA-2.0 0.127215571 s
 com.ibm.websphere.appserver.localConnector-1.0 0.002911764 s
 com.ibm.websphere.health.healthManager-1.0 0.230190773 s
-com.ibm.websphere.appserver.httpservice-2.2 0.005829436 s
 com.ibm.websphere.appserver.mqtt-3.1 0.025521501 s
 io.openliberty.enterpriseBeansLite-4.0 0.028174341 s
 com.ibm.websphere.appserver.scim-2.0 0.061969719 s
-com.ibm.websphere.appserver.fileinstall-1.0 0.001187414 s
 io.openliberty.jsonbContainer-3.0 0.010443026 s
 io.openliberty.webProfile-9.1 0.427188386 s
 com.ibm.websphere.appserver.osgiConsole-1.0 0.002062161 s
@@ -36,7 +34,6 @@ io.openliberty.mpRestClient-3.0 0.106298637 s
 com.ibm.websphere.appserver.beanValidation-2.0 0.016861005 s
 com.ibm.websphere.appserver.distributedMap-1.0 0.010481421 s
 com.ibm.websphere.appserver.transportSecurity-1.0 0.003752261 s
-com.ibm.websphere.appserver.featureverifier-1.0 0.002279037 s
 com.ibm.websphere.appserver.mongodb-2.0 0.007840448 s
 io.openliberty.mail-2.0 0.008042821 s
 io.openliberty.mail-2.1 0.010166927 s
@@ -51,7 +48,6 @@ com.ibm.websphere.appserver.passwordUtilities-1.1 0.051852864 s
 com.ibm.websphere.appserver.mpOpenTracing-2.0 0.102453282 s
 io.openliberty.mpLRACoordinator-1.0 0.042391451 s
 com.ibm.websphere.appserver.mpContextPropagation-1.2 0.016151538 s
-customTaiSample2-1.0 0.001174805 s
 com.ibm.websphere.appserver.mpContextPropagation-1.0 0.011132801 s
 com.ibm.websphere.appserver.federatedRegistry-1.0 0.007226901 s
 com.ibm.websphere.appserver.j2eeManagement-1.1 0.017950129 s
@@ -101,7 +97,6 @@ io.openliberty.appClientSupport-2.0 0.022716686 s
 com.ibm.websphere.appserver.mpGraphQL-1.0 0.042199426 s
 com.ibm.websphere.appserver.mediaServerControl-1.0 0.002358145 s
 com.ibm.websphere.appserver.jsonbContainer-1.0 0.009351198 s
-customRegistrySample-1.0 0.001531300 s
 io.openliberty.pages-3.0 0.020040140 s
 com.ibm.websphere.appserver.logstashCollector-1.0 0.006275205 s
 io.openliberty.pages-3.1 0.025526246 s
@@ -120,7 +115,6 @@ com.ibm.websphere.appserver.mpRestClient-2.0 0.035011277 s
 com.ibm.websphere.appserver.jms-2.0 0.033296951 s
 io.openliberty.enterpriseBeansPersistentTimer-4.0 0.061651854 s
 io.openliberty.jsonb-3.0 0.007780958 s
-com.ibm.websphere.appserver.componenttest-1.0 0.001185704 s
 io.openliberty.webProfile-11.0 0.276581092 s
 com.ibm.websphere.appserver.servlet-4.0 0.013875021 s
 com.ibm.websphere.dynamicRouting-1.0 0.095443696 s
@@ -161,7 +155,6 @@ io.openliberty.cdi-4.1 0.034424028 s
 com.ibm.websphere.appserver.samlWeb-2.0 0.051435206 s
 com.ibm.websphere.appserver.batchManagement-1.0 0.683526041 s
 com.ibm.websphere.appserver.javaee-7.0 0.332427786 s
-com.ibm.websphere.appserver.repositoryConnection-2.0 0.141260961 s
 io.openliberty.mpFaultTolerance-4.0 0.048129056 s
 io.openliberty.mpFaultTolerance-4.1 0.037871880 s
 com.ibm.websphere.appserver.webCacheMonitor-1.0 0.026258505 s
@@ -210,21 +203,16 @@ io.openliberty.concurrent-2.0 0.015393169 s
 com.ibm.websphere.appserver.apiDiscovery-1.0 0.055372203 s
 io.openliberty.jsonbContainer-2.0 0.007401366 s
 com.ibm.websphere.appserver.jcaInboundSecurity-1.0 0.033326640 s
-io.openliberty.arquillian.arquillian-support-1.0 0.017641049 s
 com.ibm.websphere.appserver.ejbRemote-3.2 0.029303481 s
-com.ibm.websphere.appserver.sampleHandler-1.0 0.001281689 s
 com.ibm.websphere.appserver.beanValidation-1.0 0.005093040 s
 com.ibm.websphere.appserver.beanValidation-1.1 0.007352783 s
 io.openliberty.crac-1.4 0.001228833 s
 io.openliberty.enterpriseBeansRemote-4.0 0.035177492 s
-com.ibm.websphere.scaling.testScalingAPIPlugin-1.0 0.002256894 s
 com.ibm.websphere.appserver.serverStatus-1.0 0.001474329 s
 com.ibm.websphere.appserver.requestTiming-1.0 0.005315346 s
 io.openliberty.mpOpenAPI-3.0 0.072999238 s
 io.openliberty.mpOpenAPI-3.1 0.059322060 s
-io.openliberty.arquillian.arquillian-support-jakarta-2.1 0.001588218 s
 com.ibm.websphere.appserver.collectiveController-1.0 0.100390072 s
-com.ibm.websphere.appserver.ejbTest-1.0 0.001617680 s
 com.ibm.websphere.appserver.scim-1.0 0.068461981 s
 com.ibm.websphere.appserver.jpaContainer-2.2 0.013990762 s
 com.ibm.websphere.appserver.jpaContainer-2.1 0.013336507 s
@@ -272,7 +260,6 @@ com.ibm.websphere.appserver.spnego-1.0 0.032822631 s
 io.openliberty.mpHealth-4.0 0.049546410 s
 com.ibm.websphere.appserver.cdi-1.0 0.015312963 s
 com.ibm.websphere.appserver.cdi-1.2 0.020616008 s
-com.ibm.websphere.appserver.sampleSource-1.0 0.001513323 s
 com.ibm.websphere.appserver.jndi-1.0 0.004160695 s
 com.ibm.websphere.appserver.jmsMdb-3.1 0.028747398 s
 com.ibm.websphere.appserver.jmsMdb-3.2 0.042648562 s
@@ -288,16 +275,12 @@ io.openliberty.mpMetrics-4.0 0.147126255 s
 com.ibm.websphere.appserver.cloudant-1.0 0.003716235 s
 com.ibm.websphere.appserver.osgiAppConsole-1.0 0.031807786 s
 io.openliberty.noShip-1.0 0.001035388 s
-customTaiSample-1.0 0.000729786 s
 com.ibm.websphere.appserver.microProfile-2.2 0.192556514 s
-com.ibm.websphere.health.testConditionPlugin-1.0 0.002065783 s
 io.openliberty.mpReactiveStreams-3.0 0.005671369 s
 com.ibm.websphere.appserver.microProfile-2.0 0.197746965 s
 io.openliberty.jsonp-2.1 0.003017439 s
 com.ibm.websphere.appserver.microProfile-2.1 0.236892856 s
 io.openliberty.jsonp-2.0 0.002046987 s
-com.ibm.websphere.appserver.componenttest-2.0 0.000702753 s
-com.ibm.websphere.appserver.repositoryConnection-1.0 0.061205763 s
 io.openliberty.jsonb-2.0 0.006907926 s
 com.ibm.websphere.appserver.monitor-1.0 0.003305127 s
 com.ibm.websphere.appserver.heritageAPIs-1.1 0.001103902 s
@@ -307,7 +290,6 @@ io.openliberty.facesContainer-3.0 0.033049373 s
 io.openliberty.mpOpenTracing-3.0 0.063853130 s
 io.openliberty.beanValidation-3.0 0.008153770 s
 io.openliberty.beanValidation-3.1 0.007480548 s
-com.ibm.websphere.appserver.http2clienttest-1.0 0.000871697 s
 com.ibm.websphere.appserver.zosSecurity-1.0 0.016494909 s
 com.ibm.websphere.appserver.jaxrs-2.1 0.028382639 s
 com.ibm.websphere.appserver.webProfile-7.0 0.090810483 s
@@ -339,7 +321,6 @@ com.ibm.websphere.appserver.el-3.0 0.001750882 s
 com.ibm.websphere.appserver.mpOpenAPI-2.0 0.042481982 s
 com.ibm.websphere.appserver.httpWhiteboard-1.0 0.021593155 s
 io.openliberty.restfulWS-4.0 0.056732250 s
-com.ibm.websphere.appserver.timedexit-1.0 0.011439993 s
 io.openliberty.cdi-3.0 0.038794139 s
 com.ibm.websphere.appserver.audit-2.0 0.034518023 s
 com.ibm.websphere.appserver.javaee-8.0 0.423313533 s

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_expected.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_expected.xml
@@ -807,30 +807,6 @@
         </output>
     </case>
     <case>
-        <name>com.ibm.websphere.appserver.componenttest-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.componenttest-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.componenttest-1.0</root>
-        </input>
-        <output>
-            <resolved>componenttest-1.0</resolved>
-        </output>
-    </case>
-    <case>
-        <name>com.ibm.websphere.appserver.componenttest-2.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.componenttest-2.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.componenttest-2.0</root>
-        </input>
-        <output>
-            <resolved>componenttest-2.0</resolved>
-        </output>
-    </case>
-    <case>
         <name>com.ibm.websphere.appserver.concurrent-1.0</name>
         <description>Singleton [ com.ibm.websphere.appserver.concurrent-1.0 ]</description>
         <input>
@@ -1263,18 +1239,6 @@
             <resolved>com.ibm.websphere.appserver.wimcore-1.0</resolved>
             <resolved>com.ibm.websphere.appserver.securityInfrastructure-1.0</resolved>
             <resolved>federatedRegistry-1.0</resolved>
-        </output>
-    </case>
-    <case>
-        <name>com.ibm.websphere.appserver.http2clienttest-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.http2clienttest-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.http2clienttest-1.0</root>
-        </input>
-        <output>
-            <resolved>http2clienttest-1.0</resolved>
         </output>
     </case>
     <case>
@@ -9237,18 +9201,6 @@
         </output>
     </case>
     <case>
-        <name>com.ibm.websphere.appserver.timedexit-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.timedexit-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.timedexit-1.0</root>
-        </input>
-        <output>
-            <resolved>timedexit-1.0</resolved>
-        </output>
-    </case>
-    <case>
         <name>com.ibm.websphere.appserver.transportSecurity-1.0</name>
         <description>Singleton [ com.ibm.websphere.appserver.transportSecurity-1.0 ]</description>
         <input>
@@ -10768,55 +10720,6 @@
             <resolved>io.openliberty.cdi3.0-transaction2.0</resolved>
             <resolved>com.ibm.websphere.appserver.securityContext-1.0</resolved>
             <resolved>io.openliberty.cdi3.0-appSecurity</resolved>
-        </output>
-    </case>
-    <case>
-        <name>io.openliberty.arquillian.arquillian-support-1.0</name>
-        <description>Singleton [ io.openliberty.arquillian.arquillian-support-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>io.openliberty.arquillian.arquillian-support-1.0</root>
-        </input>
-        <output>
-            <resolved>com.ibm.websphere.appserver.eeCompatible-6.0</resolved>
-            <resolved>io.openliberty.servlet.api-3.1</resolved>
-            <resolved>com.ibm.websphere.appserver.javaeeddSchema-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.servlet-servletSpi1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.channelfw-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.httptransport-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.requestProbes-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.javax.annotation-1.1</resolved>
-            <resolved>com.ibm.websphere.appserver.artifact-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.javaeedd-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.anno-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.containerServices-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.injection-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.appLifecycle-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.dynamicBundle-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.classloading-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.appmanager-1.0</resolved>
-            <resolved>com.ibm.websphere.appserver.javaeePlatform-6.0</resolved>
-            <resolved>com.ibm.websphere.appserver.javaeePlatform-7.0</resolved>
-            <resolved>servlet-3.1</resolved>
-            <resolved>io.openliberty.servlet.internal-3.1</resolved>
-            <resolved>io.openliberty.webBundle.internal.ee-6.0</resolved>
-            <resolved>io.openliberty.webBundle.internal-1.0</resolved>
-            <resolved>com.ibm.wsspi.appserver.webBundle-1.0</resolved>
-            <resolved>arquillian-support-1.0</resolved>
-        </output>
-    </case>
-    <case>
-        <name>io.openliberty.arquillian.arquillian-support-jakarta-2.1</name>
-        <description>Singleton [ io.openliberty.arquillian.arquillian-support-jakarta-2.1 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>io.openliberty.arquillian.arquillian-support-jakarta-2.1</root>
-        </input>
-        <output>
-            <resolved>localConnector-1.0</resolved>
-            <resolved>arquillian-support-jakarta-2.1</resolved>
         </output>
     </case>
     <case>

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_expected_WL.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/verify/singleton_expected_WL.xml
@@ -1164,23 +1164,6 @@
         </output>
     </case>
     <case>
-        <name>com.ibm.websphere.appserver.httpservice-2.2</name>
-        <description>Singleton [ com.ibm.websphere.appserver.httpservice-2.2 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.httpservice-2.2</root>
-        </input>
-        <output>
-            <resolved-feature>com.ibm.websphere.appserver.eeCompatible-6.0</resolved-feature>
-            <resolved-feature>io.openliberty.servlet.api-3.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.channelfw-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.httptransport-1.0</resolved-feature>
-            <resolved-feature>httpservice-2.2</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.waswelcomepage-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
         <name>com.ibm.websphere.appserver.mqtt-3.1</name>
         <description>Singleton [ com.ibm.websphere.appserver.mqtt-3.1 ]</description>
         <input>
@@ -1333,18 +1316,6 @@
             <resolved-feature>com.ibm.websphere.appserver.autoRestHandlerApiDiscovery-1.0</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.waswelcomepage-1.0</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.autoRestHandlerCollectivePlugins-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
-        <name>com.ibm.websphere.appserver.fileinstall-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.fileinstall-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.fileinstall-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>fileinstall-1.0</resolved-feature>
         </output>
     </case>
     <case>
@@ -1833,18 +1804,6 @@
             <resolved-feature>com.ibm.websphere.appserver.certificateCreator-1.0</resolved-feature>
             <resolved-feature>ssl-1.0</resolved-feature>
             <resolved-feature>transportSecurity-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
-        <name>com.ibm.websphere.appserver.featureverifier-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.featureverifier-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.featureverifier-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>featureverifier-1.0</resolved-feature>
         </output>
     </case>
     <case>
@@ -6210,18 +6169,6 @@
         </output>
     </case>
     <case>
-        <name>com.ibm.websphere.appserver.componenttest-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.componenttest-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.componenttest-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>componenttest-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
         <name>com.ibm.websphere.appserver.servlet-4.0</name>
         <description>Singleton [ com.ibm.websphere.appserver.servlet-4.0 ]</description>
         <input>
@@ -8614,80 +8561,6 @@
             <resolved-feature>com.ibm.websphere.appserver.orbJ2eeManagement-1.0</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.jaccWeb-1.5</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.jaxwsSecurity-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
-        <name>com.ibm.websphere.appserver.repositoryConnection-2.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.repositoryConnection-2.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.repositoryConnection-2.0</root>
-        </input>
-        <output>
-            <resolved-feature>com.ibm.websphere.appserver.appLifecycle-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.artifact-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javaeedd-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.eeCompatible-9.0</resolved-feature>
-            <resolved-feature>io.openliberty.jakarta.annotation-2.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.anno-2.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.containerServices-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.dynamicBundle-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.classloading-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.appmanager-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javaeePlatform-6.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javaeePlatform-7.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javaeePlatform-8.0</resolved-feature>
-            <resolved-feature>io.openliberty.jakartaeePlatform-9.0</resolved-feature>
-            <resolved-feature>io.openliberty.servlet.api-5.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javaeeddSchema-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.injection-2.0</resolved-feature>
-            <resolved-feature>io.openliberty.servlet-servletSpi2.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.channelfw-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.httptransport-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.requestProbes-1.0</resolved-feature>
-            <resolved-feature>servlet-5.0</resolved-feature>
-            <resolved-feature>io.openliberty.servlet.internal-5.0</resolved-feature>
-            <resolved-feature>io.openliberty.webBundle.internal.ee-9.0</resolved-feature>
-            <resolved-feature>io.openliberty.webBundle.internal-1.0</resolved-feature>
-            <resolved-feature>com.ibm.wsspi.appserver.webBundle-1.0</resolved-feature>
-            <resolved-feature>json-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.internal.slf4j-1.7</resolved-feature>
-            <resolved-feature>jndi-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.distributedMapInternal-2.0</resolved-feature>
-            <resolved-feature>distributedMap-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.basicRegistry-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.securityInfrastructure-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.builtinAuthorization-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.certificateCreator-1.0</resolved-feature>
-            <resolved-feature>ssl-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.ltpa-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.jcache.internal1.1.ee-9.0</resolved-feature>
-            <resolved-feature>io.openliberty.jcache.internal-1.1</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.builtinAuthentication-2.0</resolved-feature>
-            <resolved-feature>io.openliberty.securityAPI.jakarta-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.security.internal.ee-9.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.security-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.authFilter1.0.internal.ee-9.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.authFilter-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.webBundleSecurity1.0.internal.ee-9.0</resolved-feature>
-            <resolved-feature>io.openliberty.webBundleSecurity.internal-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.adminSecurity-2.0</resolved-feature>
-            <resolved-feature>io.openliberty.restHandler1.0.internal.ee-9.0</resolved-feature>
-            <resolved-feature>io.openliberty.restHandler.internal-1.0</resolved-feature>
-            <resolved-feature>com.ibm.wsspi.appserver.webBundleSecurity-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.securityAPI.javaee-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.restHandler-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.restConnector2.0.internal.ee-9.0</resolved-feature>
-            <resolved-feature>restConnector-2.0</resolved-feature>
-            <resolved-feature>repositoryConnection-2.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javaeePlatform7.0-jndi1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.autoRestHandlerApiDiscovery-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.autoRestConnector-2.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.waswelcomepage-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.autoRestHandlerCollectivePlugins-1.0</resolved-feature>
-            <resolved-feature>transportSecurity-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.transportSecurity1.0.jakarta</resolved-feature>
         </output>
     </case>
     <case>
@@ -11409,41 +11282,6 @@
         </output>
     </case>
     <case>
-        <name>io.openliberty.arquillian.arquillian-support-1.0</name>
-        <description>Singleton [ io.openliberty.arquillian.arquillian-support-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>io.openliberty.arquillian.arquillian-support-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>com.ibm.websphere.appserver.eeCompatible-6.0</resolved-feature>
-            <resolved-feature>io.openliberty.servlet.api-3.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.servlet-servletSpi1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.channelfw-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.httptransport-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.requestProbes-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.artifact-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javaeedd-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javax.annotation-1.1</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.anno-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.containerServices-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.injection-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.appLifecycle-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.dynamicBundle-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.classloading-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.appmanager-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javaeePlatform-6.0</resolved-feature>
-            <resolved-feature>servlet-3.0</resolved-feature>
-            <resolved-feature>io.openliberty.servlet.internal-3.0</resolved-feature>
-            <resolved-feature>io.openliberty.webBundle.internal.ee-6.0</resolved-feature>
-            <resolved-feature>io.openliberty.webBundle.internal-1.0</resolved-feature>
-            <resolved-feature>com.ibm.wsspi.appserver.webBundle-1.0</resolved-feature>
-            <resolved-feature>arquillian-support-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.waswelcomepage-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
         <name>com.ibm.websphere.appserver.ejbRemote-3.2</name>
         <description>Singleton [ com.ibm.websphere.appserver.ejbRemote-3.2 ]</description>
         <input>
@@ -11493,18 +11331,6 @@
             <resolved-feature>com.ibm.websphere.appserver.classloaderContext-1.0</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.iioptransport.transaction-1.0</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.ejbComponentMetadataDecorator-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
-        <name>com.ibm.websphere.appserver.sampleHandler-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.sampleHandler-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.sampleHandler-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>sampleHandler-1.0</resolved-feature>
         </output>
     </case>
     <case>
@@ -11629,20 +11455,6 @@
             <resolved-feature>com.ibm.websphere.appserver.classloaderContext-1.0</resolved-feature>
             <resolved-feature>io.openliberty.iioptransport.transaction-2.0</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.ejbComponentMetadataDecorator-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
-        <name>com.ibm.websphere.scaling.testScalingAPIPlugin-1.0</name>
-        <description>Singleton [ com.ibm.websphere.scaling.testScalingAPIPlugin-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.scaling.testScalingAPIPlugin-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>json-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.imf-1.0</resolved-feature>
-            <resolved-feature>testScalingAPIPlugin-1.0</resolved-feature>
         </output>
     </case>
     <case>
@@ -11839,19 +11651,6 @@
         </output>
     </case>
     <case>
-        <name>io.openliberty.arquillian.arquillian-support-jakarta-2.1</name>
-        <description>Singleton [ io.openliberty.arquillian.arquillian-support-jakarta-2.1 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>io.openliberty.arquillian.arquillian-support-jakarta-2.1</root>
-        </input>
-        <output>
-            <resolved-feature>localConnector-1.0</resolved-feature>
-            <resolved-feature>arquillian-support-jakarta-2.1</resolved-feature>
-        </output>
-    </case>
-    <case>
         <name>com.ibm.websphere.appserver.collectiveController-1.0</name>
         <description>Singleton [ com.ibm.websphere.appserver.collectiveController-1.0 ]</description>
         <input>
@@ -11928,19 +11727,6 @@
             <resolved-feature>com.ibm.websphere.appserver.optional.jaxb-2.2</resolved-feature>
             <resolved-feature>jaxrs-1.1</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.restConnectorjaxrs-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
-        <name>com.ibm.websphere.appserver.ejbTest-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.ejbTest-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.ejbTest-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>componenttest-1.0</resolved-feature>
-            <resolved-feature>ejbTest-1.0</resolved-feature>
         </output>
     </case>
     <case>
@@ -14529,18 +14315,6 @@
         </output>
     </case>
     <case>
-        <name>com.ibm.websphere.appserver.sampleSource-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.sampleSource-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.sampleSource-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>sampleSource-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
         <name>com.ibm.websphere.appserver.jndi-1.0</name>
         <description>Singleton [ com.ibm.websphere.appserver.jndi-1.0 ]</description>
         <input>
@@ -15397,20 +15171,6 @@
         </output>
     </case>
     <case>
-        <name>com.ibm.websphere.health.testConditionPlugin-1.0</name>
-        <description>Singleton [ com.ibm.websphere.health.testConditionPlugin-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.health.testConditionPlugin-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>json-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.imf-1.0</resolved-feature>
-            <resolved-feature>testConditionPlugin-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
         <name>io.openliberty.mpReactiveStreams-3.0</name>
         <description>Singleton [ io.openliberty.mpReactiveStreams-3.0 ]</description>
         <input>
@@ -15751,93 +15511,6 @@
         </output>
     </case>
     <case>
-        <name>com.ibm.websphere.appserver.componenttest-2.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.componenttest-2.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.componenttest-2.0</root>
-        </input>
-        <output>
-            <resolved-feature>componenttest-2.0</resolved-feature>
-        </output>
-    </case>
-    <case>
-        <name>com.ibm.websphere.appserver.repositoryConnection-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.repositoryConnection-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.repositoryConnection-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>com.ibm.websphere.appserver.eeCompatible-6.0</resolved-feature>
-            <resolved-feature>io.openliberty.servlet.api-3.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.servlet-servletSpi1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.channelfw-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.httptransport-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.requestProbes-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.artifact-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javaeedd-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javax.annotation-1.1</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.anno-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.containerServices-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.injection-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.appLifecycle-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.dynamicBundle-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.classloading-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.appmanager-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.javaeePlatform-6.0</resolved-feature>
-            <resolved-feature>servlet-3.0</resolved-feature>
-            <resolved-feature>io.openliberty.servlet.internal-3.0</resolved-feature>
-            <resolved-feature>io.openliberty.webBundle.internal.ee-6.0</resolved-feature>
-            <resolved-feature>io.openliberty.webBundle.internal-1.0</resolved-feature>
-            <resolved-feature>com.ibm.wsspi.appserver.webBundle-1.0</resolved-feature>
-            <resolved-feature>json-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.internal.slf4j-1.7</resolved-feature>
-            <resolved-feature>jndi-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.distributedMapInternal-1.0</resolved-feature>
-            <resolved-feature>distributedMap-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.basicRegistry-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.securityInfrastructure-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.builtinAuthorization-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.certificateCreator-1.0</resolved-feature>
-            <resolved-feature>ssl-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.ltpa-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.jcache.internal1.1.ee-6.0</resolved-feature>
-            <resolved-feature>io.openliberty.jcache.internal-1.1</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.builtinAuthentication-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.securityAPI.javaee-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.security.internal.ee-6.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.security-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.authFilter1.0.internal.ee-6.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.authFilter-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.webBundleSecurity1.0.internal.ee-6.0</resolved-feature>
-            <resolved-feature>io.openliberty.webBundleSecurity.internal-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.adminSecurity-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.restHandler1.0.internal.ee-6.0</resolved-feature>
-            <resolved-feature>io.openliberty.restHandler.internal-1.0</resolved-feature>
-            <resolved-feature>com.ibm.wsspi.appserver.webBundleSecurity-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.securityAPI.jakarta-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.restHandler-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.internal.optional.jaxb-2.2</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.jta-1.1</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.httpcommons-1.0</resolved-feature>
-            <resolved-feature>io.openliberty.globalhandler1.0.internal.ee-6.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.globalhandler-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.jaxrsApiStub-1.1</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.internal.jaxrs-1.1</resolved-feature>
-            <resolved-feature>restConnector-1.0</resolved-feature>
-            <resolved-feature>repositoryConnection-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.autoRestHandlerApiDiscovery-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.waswelcomepage-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.autoRestHandlerCollectivePlugins-1.0</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.optional.jaxb-2.2</resolved-feature>
-            <resolved-feature>jaxrs-1.1</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.restConnectorjaxrs-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
         <name>io.openliberty.jsonb-2.0</name>
         <description>Singleton [ io.openliberty.jsonb-2.0 ]</description>
         <input>
@@ -16145,18 +15818,6 @@
             <resolved-feature>io.openliberty.jakarta.interceptor-2.2</resolved-feature>
             <resolved-feature>io.openliberty.jakarta.cdi-4.1</resolved-feature>
             <resolved-feature>validation-3.1</resolved-feature>
-        </output>
-    </case>
-    <case>
-        <name>com.ibm.websphere.appserver.http2clienttest-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.http2clienttest-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.http2clienttest-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>http2clienttest-1.0</resolved-feature>
         </output>
     </case>
     <case>
@@ -18224,18 +17885,6 @@
         </output>
     </case>
     <case>
-        <name>com.ibm.websphere.appserver.timedexit-1.0</name>
-        <description>Singleton [ com.ibm.websphere.appserver.timedexit-1.0 ]</description>
-        <input>
-            <kernel>com.ibm.websphere.appserver.kernelCore-1.0</kernel>
-            <kernel>com.ibm.websphere.appserver.logging-1.0</kernel>
-            <root>com.ibm.websphere.appserver.timedexit-1.0</root>
-        </input>
-        <output>
-            <resolved-feature>timedexit-1.0</resolved-feature>
-        </output>
-    </case>
-    <case>
         <name>io.openliberty.cdi-3.0</name>
         <description>Singleton [ io.openliberty.cdi-3.0 ]</description>
         <input>
@@ -19729,7 +19378,6 @@
             <resolved-feature>restConnector-1.0</resolved-feature>
             <resolved-feature>jsp-2.2</resolved-feature>
             <resolved-feature>io.openliberty.adminCenter1.0.javaee</resolved-feature>
-            <resolved-feature>com.ibm.websphere.appserver.adminCenter.ExampleTool-1.0</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.autoRestHandlerApiDiscovery-1.0</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.waswelcomepage-1.0</resolved-feature>
             <resolved-feature>com.ibm.websphere.appserver.autoRestHandlerCollectivePlugins-1.0</resolved-feature>


### PR DESCRIPTION
- Add checking for `IBM-Test-Feature` header being true in the FeatureUtil.isTest method to handle additional test features to not cause build break when test features are no longer found in liberty build image.
- Update verify dataset to remove test features with `IBM-Test-Feature: true` set.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
