### PR TITLE
Add requestFirstLine to the default log format for access logging and support tracing

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorConstants.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorConstants.java
@@ -47,4 +47,10 @@ public class CollectorConstants {
     public static final short KEYS_JSON = 0;
     public static final short KEYS_LOGSTASH = 1;
     public static final short KEYS_TELEMETRY_LOGGING = 2;
+
+    /* mpTelemetry access log trace headers for different propagators */
+    public static final String ACCESS_TRACE_W3C_HEADER_NAME = "traceparent";
+    public static final String ACCESS_TRACE_JAEGER_HEADER_NAME = "uber-trace-id";
+    public static final String ACCESS_TRACE_B3_HEADER_NAME = "b3";
+
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
@@ -521,7 +521,8 @@ public class AccessLogSource implements Source {
         .add(addUriPathField          (format))  // %U
         .add(addUserAgentField        (format))  // User agent
         .add(addDatetimeField         (format))  // Datetime, present in all access logs
-        .add(addSequenceField         (format)); // Sequence, present in all access logs
+        .add(addSequenceField         (format))  // Sequence, present in all access logs
+        .add(addRequestFirstLineField (format)); // %r
 
         return builder.build();
         //@formatter:on

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
@@ -498,7 +498,8 @@ public class AccessLogSource implements Source {
         }
         //@formatter:off
         builder.add(addDatetimeFieldTelemetry(format))  // Datetime, present in all access logs
-               .add(addSequenceFieldTelemetry(format)); // Sequence, present in all access logs
+               .add(addSequenceFieldTelemetry(format)) // Sequence, present in all access logs
+               .add(addRequestHeaderFieldTelemetry(format)); // Adding the 'traceparent' request header field which contains trace/span in order to correlate access logs via trace/spans
         //@formatter:on
 
         return builder.build();
@@ -546,8 +547,8 @@ public class AccessLogSource implements Source {
         .add(addUserAgentFieldTelemetry        (format))  // User agent
         .add(addDatetimeFieldTelemetry         (format))  // Datetime, present in all access logs
         .add(addSequenceFieldTelemetry         (format))  // Sequence, present in all access logs
-        .add(addRequestFirstLineFieldTelemetry (format)); // Adding requestFirstLine by default only to be used in the OTel logs body
-
+        .add(addRequestFirstLineFieldTelemetry (format))  // Adding requestFirstLine by default only to be used in the OTel logs body
+        .add(addRequestHeaderFieldTelemetry    (format)); // Adding the 'traceparent' request header field which contains trace/span in order to correlate access logs via trace/spans
         return builder.build();
         //@formatter:on
     }
@@ -593,12 +594,14 @@ public class AccessLogSource implements Source {
 
             //Include the requestFirstLine for Telemetry to be used as the body where applicable
             fieldSetters.add((ald, alrd) -> ald.setRequestFirstLine(AccessLogFirstLine.getFirstLineAsString(alrd.getResponse(), alrd.getRequest(), null)));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("traceparent", AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "traceparent")));
 
         } else if (accessLogFieldsTelemetryConfig.equals("logFormat")) {
             formatters[5] = populateCustomTelemetryFormatters(fieldsToAddTelemetryLogging, CollectorConstants.KEYS_TELEMETRY_LOGGING);
 
             //Include the requestFirstLine for Telemetry to be used as the body where applicable
             fieldSetters.add((ald, alrd) -> ald.setRequestFirstLine(AccessLogFirstLine.getFirstLineAsString(alrd.getResponse(), alrd.getRequest(), null)));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("traceparent", AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "traceparent")));
         }
 
         newSF.setSettersAndFormatters(fieldSetters, formatters);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
@@ -595,6 +595,9 @@ public class AccessLogSource implements Source {
             //Include the requestFirstLine for Telemetry to be used as the body where applicable
             fieldSetters.add((ald, alrd) -> ald.setRequestFirstLine(AccessLogFirstLine.getFirstLineAsString(alrd.getResponse(), alrd.getRequest(), null)));
             fieldSetters.add((ald, alrd) -> ald.setRequestHeader("traceparent", AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "traceparent")));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("b3", AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "b3")));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("uber-trace-id",
+                                                                 AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "uber-trace-id")));
 
         } else if (accessLogFieldsTelemetryConfig.equals("logFormat")) {
             formatters[5] = populateCustomTelemetryFormatters(fieldsToAddTelemetryLogging, CollectorConstants.KEYS_TELEMETRY_LOGGING);
@@ -602,6 +605,10 @@ public class AccessLogSource implements Source {
             //Include the requestFirstLine for Telemetry to be used as the body where applicable
             fieldSetters.add((ald, alrd) -> ald.setRequestFirstLine(AccessLogFirstLine.getFirstLineAsString(alrd.getResponse(), alrd.getRequest(), null)));
             fieldSetters.add((ald, alrd) -> ald.setRequestHeader("traceparent", AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "traceparent")));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("b3", AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "b3")));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("uber-trace-id",
+                                                                 AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "uber-trace-id")));
+
         }
 
         newSF.setSettersAndFormatters(fieldSetters, formatters);

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
@@ -594,20 +594,30 @@ public class AccessLogSource implements Source {
 
             //Include the requestFirstLine for Telemetry to be used as the body where applicable
             fieldSetters.add((ald, alrd) -> ald.setRequestFirstLine(AccessLogFirstLine.getFirstLineAsString(alrd.getResponse(), alrd.getRequest(), null)));
-            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("traceparent", AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "traceparent")));
-            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("b3", AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "b3")));
-            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("uber-trace-id",
-                                                                 AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "uber-trace-id")));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader(CollectorConstants.ACCESS_TRACE_W3C_HEADER_NAME,
+                                                                 AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(),
+                                                                                                            CollectorConstants.ACCESS_TRACE_W3C_HEADER_NAME)));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader(CollectorConstants.ACCESS_TRACE_B3_HEADER_NAME,
+                                                                 AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(),
+                                                                                                            CollectorConstants.ACCESS_TRACE_B3_HEADER_NAME)));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader(CollectorConstants.ACCESS_TRACE_JAEGER_HEADER_NAME,
+                                                                 AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(),
+                                                                                                            CollectorConstants.ACCESS_TRACE_JAEGER_HEADER_NAME)));
 
         } else if (accessLogFieldsTelemetryConfig.equals("logFormat")) {
             formatters[5] = populateCustomTelemetryFormatters(fieldsToAddTelemetryLogging, CollectorConstants.KEYS_TELEMETRY_LOGGING);
 
             //Include the requestFirstLine for Telemetry to be used as the body where applicable
             fieldSetters.add((ald, alrd) -> ald.setRequestFirstLine(AccessLogFirstLine.getFirstLineAsString(alrd.getResponse(), alrd.getRequest(), null)));
-            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("traceparent", AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "traceparent")));
-            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("b3", AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "b3")));
-            fieldSetters.add((ald, alrd) -> ald.setRequestHeader("uber-trace-id",
-                                                                 AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), "uber-trace-id")));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader(CollectorConstants.ACCESS_TRACE_W3C_HEADER_NAME,
+                                                                 AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(),
+                                                                                                            CollectorConstants.ACCESS_TRACE_W3C_HEADER_NAME)));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader(CollectorConstants.ACCESS_TRACE_B3_HEADER_NAME,
+                                                                 AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(),
+                                                                                                            CollectorConstants.ACCESS_TRACE_B3_HEADER_NAME)));
+            fieldSetters.add((ald, alrd) -> ald.setRequestHeader(CollectorConstants.ACCESS_TRACE_JAEGER_HEADER_NAME,
+                                                                 AccessLogRequestHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(),
+                                                                                                            CollectorConstants.ACCESS_TRACE_JAEGER_HEADER_NAME)));
 
         }
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogFieldConstants.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogFieldConstants.java
@@ -152,5 +152,8 @@ public class MpTelemetryLogFieldConstants {
     public static final String ACCESS_BYTES_SENT = "bytesSent";
     public static final String ACCESS_USER_AGENT = "userAgent";
     public static final String ACCESS_BYTES_RECEIVED = "bytesReceived";
+    public static final String ACCESS_TRACE_W3C_HEADER_NAME = "traceparent";
+    public static final String ACCESS_TRACE_JAEGER_HEADER_NAME = "uber-trace-id";
+    public static final String ACCESS_TRACE_B3_HEADER_NAME = "b3";
 
 }

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
@@ -26,7 +26,6 @@ import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.logging.collector.CollectorConstants;
 import com.ibm.ws.logging.collector.CollectorJsonHelpers;
 import com.ibm.ws.logging.collector.LogFieldConstants;
-import com.ibm.ws.logging.data.AccessLogConfig;
 import com.ibm.ws.logging.data.AccessLogData;
 import com.ibm.ws.logging.data.AccessLogDataFormatter;
 import com.ibm.ws.logging.data.AuditData;
@@ -368,9 +367,7 @@ public class MpTelemetryLogMappingUtils {
                 } else if (key.equals("requestPort")) {
                     attributes.put(formattedKey, Integer.parseInt((String) value));
                 } else if (key.equals("requestFirstLine")) {
-                    if (!AccessLogConfig.accessLogFieldsTelemetryConfig.equals("default")) {
-                        attributes.put(formattedKey, (String) value);
-                    }
+                    attributes.put(formattedKey, (String) value);
 
                     String accessLogMsg = accessLogData.getRequestFirstLine();
                     // Set the body to the request first line

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
@@ -347,7 +347,7 @@ public class MpTelemetryLogMappingUtils {
 
         String key = null;
         Object value = null;
-        String traceParent = null;
+        Span customSpan = null;
 
         for (Iterator<KeyValuePair> element = kvpList.iterator(); element.hasNext();) {
             KeyValuePair next = element.next();
@@ -365,7 +365,11 @@ public class MpTelemetryLogMappingUtils {
                     builder.setTimestamp(formatDateTime((String) value));
                 } else if (key.contains("requestHeader") || key.contains("responseHeader")) {
                     if (key.contains("traceparent"))
-                        traceParent = (String) value;
+                        customSpan = createSpan((String) value, 0);
+                    else if (key.contains("b3"))
+                        customSpan = createSpan((String) value, 1);
+                    else if (key.contains("uber-trace-id"))
+                        customSpan = createSpan((String) value, 2);
                     else {
                         String[] headerSplit = ((String) value).split(",");
                         for (int i = 0; i < headerSplit.length; i++) {
@@ -402,14 +406,31 @@ public class MpTelemetryLogMappingUtils {
 
         // Set the Span and Trace IDs from the current context. We're not on the same thread at the point when access logs are collected
         // so we need to extract the trace/span ID from the 'traceparent' request header.
-        if (traceParent != null) {
-            String[] traceSplit = traceParent.split("-");
-
-            SpanContext customSpanContext = SpanContext.create(traceSplit[1], traceSplit[2], TraceFlags.getSampled(), TraceState.getDefault());
-            Span customSpan = Span.wrap(customSpanContext);
+        if (customSpan != null) {
             builder.setContext(Context.current().with(customSpan));
         } else
             builder.setContext(Context.current());
+
+    }
+
+    private static Span createSpan(String requestHeader, int propagator) {
+        SpanContext customSpanContext = null;
+        if (propagator == 0) { // Check the w3c format for the "traceparent" header
+            String[] traceSplit = requestHeader.split("-");
+            customSpanContext = SpanContext.create(traceSplit[1], traceSplit[2], TraceFlags.getSampled(), TraceState.getDefault());
+        } else if (propagator == 1) { // Check the b3 format for the "b3" header
+            String[] traceSplit = requestHeader.split("-");
+            customSpanContext = SpanContext.create(traceSplit[0], traceSplit[1], TraceFlags.getSampled(), TraceState.getDefault());
+        } else if (propagator == 2) { // Check the Jaeger format for the "uber-trace-id" header
+            String[] traceSplit = requestHeader.split(":");
+            customSpanContext = SpanContext.create(traceSplit[0], traceSplit[1], TraceFlags.getSampled(), TraceState.getDefault());
+        }
+
+        if (customSpanContext != null) {
+            Span customSpan = Span.wrap(customSpanContext);
+            return customSpan;
+        } else
+            return null;
 
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
@@ -364,13 +364,10 @@ public class MpTelemetryLogMappingUtils {
                 } else if (key.equals("datetime") || key.equals("accessLogDatetime")) {
                     builder.setTimestamp(formatDateTime((String) value));
                 } else if (key.contains("requestHeader") || key.contains("responseHeader")) {
-                    if (key.contains("traceparent"))
-                        customSpan = createSpan((String) value, 0);
-                    else if (key.contains("b3"))
-                        customSpan = createSpan((String) value, 1);
-                    else if (key.contains("uber-trace-id"))
-                        customSpan = createSpan((String) value, 2);
-                    else {
+                    if (key.contains(MpTelemetryLogFieldConstants.ACCESS_TRACE_W3C_HEADER_NAME) || key.contains(MpTelemetryLogFieldConstants.ACCESS_TRACE_B3_HEADER_NAME)
+                        || key.contains(MpTelemetryLogFieldConstants.ACCESS_TRACE_JAEGER_HEADER_NAME)) {
+                        customSpan = createSpan(key, (String) value);
+                    } else {
                         String[] headerSplit = ((String) value).split(",");
                         for (int i = 0; i < headerSplit.length; i++) {
                             headerSplit[i] = headerSplit[i].trim();
@@ -413,15 +410,16 @@ public class MpTelemetryLogMappingUtils {
 
     }
 
-    private static Span createSpan(String requestHeader, int propagator) {
+    private static Span createSpan(String key, String requestHeader) {
+
         SpanContext customSpanContext = null;
-        if (propagator == 0) { // Check the w3c format for the "traceparent" header
+        if (key.equals(MpTelemetryLogFieldConstants.ACCESS_REQUEST_HEADER_PREFIX + MpTelemetryLogFieldConstants.ACCESS_TRACE_W3C_HEADER_NAME)) { // Check the w3c format for the "traceparent" header. This is the default otel propagator
             String[] traceSplit = requestHeader.split("-");
             customSpanContext = SpanContext.create(traceSplit[1], traceSplit[2], TraceFlags.getSampled(), TraceState.getDefault());
-        } else if (propagator == 1) { // Check the b3 format for the "b3" header
+        } else if (key.equals(MpTelemetryLogFieldConstants.ACCESS_REQUEST_HEADER_PREFIX + MpTelemetryLogFieldConstants.ACCESS_TRACE_B3_HEADER_NAME)) { // Check the b3 format for the "b3" header
             String[] traceSplit = requestHeader.split("-");
             customSpanContext = SpanContext.create(traceSplit[0], traceSplit[1], TraceFlags.getSampled(), TraceState.getDefault());
-        } else if (propagator == 2) { // Check the Jaeger format for the "uber-trace-id" header
+        } else if (key.equals(MpTelemetryLogFieldConstants.ACCESS_REQUEST_HEADER_PREFIX + MpTelemetryLogFieldConstants.ACCESS_TRACE_JAEGER_HEADER_NAME)) { // Check the Jaeger format for the "uber-trace-id" header
             String[] traceSplit = requestHeader.split(":");
             customSpanContext = SpanContext.create(traceSplit[0], traceSplit[1], TraceFlags.getSampled(), TraceState.getDefault());
         }

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
@@ -13,7 +13,6 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -360,10 +359,13 @@ public class MpTelemetryLogMappingUtils {
                 } else if (key.equals("datetime") || key.equals("accessLogDatetime")) {
                     builder.setTimestamp(formatDateTime((String) value));
                 } else if (key.contains("requestHeader") || key.contains("responseHeader")) {
-
-                    String[] headerSplit = Arrays.stream(((String) value).split(",")).map(String::trim).toArray(String[]::new);
+                    String[] headerSplit = ((String) value).split(",");
+                    for (int i = 0; i < headerSplit.length; i++) {
+                        headerSplit[i] = headerSplit[i].trim();
+                    }
 
                     attributes.put(formattedKey, headerSplit);
+
                 } else if (key.equals("requestPort")) {
                     attributes.put(formattedKey, Integer.parseInt((String) value));
                 } else if (key.equals("requestFirstLine")) {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/MpTelemetryLogMappingUtils.java
@@ -39,6 +39,10 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.logs.LogRecordBuilder;
 import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.semconv.SemanticAttributes;
 
@@ -343,6 +347,7 @@ public class MpTelemetryLogMappingUtils {
 
         String key = null;
         Object value = null;
+        String traceParent = null;
 
         for (Iterator<KeyValuePair> element = kvpList.iterator(); element.hasNext();) {
             KeyValuePair next = element.next();
@@ -359,13 +364,15 @@ public class MpTelemetryLogMappingUtils {
                 } else if (key.equals("datetime") || key.equals("accessLogDatetime")) {
                     builder.setTimestamp(formatDateTime((String) value));
                 } else if (key.contains("requestHeader") || key.contains("responseHeader")) {
-                    String[] headerSplit = ((String) value).split(",");
-                    for (int i = 0; i < headerSplit.length; i++) {
-                        headerSplit[i] = headerSplit[i].trim();
+                    if (key.contains("traceparent"))
+                        traceParent = (String) value;
+                    else {
+                        String[] headerSplit = ((String) value).split(",");
+                        for (int i = 0; i < headerSplit.length; i++) {
+                            headerSplit[i] = headerSplit[i].trim();
+                        }
+                        attributes.put(formattedKey, headerSplit);
                     }
-
-                    attributes.put(formattedKey, headerSplit);
-
                 } else if (key.equals("requestPort")) {
                     attributes.put(formattedKey, Integer.parseInt((String) value));
                 } else if (key.equals("requestFirstLine")) {
@@ -393,8 +400,16 @@ public class MpTelemetryLogMappingUtils {
         // Set the Attributes to the builder.
         builder.setAllAttributes(attributes.build());
 
-        // Set the Span and Trace IDs from the current context.
-        builder.setContext(Context.current());
+        // Set the Span and Trace IDs from the current context. We're not on the same thread at the point when access logs are collected
+        // so we need to extract the trace/span ID from the 'traceparent' request header.
+        if (traceParent != null) {
+            String[] traceSplit = traceParent.split("-");
+
+            SpanContext customSpanContext = SpanContext.create(traceSplit[1], traceSplit[2], TraceFlags.getSampled(), TraceState.getDefault());
+            Span customSpan = Span.wrap(customSpanContext);
+            builder.setContext(Context.current().with(customSpan));
+        } else
+            builder.setContext(Context.current());
 
     }
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/OpenTelemetryLogHandler.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/src/io/openliberty/microprofile/telemetry20/logging/internal/OpenTelemetryLogHandler.java
@@ -346,8 +346,6 @@ public class OpenTelemetryLogHandler implements SynchronousHandler {
             if (accessLogField.toLowerCase().equals("default") || accessLogField.toLowerCase().equals("logformat"))
                 AccessLogConfig.accessLogFieldsTelemetryConfig = accessLogField;
             else {
-                Tr.warning(tc, "CWMOT5008.mptelemetry.unknown.access.log.field",
-                           accessLogField);
                 AccessLogConfig.accessLogFieldsTelemetryConfig = "default";
             }
         } else {

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_2_fat/publish/files/invalidAccessFormat.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_2_fat/publish/files/invalidAccessFormat.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2024, 2025 IBM Corporation and others.
+    Copyright (c) 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_2_fat/publish/files/invalidAccessSource.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal_2_fat/publish/files/invalidAccessSource.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2024, 2025 IBM Corporation and others.
+    Copyright (c) 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.telemetry.internal.common/resources/io/openliberty/microprofile/telemetry/internal/common/resources/MPTelemetry.nlsprops
+++ b/dev/io.openliberty.microprofile.telemetry.internal.common/resources/io/openliberty/microprofile/telemetry/internal/common/resources/MPTelemetry.nlsprops
@@ -63,10 +63,6 @@ CWMOT5007.tel.enabled.conflict=CWMOT5007W: Conflicting configuration for the ote
 CWMOT5007.tel.enabled.conflict.explanation: MicroProfile Telemetry can be enabled for the whole server by using system properties or environment variables. If it isn't enabled for the whole server, it can be enabled for an application by setting MicroProfile Config properties; for example, by setting variables in the server.xml file. This warning is given if Telemetry is enabled for the whole server, but the MicroProfile Config properties disable Telemetry for an application. Because Telemetry is enabled for the whole server, the configuration for that application is ignored.
 CWMOT5007.tel.enabled.conflict.useraction: Specify the settings to enable or disable OpenTelemetry instances by using either environment variables and system properties or other MP Config sources but not both.
 
-CWMOT5008.mptelemetry.unknown.access.log.field=CWMOT5008W: The MicroProfile Telemetry logging feature does not recognize the [ {0} ] telemetry access log format.
-CWMOT5008.mptelemetry.unknown.access.log.field.explanation=The Liberty runtime environment does not provide the specified log format.
-CWMOT5008.mptelemetry.unknown.access.log.field.useraction=Specify either default or logFormat for the mpTelemetry accessLogFields attribute.
-
 #-----------------------------------------------------------------------------------------------------------------------------
 # Monitor Metrics messages
 #-----------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

This PR includes:

- Adding requestFirstLine to the default access logging attributes for jsonLogging, logStashCollector and mpTelemetry.
- Add traces/spans to applicable access logs
- Removal of unused warning
- Some code speedup
- Copyright cleanup

Final changes for #29228 