### PR TITLE
Updates for Jakarta Authorization 3.0 implementation

### DIFF
--- a/dev/com.ibm.ws.security.authorization.jacc.ejb/src/com/ibm/ws/security/authorization/jacc/ejb/impl/EJBJaccServiceImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.ejb/src/com/ibm/ws/security/authorization/jacc/ejb/impl/EJBJaccServiceImpl.java
@@ -80,6 +80,7 @@ public class EJBJaccServiceImpl implements EJBJaccService {
 
             if (principalMapperSupported) {
                 PolicyContext.registerHandler("jakarta.security.jacc.PrincipalMapper", pch, true);
+                handlerObjects.put("jakarta.security.jacc.PrincipalMapper", policyProxy.getPrincipalMapper());
             } else {
                 PolicyContext.registerHandler("javax.ejb.arguments", pch, true);
                 handlerObjects.put("javax.ejb.arguments", methodParameters);
@@ -204,13 +205,13 @@ public class EJBJaccServiceImpl implements EJBJaccService {
 
     private boolean checkResourceConstraints(String contextId, List<Object> methodParameters, EnterpriseBean bean, Permission ejbPerm, Subject subject, PolicyProxy policyProxy) {
         boolean result = false;
-        final Object[] ma = null;
+        Object[] ma = null;
 
         /*
          * TODO Doesn't seem to handle EJB-3.0 annotated beans.
          */
         if (methodParameters != null && methodParameters.size() > 0) {
-            methodParameters.toArray(new Object[methodParameters.size()]);
+            ma = methodParameters.toArray(new Object[methodParameters.size()]);
         }
         try {
             result = checkMethodConstraints(contextId, ma, bean, ejbPerm, subject, policyProxy);

--- a/dev/com.ibm.ws.security.authorization.jacc.ejb/test/com/ibm/ws/security/authorization/jacc/ejb/impl/EJBJaccServiceImplTest.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.ejb/test/com/ibm/ws/security/authorization/jacc/ejb/impl/EJBJaccServiceImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -172,7 +172,7 @@ public class EJBJaccServiceImplTest {
                 will(returnValue(jaccProviderService));
                 allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
                 will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(policyProxy));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(pcf));
@@ -264,7 +264,7 @@ public class EJBJaccServiceImplTest {
                 will(returnValue(jaccProviderService));
                 allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
                 will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(policyProxy));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(pcf));
@@ -356,7 +356,7 @@ public class EJBJaccServiceImplTest {
                 will(returnValue(jaccProviderService));
                 allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
                 will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(policyProxy));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(pcf));
@@ -408,7 +408,7 @@ public class EJBJaccServiceImplTest {
                 will(returnValue(jaccProviderService));
                 allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
                 will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(policyProxy));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(pcf));

--- a/dev/com.ibm.ws.security.authorization.jacc.web/src/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.web/src/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImpl.java
@@ -93,6 +93,7 @@ public class WebJaccServiceImpl implements WebJaccService {
 
             if (principalMapperSupported) {
                 PolicyContext.registerHandler("jakarta.security.jacc.PrincipalMapper", pch, true);
+                handlerObjects.put("jakarta.security.jacc.PrincipalMapper", policyProxy.getPrincipalMapper());
             }
 
             if (javaxSupported) {

--- a/dev/com.ibm.ws.security.authorization.jacc.web/test/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImplTest.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.web/test/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImplTest.java
@@ -191,7 +191,7 @@ public class WebJaccServiceImplTest {
                 will(returnValue(jaccProviderService));
                 allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
                 will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(policyProxy));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(pcf));
@@ -274,7 +274,7 @@ public class WebJaccServiceImplTest {
                 will(returnValue(jaccProviderService));
                 allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
                 will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(policyProxy));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(pcf));
@@ -356,7 +356,7 @@ public class WebJaccServiceImplTest {
                 will(returnValue(jaccProviderService));
                 allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
                 will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(policyProxy));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(pcf));

--- a/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/PolicyConfigurationManager.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/PolicyConfigurationManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -31,4 +31,6 @@ public interface PolicyConfigurationManager {
     void removeModule(String appName, String contextId);
 
     void addEJB(String appName, String contextId);
+
+    public boolean isApplicationRunning(String appName);
 }

--- a/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyConfigurationManagerImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyConfigurationManagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.security.jacc.PolicyConfiguration;
 import javax.security.jacc.PolicyConfigurationFactory;
@@ -36,7 +37,7 @@ public class PolicyConfigurationManagerImpl implements ApplicationStateListener,
     private final Map<String, List<PolicyConfiguration>> pcConfigsMap = new ConcurrentHashMap<String, List<PolicyConfiguration>>();
     private final Map<String, List<String>> pcModulesMap = new ConcurrentHashMap<String, List<String>>();
     private final Map<String, List<String>> pcEjbMap = new ConcurrentHashMap<String, List<String>>();
-    private final List<String> pcRunningList = new ArrayList<String>();
+    private final List<String> pcRunningList = new CopyOnWriteArrayList<String>();
 
     private PolicyConfigurationFactory pcf = null;
     private PolicyProxy policyProxy = null;
@@ -130,6 +131,7 @@ public class PolicyConfigurationManagerImpl implements ApplicationStateListener,
         addModule(appName, contextId);
     }
 
+    @Override
     public boolean isApplicationRunning(String appName) {
         return pcRunningList.contains(appName);
     }

--- a/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyContextUtil.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyContextUtil.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.authorization.jacc.common;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
+
+public class PolicyContextUtil {
+
+    public static String getContextId(WsLocationAdmin locationAdmin, String applicationName, String moduleName) {
+        StringBuilder output = new StringBuilder();
+        output.append(getHostName()).append("#").append(locationAdmin.resolveString("${wlp.user.dir}").replace('\\',
+                                                                                                               '/')).append("#").append(locationAdmin.getServerName()).append("#");
+        output.append(applicationName).append("#").append(moduleName);
+        return output.toString();
+    }
+
+    /**
+     * Get the host name.
+     *
+     * @return String value of the host name or "localhost" if not able to resolve
+     */
+    private static String getHostName() {
+        String hostName = AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                try {
+                    return java.net.InetAddress.getLocalHost().getCanonicalHostName().toLowerCase();
+                } catch (java.net.UnknownHostException e) {
+                    return "localhost";
+                }
+            }
+        });
+        return hostName;
+    }
+}

--- a/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyProxy.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,9 +18,23 @@ import javax.security.auth.Subject;
  */
 public interface PolicyProxy {
 
-    public void refresh();
+    default public void refresh() {
+        // Do nothing for EE 11+
+    }
 
-    public void setPolicy();
+    default public void setPolicy() {
+        // Do nothing for EE 11+
+    }
 
     public boolean implies(String contextId, Subject subject, Permission permission);
+
+    /**
+     * In a Jakarta EE 11+ implementation this method returns the PrincipalMapper implementation
+     *
+     * @return PrincipalMapper implementation
+     */
+    default public Object getPrincipalMapper() {
+        // Default is to throws exception since it isn't expected to be called for pre-EE 11 scenarios
+        throw new UnsupportedOperationException();
+    }
 }

--- a/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/ProviderServiceProxy.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/ProviderServiceProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@ package com.ibm.ws.security.authorization.jacc.common;
 
 import javax.security.jacc.PolicyConfigurationFactory;
 
+import com.ibm.ws.security.authorization.jacc.PolicyConfigurationManager;
+
 public interface ProviderServiceProxy {
 
     /**
@@ -19,7 +21,7 @@ public interface ProviderServiceProxy {
      *
      * @return An instance which implements PolicyProxy interface.
      */
-    public PolicyProxy getPolicyProxy();
+    public PolicyProxy getPolicyProxy(PolicyConfigurationManager pcm);
 
     /**
      * Returns the instance representing the provider-specific implementation

--- a/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/internal/JaccServiceImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/internal/JaccServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.security.authorization.jacc.JaccService;
 import com.ibm.ws.security.authorization.jacc.PolicyConfigurationManager;
+import com.ibm.ws.security.authorization.jacc.common.PolicyContextUtil;
 import com.ibm.ws.security.authorization.jacc.common.PolicyProxy;
 import com.ibm.ws.security.authorization.jacc.common.ProviderServiceProxy;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
@@ -116,7 +117,7 @@ public class JaccServiceImpl implements JaccService {
             @Override
             public Boolean run() {
 
-                policyProxy = jaccProviderServiceProxy.getService().getPolicyProxy();
+                policyProxy = jaccProviderServiceProxy.getService().getPolicyProxy(pcm);
                 if (tc.isDebugEnabled())
                     Tr.debug(tc, "policy object" + policyProxy);
                 // in order to support the CTS provider, Policy object should be set prior to
@@ -151,12 +152,8 @@ public class JaccServiceImpl implements JaccService {
 
     @Override
     public String getContextId(String applicationName, String moduleName) {
-        StringBuffer output = new StringBuffer();
         WsLocationAdmin locationAdmin = locationAdminRef.getService();
-        output.append(getHostName()).append("#").append(locationAdmin.resolveString("${wlp.user.dir}").replace('\\',
-                                                                                                               '/')).append("#").append(locationAdmin.getServerName()).append("#");
-        output.append(applicationName).append("#").append(moduleName);
-        return output.toString();
+        return PolicyContextUtil.getContextId(locationAdmin, applicationName, moduleName);
     }
 
     @Override
@@ -185,25 +182,6 @@ public class JaccServiceImpl implements JaccService {
             }
         }
         return value;
-    }
-
-    /**
-     * Get the host name.
-     *
-     * @return String value of the host name or "localhost" if not able to resolve
-     */
-    private String getHostName() {
-        String hostName = AccessController.doPrivileged(new PrivilegedAction<String>() {
-            @Override
-            public String run() {
-                try {
-                    return java.net.InetAddress.getLocalHost().getCanonicalHostName().toLowerCase();
-                } catch (java.net.UnknownHostException e) {
-                    return "localhost";
-                }
-            }
-        });
-        return hostName;
     }
 
     @Override

--- a/dev/com.ibm.ws.security.authorization.jacc/src/io/openliberty/security/authorization/jacc/internal/proxy/ProviderServiceProxyImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/io/openliberty/security/authorization/jacc/internal/proxy/ProviderServiceProxyImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.authorization.jacc.PolicyConfigurationManager;
 import com.ibm.ws.security.authorization.jacc.common.PolicyProxy;
 import com.ibm.ws.security.authorization.jacc.common.ProviderServiceProxy;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
@@ -59,7 +60,7 @@ public class ProviderServiceProxyImpl implements ProviderServiceProxy {
     }
 
     @Override
-    public PolicyProxy getPolicyProxy() {
+    public PolicyProxy getPolicyProxy(PolicyConfigurationManager pcm) {
         ProviderService providerService = jaccProviderService.getService();
         if (providerService == null) {
             return null;

--- a/dev/com.ibm.ws.security.authorization.jacc/test/com/ibm/ws/security/authorization/jacc/internal/JaccServiceImplTest.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/test/com/ibm/ws/security/authorization/jacc/internal/JaccServiceImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -147,7 +147,7 @@ public class JaccServiceImplTest {
                 will(returnValue(jaccProviderService));
                 allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
                 will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(policyProxy));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(pcf));
@@ -215,7 +215,7 @@ public class JaccServiceImplTest {
                 will(returnValue(jaccProviderService));
                 allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
                 will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(policyProxy));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(pcf));
@@ -358,7 +358,7 @@ public class JaccServiceImplTest {
                 will(returnValue(jaccProviderService));
 //                allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
 //                will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(null));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(pcf));
@@ -418,7 +418,7 @@ public class JaccServiceImplTest {
                 will(returnValue(jaccProviderService));
                 allowing(cc).locateService("locationAdmin", wsLocationAdminRef);
                 will(returnValue(wsLocationAdmin));
-                allowing(jaccProviderServiceProxy).getPolicyProxy();
+                allowing(jaccProviderServiceProxy).getPolicyProxy(pcm);
                 will(returnValue(policyProxy));
                 allowing(jaccProviderServiceProxy).getPolicyConfigFactory();
                 will(returnValue(null));

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/SecurityContextImpl.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/SecurityContextImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,7 +14,6 @@ package com.ibm.ws.security.javaeesec.cdi.extensions;
 
 import java.security.Principal;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -25,17 +24,11 @@ import javax.security.enterprise.authentication.mechanism.http.AuthenticationPar
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.websphere.security.cred.WSCredential;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
-import com.ibm.ws.security.authentication.principals.WSPrincipal;
-import com.ibm.ws.security.authentication.utility.SubjectHelper;
 import com.ibm.ws.security.authorization.AuthorizationService;
 import com.ibm.ws.security.context.SubjectManager;
 import com.ibm.ws.security.intfc.SubjectManagerService;
 import com.ibm.ws.security.javaeesec.JavaEESecConstants;
-import com.ibm.ws.security.mp.jwt.proxy.MpJwtHelper;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.ws.webcontainer.security.metadata.MatchResponse;
 import com.ibm.ws.webcontainer.security.metadata.SecurityConstraintCollection;
@@ -46,9 +39,6 @@ import com.ibm.ws.webcontainer.security.util.WebConfigUtils;
  *
  */
 public class SecurityContextImpl implements SecurityContext {
-    private static final TraceComponent tc = Tr.register(SecurityContextImpl.class);
-
-    private final SubjectManager subjectManager = null;
 
     /*
      * (non-Javadoc)
@@ -82,94 +72,8 @@ public class SecurityContextImpl implements SecurityContext {
     @Override
     public Principal getCallerPrincipal() {
 
-        String securityName = null;
-        Principal principal = null;
         Subject callerSubject = getCallerSubject();
-
-        if (callerSubject == null) {
-            return null;
-        }
-
-        SubjectHelper subjectHelper = new SubjectHelper();
-        if (subjectHelper.isUnauthenticated(callerSubject)) {
-            return null;
-        }
-
-        // Here is the order to get the callerPrincipal
-        // 1) jsonWebToken in subject
-        // 2) From JASPIC property
-        // 3) From WSCredential.getSecurityName
-        // 4) From WSPrincipal
-        // 5) First Principal in Subject
-
-        // 1) From jsonWebToken in subject
-        Principal jsonWebToken = MpJwtHelper.getJsonWebTokenPricipal(callerSubject);
-        if (jsonWebToken != null) {
-            return jsonWebToken;
-        }
-
-        WSCredential wscredential = getWSCredential(callerSubject);
-
-        // 2) From JASPIC property
-        if (wscredential != null) {
-            try {
-                principal = (Principal) wscredential.get("com.ibm.wsspi.security.cred.jaspi.principal");
-                if (principal != null)
-                    return principal;
-            } catch (Exception e) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Internal error getting JASPIC Principal from credential", e);
-                }
-            }
-
-            // 3) From WSCredential.getSecurityName
-            try {
-                securityName = wscredential.getSecurityName();
-            } catch (Exception e) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Error getting securityName from WSCredential", e);
-                }
-            }
-
-            WSPrincipal wsPrincipal = null;
-            if (securityName != null) {
-                Set<WSPrincipal> principals = callerSubject.getPrincipals(WSPrincipal.class);
-                if (!principals.isEmpty()) {
-                    wsPrincipal = principals.iterator().next();
-                    wsPrincipal = new WSPrincipal(securityName, wsPrincipal.getAccessId(), wsPrincipal.getAuthenticationMethod());
-                }
-
-                if (wsPrincipal != null) {
-                    return wsPrincipal;
-                }
-            }
-
-            // 4) From WSPrincipal
-            Set<Principal> principals = callerSubject.getPrincipals();
-            if (principals.size() > 0) {
-                for (Iterator<Principal> iterator = principals.iterator(); iterator.hasNext();) {
-                    principal = iterator.next();
-                    if (principal instanceof WSPrincipal)
-                        return principal;
-                }
-            }
-
-            // There is no WSPrincipal so just return first one
-            // 5) First Principal in Subject
-            return principals.iterator().next();
-        }
-
-        return null;
-    }
-
-    private WSCredential getWSCredential(Subject subject) {
-        WSCredential wsCredential = null;
-        Set<WSCredential> wsCredentials = subject.getPublicCredentials(WSCredential.class);
-        Iterator<WSCredential> wsCredentialsIterator = wsCredentials.iterator();
-        if (wsCredentialsIterator.hasNext()) {
-            wsCredential = wsCredentialsIterator.next();
-        }
-        return wsCredential;
+        return SubjectManager.getCallerPrincipal(callerSubject);
     }
 
     /*

--- a/dev/com.ibm.ws.security/bnd.bnd
+++ b/dev/com.ibm.ws.security/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -76,7 +76,8 @@ instrument.classesExcludes: com/ibm/ws/security/internal/resources/*.class
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.kernel.service;version=latest, \
 	com.ibm.ws.security.mp.jwt.proxy;version=latest, \
-	com.ibm.ws.security.ready.service;version=latest
+	com.ibm.ws.security.ready.service;version=latest, \
+	com.ibm.ws.security.credentials;version=latest
 
 -testpath: \
 	org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/context/SubjectManager.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/context/SubjectManager.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,10 +12,20 @@
  *******************************************************************************/
 package com.ibm.ws.security.context;
 
+import java.security.Principal;
+import java.util.Iterator;
+import java.util.Set;
+
 import javax.security.auth.Subject;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.websphere.security.cred.WSCredential;
+import com.ibm.ws.security.authentication.principals.WSPrincipal;
+import com.ibm.ws.security.authentication.utility.SubjectHelper;
 import com.ibm.ws.security.context.internal.SubjectThreadContext;
+import com.ibm.ws.security.mp.jwt.proxy.MpJwtHelper;
 
 /**
  * The SubjectManager sets and gets caller/invocation subjects off the thread
@@ -23,7 +33,9 @@ import com.ibm.ws.security.context.internal.SubjectThreadContext;
  */
 public class SubjectManager {
 
-    private static ThreadLocal<SubjectThreadContext> threadLocal = new SecurityThreadLocal();
+    private static final ThreadLocal<SubjectThreadContext> threadLocal = new SecurityThreadLocal();
+    private static final SubjectHelper subjectHelper = new SubjectHelper();
+    private static final TraceComponent tc = Tr.register(SubjectManager.class);
 
     /**
      * Sets the caller subject on the thread.
@@ -89,7 +101,7 @@ public class SubjectManager {
      * Gets the subject thread context that is unique per thread.
      * If/when a common thread storage framework is supplied, then this method
      * implementation may need to be updated to take it into consideration.
-     * 
+     *
      * @return the subject thread context.
      */
     @Trivial
@@ -107,7 +119,7 @@ public class SubjectManager {
      * Gets the thread local object.
      * If/when a common thread storage framework is supplied, then this method
      * implementation may need to be updated to take it into consideration.
-     * 
+     *
      * @return the thread local object.
      */
     @Trivial
@@ -122,4 +134,81 @@ public class SubjectManager {
         }
     }
 
+    public static Principal getCallerPrincipal(Subject callerSubject) {
+        if (callerSubject == null) {
+            return null;
+        }
+
+        if (subjectHelper.isUnauthenticated(callerSubject)) {
+            return null;
+        }
+
+        // Here is the order to get the callerPrincipal
+        // 1) jsonWebToken in subject
+        // 2) From JASPIC property
+        // 3) From WSCredential.getSecurityName
+        // 4) From WSPrincipal
+        // 5) First Principal in Subject
+
+        // 1) From jsonWebToken in subject
+        Principal jsonWebToken = MpJwtHelper.getJsonWebTokenPricipal(callerSubject);
+        if (jsonWebToken != null) {
+            return jsonWebToken;
+        }
+
+        WSCredential wscredential = subjectHelper.getWSCredential(callerSubject);
+
+        // 2) From JASPIC property
+        if (wscredential != null) {
+            Principal principal = null;
+            try {
+                principal = (Principal) wscredential.get("com.ibm.wsspi.security.cred.jaspi.principal");
+                if (principal != null)
+                    return principal;
+            } catch (Exception e) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Internal error getting JASPIC Principal from credential", e);
+                }
+            }
+
+            String securityName = null;
+            // 3) From WSCredential.getSecurityName
+            try {
+                securityName = wscredential.getSecurityName();
+            } catch (Exception e) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Error getting securityName from WSCredential", e);
+                }
+            }
+
+            WSPrincipal wsPrincipal = null;
+            if (securityName != null) {
+                Set<WSPrincipal> principals = callerSubject.getPrincipals(WSPrincipal.class);
+                if (!principals.isEmpty()) {
+                    wsPrincipal = principals.iterator().next();
+                    wsPrincipal = new WSPrincipal(securityName, wsPrincipal.getAccessId(), wsPrincipal.getAuthenticationMethod());
+                }
+
+                if (wsPrincipal != null) {
+                    return wsPrincipal;
+                }
+            }
+
+            // 4) From WSPrincipal
+            Set<Principal> principals = callerSubject.getPrincipals();
+            if (principals.size() > 0) {
+                for (Iterator<Principal> iterator = principals.iterator(); iterator.hasNext();) {
+                    principal = iterator.next();
+                    if (principal instanceof WSPrincipal)
+                        return principal;
+                }
+            }
+
+            // There is no WSPrincipal so just return first one
+            // 5) First Principal in Subject
+            return principals.iterator().next();
+        }
+
+        return null;
+    }
 }

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/bnd.bnd
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -39,4 +39,5 @@ Private-Package: \
   com.ibm.ws.logging;version=latest,\
   com.ibm.websphere.appserver.spi.kernel.service;version=latest, \
   io.openliberty.jakarta.authorization.3.0;version=latest, \
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+  com.ibm.ws.security;version=latest

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/com/ibm/wsspi/security/authorization/jacc/ProviderService.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/com/ibm/wsspi/security/authorization/jacc/ProviderService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,18 +10,20 @@
 
 package com.ibm.wsspi.security.authorization.jacc;
 
+import jakarta.security.jacc.Policy;
 import jakarta.security.jacc.PolicyConfigurationFactory;
-import jakarta.security.jacc.PolicyFactory;
 
 public interface ProviderService {
 
     /**
      * Returns the instance representing the provider-specific implementation
-     * of the jakarta.security.jacc.PolicyFactory abstract class.
+     * of the jakarta.security.jacc.Policy interface associated with the provided
+     * PolicyContext.
      *
-     * @return An instance which implements the PolicyFactory class.
+     * @param policy context ID that is associated with the returned Policy
+     * @return An instance which implements the Policy interface.
      */
-    public PolicyFactory getPolicyFactory();
+    public Policy getPolicy(String contextId);
 
     /**
      * Returns the instance representing the provider-specific implementation

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyFactoryProxyImpl.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyFactoryProxyImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,19 +17,11 @@ import com.ibm.ws.security.authorization.jacc.common.PolicyProxy;
 
 import jakarta.security.jacc.Policy;
 import jakarta.security.jacc.PolicyFactory;
+import jakarta.security.jacc.PrincipalMapper;
 
 public class JakartaPolicyFactoryProxyImpl implements PolicyProxy {
 
-    JakartaPolicyFactoryProxyImpl(PolicyFactory policyFactory) {
-        PolicyFactory.setPolicyFactory(policyFactory);
-    }
-
-    @Override
-    public void refresh() {
-    }
-
-    @Override
-    public void setPolicy() {
+    JakartaPolicyFactoryProxyImpl() {
     }
 
     @Override
@@ -43,5 +35,10 @@ public class JakartaPolicyFactoryProxyImpl implements PolicyProxy {
             return false;
         }
         return policy.implies(permission, subject);
+    }
+
+    @Override
+    public PrincipalMapper getPrincipalMapper() {
+        return new PrincipalMapperImpl();
     }
 }

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/PolicyFactoryImpl.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/PolicyFactoryImpl.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.jacc.internal.proxy;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.ModuleMetaData;
+import com.ibm.ws.security.authorization.jacc.PolicyConfigurationManager;
+import com.ibm.ws.security.authorization.jacc.common.PolicyContextUtil;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
+import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
+import com.ibm.wsspi.security.authorization.jacc.ProviderService;
+
+import jakarta.security.jacc.Policy;
+import jakarta.security.jacc.PolicyFactory;
+
+/**
+ * Liberty provided PolicyFactory implementation that conditionally could wrap a user
+ * provided PolicyFactory that is specified via spec defined system property.
+ */
+public class PolicyFactoryImpl extends PolicyFactory {
+
+    private static final ComponentMetaDataAccessorImpl cmdAccessor = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor();
+
+    private final PolicyFactory wrapped;
+
+    private final Map<String, Policy> policyMap;
+
+    private final WsLocationAdmin locationAdmin;
+
+    private final PolicyConfigurationManager pcm;
+
+    final ProviderService providerService;
+
+    PolicyFactoryImpl(WsLocationAdmin locationAdmin, ProviderService providerService, PolicyConfigurationManager pcm) {
+        wrapped = null;
+        this.locationAdmin = locationAdmin;
+        this.providerService = providerService;
+        this.pcm = pcm;
+        policyMap = new ConcurrentHashMap<>();
+    }
+
+    PolicyFactoryImpl(PolicyFactory wrapped, WsLocationAdmin locationAdmin, ProviderService providerService, PolicyConfigurationManager pcm) {
+        super(wrapped);
+        this.wrapped = wrapped;
+        this.locationAdmin = locationAdmin;
+        this.providerService = providerService;
+        this.pcm = pcm;
+        policyMap = wrapped == null ? new ConcurrentHashMap<>() : null;
+    }
+
+    private String getContextIdFromComponentMetaData(String callingMethod) {
+        ComponentMetaData cmd = cmdAccessor.getComponentMetaData();
+        String appName = null;
+        String moduleName = null;
+        if (cmd != null) {
+            appName = cmd.getJ2EEName().getApplication();
+            ModuleMetaData mmd = cmd.getModuleMetaData();
+            if (mmd != null) {
+                moduleName = mmd.getName();
+            }
+        }
+        if (appName != null) {
+            if (pcm.isApplicationRunning(appName)) {
+                throw new IllegalStateException(callingMethod + " can only be called during application startup or during permission check");
+            }
+            if (moduleName != null) {
+                return PolicyContextUtil.getContextId(locationAdmin, appName, moduleName);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Policy getPolicy(String contextId) {
+        if (contextId == null) {
+            contextId = getContextIdFromComponentMetaData("PolicyFactory.getPolicy");
+        }
+
+        // If it is still null, just return a null Policy object
+        Policy policy;
+        if (contextId == null) {
+            policy = null;
+        } else if (wrapped != null) {
+            policy = wrapped.getPolicy(contextId);
+        } else {
+            policy = policyMap.get(contextId);
+            if (policy == null && !policyMap.containsKey(contextId)) {
+                // get policy and set it in the map
+                policy = providerService.getPolicy(contextId);
+                policyMap.put(contextId, policy);
+            }
+        }
+
+        return policy;
+    }
+
+    @Override
+    public void setPolicy(String contextId, Policy policy) {
+        if (contextId == null) {
+            contextId = getContextIdFromComponentMetaData("PolicyFactory.setPolicy");
+        }
+        // If it is still null, do nothing
+        if (contextId != null) {
+            if (wrapped != null) {
+                wrapped.setPolicy(contextId, policy);
+            } else {
+                policyMap.put(contextId, policy);
+            }
+        }
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/PrincipalMapperImpl.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/PrincipalMapperImpl.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.jacc.internal.proxy;
+
+import java.security.Principal;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+
+import com.ibm.ws.security.context.SubjectManager;
+
+import jakarta.security.jacc.PrincipalMapper;
+
+public class PrincipalMapperImpl implements PrincipalMapper {
+
+    @Override
+    public Principal getCallerPrincipal(Subject subject) {
+        return SubjectManager.getCallerPrincipal(subject);
+    }
+
+    @Override
+    public Set<String> getMappedRoles(Subject subject) {
+        return null;
+    }
+
+    @Override
+    public boolean isAnyAuthenticatedUserRoleMapped() {
+        return false;
+    }
+}

--- a/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/PolicyFactoryImpl.java
+++ b/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/PolicyFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,10 @@ public class PolicyFactoryImpl extends PolicyFactory {
 
     @Override
     public Policy getPolicy(String contextId) {
+        if (contextId == null) {
+            return null;
+        }
+
         Policy policy = policyMap.get(contextId);
         if (policy == null) {
             // get policy and set it in the map
@@ -33,7 +37,9 @@ public class PolicyFactoryImpl extends PolicyFactory {
 
     @Override
     public void setPolicy(String contextId, Policy policy) {
-        policyMap.put(contextId, policy);
+        if (contextId != null) {
+            policyMap.put(contextId, policy);
+        }
     }
 
 }

--- a/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/service/ProviderServiceImpl.java
+++ b/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/service/ProviderServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,16 +24,15 @@ import org.osgi.service.component.annotations.Modified;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.security.authorization.jacc.provider.PolicyFactoryImpl;
+import com.ibm.ws.security.authorization.jacc.provider.JaccPolicyProxy;
 import com.ibm.ws.security.authorization.jacc.role.FileRoleMapping;
 import com.ibm.wsspi.security.authorization.jacc.ProviderService;
 
+import jakarta.security.jacc.Policy;
 import jakarta.security.jacc.PolicyConfigurationFactory;
-import jakarta.security.jacc.PolicyFactory;
 
 @Component(service = ProviderService.class, immediate = true, name = "com.ibm.ws.security.authorization.jacc.provider", configurationPolicy = ConfigurationPolicy.OPTIONAL, property = { "service.vendor=IBM",
                                                                                                                                                                                          //                        "RequestMethodArgumentsRequired=true",
-                                                                                                                                                                                         "jakarta.security.jacc.PolicyFactory.provider=com.ibm.ws.security.authorization.jacc.provider.PolicyFactoryImpl",
                                                                                                                                                                                          "jakarta.security.jacc.PolicyConfigurationFactory.provider=com.ibm.ws.security.authorization.jacc.provider.WSPolicyConfigurationFactoryImpl"
 })
 public class ProviderServiceImpl implements ProviderService {
@@ -42,8 +41,6 @@ public class ProviderServiceImpl implements ProviderService {
     private static final String JACC_FACTORY = PolicyConfigurationFactory.FACTORY_NAME;
     private static final String JACC_FACTORY_IMPL = "com.ibm.ws.security.authorization.jacc.provider.WSPolicyConfigurationFactoryImpl";
 
-    private static final String JACC_POLICY_FACTORY_PROVIDER = PolicyFactory.FACTORY_NAME;
-    private static final String JACC_POLICY_FACTORY_PROVIDER_IMPL = "com.ibm.ws.security.authorization.jacc.provider.PolicyFactoryImpl";
     private static final String CFG_ROLE_MAPPING_FILE = "roleMappingFile";
 
     public ProviderServiceImpl() {
@@ -66,11 +63,8 @@ public class ProviderServiceImpl implements ProviderService {
 
     /** {@inheritDoc} */
     @Override
-    public PolicyFactory getPolicyFactory() {
-        if (System.getProperty(JACC_POLICY_FACTORY_PROVIDER) == null) {
-            System.setProperty(JACC_POLICY_FACTORY_PROVIDER, JACC_POLICY_FACTORY_PROVIDER_IMPL);
-        }
-        return new PolicyFactoryImpl();
+    public Policy getPolicy(String contextId) {
+        return new JaccPolicyProxy(contextId);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
- Add PrincipalMapper implementation, but only truly implement getCallerPrincipal so far
- Add new getCallerPrincipal(Subject) method to SubjectManager (content from SecurityContextImpl) and have SecurityContextImpl and PrincipalMapperImpl call it
- Use a Liberty implementation of PolicyFactory that can stand alone or wrap a user provided PolicyFactory
- Liberty provided PolicyFactory gets Policy from ProviderService which now gets a Policy instead of PolicyFactory instance
- Have getPolicy and setPolicy methods throw exception if called outside of Policy check or after application is started
- Update test provider for the change to return Policy instead of PolicyFactory
- Actually have the ejb arguments handler include the arguments instead of always being null

Fixes #30890

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
