### PR TITLE
fix signature verification in audit reader

### DIFF
--- a/dev/com.ibm.websphere.security/src/com/ibm/wsspi/security/audit/AuditSigning.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/wsspi/security/audit/AuditSigning.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,10 +45,11 @@ public interface AuditSigning {
      * </p>
      *
      * @param a signed byte array of data
+     * @param the signature
      * @param the key used to sign the byte array of data
      * @returns a boolean value based the successful verification of the data
      * @throws AuditSignException
      **/
-    public boolean verify(byte[] data, Key key) throws AuditSigningException;
+    public boolean verify(byte[] data, byte[] signature, Key key) throws AuditSigningException;
 
 }

--- a/dev/com.ibm.websphere.security/src/com/ibm/wsspi/security/audit/AuditSigning.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/wsspi/security/audit/AuditSigning.java
@@ -45,6 +45,18 @@ public interface AuditSigning {
      * </p>
      *
      * @param a signed byte array of data
+     * @param the key used to sign the byte array of data
+     * @returns a boolean value based the successful verification of the data
+     * @throws AuditSignException
+     **/
+    public boolean verify(byte[] data, Key key) throws AuditSigningException;
+    
+    /**
+     * <p>
+     * The <code>verify</code> method verifies the data is signed with a key
+     * </p>
+     *
+     * @param a signed byte array of data
      * @param the signature
      * @param the key used to sign the byte array of data
      * @returns a boolean value based the successful verification of the data

--- a/dev/com.ibm.websphere.security/src/com/ibm/wsspi/security/audit/package-info.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/wsspi/security/audit/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,8 +12,8 @@
  *******************************************************************************/
 
 /**
- * @version 1.0.0
+ * @version 1.1.0
  */
 
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package com.ibm.wsspi.security.audit;

--- a/dev/com.ibm.ws.security.audit.reader.auditreader/bnd.bnd
+++ b/dev/com.ibm.ws.security.audit.reader.auditreader/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2024 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -29,7 +29,6 @@ Require-Bundle: \
     com.ibm.json4j; version="[1,1.1)", \
     com.ibm.ws.frappe.utils; version="[1,1.1)", \
     com.ibm.ws.security.audit.source; version="[1,1.1)", \
-    com.ibm.wsspi.security.audit; version="[1,1.1)", \
     com.ibm.websphere.security; version="[1,1.2)", \
     com.ibm.crypto.ibmkeycert; version="[1,1.2)", \
     com.ibm.wsspi.security.audit; version="[1,1.2)", \

--- a/dev/com.ibm.ws.security.audit.reader/resources/com/ibm/ws/security/audit/reader/resources/UtilityMessages.nlsprops
+++ b/dev/com.ibm.ws.security.audit.reader/resources/com/ibm/ws/security/audit/reader/resources/UtilityMessages.nlsprops
@@ -65,5 +65,5 @@ security.audit.MismatchingSigningKeystores=The input value, {0}, for the keystor
 security.audit.CannotFindCertificate=The {0} certificate alias does not exist in the {1} keystore.
 
 # Do not translate "auditRecord"
-security.audit.FailedToValidateSignature=Failed to validate the signature of the auditRecord at index [{0}].
-security.audit.FailedToDecryptAuditRecord=Failed to decrypt the auditRecord at index [{0}].
+security.audit.FailedToValidateSignature=The validation of the auditRecord signature failed at index [{0}].
+security.audit.FailedToDecryptAuditRecord=The decryption of the auditRecord failed at index [{0}].

--- a/dev/com.ibm.ws.security.audit.reader/resources/com/ibm/ws/security/audit/reader/resources/UtilityMessages.nlsprops
+++ b/dev/com.ibm.ws.security.audit.reader/resources/com/ibm/ws/security/audit/reader/resources/UtilityMessages.nlsprops
@@ -1,5 +1,5 @@
 #/*******************************************************************************
-# * Copyright (c) 2018, 2019 IBM Corporation and others.
+# * Copyright (c) 2018, 2025 IBM Corporation and others.
 # * All rights reserved. This program and the accompanying materials
 # * are made available under the terms of the Eclipse Public License 2.0
 # * which accompanies this distribution, and is available at
@@ -63,3 +63,7 @@ security.audit.ErrorLoadingKeystore=Error loading the keystore {0}. The password
 security.audit.MismatchingEncKeystores=The input value, {0}, for the keystore specified to contain the certificate used to decrypt audit records does not match the keystore, {1}, specified in the audit log.
 security.audit.MismatchingSigningKeystores=The input value, {0}, for the keystore specified to contain the certificate used to unsign audit records does not match the keystore, {1}, specified in the audit log.
 security.audit.CannotFindCertificate=The {0} certificate alias does not exist in the {1} keystore.
+
+# Do not translate "auditRecord"
+security.audit.FailedToValidateSignature=Failed to validate the signature of the auditRecord at index [{0}].
+security.audit.FailedToDecryptAuditRecord=Failed to decrypt the auditRecord at index [{0}].

--- a/dev/com.ibm.ws.security.audit.reader/src/com/ibm/ws/security/audit/reader/tasks/AuditLogReader.java
+++ b/dev/com.ibm.ws.security.audit.reader/src/com/ibm/ws/security/audit/reader/tasks/AuditLogReader.java
@@ -557,7 +557,9 @@ public class AuditLogReader {
         int signatureOpenIdx = recordWithSignature.indexOf(signatureOpenTag);
         int signatureCloseIdx = recordWithSignature.indexOf(signatureCloseTag);
         if (signatureOpenIdx == -1 || signatureCloseIdx == -1 || signatureOpenIdx > signatureCloseIdx) {
-            throw new Exception("Unable to validate signature of auditRecord at index [" + (num_captured_records - 1) + "]");
+            int auditRecordIdx = num_captured_records - 1;
+            String msg = CommandUtils.getMessage("security.audit.FailedToValidateSignature", auditRecordIdx);
+            throw new Exception(msg);
         }
 
         byte[] record = new byte[signatureOpenIdx];
@@ -577,7 +579,9 @@ public class AuditLogReader {
         javax.crypto.spec.SecretKeySpec recreatedSignedSharedKey = new javax.crypto.spec.SecretKeySpec(signingSharedKey, algorithm);
         boolean verified = as.verify(record, signature, recreatedSignedSharedKey);
         if (!verified) {
-            throw new Exception("Unable to validate signature of auditRecord at index [" + (num_captured_records - 1) + "]");
+            int auditRecordIdx = num_captured_records - 1;
+            String msg = CommandUtils.getMessage("security.audit.FailedToValidateSignature", auditRecordIdx);
+            throw new Exception(msg);
         }
         if (debugEnabled) {
             theLogger.fine("processRecord: successfully verified the auditRecord signature");
@@ -593,7 +597,9 @@ public class AuditLogReader {
         javax.crypto.spec.SecretKeySpec recreatedSharedKey = new javax.crypto.spec.SecretKeySpec(encryptionSharedKey, algorithm);
         byte[] decryptedRecord = ae.decrypt(encryptedRecord, recreatedSharedKey);
         if (decryptedRecord == null) {
-            throw new Exception("Unable to decrypt auditRecord at index [" + (num_captured_records - 1) + "]");
+            int auditRecordIdx = num_captured_records - 1;
+            String msg = CommandUtils.getMessage("security.audit.FailedToDecryptAuditRecord", auditRecordIdx);
+            throw new Exception(msg);
         }
         if (debugEnabled) {
             theLogger.fine("processRecord: successfully decrypted the auditRecord");

--- a/dev/com.ibm.ws.security.audit.reader/src/com/ibm/ws/security/audit/reader/tasks/AuditLogReader.java
+++ b/dev/com.ibm.ws.security.audit.reader/src/com/ibm/ws/security/audit/reader/tasks/AuditLogReader.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
@@ -240,7 +241,7 @@ public class AuditLogReader {
                     throw new Exception(ase);
                 }
 
-                byte[] yy = Base64Coder.base64Decode(encryptedSignerSharedKey.getBytes("UTF8"));
+                byte[] yy = Base64Coder.base64Decode(encryptedSignerSharedKey.getBytes(StandardCharsets.UTF_8));
 
                 byte[] sk = encryptedSignerSharedKey.getBytes();
                 String x = new String(sk);
@@ -282,7 +283,7 @@ public class AuditLogReader {
                     throw new Exception(aee);
                 }
 
-                byte[] yy = Base64Coder.base64Decode(encSharedKey.getBytes("UTF8"));
+                byte[] yy = Base64Coder.base64Decode(encSharedKey.getBytes(StandardCharsets.UTF_8));
                 byte[] sk = encSharedKey.getBytes();
                 String x = new String(sk);
                 byte[] decryptedSharedKey = ae.decryptSharedKey(yy, publicKey);
@@ -330,7 +331,7 @@ public class AuditLogReader {
                     throw new Exception(ase);
                 }
 
-                byte[] yy = Base64Coder.base64Decode(encryptedSignerSharedKey.getBytes("UTF8"));
+                byte[] yy = Base64Coder.base64Decode(encryptedSignerSharedKey.getBytes(StandardCharsets.UTF_8));
 
                 byte[] sk = encryptedSignerSharedKey.getBytes();
                 byte[] decryptedSigningSharedKey = as.decryptSharedKey(yy, publicKey);
@@ -361,7 +362,7 @@ public class AuditLogReader {
                 }
                 // Now that I have my key, decrypt the encrypted shared key
 
-                yy = Base64Coder.base64Decode(encSharedKey.getBytes("UTF8"));
+                yy = Base64Coder.base64Decode(encSharedKey.getBytes(StandardCharsets.UTF_8));
 
                 if (debugEnabled)
                     theLogger.fine("Was able to base64Decode the encrypted shared key");
@@ -495,14 +496,14 @@ public class AuditLogReader {
                         num_captured_records++;
                         auditRecord = "";
 
-                        byte[] bites = capturedRecord.getBytes("UTF8");
+                        byte[] bites = capturedRecord.getBytes(StandardCharsets.UTF_8);
 
                         if (bites.length % 4 != 0) {
                             if (debugEnabled)
                                 theLogger.fine("capturedRecord length: " + bites.length + " capturedRecord: " + capturedRecord);
                         }
 
-                        byte[] decodedRecord = Base64Coder.base64Decode(capturedRecord.getBytes("UTF8"));
+                        byte[] decodedRecord = Base64Coder.base64Decode(capturedRecord.getBytes(StandardCharsets.UTF_8));
 
                         if (signedLog && !encryptedLog) {
 
@@ -512,13 +513,13 @@ public class AuditLogReader {
 
                             byte[] verifiedRecord = verifyRecord(as, record, signature, decryptedSigningSharedKey);
 
-                            rec = new String(verifiedRecord);
+                            rec = new String(verifiedRecord, StandardCharsets.UTF_8);
 
                         } else if (!signedLog && encryptedLog) {
 
                             byte[] decryptedRecord = decryptRecord(ae, decodedRecord, decryptedSharedKey);
 
-                            rec = new String(decryptedRecord);
+                            rec = new String(decryptedRecord, StandardCharsets.UTF_8);
 
                         } else if (signedLog && encryptedLog) {
 
@@ -530,7 +531,7 @@ public class AuditLogReader {
 
                             byte[] verifiedDecryptedRecord = decryptRecord(ae, verifiedEncryptedRecord, decryptedSharedKey);
 
-                            rec = new String(verifiedDecryptedRecord);
+                            rec = new String(verifiedDecryptedRecord, StandardCharsets.UTF_8);
 
                         }
 

--- a/dev/com.ibm.ws.security.audit.reader/src/com/ibm/ws/security/audit/reader/tasks/AuditLogReader.java
+++ b/dev/com.ibm.ws.security.audit.reader/src/com/ibm/ws/security/audit/reader/tasks/AuditLogReader.java
@@ -59,6 +59,8 @@ public class AuditLogReader {
     private static String encSharedKey = new String();
     private static boolean debugEnabled = false;
 
+    private static int num_captured_records = 0;
+
     public static String getReport(String fileName, String outputLocation,
                                    String encrypted, String encKeyStoreLoc, String encKeyStorePassword, String encKeyStoreType,
                                    String signed, String signingKeyStoreLoc, String signingKeyStorePassword, String signingKeyStoreType,
@@ -242,8 +244,8 @@ public class AuditLogReader {
 
                 byte[] sk = encryptedSignerSharedKey.getBytes();
                 String x = new String(sk);
-                byte[] decryptedSharedKey = as.decryptSharedKey(yy, publicKey);
-                String z = new String(decryptedSharedKey);
+                byte[] decryptedSigningSharedKey = as.decryptSharedKey(yy, publicKey);
+                String z = new String(decryptedSigningSharedKey);
 
                 // Read our signed audit records
                 try {
@@ -252,7 +254,7 @@ public class AuditLogReader {
                     throw fnf;
                 }
 
-                processRecord(file_reader, signedLog, encryptedLog, null, null);
+                processRecord(file_reader, signedLog, encryptedLog, null, decryptedSigningSharedKey, null, as);
 
             } // if (signedLog && !encryptedLog)
 
@@ -293,7 +295,7 @@ public class AuditLogReader {
                     throw fnf;
                 }
 
-                processRecord(file_reader, signedLog, encryptedLog, decryptedSharedKey, ae);
+                processRecord(file_reader, signedLog, encryptedLog, decryptedSharedKey, null, ae, null);
 
             }
 
@@ -331,7 +333,7 @@ public class AuditLogReader {
                 byte[] yy = Base64Coder.base64Decode(encryptedSignerSharedKey.getBytes("UTF8"));
 
                 byte[] sk = encryptedSignerSharedKey.getBytes();
-                byte[] decryptedSignedSharedKey = as.decryptSharedKey(yy, publicKey);
+                byte[] decryptedSigningSharedKey = as.decryptSharedKey(yy, publicKey);
 
                 // Let's get our public key for our encrypted records
                 try {
@@ -383,7 +385,7 @@ public class AuditLogReader {
                     throw fnf;
                 }
 
-                processRecord(file_reader, signedLog, encryptedLog, decryptedSharedKey, ae);
+                processRecord(file_reader, signedLog, encryptedLog, decryptedSharedKey, decryptedSigningSharedKey, ae, as);
             }
 
             if (!encryptedLog && !signedLog) {
@@ -436,13 +438,13 @@ public class AuditLogReader {
     }
 
     public static void processRecord(FileReader file_reader, boolean signedLog, boolean encryptedLog,
-                                     byte[] decryptedSharedKey, AuditEncryptionImpl ae) throws Exception {
+                                     byte[] decryptedSharedKey, byte[] decryptedSigningSharedKey, AuditEncryptionImpl ae, AuditSigningImpl as) throws Exception {
 
         int inByte;
         String auditRecord = new String();
         String capturedRecord = new String();
         boolean startOfRecord = false;
-        int num_captured_records = 0;
+        num_captured_records = 0;
         String rec = null;
         if (debugEnabled) {
             theLogger.fine("processRecord: decryptedSharedKey: " + decryptedSharedKey);
@@ -504,53 +506,32 @@ public class AuditLogReader {
 
                         if (signedLog && !encryptedLog) {
 
-                            // If the record is just signed and not encrypted, throw away the signature and process
-                            // the record itself
-                            rec = new String(decodedRecord);
-                            int index3 = rec.indexOf(signatureOpenTag);
-                            rec = rec.substring(0, index3);
+                            byte[][] recordAndSignature = splitRecordAndSignatureFromDecodedRecord(decodedRecord);
+                            byte[] record = recordAndSignature[0];
+                            byte[] signature = recordAndSignature[1];
+
+                            byte[] verifiedRecord = verifyRecord(as, record, signature, decryptedSigningSharedKey);
+
+                            rec = new String(verifiedRecord);
 
                         } else if (!signedLog && encryptedLog) {
 
-                            // Recreate the shared key
-                            String algorithm = CryptoUtils.ENCRYPT_ALGORITHM;
+                            byte[] decryptedRecord = decryptRecord(ae, decodedRecord, decryptedSharedKey);
 
-                            if (debugEnabled) {
-                                theLogger.fine("processRecord: recreate shared key with algoritm: " + algorithm);
-                            }
-                            javax.crypto.spec.SecretKeySpec recreatedSharedKey = new javax.crypto.spec.SecretKeySpec(decryptedSharedKey, algorithm);
+                            rec = new String(decryptedRecord);
 
-                            byte[] decryptedRecord = ae.decrypt(decodedRecord, recreatedSharedKey);
-                            if (decryptedRecord != null) {
-                                rec = new String(decryptedRecord);
-                            }
                         } else if (signedLog && encryptedLog) {
 
-                            String parsedSigRecord = new String();
-                            byte[] strippedRecord = null;
-                            for (int i = 0; i < decodedRecord.length; i++) {
-                                parsedSigRecord = parsedSigRecord.concat(Character.toString((char) decodedRecord[i]));
-                                if (parsedSigRecord.contains(signatureOpenTag)) {
-                                    strippedRecord = new byte[parsedSigRecord.length() - signatureOpenTag.length()];
-                                    System.arraycopy(decodedRecord, 0, strippedRecord, 0, parsedSigRecord.length() - signatureOpenTag.length());
-                                    break;
-                                }
-                            }
-                            String algorithm = CryptoUtils.ENCRYPT_ALGORITHM;
+                            byte[][] recordAndSignature = splitRecordAndSignatureFromDecodedRecord(decodedRecord);
+                            byte[] encryptedRecord = recordAndSignature[0];
+                            byte[] signature = recordAndSignature[1];
 
-                            if (debugEnabled)
-                                theLogger.fine("processRecord: recreate shared key with algorithm: " + algorithm);
+                            byte[] verifiedEncryptedRecord = verifyRecord(as, encryptedRecord, signature, decryptedSigningSharedKey);
 
-                            // Recreate the shared key
-                            javax.crypto.spec.SecretKeySpec recreatedSharedKey = new javax.crypto.spec.SecretKeySpec(decryptedSharedKey, algorithm);
+                            byte[] verifiedDecryptedRecord = decryptRecord(ae, verifiedEncryptedRecord, decryptedSharedKey);
 
-                            // Decrypt the record
-                            if (tc.isDebugEnabled()) {
-                                byte[] rkey = ((java.security.Key) recreatedSharedKey).getEncoded();
-                            }
+                            rec = new String(verifiedDecryptedRecord);
 
-                            byte[] decryptedRecord = ae.decrypt(strippedRecord, recreatedSharedKey);
-                            rec = new String(decryptedRecord);
                         }
 
                         parseRecord(rec);
@@ -564,6 +545,59 @@ public class AuditLogReader {
         } catch (Exception e) {
             throw e;
         }
+    }
+
+    private static byte[][] splitRecordAndSignatureFromDecodedRecord(byte[] decodedRecord) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < decodedRecord.length; i++) { // need to do it this way to ensure length does not change when converting to string
+            sb = sb.append(Character.toString((char) decodedRecord[i]));
+        }
+        String recordWithSignature = sb.toString();
+        int signatureOpenIdx = recordWithSignature.indexOf(signatureOpenTag);
+        int signatureCloseIdx = recordWithSignature.indexOf(signatureCloseTag);
+        if (signatureOpenIdx == -1 || signatureCloseIdx == -1 || signatureOpenIdx > signatureCloseIdx) {
+            throw new Exception("Unable to validate signature of auditRecord at index [" + (num_captured_records - 1) + "]");
+        }
+
+        byte[] record = new byte[signatureOpenIdx];
+        System.arraycopy(decodedRecord, 0, record, 0, record.length);
+
+        byte[] signature = new byte[signatureCloseIdx - (signatureOpenIdx + signatureOpenTag.length())];
+        System.arraycopy(decodedRecord, (signatureOpenIdx + signatureOpenTag.length()), signature, 0, signature.length);
+
+        return new byte[][] { record, signature };
+    }
+
+    private static byte[] verifyRecord(AuditSigningImpl as, byte[] record, byte[] signature, byte[] signingSharedKey) throws Exception {
+        String algorithm = CryptoUtils.ENCRYPT_ALGORITHM;
+        if (debugEnabled) {
+            theLogger.fine("processRecord: recreate signing shared key with algorithm: " + algorithm);
+        }
+        javax.crypto.spec.SecretKeySpec recreatedSignedSharedKey = new javax.crypto.spec.SecretKeySpec(signingSharedKey, algorithm);
+        boolean verified = as.verify(record, signature, recreatedSignedSharedKey);
+        if (!verified) {
+            throw new Exception("Unable to validate signature of auditRecord at index [" + (num_captured_records - 1) + "]");
+        }
+        if (debugEnabled) {
+            theLogger.fine("processRecord: successfully verified the auditRecord signature");
+        }
+        return record;
+    }
+
+    private static byte[] decryptRecord(AuditEncryptionImpl ae, byte[] encryptedRecord, byte[] encryptionSharedKey) throws Exception {
+        String algorithm = CryptoUtils.ENCRYPT_ALGORITHM;
+        if (debugEnabled) {
+            theLogger.fine("processRecord: recreate encryption shared key with algorithm: " + algorithm);
+        }
+        javax.crypto.spec.SecretKeySpec recreatedSharedKey = new javax.crypto.spec.SecretKeySpec(encryptionSharedKey, algorithm);
+        byte[] decryptedRecord = ae.decrypt(encryptedRecord, recreatedSharedKey);
+        if (decryptedRecord == null) {
+            throw new Exception("Unable to decrypt auditRecord at index [" + (num_captured_records - 1) + "]");
+        }
+        if (debugEnabled) {
+            theLogger.fine("processRecord: successfully decrypted the auditRecord");
+        }
+        return decryptedRecord;
     }
 
     public static Key getPublicKey(String keyStoreType, String keyStoreLocation,

--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/encryption/AuditSigningImpl.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/encryption/AuditSigningImpl.java
@@ -24,6 +24,7 @@ import java.security.MessageDigest;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 
 import javax.management.ObjectName;
 
@@ -465,26 +466,38 @@ public class AuditSigningImpl implements AuditSigning {
      * </p>
      *
      * @param a signed byte array of data
+     * @param the signature
      * @param the key used to sign the byte array of data
      * @returns a boolean value based the successful verification of the data
      * @throws AuditSigningException
      **/
     @Override
-    public boolean verify(byte[] data, Key key) throws AuditSigningException {
-        if (signature != null) {
-            try {
-                signature.initVerify((PublicKey) key);
-                signature.update(data);
-                if (tc.isEntryEnabled())
-                    Tr.exit(tc, "verify");
-                return signature.verify(sigBytes);
-            } catch (Exception ex) {
-                throw new AuditSigningException(ex);
-            }
-        } else {
-            String msg = "Signature is null.  Cannot verify data.";
-            throw new AuditSigningException(msg);
+    public boolean verify(byte[] data, byte[] signature, Key key) throws AuditSigningException {
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "verify");
+
+        byte[] messageDigest = null;
+        MessageDigest md = null;
+        try {
+            md = MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512);
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new AuditSigningException(e);
         }
+        if (data != null) {
+            md.reset();
+            md.update(data);
+            messageDigest = md.digest();
+        } else {
+            throw new AuditSigningException("Invalid data passed into verifying algorithm");
+        }
+
+        if (messageDigest == null) {
+            throw new AuditSigningException("MessageDigest is invalid");
+        }
+
+        byte[] unsignedData = unsign(signature, key);
+
+        return Arrays.equals(messageDigest, unsignedData);
     }
 
     public String getSignerKeyFileLocation() {

--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/encryption/AuditSigningImpl.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/encryption/AuditSigningImpl.java
@@ -466,6 +466,34 @@ public class AuditSigningImpl implements AuditSigning {
      * </p>
      *
      * @param a signed byte array of data
+     * @param the key used to sign the byte array of data
+     * @returns a boolean value based the successful verification of the data
+     * @throws AuditSigningException
+     **/
+    @Override
+    public boolean verify(byte[] data, Key key) throws AuditSigningException {
+        if (signature != null) {
+            try {
+                signature.initVerify((PublicKey) key);
+                signature.update(data);
+                if (tc.isEntryEnabled())
+                    Tr.exit(tc, "verify");
+                return signature.verify(sigBytes);
+            } catch (Exception ex) {
+                throw new AuditSigningException(ex);
+            }
+        } else {
+            String msg = "Signature is null.  Cannot verify data.";
+            throw new AuditSigningException(msg);
+        }
+    }
+
+    /**
+     * <p>
+     * The <code>verify</code> method verifies the data is signed with a key
+     * </p>
+     *
+     * @param a signed byte array of data
      * @param the signature
      * @param the key used to sign the byte array of data
      * @returns a boolean value based the successful verification of the data


### PR DESCRIPTION
the audit reader utility currently does nothing with the signature.

this pr addresses this missing functionality by verifying that the signature matches the data by:
- decrypting the signature using aes with the signing shared key
- computing the sha512 digest of the audit record (can be encrypted or not encrypted case)
- comparing the decrypted signature with the sha512 digest of the record
- if they match, then continue, otherwise stop processing and throw an error