### PR TITLE
Test InvocationContext sees bindings from Extension

### DIFF
--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/BindingExtension.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/BindingExtension.java
@@ -1,0 +1,256 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.extension.apps.invocationContext;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedConstructor;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedParameter;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * Extension which adds interceptor bindings using the {@code ProcessAnnotatedType} event.
+ */
+public class BindingExtension implements Extension {
+
+    @SuppressWarnings("serial")
+    private static class MyAddedByExtensionBindingLiteral extends AnnotationLiteral<MyAddedByExtensionBinding> implements MyAddedByExtensionBinding {};
+
+    private static final Annotation ADDED_BY_EXTENSION_BINDING = new MyAddedByExtensionBindingLiteral();
+
+    /**
+     * Add {@code @MyAddedByExtensionBinding} to {@code InterceptedBean}
+     *
+     * @param pat event
+     */
+    public void addClassAnnotation(@Observes ProcessAnnotatedType<InterceptedBean> pat) {
+        pat.setAnnotatedType(addAnnotation(pat.getAnnotatedType(), ADDED_BY_EXTENSION_BINDING));
+    }
+
+    /**
+     * Add {@code @MyAddedByExtensionBinding} to {@code InterceptedMethodsBean.iExist}
+     *
+     * @param pat event
+     */
+    public void addMethodAnnotation(@Observes ProcessAnnotatedType<InterceptedMethodsBean> pat) {
+        AnnotatedType<InterceptedMethodsBean> type = pat.getAnnotatedType();
+        AnnotatedMethod<? super InterceptedMethodsBean> method = type.getMethods()
+                                                                     .stream()
+                                                                     .filter(m -> m.getJavaMember().getName().equals("iExist"))
+                                                                     .findFirst()
+                                                                     .get();
+
+        AnnotatedMethod<? super InterceptedMethodsBean> newMethod = addAnnotation(method, ADDED_BY_EXTENSION_BINDING);
+        AnnotatedType<InterceptedMethodsBean> newType = replaceMethod(type, method, newMethod);
+
+        pat.setAnnotatedType(newType);
+    }
+
+    /*
+     * -----------------------------------------------------------------------------------
+     * Rest of the class is long-winded helper methods for adding annotations to classes and methods.
+     * This is much easier in CDI 2.0, but this test also runs on CDI 1.2.
+     * -----------------------------------------------------------------------------------
+     */
+
+    private <X> AnnotatedType<X> addAnnotation(AnnotatedType<X> type, Annotation newAnnotation) {
+
+        Set<Annotation> annotations = new HashSet<>(type.getAnnotations());
+        annotations.add(newAnnotation);
+
+        return new AnnotatedType<X>() {
+
+            @Override
+            public <T extends Annotation> T getAnnotation(Class<T> clazz) {
+                if (newAnnotation.annotationType() == clazz) {
+                    return clazz.cast(newAnnotation);
+                } else {
+                    return type.getAnnotation(clazz);
+                }
+            }
+
+            @Override
+            public boolean isAnnotationPresent(Class<? extends Annotation> clazz) {
+                if (newAnnotation.annotationType() == clazz) {
+                    return true;
+                } else {
+                    return type.isAnnotationPresent(clazz);
+                }
+            }
+
+            @Override
+            public Set<Annotation> getAnnotations() {
+                return annotations;
+            }
+
+            @Override
+            public Type getBaseType() {
+                return type.getBaseType();
+            }
+
+            @Override
+            public Set<AnnotatedConstructor<X>> getConstructors() {
+                return type.getConstructors();
+            }
+
+            @Override
+            public Set<AnnotatedField<? super X>> getFields() {
+                return type.getFields();
+            }
+
+            @Override
+            public Class<X> getJavaClass() {
+                return type.getJavaClass();
+            }
+
+            @Override
+            public Set<AnnotatedMethod<? super X>> getMethods() {
+                return type.getMethods();
+            }
+
+            @Override
+            public Set<Type> getTypeClosure() {
+                return type.getTypeClosure();
+            }
+        };
+    }
+
+    private <X> AnnotatedMethod<X> addAnnotation(AnnotatedMethod<X> method, Annotation newAnnotation) {
+        Set<Annotation> annotations = new HashSet<>(method.getAnnotations());
+        annotations.add(ADDED_BY_EXTENSION_BINDING);
+
+        AnnotatedMethod<X> result = new AnnotatedMethod<X>() {
+
+            @Override
+            public <T extends Annotation> T getAnnotation(Class<T> clazz) {
+                if (newAnnotation.annotationType() == clazz) {
+                    return clazz.cast(newAnnotation);
+                } else {
+                    return method.getAnnotation(clazz);
+                }
+            }
+
+            @Override
+            public Set<Annotation> getAnnotations() {
+                return annotations;
+            }
+
+            @Override
+            public Type getBaseType() {
+                return method.getBaseType();
+            }
+
+            @Override
+            public AnnotatedType<X> getDeclaringType() {
+                return method.getDeclaringType();
+            }
+
+            @Override
+            public Method getJavaMember() {
+                return method.getJavaMember();
+            }
+
+            @Override
+            public List<AnnotatedParameter<X>> getParameters() {
+                return method.getParameters();
+            }
+
+            @Override
+            public Set<Type> getTypeClosure() {
+                return method.getTypeClosure();
+            }
+
+            @Override
+            public boolean isAnnotationPresent(Class<? extends Annotation> clazz) {
+                if (newAnnotation.annotationType() == clazz) {
+                    return true;
+                } else {
+                    return method.isAnnotationPresent(clazz);
+                }
+            }
+
+            @Override
+            public boolean isStatic() {
+                return method.isStatic();
+            }
+        };
+        return result;
+    }
+
+    private <X> AnnotatedType<X> replaceMethod(AnnotatedType<X> newType,
+                                               AnnotatedMethod<? super X> method,
+                                               AnnotatedMethod<? super X> newMethod) {
+
+        Set<AnnotatedMethod<? super X>> methods = new HashSet<>(newType.getMethods());
+        methods.remove(method);
+        methods.add(newMethod);
+
+        AnnotatedType<X> result = new AnnotatedType<X>() {
+
+            @Override
+            public Set<AnnotatedMethod<? super X>> getMethods() {
+                return methods;
+            }
+
+            @Override
+            public <T extends Annotation> T getAnnotation(Class<T> clazz) {
+                return newType.getAnnotation(clazz);
+            }
+
+            @Override
+            public Set<Annotation> getAnnotations() {
+                return newType.getAnnotations();
+            }
+
+            @Override
+            public Type getBaseType() {
+                return newType.getBaseType();
+            }
+
+            @Override
+            public Set<AnnotatedConstructor<X>> getConstructors() {
+                return newType.getConstructors();
+            }
+
+            @Override
+            public Set<AnnotatedField<? super X>> getFields() {
+                return newType.getFields();
+            }
+
+            @Override
+            public Class<X> getJavaClass() {
+                return newType.getJavaClass();
+            }
+
+            @Override
+            public Set<Type> getTypeClosure() {
+                return newType.getTypeClosure();
+            }
+
+            @Override
+            public boolean isAnnotationPresent(Class<? extends Annotation> arg0) {
+                return newType.isAnnotationPresent(arg0);
+            }
+        };
+        return result;
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/InvocationContextTestServlet.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/InvocationContextTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,7 @@ public class InvocationContextTestServlet extends FATServlet {
         imb.iExist();  //The real test takes place inisde the interceptors' methods.
         assertTrue(bindingInterceptorRan);
         assertTrue(nonBindingInterceptorRan);
-        assertFalse(nonBindingInterceptorAroundConstructRan); //Since we're reusing the interceptor it will not construct a second time.
+        assertFalse(nonBindingInterceptorAroundConstructRan); //Since the interceptor is bound to the method, we don't expect object construction interception to occur
         assertFalse(nonBindingInterceptorPostConstructRan);
     }
 

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/MyAddedByExtensionBinding.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/MyAddedByExtensionBinding.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.cdi.extension.apps.invocationContext;
 
@@ -20,9 +17,11 @@ import java.lang.annotation.Target;
 import javax.interceptor.InterceptorBinding;
 
 /**
- * Basic interceptor binding
+ * Binding annotation added to test class and method by an extension
  */
 @InterceptorBinding
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface MyInterceptorBinding {}
+public @interface MyAddedByExtensionBinding {
+
+}

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/MyInterceptor.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/MyInterceptor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -38,8 +38,11 @@ public class MyInterceptor {
 
         //In a real app this wouldn't be possible, but for now we're just testing this utility method.
         Set<Annotation> interceptorBindings = CDIUtils.getInterceptorBindingsFromInvocationContext(ctx);
-        assertThat(interceptorBindings, containsInAnyOrder(instanceOf(MyNonBindingInterceptorBinding.class), instanceOf(MyInterceptorBinding.class), instanceOf(MyUnusedInterceptorBinding.class)));
-        assertEquals(3, interceptorBindings.size());
+        assertThat(interceptorBindings, containsInAnyOrder(instanceOf(MyNonBindingInterceptorBinding.class),
+                                                           instanceOf(MyInterceptorBinding.class),
+                                                           instanceOf(MyUnusedInterceptorBinding.class),
+                                                           instanceOf(MyAddedByExtensionBinding.class)));
+        assertEquals(4, interceptorBindings.size());
 
         return ctx.proceed();
     }

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/MyNonBindingInterceptor.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/MyNonBindingInterceptor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,8 +20,8 @@ import static org.junit.Assert.assertEquals;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 
-import javax.annotation.Priority;
 import javax.annotation.PostConstruct;
+import javax.annotation.Priority;
 import javax.interceptor.AroundConstruct;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -59,8 +59,11 @@ public class MyNonBindingInterceptor {
 
         //In a real app this wouldn't be possible, but for now we're just testing this utility method.
         Set<Annotation> interceptorBindings = CDIUtils.getInterceptorBindingsFromInvocationContext(ctx);
-        assertThat(interceptorBindings, containsInAnyOrder(instanceOf(MyNonBindingInterceptorBinding.class), instanceOf(MyInterceptorBinding.class), instanceOf(MyUnusedInterceptorBinding.class)));
-        assertEquals(3, interceptorBindings.size());
+        assertThat(interceptorBindings, containsInAnyOrder(instanceOf(MyNonBindingInterceptorBinding.class),
+                                                           instanceOf(MyInterceptorBinding.class),
+                                                           instanceOf(MyUnusedInterceptorBinding.class),
+                                                           instanceOf(MyAddedByExtensionBinding.class)));
+        assertEquals(4, interceptorBindings.size());
 
         for (Annotation ann : interceptorBindings) {
             if (ann instanceof MyNonBindingInterceptorBinding) {

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/MyNonBindingInterceptorBinding.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/apps/invocationContext/MyNonBindingInterceptorBinding.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,11 +20,14 @@ import java.lang.annotation.Target;
 import javax.enterprise.util.Nonbinding;
 import javax.interceptor.InterceptorBinding;
 
-
+/**
+ * Interceptor binding with a {@code @Nonbinding} field
+ */
 @InterceptorBinding
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MyNonBindingInterceptorBinding {
 
-    @Nonbinding String text() default "testString";
+    @Nonbinding
+    String text() default "testString";
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/tests/CDI12ExtensionTest.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi/extension/tests/CDI12ExtensionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.cdi.extension.tests;
+
+import javax.enterprise.inject.spi.Extension;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -34,6 +36,7 @@ import com.ibm.ws.cdi.extension.apps.enablementWar.EnablementSharedLibServlet;
 import com.ibm.ws.cdi.extension.apps.enablementWar.EnablementTestServlet;
 import com.ibm.ws.cdi.extension.apps.helloworld.HelloWorldExtensionBean;
 import com.ibm.ws.cdi.extension.apps.helloworld.HelloWorldExtensionTestServlet;
+import com.ibm.ws.cdi.extension.apps.invocationContext.BindingExtension;
 import com.ibm.ws.cdi.extension.apps.invocationContext.InvocationContextTestServlet;
 import com.ibm.ws.cdi.extension.apps.multipleWar.NoBeansTestServlet;
 import com.ibm.ws.cdi.extension.apps.multipleWar.ejb.EmbeddedJarMyEjb;
@@ -136,7 +139,9 @@ public class CDI12ExtensionTest extends FATServletClient {
         // invocationContext.war
 
         WebArchive invocationContextWar = ShrinkWrap.create(WebArchive.class, "invocationContext.war")
-                                                    .addPackage(InvocationContextTestServlet.class.getPackage());
+                                                    .addPackage(InvocationContextTestServlet.class.getPackage())
+                                                    .addAsServiceProvider(Extension.class, BindingExtension.class);
+        CDIArchiveHelper.addBeansXML(invocationContextWar, DiscoveryMode.ANNOTATED);
 
         ShrinkHelper.exportDropinAppToServer(server, invocationContextWar, DeployOptions.SERVER_ONLY);
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Ensure that annotation bindings added by an extension can be retrieved
from the InvocationContext.

For #27826