### PR TITLE
Fixes for Db2 JCC 12 driver

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.sqlj.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.sqlj.fat/server.xml
@@ -37,6 +37,7 @@
 
     <variable name="onError" value="FAIL"/>
     
+    <javaPermission className="java.util.PropertyPermission" name="sqlj.runtime.uncustomizedWarningOrException" actions="read"/>
     <javaPermission className="java.util.PropertyPermission" name="sqlj.runtime" actions="read"/>
     <javaPermission className="java.sql.SQLPermission" name="setNetworkTimeout"/>
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>

--- a/dev/com.ibm.ws.jdbc_fat_krb5/test-applications/krb5-db2-app/src/jdbc/krb5/db2/web/DB2KerberosTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/test-applications/krb5-db2-app/src/jdbc/krb5/db2/web/DB2KerberosTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,7 +21,7 @@ import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.SQLInvalidAuthorizationSpecException;
+import java.sql.SQLNonTransientException;
 import java.sql.Statement;
 import java.util.HashSet;
 import java.util.Set;
@@ -86,7 +86,7 @@ public class DB2KerberosTestServlet extends FATServlet {
     public void testNonKerberosConnectionRejected() throws Exception {
         try (Connection con = noKrb5.getConnection()) {
             throw new Exception("Should not be able to obtain a non-kerberos connection from a kerberos-only database");
-        } catch (SQLInvalidAuthorizationSpecException e) {
+        } catch (SQLNonTransientException e) {
             System.out.println("Got expected error getting non-kerberos connection");
         }
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Adds J2S permission for SQLJ tests and adjusts caught SQLException to handle driver change