### PR TITLE
Add test case to show problem with application replace after PR #30730 was merged

### DIFF
--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_DataApps.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_DataApps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -194,13 +194,18 @@ public class TargetCacheImpl_DataApps extends TargetCacheImpl_DataBase {
      * @param appName The name of the application.
      */
     public boolean release(String appName) {
-        synchronized( appsLock ) {
+        return false;
+        // by commenting out this code and just returning false,
+        // the code reverts back to its old behavior where the apps object keeps
+        // a reference onto the application specific data.  The cleaning up of the app data
+        // from the apps object caused a regression which need to be worked out before this can be re-enabled.
+        /*synchronized( appsLock ) {
             if (appNamesToKeys.containsKey(appName)) {
                 AppKey key = appNamesToKeys.remove(appName);
                 return apps.remove(key) != null;
             }
             return false;
-        }
+        }*/
     }
 
     //

--- a/dev/com.ibm.ws.anno_fat/bnd.bnd
+++ b/dev/com.ibm.ws.anno_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017,2019 IBM Corporation and others.
+# Copyright (c) 2017,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -34,6 +34,7 @@ fat.project: true
     io.openliberty.org.apache.commons.codec;version=latest, \
     com.ibm.websphere.javaee.servlet.3.0;version=latest, \
     com.ibm.websphere.javaee.jsp.2.2;version=latest, \
+    com.ibm.websphere.javaee.ejb.3.2;version=latest, \
     commons-httpclient:commons-httpclient;version=3.1, \
     httpunit:httpunit;version=1.5.4, \
     net.sf.jtidy:jtidy;version=9.3.8, \

--- a/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/FATSuite.java
+++ b/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012,2014 IBM Corporation and others.
+ * Copyright (c) 2012,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,12 +18,12 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.fat.util.FatLogHandler;
+import com.ibm.ws.tests.anno.caching.AppReplaceTest;
 import com.ibm.ws.tests.anno.caching.CacheEnablementTest;
 import com.ibm.ws.tests.anno.caching.FragmentOrderTest;
 import com.ibm.ws.tests.anno.caching.LooseConfigTest;
 import com.ibm.ws.tests.anno.caching.MetadataCompleteTest;
 import com.ibm.ws.tests.anno.caching.MetadataIncompleteTest;
-import com.ibm.ws.tests.anno.caching.unused.BigAppTest;
 import com.ibm.ws.tests.anno.jandex.JandexAppDefaultAppMgrDefaultTest;
 import com.ibm.ws.tests.anno.jandex.JandexAppDefaultAppMgrTrueTest;
 import com.ibm.ws.tests.anno.jandex.JandexAppFalseAppMgrFalseTest;
@@ -67,7 +67,7 @@ import com.ibm.ws.tests.anno.jandex.JandexAppTrueAppMgrTrueTest;
     MetadataIncompleteTest.class,
     FragmentOrderTest.class,
     LooseConfigTest.class,
-
+    AppReplaceTest.class
     // BigAppTest.class
 })
 

--- a/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/caching/AppReplaceTest.java
+++ b/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/caching/AppReplaceTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.tests.anno.caching;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+/**
+ * Test validates that if you start an application and stop it and replace the application with different content that it works
+ */
+@RunWith(FATRunner.class)
+public class AppReplaceTest {
+
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("appReplaceTestServer");
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    private EnterpriseArchive getEAR(String packageSuffix) {
+        EnterpriseArchive earArchive = ShrinkWrap.create(EnterpriseArchive.class, "TestReplace.ear");
+
+        WebArchive warArchive = ShrinkWrap.create(WebArchive.class, "TestReplace.war");
+        warArchive.addPackage("com.ibm.ws.tests.anno.servlets." + packageSuffix);
+
+        JavaArchive jarArchive = ShrinkWrap.create(JavaArchive.class, "TestReplaceEJB.jar");
+
+        jarArchive.addPackage("com.ibm.ws.tests.anno.ejbs." + packageSuffix);
+        earArchive.addAsModule(warArchive);
+        earArchive.addAsModule(jarArchive);
+        return earArchive;
+    }
+
+    @Test
+    public void testEARwithEJBJar() throws Exception {
+
+        EnterpriseArchive earArchive = getEAR("one");
+
+        ShrinkHelper.exportDropinAppToServer(server, earArchive, ShrinkHelper.DeployOptions.OVERWRITE);
+
+        server.addInstalledAppForValidation("TestReplace");
+        server.startServer();
+        server.removeDropinsApplications("TestReplace.ear");
+        assertNotNull(server.waitForStringInLog("CWWKZ0009I:.*TestReplace.*"));
+
+        earArchive = getEAR("two");
+
+        server.setMarkToEndOfLog();
+
+        ShrinkHelper.exportDropinAppToServer(server, earArchive, ShrinkHelper.DeployOptions.OVERWRITE);
+        assertNotNull(server.waitForStringInLog("CWWKZ0001I:.*TestReplace.*"));
+    }
+
+}

--- a/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/ejbs/one/TestReplaceEJB.java
+++ b/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/ejbs/one/TestReplaceEJB.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.tests.anno.ejbs.one;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class TestReplaceEJB {
+
+}

--- a/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/ejbs/two/TestReplaceEJB.java
+++ b/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/ejbs/two/TestReplaceEJB.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.tests.anno.ejbs.two;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class TestReplaceEJB {
+
+}

--- a/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/servlets/one/TestReplaceServlet.java
+++ b/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/servlets/one/TestReplaceServlet.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.tests.anno.servlets.one;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/testReplaceOne")
+public class TestReplaceServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public TestReplaceServlet() {
+        super();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        ServletOutputStream sos = response.getOutputStream();
+        sos.println("pong");
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        doGet(request, response);
+    }
+}

--- a/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/servlets/two/TestReplaceServlet.java
+++ b/dev/com.ibm.ws.anno_fat/fat/src/com/ibm/ws/tests/anno/servlets/two/TestReplaceServlet.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.tests.anno.servlets.two;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/testReplaceTwo")
+public class TestReplaceServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public TestReplaceServlet() {
+        super();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        ServletOutputStream sos = response.getOutputStream();
+        sos.println("pong");
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        doGet(request, response);
+    }
+}

--- a/dev/com.ibm.ws.anno_fat/publish/servers/appReplaceTestServer/bootstrap.properties
+++ b/dev/com.ibm.ws.anno_fat/publish/servers/appReplaceTestServer/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.anno_fat/publish/servers/appReplaceTestServer/server.xml
+++ b/dev/com.ibm.ws.anno_fat/publish/servers/appReplaceTestServer/server.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>ejb-3.2</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+</server>


### PR DESCRIPTION
- Test case shows issue when updating an application that includes removing classes.  This problem is only seen with the inclusion of OL PR #30730
- Disable code that causes the regression

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
