### PR TITLE
countBy/existsBy error path testing for results

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1027,11 +1027,18 @@ public class QueryInfo {
         }
 
         Class<?> returnType = method.getReturnType();
-        if (Optional.class.equals(returnType)) {
+        if (isOptional) {
             returnValue = Optional.of(returnValue);
         } else if (CompletableFuture.class.equals(returnType) ||
                    CompletionStage.class.equals(returnType)) {
             returnValue = CompletableFuture.completedFuture(returnValue);
+        } else if (multiType != null) {
+            throw exc(MappingException.class,
+                      "CWWKD1049.count.convert.err",
+                      count,
+                      method.getName(),
+                      repositoryInterface.getName(),
+                      method.getGenericReturnType().getTypeName());
         }
 
         if (trace && tc.isEntryEnabled())

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -48,7 +48,6 @@ public class DataErrPathsTest extends FATServletClient {
     private static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
                                    "CWWJP9991W.*4002", // 2 persistence units attempt to autocreate same table
-                                   "CWWKD1003E.*countByBirthday", // exists method returning Page<Long>
                                    "CWWKD1003E.*existsByAddress", // exists method returning int
                                    "CWWKD1003E.*existsByBirthday", // exists method returning Page<Boolean>
                                    "CWWKD1003E.*existsByName", // exists method returning CompletableFuture<Long>
@@ -74,6 +73,7 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1033E.*selectByFirstName", // CursoredPage with ORDER BY in Query
                                    "CWWKD1037E.*findByBirthdayOrderBySSN", // CursoredPage of non-entity
                                    "CWWKD1037E.*registrations", // CursoredPage of non-entity
+                                   "CWWKD1049E.*countByBirthday", // exists method returning Page<Long>
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",
                                    "CWWKD1078E.*test.jakarta.data.errpaths.web.InvalidNonJNDIRepo",
                                    "CWWKD1079E.*test.jakarta.data.errpaths.web.InvalidJNDIRepo",

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -48,7 +48,9 @@ public class DataErrPathsTest extends FATServletClient {
     private static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
                                    "CWWJP9991W.*4002", // 2 persistence units attempt to autocreate same table
+                                   "CWWKD1003E.*countByBirthday", // exists method returning Page<Long>
                                    "CWWKD1003E.*existsByAddress", // exists method returning int
+                                   "CWWKD1003E.*existsByBirthday", // exists method returning Page<Boolean>
                                    "CWWKD1003E.*existsByName", // exists method returning CompletableFuture<Long>
                                    "CWWKD1006E.*removeBySSN", // delete method attempts to return record
                                    "CWWKD1009E.*addNothing", // Insert method without parameters
@@ -58,6 +60,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1009E.*storeNothing", // Save method without parameters
                                    "CWWKD1009E.*storeInDatabase", // Save method with multiple parameters
                                    "CWWKD1010E.*nameAndZipCode", // Record return type with invalid attribute name
+                                   "CWWKD1010E.*sortedByEndOfAddress", // OrderBy with invalid function
+                                   "CWWKD1010E.*sortedByZipCode", // OrderBy with invalid attribute name
                                    "CWWKD1015E.*addPollingLocation", // insert null entity
                                    "CWWKD1015E.*addOrUpdatePollingLocation", // save null entity
                                    "CWWKD1017E.*livesAt", // multiple Limit parameters

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -169,6 +169,25 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Verify an error is raised when a count Query by Method Name method
+     * tries to return a long value as a Page of Long.
+     */
+    @Test
+    public void testCountAsPage() {
+        try {
+            LocalDate today = LocalDate.of(2025, Month.FEBRUARY, 18);
+            Page<Long> page = voters.countByBirthday(today);
+            fail("Should not be able to use a count query that returns a" +
+                 " Page rather than long. Page is: " + page);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1049E:") ||
+                !x.getMessage().contains("Page<java.lang.Long>"))
+                throw x;
+        }
+    }
+
+    /**
      * Verify an error is raised for a repository method that attempts to
      * return a CursoredPage of a record, rather than of the entity.
      */
@@ -562,6 +581,26 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1003E:") ||
                 !x.getMessage().contains("CompletableFuture<java.lang.Long>"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised when an exists Query by Method Name method
+     * tries to return a true/false value as a Page.
+     */
+    @Test
+    public void testExistsAsPage() {
+        try {
+            LocalDate today = LocalDate.of(2025, Month.FEBRUARY, 18);
+            Page<Boolean> page = voters.existsByBirthday(today,
+                                                         PageRequest.ofSize(5));
+            fail("Should not be able to use an exists query that returns a" +
+                 " Page rather than boolean. Page is: " + page);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1003E:") ||
+                !x.getMessage().contains("Page<java.lang.Boolean>"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -1141,6 +1141,46 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Verify an error is raised when a repository method has an OrderBy annotation
+     * that attempts to sort by an invalid, non-existent function.
+     */
+    @Test
+    public void testOrderByInvalidFunction() {
+        try {
+            List<Voter> found = voters.sortedByEndOfAddress();
+            fail("OrderBy annotation with invalid function must cause an error." +
+                 " Instead, the repository method returned: " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() != null &&
+                x.getMessage().startsWith("CWWKD1010E") &&
+                x.getMessage().contains("last5DigitsOf(address)"))
+                ; // expected
+            else
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised when a repository method has an OrderBy annotation
+     * that attempts to sort by an invalid, non-existent function.
+     */
+    @Test
+    public void testOrderByUnkownEntityAttribute() {
+        try {
+            List<Voter> found = voters.sortedByZipCode();
+            fail("OrderBy annotation with invalid entity attribute must cause an" +
+                 " error. Instead, the repository method returned: " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() != null &&
+                x.getMessage().startsWith("CWWKD1010E") &&
+                x.getMessage().contains("sortedByZipCode"))
+                ; // expected
+            else
+                throw x;
+        }
+    }
+
+    /**
      * Tests an error path where a paremeter-based query method attempts to place
      * the special parameters ahead of the query parameters.
      */

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -112,6 +112,11 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     List<Voter> changeBoth(Voter v1, Voter v2);
 
     /**
+     * This invalid method attempts to return a long count result as Page of Long.
+     */
+    Page<Long> countByBirthday(LocalDate birthday);
+
+    /**
      * Invalid method. A method with a life cycle annotation must have exactly
      * 1 parameter.
      */
@@ -149,6 +154,12 @@ public interface Voters extends BasicRepository<Voter, Integer> {
      * This invalid method attempts to return a true/false exist result as int.
      */
     int existsByAddress(String homeAddress);
+
+    /**
+     * This invalid method attempts to return a true/false exists result as Page
+     * of Boolean.
+     */
+    Page<Boolean> existsByBirthday(LocalDate birthday, PageRequest pageReq);
 
     /**
      * This invalid method attempts to return a true/false exist result as a

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -146,12 +146,12 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     int discardSorted(@By("address") String mailingAddress, Sort<Voter> sort);
 
     /**
-     * This invalid method attempts to return a true/false exists results as int.
+     * This invalid method attempts to return a true/false exist result as int.
      */
     int existsByAddress(String homeAddress);
 
     /**
-     * This invalid method attempts to return a true/false exists results as a
+     * This invalid method attempts to return a true/false exist result as a
      * Long value within a CompletableFuture. The CompletableFuture is fine, but
      * Long does not match the true/false result type.
      */
@@ -372,6 +372,22 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     CursoredPage<Voter> selectByName(@By("name") String name,
                                      PageRequest pageReq,
                                      Sort<Voter> sort);
+
+    /**
+     * Invalid method. A function that does not exist cannot be used within the
+     * sort criteria.
+     */
+    @Find
+    @OrderBy("last5DigitsOf(address)")
+    List<Voter> sortedByEndOfAddress();
+
+    /**
+     * Invalid method. The entity has no zipcode attribute upon which to sort.
+     */
+    @Find
+    @OrderBy("birthday")
+    @OrderBy("zipcode")
+    List<Voter> sortedByZipCode();
 
     /**
      * Invalid method. A method with a life cycle annotation must have exactly


### PR DESCRIPTION
Ensure a meaningful error is raised for countBy/existsBy repository methods attempting to return invalid types of results.
Also test error paths for OrderBy supplying invalid sort criteria.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
