### PR TITLE
Test of LOWER(ID(o)) in a Query

### DIFF
--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -556,7 +556,6 @@ public class DataExperimentalServlet extends FATServlet {
                                      .map(c -> c.name + ' ' + c.stateName)
                                      .collect(Collectors.toList()));
 
-        // TODO enable once LOWER(id(o)) is working in EclipseLink
         assertEquals(List.of("Kansas City Missouri",
                              "Rochester Minnesota",
                              "Springfield Illinois"),

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -96,6 +96,9 @@ public interface Counties {
         }
     }
 
+    @Query("SELECT o.population FROM County o WHERE LOWER(id(o)) = ?1")
+    Optional<Integer> populationOf(String lowerCaseName);
+
     @Delete
     void remove(County c);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2860,6 +2860,38 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Verify that LOWER(ID(o)) is valid in a query.
+     */
+    @Test
+    public void testLowerId() {
+        assertEquals(0, counties.deleteByNameIn(List.of("Freeborn", "Steele")));
+
+        int[] freebornZipCodes = new int[] { 55912, 56007, 56009, 56016, 56020, //
+                                             56026, 56029, 56032, 56035, 56036 };
+
+        int[] steeleZipCodes = new int[] { 55049, 55060, 55917, 55924, 55926, //
+                                           55946, 559072 };
+
+        County freeborn = new County("Freeborn", "Minnesota", 30895, freebornZipCodes, //
+                        "Albert Lea", "Alden", "Clarks Grove", "Conger", "Emmons", //
+                        "Freeborn", "Geneva", "Glenville", "Hartland", "Hayward", //
+                        "Hollandale", "Manchester", "Myrtle", "Twin Lakes");
+
+        County steele = new County("Steele", "Minnesota", 37406, steeleZipCodes, //
+                        "Blooming Prairie", "Ellendale", "Medford", "Owatonna");
+
+        counties.save(freeborn, steele);
+
+        assertEquals(Integer.valueOf(30895),
+                     counties.populationOf("freeborn").orElseThrow());
+
+        assertEquals(Integer.valueOf(37406),
+                     counties.populationOf("steele").orElseThrow());
+
+        assertEquals(2, counties.deleteByNameIn(List.of("Freeborn", "Steele")));
+    }
+
+    /**
      * Use a custom join query so that a ManyToMany association can query by attributes of the many side of the relationship.
      */
     @Test


### PR DESCRIPTION
A TODO comment claimed `LOWER(ID(o))` was not working due to a bug, so I added a test to verify that it has since been fixed.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
