### PR TITLE
Update file-based health checks' `/health` directory to be placed under the `server.output.dir` over the `server.config.dir` property. 

### DIFF
--- a/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthFileUtils.java
+++ b/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthFileUtils.java
@@ -31,7 +31,7 @@ public class HealthFileUtils {
     public static File getHealthDirFile() {
 
         if (healthDirFile == null) {
-            File serverConfigDirFile = new File(System.getProperty("server.config.dir"));
+            File serverConfigDirFile = new File(System.getProperty("server.output.dir"));
             healthDirFile = new File(serverConfigDirFile, "health");
         }
 


### PR DESCRIPTION
Better location is to be based off of the `server.output.dir` property, which is directly related to the `WLP_OUTPUT_DIR` server env, this is provides better compatibility with container deployments

By default, the `server.output.dir` is the `<wlp>/usr/servers/<serverName>/` location.

As part of #30056
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

