### PR TITLE
Updating the SSLHandshakeIOCallback to track the SSL handshake errors

### DIFF
--- a/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLHandshakeIOCallback.java
+++ b/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLHandshakeIOCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2008 IBM Corporation and others.
+ * Copyright (c) 2003, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -87,6 +87,11 @@ public class SSLHandshakeIOCallback implements TCPReadCompletedCallback, TCPWrit
             SSLUtils.handleHandshake(connLink, netBuffer, decryptedNetBuffer,
                                      encryptedAppBuffer, result, callback, true);
         } catch (IOException ioe) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught IOException while performing callback read, " + ioe);
+            }
+
+            connLink.getChannel().getHandshakeErrorTracker().noteHandshakeError(ioe, connLink.getRemoteAddress(), connLink.getRemotePort(), connLink.getLocalAddress(), connLink.getLocalPort());
             error(vc, rsc, ioe);
         }
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
@@ -119,6 +124,11 @@ public class SSLHandshakeIOCallback implements TCPReadCompletedCallback, TCPWrit
             SSLUtils.handleHandshake(connLink, netBuffer, decryptedNetBuffer,
                                      encryptedAppBuffer, result, callback, true);
         } catch (IOException ioe) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught IOException while performing callback write, " + ioe);
+            }
+
+            connLink.getChannel().getHandshakeErrorTracker().noteHandshakeError(ioe, connLink.getRemoteAddress(), connLink.getRemotePort(), connLink.getLocalAddress(), connLink.getLocalPort());
             error(vc, wsc, ioe);
         }
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {


### PR DESCRIPTION
Updating the SSLHandshakeIOCallback to track the SSL handshake errors using the noteHandshakeError


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
