### PR TITLE
Computation of entity attribute names

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -490,9 +490,14 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
                 if (propertyDescriptors != null)
                     for (PropertyDescriptor p : propertyDescriptors) {
                         Method setter = p.getWriteMethod();
-                        if (setter != null)
-                            attributes.putIfAbsent(p.getName(),
-                                                   p.getPropertyType());
+                        if (setter != null) {
+                            String n = setter.getName();
+                            String name = new StringBuilder(n.length() - 3) //
+                                            .append(Character.toLowerCase(n.charAt(3))) //
+                                            .append(n.substring(4)) //
+                                            .toString(); //
+                            attributes.putIfAbsent(name, p.getPropertyType());
+                        }
                     }
             } catch (IntrospectionException x) {
                 throw new MappingException(x);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -365,6 +365,7 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
                 // entity class that is used internally in place of a record.
                 String tableName = c.getSimpleName();
 
+                Class<?> ec = c;
                 if (c.isRecord()) {
                     // an entity class is generated for the record
                     String entityClassName = c.getName() + EntityInfo.RECORD_ENTITY_SUFFIX;
@@ -375,17 +376,15 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
                                                               repositoryInterfaces);
                     String name = entityClassName.replace('.', '/') + ".class";
                     generatedEntities.add(new InMemoryMappingFile(generatedEntityBytes, name));
-                    Class<?> generatedEntity = classDefiner //
-                                    .findLoadedOrDefineClass(getRepositoryClassLoader(),
-                                                             entityClassName,
-                                                             generatedEntityBytes);
-                    generatedToRecordClass.put(generatedEntity, c);
-                    c = generatedEntity;
+                    ec = classDefiner.findLoadedOrDefineClass(getRepositoryClassLoader(),
+                                                              entityClassName,
+                                                              generatedEntityBytes);
+                    generatedToRecordClass.put(ec, c);
                 }
 
                 StringBuilder xml = new StringBuilder(500);
 
-                xml.append(" <entity class=\"").append(c.getName()) //
+                xml.append(" <entity class=\"").append(ec.getName()) //
                                 .append("\">").append(EOLN);
 
                 xml.append("  <table name=\"") //

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,8 @@ package test.jakarta.data.web;
  */
 public class Apartment extends Residence {
 
-    public long aptId;
+    // All upper case is a bad practice, but the spec allows it
+    public long APTID;
 
     public int quartersWidth;
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Apartments.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -80,6 +80,7 @@ public interface Apartments {
     // Write query using embeddable in a mapped superclass
     @Find
     @OrderBy("occupant.firstName")
+    @OrderBy("APTID")
     public List<Apartment> findByOccupantLastNameOrderByFirstName(@By("occupant_lastName") String lastName);
 
     //  Write query using entity that has colliding non-delimited attribute name (quartersWidth)

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Cylinder.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Cylinder.java
@@ -15,7 +15,7 @@ package test.jakarta.data.web;
  * in its hierarchy.
  */
 public record Cylinder(
-                String cylID, // TODO why does this fail if named cID ?
+                String cID,
                 Coordinate center,
                 Side side) {
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4171,7 +4171,7 @@ public class DataTestServlet extends FATServlet {
         a101.occupant.firstName = "Kyle";
         a101.occupant.lastName = "Smith";
         a101.isOccupied = true;
-        a101.aptId = 101L;
+        a101.APTID = 101L;
         a101.quarters = new Bedroom();
         a101.quarters.length = 10;
         a101.quarters.width = 10;
@@ -4182,7 +4182,7 @@ public class DataTestServlet extends FATServlet {
         a102.occupant.firstName = "Brent";
         a102.occupant.lastName = "Smith";
         a102.isOccupied = false;
-        a102.aptId = 102L;
+        a102.APTID = 102L;
         a102.quarters = new Bedroom();
         a102.quarters.length = 11;
         a102.quarters.width = 11;
@@ -4193,7 +4193,7 @@ public class DataTestServlet extends FATServlet {
         a103.occupant.firstName = "Brian";
         a103.occupant.lastName = "Smith";
         a103.isOccupied = false;
-        a103.aptId = 103L;
+        a103.APTID = 103L;
         a103.quarters = new Bedroom();
         a103.quarters.length = 11;
         a103.quarters.width = 12;
@@ -4204,7 +4204,7 @@ public class DataTestServlet extends FATServlet {
         a104.occupant.firstName = "Scott";
         a104.occupant.lastName = "Smith";
         a104.isOccupied = false;
-        a104.aptId = 104L;
+        a104.APTID = 104L;
         a104.quarters = new Bedroom();
         a104.quarters.length = 12;
         a104.quarters.width = 11;

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participant.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,17 +18,27 @@ package test.jakarta.data.web;
  */
 public class Participant {
 
-    public Integer id;
+    private Integer pID;
 
     public Name name;
 
     public static record Name(String first, String last) {
     }
 
+    // Exception Description: Could not load the field named [PID] on the class [class test.jakarta.data.web.Participant]. Ensure there is a corresponding field with that name defined on the class.
+
+    public Integer getPID() {
+        return pID;
+    }
+
     public static Participant of(String firstName, String lastName, int id) {
         Participant p = new Participant();
-        p.id = id;
+        p.pID = id;
         p.name = new Name(firstName, lastName);
         return p;
+    }
+
+    public void setPID(Integer value) {
+        pID = value;
     }
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participants.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -38,10 +38,10 @@ public interface Participants extends DataRepository<Participant, Integer> {
 
     // Using Query by Method Name would require @Select("name"),
     // which is not available in Data 1.0 // TODO move to 1.1 tests
-    @Query("SELECT name WHERE id = ?1")
+    @Query("SELECT name WHERE pID = ?1")
     Optional<Name> findNameById(int id);
 
-    @Query("SELECT name.first WHERE id = ?1")
+    @Query("SELECT name.first WHERE pID = ?1")
     Optional<String> getFirstName(int id);
 
     @Delete
@@ -49,6 +49,6 @@ public interface Participants extends DataRepository<Participant, Integer> {
 
     @Find
     @OrderBy("name.first")
-    @OrderBy("id")
+    @OrderBy("pID")
     Stream<Participant> withSurname(@By("name.last") String lastName);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Rating.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Rating.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import java.util.Set;
  * Entity that is a Java record with embeddable and collection attributes.
  */
 public record Rating(
-                int id,
+                int ID, // All upper case is a bad practice, but the spec allows it
                 Item item,
                 int numStars,
                 Reviewer reviewer,

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Ratings.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Ratings.java
@@ -44,11 +44,11 @@ public interface Ratings {
 
     Stream<Rating> findByItemPriceBetween(float min, float max, Sort<?>... sorts);
 
-    @Query("SELECT comments WHERE id=?1")
+    @Query("SELECT comments WHERE ID=?1")
     Set<String> getComments(int id);
 
     @Find
     @OrderBy("item.price")
-    @OrderBy("id")
+    @OrderBy("ID")
     Stream<Rating> search(int numStars);
 }


### PR DESCRIPTION
Entity attribute names for unannotated entities can be based on any of:
- record component name (if a record entity)
- field name
- setter method name

In the case of the latter, we need to determine whether or not to lowercase the first letter following "set".  It appears that Jakarta Persistence/EclipseLink does this, making an all caps setter not even possible, so we will follow that approach.

Also ensure test coverage for some unusual, but allowed, patterns with capital letters.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
