### PR TITLE
Enable tests now that #28813 (EclipseLink DateTimeParseException) is fixed

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -300,8 +300,7 @@ public class DataJPATestServlet extends FATServlet {
      * Use a repository method comparing a BigDecimal value on an entity that includes BigDecimal attributes.
      * This includes both a comparison in the query conditions as well as ordering on the BigDecimal attribute.
      */
-    // TODO re-enable once 28813 (java.time.Instant DateTimeParseException) is fixed
-    //@Test
+    @Test
     public void testBigDecimal() {
         final ZoneId EASTERN = ZoneId.of("America/New_York");
 
@@ -329,8 +328,7 @@ public class DataJPATestServlet extends FATServlet {
      * Use a repository method comparing a BigInteger value on an entity that includes BigInteger attributes.
      * This includes both a comparison in the query conditions as well as ordering on the BigInteger attribute.
      */
-    // TODO re-enable once 28813 (java.time.Instant DateTimeParseException) is fixed
-    //@Test
+    @Test
     public void testBigInteger() {
         ZoneId ET = ZoneId.of("America/New_York");
 
@@ -2084,9 +2082,7 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(Integer.valueOf(1983), camry.getYearIntroduced());
         assertEquals("Toyota", camry.getManufacturer().getName());
 
-        // TODO enable once EclipseLink bug #28813 is fixed
-        //Instant corollaLastMod;
-        Long corollaLastMod;
+        Instant corollaLastMod;
         corollaLastMod = models.lastModified(corollaId).orElseThrow();
         List<Model> found = models.modifiedAt(corollaLastMod);
         assertEquals(false, found.isEmpty());
@@ -2726,8 +2722,7 @@ public class DataJPATestServlet extends FATServlet {
      * Repository method that queries by an Instant attribute and retrieves an
      * entity that includes the Instant attribute.
      */
-    // TODO requires #28813 to fix java.time.Instant DateTimeParseException
-    //@Test
+    @Test
     public void testInstant() {
         final ZoneId EASTERN = ZoneId.of("America/New_York");
         final Instant apr_28_2023 = ZonedDateTime.of(2023, 4, 28,
@@ -2743,13 +2738,13 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(134060000L,
                      info.numFullTimeWorkers.longValue());
 
-        assertEquals(6852746625848.93,
+        assertEquals(6852746625849.0,
                      info.intragovernmentalDebt.doubleValue(),
-                     0.01);
+                     1.0);
 
-        assertEquals(24605068022566.94,
+        assertEquals(24605068022567.0,
                      info.publicDebt.doubleValue(),
-                     0.01);
+                     1.0);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Model.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Model.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import java.time.Instant;
 import java.util.UUID;
 
 import jakarta.persistence.Column;
@@ -38,9 +39,7 @@ public class Model {
 
     @Column(name = "updated_at")
     @Version
-    // TODO enable once EclipseLink bug #28813 is fixed
-    //Instant updatedAt;
-    Long updatedAt;
+    Instant updatedAt;
 
     @Column(name = "intro_year")
     private Integer yearIntroduced;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Models.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Models.java
@@ -27,12 +27,8 @@ import jakarta.data.repository.Repository;
 @Repository
 public interface Models extends CrudRepository<Model, UUID> {
     @Find
-    // TODO enable once EclipseLink bug #28813 is fixed
-    //Optional<Instant> lastModified(UUID id);
-    Optional<Long> lastModified(UUID id);
+    Optional<Instant> lastModified(UUID id);
 
     @Find
-    // TODO enable once EclipseLink bug #28813 is fixed
-    //List<Model> modifiedAt(Instant updatedAt);
-    List<Model> modifiedAt(Long updatedAt);
+    List<Model> modifiedAt(Instant updatedAt);
 }


### PR DESCRIPTION
Enable tests now that #28813 (EclipseLink DateTimeParseException) is fixed

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
