### PR TITLE
clear cache once before uninstall operation

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/UninstallDirector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -103,6 +103,10 @@ class UninstallDirector extends AbstractDirector {
 
         //get all installed features
         Map<String, ProvisioningFeatureDefinition> features = product.getFeatureDefinitions();
+        
+        //Need to update the bundle repository registry
+        BundleRepositoryRegistry.disposeAll();
+        BundleRepositoryRegistry.initializeDefaults(null, false);
 
         // Run file checking only on Windows
         if (InstallUtils.isWindows) {

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -60,7 +60,6 @@ import com.ibm.ws.install.internal.asset.ESAAsset;
 import com.ibm.ws.install.internal.asset.UninstallAsset;
 import com.ibm.ws.install.internal.platform.InstallPlatformUtils;
 import com.ibm.ws.kernel.boot.cmdline.Utils;
-import com.ibm.ws.kernel.feature.Visibility;
 import com.ibm.ws.kernel.feature.internal.HashUtils;
 import com.ibm.ws.kernel.feature.internal.generator.ManifestFileProcessor;
 import com.ibm.ws.kernel.feature.provisioning.FeatureResource;
@@ -544,9 +543,6 @@ public class ESAAdaptor extends ArchiveAdaptor {
                                                                  boolean checkDependency) {
         HashMap<String, File> resourceMap = new HashMap<String, File>();
 
-        // Need to update the bundle repository registry
-        BundleRepositoryRegistry.disposeAll();
-        BundleRepositoryRegistry.initializeDefaults(null, false);
         BundleRepositoryRegistry.addBundleRepository(baseDir.getAbsolutePath(), targetFd.getBundleRepositoryType());
         BundleRepositoryHolder brh = BundleRepositoryRegistry.getRepositoryHolder(targetFd.getBundleRepositoryType());
         ContentBasedLocalBundleRepository br = brh.getBundleRepository();

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/adaptor/ESAAdaptor.java
@@ -60,6 +60,7 @@ import com.ibm.ws.install.internal.asset.ESAAsset;
 import com.ibm.ws.install.internal.asset.UninstallAsset;
 import com.ibm.ws.install.internal.platform.InstallPlatformUtils;
 import com.ibm.ws.kernel.boot.cmdline.Utils;
+import com.ibm.ws.kernel.feature.Visibility;
 import com.ibm.ws.kernel.feature.internal.HashUtils;
 import com.ibm.ws.kernel.feature.internal.generator.ManifestFileProcessor;
 import com.ibm.ws.kernel.feature.provisioning.FeatureResource;


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

To improve performance, clear features repository cache once instead of clearing the cache each time for each features to uninstall. 

This improved performance from 598198 ms (9.97 min) to 24583 ms (0.41min)

- Liberty directory structure before and after change were same.
- InstallUtility uninstall command removed the same files.
- Tested install/uninstall of user features

