### PR TITLE
Fix various issues with SameSite and Partitioned logic

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
@@ -1041,7 +1041,7 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
         }
 
         for (HttpCookie cookie : list) {
-            String value = CookieEncoder.encode(cookie, header, config, userAgent);
+            String value = CookieEncoder.encodeCookie(cookie, header, config, userAgent);
             
             if (null != value) {
                 if(filterDuplicates){

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -629,7 +629,7 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
         String result = null;
         if (Objects.nonNull(cookie) && Objects.nonNull(header)) {
             String userAgent = getServiceContext().getRequest().getHeader(HttpHeaderKeys.HDR_USER_AGENT).asString();
-            result = CookieEncoder.encode(cookie, header, config, userAgent);
+            result = CookieEncoder.encodeCookie(cookie, header, config, userAgent);
 
             if (Objects.nonNull(result)) {
                 if (config.doNotAllowDuplicateSetCookies() && header.equals(HttpHeaderKeys.HDR_SET_COOKIE)) {

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/netty/cookie/CookieEncoderTests.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/netty/cookie/CookieEncoderTests.java
@@ -106,7 +106,8 @@ public class CookieEncoderTests{
         }
     }
 
-    @Test 
+    // This would be for future enhacement, for not it is not supported behavior.
+    //@Test 
     public void testEncodeVersion0WithMaxAgeShouldUpgrade(){
         HttpCookie cookie = new HttpCookie(NAME, VALUE);
         cookie.setVersion(0);
@@ -116,7 +117,7 @@ public class CookieEncoderTests{
 
         setupSameSiteConfig(true, SAMESITE_NONE, true);
 
-        String encoded = CookieEncoder.encode(cookie, header, config, UA);
+        String encoded = CookieEncoder.encodeCookie(cookie, header, config, UA);
 
         assertThat(encoded, containsString("testCookieName=testCookieValue"));
         assertThat(encoded, containsString("Max-Age=3600"));
@@ -143,7 +144,7 @@ public class CookieEncoderTests{
         when(config.getSameSiteCookies()).thenReturn(sameSiteMap);
         
 
-        String encoded = CookieEncoder.encode(cookie, HttpHeaderKeys.HDR_SET_COOKIE, config, UA).toLowerCase();
+        String encoded = CookieEncoder.encodeCookie(cookie, HttpHeaderKeys.HDR_SET_COOKIE, config, UA).toLowerCase();
         assertThat("Encoded cookie should include samesite=strict", encoded, containsString("samesite=strict"));
     }
 
@@ -158,7 +159,7 @@ public class CookieEncoderTests{
 
         setupSameSiteConfig(true, SAMESITE_NONE, true);
 
-        String encoded = CookieEncoder.encode(cookie, HttpHeaderKeys.HDR_SET_COOKIE, config, UA).toLowerCase();
+        String encoded = CookieEncoder.encodeCookie(cookie, HttpHeaderKeys.HDR_SET_COOKIE, config, UA).toLowerCase();
         assertThat("Encoded cookie should have samesite=none", encoded, containsString("samesite=none"));
         assertThat("Encoded cookie should be secure", encoded, containsString("secure"));
         assertThat("Encoded cookie should be partitioned", encoded, containsString("partitioned"));
@@ -178,7 +179,7 @@ public class CookieEncoderTests{
         patternMap.put(Pattern.compile("user_.*"), "Lax");
         when(config.getSameSitePatterns()).thenReturn(patternMap);
 
-        String encoded = CookieEncoder.encode(cookie, HttpHeaderKeys.HDR_SET_COOKIE, config, UA).toLowerCase();
+        String encoded = CookieEncoder.encodeCookie(cookie, HttpHeaderKeys.HDR_SET_COOKIE, config, UA).toLowerCase();
         assertThat("Encoded cookie should include samesite=Lax for pattern match", encoded, containsString("samesite=lax"));
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This update fixes several bugs related to `SameSite` cookie handling and the `partitioned` attribute logic, ensuring that cookies are treated in the same way the legacy code.

### Retaining User-Supplied SameSite Attributes

Issue: If the application or user code supplied an invalid `SameSite` value (e.g., "SameSite=Incorrect"), our logic used to parse it would remove that attribute, even though the app explicitly set it.

Issue: The final pass that removes or disables partitioned if `SameSite` isn’t "None" wasn’t always happening at the correct time. In some cases, the `partitioned` attribute inadvertently stayed set.

### Testing 
Tested resolved issues with

- com.ibm.ws.transport.http:test
- com.ibm.ws.webcontainer.servlet.4.0_fat.2