### PR TITLE
Add helpful message when uninitialized

### DIFF
--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -202,6 +202,23 @@ if (javaVersion < 21) {
   }
 }
 
+// Require cnf:initialize on clean workspace.
+File bndPluginsClassesDir = file(bnd_cnf+'/bndplugins/classes')
+boolean initialize = false
+Set<String> projectNames = new LinkedHashSet<>()
+for (Iterator<String> iter = startParameter.taskNames.iterator(); iter.hasNext();) {
+  String taskName = iter.next()
+  if (taskName == 'cnf:initialize') {
+    initialize = true
+  }
+}
+if (!initialize && !bndPluginsClassesDir.exists()) {
+  print "ERROR: Building this repository requires bnd plugins to be compiled before building projects.  Please follow these steps:\n" +
+      "  1) Run the cnf project's initialize task with `./gradlew cnf:initialize`\n" +
+      "  2) Re-run the Gradle task you intend to build.\n";
+  throw new GradleException('cnf workspace needs to be initialized.')
+}
+
 //DirectoryScanner.removeDefaultExclude("**/.gitignore")
 //DirectoryScanner.removeDefaultExclude("**/.gitattributes")
 


### PR DESCRIPTION
- Guard when bndplugins/classes is empty and the task being run isn't cnf:initialize to avoid users encountering a cryptic error message.

```
error  : Exception: java.lang.ClassNotFoundException: [com.ibm.ws](http://com.ibm.ws/).build.bnd.plugins.ExternalPackageProcessor not found, parent: InstrumentingVisitableURLClassLoader(ClassLoaderScopeIdentifier.Id{coreAndPlugins:script-file:/C:/Users/078112866/liberty/open-liberty/dev/wlp-gradle/bndSettings.gradle(export)}) urls:[C:\Users\078112866\liberty\open-liberty\dev\cnf\bndplugins\classes, C:\Users\078112866\.ibmartifactory\repository\org\apache\aries\org.apache.aries.util\1.1.3\org.apache.aries.util-1.1.3.jar]looked in [] exception:java.lang.ClassNotFoundException: [com.ibm.ws](http://com.ibm.ws/).build.bnd.plugins.ExternalPackageProcessor not found in aQute.bnd.osgi.Processor$CL@701065ea
```