### PR TITLE
Fix FAT failures when there is a race condition for doLast method call

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/build.gradle
+++ b/dev/com.ibm.ws.security.acme_fat/build.gradle
@@ -51,6 +51,9 @@ autoFVT.doLast {
       into new File(autoFvtDir, 'publish/servers/' + server.name + '/resources/security')
     }
   }
+
+  def publishBaseDir = new File(autoFvtDir, 'publish') 
+  defaultCopyLTPAFIPSKeys(publishBaseDir)
 }
 
 tasks.withType(JavaExec) {

--- a/dev/com.ibm.ws.security.authentication.filter_fat/build.gradle
+++ b/dev/com.ibm.ws.security.authentication.filter_fat/build.gradle
@@ -104,4 +104,7 @@ autoFVT.doLast {
     into new File(autoFvtDir, 'publish/servers/' + server + '/resources/security')
     include '**'
   }
+  
+  def publishBaseDir = new File(autoFvtDir, 'publish') 
+  defaultCopyLTPAFIPSKeys(publishBaseDir)
 }

--- a/dev/com.ibm.ws.security.spnego_fat.1/build.gradle
+++ b/dev/com.ibm.ws.security.spnego_fat.1/build.gradle
@@ -171,4 +171,7 @@ autoFVT.doLast {
     into new File(autoFvtDir, 'publish/servers/' + server + '/resources/security')
     include '**'
   }
+  
+  def publishBaseDir = new File(autoFvtDir, 'publish') 
+  defaultCopyLTPAFIPSKeys(publishBaseDir)
 }

--- a/dev/com.ibm.ws.security.spnego_fat.2/build.gradle
+++ b/dev/com.ibm.ws.security.spnego_fat.2/build.gradle
@@ -138,4 +138,7 @@ autoFVT.doLast {
     into new File(autoFvtDir, 'publish/servers/' + server + '/resources/security')
     include '**'
   }
+  
+  def publishBaseDir = new File(autoFvtDir, 'publish') 
+  defaultCopyLTPAFIPSKeys(publishBaseDir)
 }

--- a/dev/com.ibm.ws.security.spnego_fat/build.gradle
+++ b/dev/com.ibm.ws.security.spnego_fat/build.gradle
@@ -268,4 +268,7 @@ autoFVT.doLast {
     into new File(autoFvtDir, 'publish/servers/' + server + '/resources/security')
     include '**'
   }
+  
+  def publishBaseDir = new File(autoFvtDir, 'publish') 
+  defaultCopyLTPAFIPSKeys(publishBaseDir)
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.2/build.gradle
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.2/build.gradle
@@ -243,6 +243,9 @@ autoFVT.doLast {
       into new File(autoFvtDir, 'publish/servers/' + server + '/resources/security')
     }
   }
+  
+  def publishBaseDir = new File(autoFvtDir, 'publish') 
+  defaultCopyLTPAFIPSKeys(publishBaseDir)
 }
 
 assemble { 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
@@ -249,6 +249,9 @@ autoFVT.doLast {
       into new File(autoFvtDir, 'publish/servers/' + server + '/resources/security')
     }
   }
+  
+  def publishBaseDir = new File(autoFvtDir, 'publish') 
+  defaultCopyLTPAFIPSKeys(publishBaseDir)
 }
 
 /*


### PR DESCRIPTION
## Background
Few FATs rely on ltpaFIPS.keys being present during the runtime. However, due to the `autoFVT.doLast` call within certain FATs being run after the fat.gradle's doLast, some projects weren't running the macro at the right time. 

## Changes
With this change, I am calling the macro to copy in the FIPS keys at the end of the doLast method for those projects to ensure the key is present during FAT run time.
