### PR TITLE
fix ltpa cache cleanup

### DIFF
--- a/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/src/com/ibm/ws/crypto/ltpakeyutil/LTPACrypto.java
@@ -52,7 +52,7 @@ final class LTPACrypto {
 
     private static final String signatureAlgorithm = CryptoUtils.getSignatureAlgorithm();
 
-    private static int MAX_CACHE = 500;
+    private static int MAX_CACHE = 500; // has to be greater than 0 and a multiple of 5
     private static IvParameterSpec ivs8 = null;
     private static IvParameterSpec ivs16 = null;
 
@@ -202,25 +202,26 @@ final class LTPACrypto {
             result.reused = true;
             return result.result;
         } else {
-            if (cryptoKeysMap.size() > MAX_CACHE) {
+            if (cryptoKeysMap.size() >= MAX_CACHE) {
                 try {
-                    CachingKey[] keys = cryptoKeysMap.keySet().toArray(new CachingKey[cryptoKeysMap.size()]);
+                    int cryptoKeysMapSize = cryptoKeysMap.size();
+                    CachingKey[] keys = cryptoKeysMap.keySet().toArray(new CachingKey[cryptoKeysMapSize]);
                     Arrays.sort(keys, cachingKeyComparator);
                     if (cachingKeyComparator.compare(keys[0], keys[keys.length - 1]) < 0) {
-                        for (int i = 0; i < cryptoKeysMap.size() / 5; i++) {
+                        for (int i = 0; i < cryptoKeysMapSize / 5; i++) {
                             cryptoKeysMap.remove(keys[i]);
-                            keys[i + 1 * cryptoKeysMap.size() / 5].successfulUses--;
-                            keys[i + 2 * cryptoKeysMap.size() / 5].successfulUses--;
-                            keys[i + 3 * cryptoKeysMap.size() / 5].successfulUses--;
-                            keys[i + 4 * cryptoKeysMap.size() / 5].successfulUses--;
+                            keys[i + 1 * cryptoKeysMapSize / 5].successfulUses--;
+                            keys[i + 2 * cryptoKeysMapSize / 5].successfulUses--;
+                            keys[i + 3 * cryptoKeysMapSize / 5].successfulUses--;
+                            keys[i + 4 * cryptoKeysMapSize / 5].successfulUses--;
                         }
-                    } else {
-                        for (int i = 0; i < cryptoKeysMap.size() / 5; i++) {
+                    } else { // TODO: consider removing bc this likely isn't used since we sort the keys above (except when all keys have the same num of uses)
+                        for (int i = 0; i < cryptoKeysMapSize / 5; i++) {
                             cryptoKeysMap.remove(keys[keys.length - 1 - i]);
-                            keys[keys.length - 1 - i - 1 * cryptoKeysMap.size() / 5].successfulUses--;
-                            keys[keys.length - 1 - i - 2 * cryptoKeysMap.size() / 5].successfulUses--;
-                            keys[keys.length - 1 - i - 3 * cryptoKeysMap.size() / 5].successfulUses--;
-                            keys[keys.length - 1 - i - 4 * cryptoKeysMap.size() / 5].successfulUses--;
+                            keys[keys.length - 1 - i - 1 * cryptoKeysMapSize / 5].successfulUses--;
+                            keys[keys.length - 1 - i - 2 * cryptoKeysMapSize / 5].successfulUses--;
+                            keys[keys.length - 1 - i - 3 * cryptoKeysMapSize / 5].successfulUses--;
+                            keys[keys.length - 1 - i - 4 * cryptoKeysMapSize / 5].successfulUses--;
                         }
                     }
                 } catch (Exception e) {
@@ -484,24 +485,25 @@ final class LTPACrypto {
             result.successfulUses += 1;
             return result.result;
         } else {
-            if (verifyKeysMap.size() > MAX_CACHE) {
-                CachingVerifyKey[] keys = verifyKeysMap.keySet().toArray(new CachingVerifyKey[verifyKeysMap.size()]);
+            if (verifyKeysMap.size() >= MAX_CACHE) {
+                int verifyKeysMapSize = verifyKeysMap.size();
+                CachingVerifyKey[] keys = verifyKeysMap.keySet().toArray(new CachingVerifyKey[verifyKeysMapSize]);
                 Arrays.sort(keys, cachingVerifyKeyComparator);
                 if (cachingVerifyKeyComparator.compare(keys[0], keys[keys.length - 1]) < 0) {
-                    for (int i = 0; i < verifyKeysMap.size() / 5; i++) {
+                    for (int i = 0; i < verifyKeysMapSize / 5; i++) {
                         verifyKeysMap.remove(keys[i]);
-                        keys[i + 1 * verifyKeysMap.size() / 5].successfulUses--;
-                        keys[i + 2 * verifyKeysMap.size() / 5].successfulUses--;
-                        keys[i + 3 * verifyKeysMap.size() / 5].successfulUses--;
-                        keys[i + 4 * verifyKeysMap.size() / 5].successfulUses--;
+                        keys[i + 1 * verifyKeysMapSize / 5].successfulUses--;
+                        keys[i + 2 * verifyKeysMapSize / 5].successfulUses--;
+                        keys[i + 3 * verifyKeysMapSize / 5].successfulUses--;
+                        keys[i + 4 * verifyKeysMapSize / 5].successfulUses--;
                     }
-                } else {
-                    for (int i = 0; i < verifyKeysMap.size() / 5; i++) {
+                } else { // TODO: consider removing bc this likely isn't used since we sort the keys above (except when all keys have the same num of uses)
+                    for (int i = 0; i < verifyKeysMapSize / 5; i++) {
                         verifyKeysMap.remove(keys[keys.length - 1 - i]);
-                        keys[keys.length - 1 - i - 1 * verifyKeysMap.size() / 5].successfulUses--;
-                        keys[keys.length - 1 - i - 2 * verifyKeysMap.size() / 5].successfulUses--;
-                        keys[keys.length - 1 - i - 3 * verifyKeysMap.size() / 5].successfulUses--;
-                        keys[keys.length - 1 - i - 4 * verifyKeysMap.size() / 5].successfulUses--;
+                        keys[keys.length - 1 - i - 1 * verifyKeysMapSize / 5].successfulUses--;
+                        keys[keys.length - 1 - i - 2 * verifyKeysMapSize / 5].successfulUses--;
+                        keys[keys.length - 1 - i - 3 * verifyKeysMapSize / 5].successfulUses--;
+                        keys[keys.length - 1 - i - 4 * verifyKeysMapSize / 5].successfulUses--;
                     }
                 }
             }

--- a/dev/com.ibm.ws.crypto.ltpakeyutil/test/com/ibm/ws/crypto/ltpakeyutil/LTPACryptoTest.java
+++ b/dev/com.ibm.ws.crypto.ltpakeyutil/test/com/ibm/ws/crypto/ltpakeyutil/LTPACryptoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2011 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@ public class LTPACryptoTest {
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        LTPACrypto.setMaxCache(0);
+        LTPACrypto.setMaxCache(5);
     }
 
     @Test


### PR DESCRIPTION
fixing 2 bugs in the cleanup steps for the LTPA caches when it reaches its max size:

- off by 1 error
   - the max size of the cache is 500
   - however, we won't cleanup the cache until there are 501 entries in the cache
   - this is problematic as the code relies on the max entries being a multiple of 5
   - the fix was checking for `size >= max` rather than `size > max` when we are checking if we need to cleanup before inserting a new cache entry

- deleting from array it's iterating over error
   - the cleanup code is iterating based on the size of the cache, but it is also deleting from the cache at the same time
   - this is causing the iteration of the cache entries to not work properly
   - the fix is the save the size of the cache at the beginning before any deletion happens

TODO: https://github.com/OpenLiberty/open-liberty/issues/30824