### PR TITLE
avoid logging customer data on bean validation path

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -55,6 +55,7 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
     private long totalElements = -1;
 
     @FFDCIgnore(Exception.class)
+    @Trivial // avoid tracing customer data
     CursoredPageImpl(QueryInfo queryInfo, PageRequest pageRequest, Object[] args) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -5018,6 +5018,7 @@ public class QueryInfo {
      *         repository Save method signature.
      * @throws Exception if an error occurs.
      */
+    @Trivial // avoid logging customer data
     Object save(Object arg, EntityManager em) throws Exception {
         arg = arg instanceof Stream //
                         ? ((Stream<?>) arg).sequential().collect(Collectors.toList()) //

--- a/dev/io.openliberty.data.internal_fat_validation/fat/src/test/jakarta/data/validation/DataValidationTest.java
+++ b/dev/io.openliberty.data.internal_fat_validation/fat/src/test/jakarta/data/validation/DataValidationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -72,10 +72,9 @@ public class DataValidationTest extends FATServletClient {
             server.stopServer();
         }
 
-        // TODO enable once the logValues config is properly implemented
-        //assertEquals("Found " + unexpected.size() +
-        //             " unexpected lines of customer data (containing ...Entitlement#...) in logs.",
-        //             0, unexpected.size());
+        assertEquals("Found " + unexpected.size() +
+                     " unexpected lines of customer data (containing ...Entitlement#...) in logs.",
+                     0, unexpected.size());
         assertEquals(true, found4);
         assertEquals(true, found5);
     }


### PR DESCRIPTION
Avoid logging customer data from the Jakarta Data code on the code path where Jakarta Validation is used.  Enable a test case that inspects the logs for customer data (from the test case) after completing a test bucket.  With these changes, this test is now passing.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
