### PR TITLE
include QueryInfo init failures in introspector output

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -4648,9 +4648,13 @@ public class QueryInfo {
      *
      * @param writer writes to the introspection file.
      * @param indent indentation for lines.
+     * @param future future for this QueryInfo.
      */
+    @FFDCIgnore(Throwable.class)
     @Trivial
-    public void introspect(PrintWriter writer, String indent) {
+    public void introspect(PrintWriter writer,
+                           String indent,
+                           CompletableFuture<QueryInfo> future) {
         writer.println(indent + "QueryInfo@" + Integer.toHexString(hashCode()));
         indent = indent + "  ";
         writer.println(indent + "entity: " + entityInfo);
@@ -4722,6 +4726,22 @@ public class QueryInfo {
 
         writer.println(indent + "validate method parameters? " + validateParams);
         writer.println(indent + "validate method result? " + validateResult);
+
+        if (future != null) {
+            writer.print(indent + "state: ");
+            if (future.isCancelled())
+                writer.println("cancelled");
+            else if (future.isDone())
+                try {
+                    future.join();
+                    writer.println("completed");
+                } catch (Throwable x) {
+                    writer.println("failed");
+                    Util.printStackTrace(x, writer, indent + "  ", null);
+                }
+            else
+                writer.println("not completed");
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -351,6 +351,18 @@ public class RepositoryImpl<R> implements InvocationHandler {
     }
 
     /**
+     * Used during introspection to report errors that occurred when processing
+     * repository methods.
+     *
+     * @param method repository method.
+     * @return future for the QueryInfo.
+     */
+    @Trivial
+    public final CompletableFuture<QueryInfo> getQueryFuture(Method method) {
+        return queries.get(method);
+    }
+
+    /**
      * Request an instance of a resource of the specified type.
      *
      * @param method the repository method.

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
@@ -200,6 +200,15 @@ public class DataIntrospectorTest extends FATServletClient {
     }
 
     /**
+     * Verify that introspector output contains the a failure that occurred when
+     * attempting to initialize query information for a repository method.
+     */
+    @Test
+    public void testOutputContainsQueryInfoInitFailure() {
+        assertLineContains("java.lang.UnsupportedOperationException: CWWKD1003E:");
+    }
+
+    /**
      * Verify that introspector output contains method signatures from an
      * application-supplied record entity.
      */


### PR DESCRIPTION
Introspector output for Jakarta Data should include failures from unsuccessful QueryInfo initialization (each corresponds to a repository method)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
