### PR TITLE
Test CDI Managed Bean bindings

### DIFF
--- a/dev/com.ibm.ws.cdi.jee_fat/build.gradle
+++ b/dev/com.ibm.ws.cdi.jee_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
+apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 configurations {
   requiredLibs {
@@ -42,6 +44,7 @@ dependencies {
       'org.apache.commons:commons-text:1.9',
       project(':io.openliberty.org.apache.xercesImpl'),
       'xalan:xalan:2.7.2',
+      'xalan:serializer:2.7.2',
       'xml-apis:xml-apis:1.4.01'
     }
 

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/FATSuite.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.cdi.jee.binding.ManagedBeanBindingTest;
 import com.ibm.ws.cdi.jee.ejbWithJsp.JEEInjectionTargetTest;
 import com.ibm.ws.cdi.jee.faces40.Faces40CDISessionPersistence;
 import com.ibm.ws.cdi.jee.jaxrs.inject.InjectIntoPathTest;
@@ -40,6 +41,7 @@ import componenttest.rules.repeater.RepeatTests;
                 SimpleJSFWithSharedLibTest.class,
                 SimpleJSPTest.class,
                 Faces40CDISessionPersistence.class,
+                ManagedBeanBindingTest.class,
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/binding/ManagedBeanBindingTest.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/binding/ManagedBeanBindingTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.binding;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.cdi.jee.binding.app.ManagedBeanBindingTestServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.EERepeatActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+
+@RunWith(FATRunner.class)
+public class ManagedBeanBindingTest {
+
+    public static final String APP_NAME = "ManagedBeanBinding";
+    public static final String SERVER_NAME = "cdi12BindingServer";
+
+    @TestServlet(contextRoot = APP_NAME, servlet = ManagedBeanBindingTestServlet.class)
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = EERepeatActions.repeat(SERVER_NAME, EERepeatActions.EE11, EERepeatActions.EE10, EERepeatActions.EE9, EERepeatActions.EE7);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                                   .addPackage(ManagedBeanBindingTestServlet.class.getPackage())
+                                   .addAsWebInfResource(ManagedBeanBindingTestServlet.class.getResource("ibm-managed-bean-bnd.xml"), "ibm-managed-bean-bnd.xml");
+
+        ShrinkHelper.exportAppToServer(server, war, SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/binding/app/BindingTestCDIBean.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/binding/app/BindingTestCDIBean.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.binding.app;
+
+import javax.annotation.Resource;
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class BindingTestCDIBean {
+
+    @Resource(name = "testValue1", lookup = "testValue1")
+    private String testValue1;
+
+    @Resource(name = "testValue2")
+    private String testValue2;
+
+    @Resource(name = "testValue3")
+    private String testValue3;
+
+    public String getTestValue1() {
+        return testValue1;
+    }
+
+    public String getTestValue2() {
+        return testValue2;
+    }
+
+    public String getTestValue3() {
+        return testValue3;
+    }
+}

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/binding/app/ManagedBeanBindingTestServlet.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/binding/app/ManagedBeanBindingTestServlet.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.binding.app;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.inject.Inject;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/bindingTest")
+public class ManagedBeanBindingTestServlet extends FATServlet {
+
+    @Inject
+    private BindingTestCDIBean bindingTestCdiBean;
+
+    @Test
+    public void testResourceInjection() {
+        String tv1FromJndi = null;
+        try {
+            tv1FromJndi = (String) new InitialContext().lookup("testValue1");
+        } catch (NamingException e) {
+        }
+
+        System.out.println("1 from JNDI: " + tv1FromJndi);
+
+        System.out.println("1: " + bindingTestCdiBean.getTestValue1());
+        System.out.println("2: " + bindingTestCdiBean.getTestValue2());
+        System.out.println("3: " + bindingTestCdiBean.getTestValue3());
+
+        // Loaded from resource directly
+        assertEquals("testValue1", bindingTestCdiBean.getTestValue1());
+
+        // Loaded via binding defined in ibm-managed-bean-bnd.xml
+        assertEquals("testValue2", bindingTestCdiBean.getTestValue2());
+
+        // Loaded via binding defined in server.xml
+        assertEquals("testValue3", bindingTestCdiBean.getTestValue3());
+    }
+}

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/binding/app/ibm-managed-bean-bnd.xml
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/binding/app/ibm-managed-bean-bnd.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<managed-bean-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="1.1">
+    <managed-bean class="com.ibm.ws.cdi.jee.binding.app.BindingTestCDIBean">
+        <env-entry name="testValue2" binding-name="testValue2Target" />
+    </managed-bean>
+</managed-bean-bnd>

--- a/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12BindingServer/.gitignore
+++ b/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12BindingServer/.gitignore
@@ -1,0 +1,1 @@
+/dropins

--- a/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12BindingServer/bootstrap.properties
+++ b/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12BindingServer/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+org.jboss.logging.provider=slf4j

--- a/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12BindingServer/server.xml
+++ b/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12BindingServer/server.xml
@@ -1,0 +1,26 @@
+<server description="Server for testing CDI">
+
+    <include location="../fatTestPorts.xml" />
+
+    <featureManager>
+        <feature>cdi-1.2</feature>
+        <feature>jndi-1.0</feature>
+        <feature>servlet-3.1</feature>
+        <feature>managedBeans-1.0</feature>
+        <feature>componentTest-1.0</feature>
+    </featureManager>
+
+    <jndiEntry jndiName="testValue1" value="testValue1" />
+    <jndiEntry jndiName="testValue2Target" value="testValue2" />
+    <jndiEntry jndiName="testValue3Target" value="testValue3" />
+
+    <application type="war" location="ManagedBeanBinding.war">
+        <managed-bean-bnd>
+            <managed-bean
+                class="com.ibm.ws.cdi.jee.binding.app.BindingTestCDIBean">
+                <env-entry name="testValue3" binding-name="testValue3Target" />
+            </managed-bean>
+        </managed-bean-bnd>
+    </application>
+
+</server>


### PR DESCRIPTION
Test use of an `ibm-managed-bean-bnd.xml` file, and the corresponding server.xml config, with CDI managed beans.

Add Xalan serializer to dependencies. Another test in this bucket requires HtmlUnit which requires Xalan. The serializer dependency is needed when we use the `ServerConfiguration` model, and the `server.xml` includes elements which aren't part of our model, such as `<managed-bean-bnd>` and its decendents.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #27027
