### PR TITLE
Fixing intermittent FAT failure

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_2_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryAccessTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_2_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal_fat/TelemetryAccessTest.java
@@ -106,7 +106,7 @@ public class TelemetryAccessTest extends FATServletClient {
                 put("http.request.method", "GET");
                 put("http.response.status_code", "200");
                 put("io.openliberty.access_log.url.path", "/MpTelemetryLogApp/AccessURL");
-                put("network.local.port", "8010");
+                put("network.local.port", Integer.toString(server.getHttpDefaultPort()));
                 put("io.openliberty.type", "liberty_accesslog");
                 put("network.protocol.name", "HTTP");
                 put("network.protocol.version", "1.1");

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_2_fat/publish/files/accessServer.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_2_fat/publish/files/accessServer.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2024, 2025 IBM Corporation and others.
+    Copyright (c) 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_2_fat/publish/servers/TelemetryAccess/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_2_fat/publish/servers/TelemetryAccess/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2024, 2025 IBM Corporation and others.
+    Copyright (c) 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes: #30885 
I noticed an intermittent case where a a server would use port 8011 instead of the expected 8010 port which would cause the test to fail. 