### PR TITLE
Select annotation can come from multiple places

### DIFF
--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package io.openliberty.data.internal.v1_0;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Set;
 
@@ -92,7 +93,7 @@ public class Data_1_0 implements DataVersionCompatibility {
 
     @Override
     @Trivial
-    public String[] getSelections(Method method) {
+    public String[] getSelections(AnnotatedElement element) {
         return null;
     }
 

--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -13,6 +13,7 @@
 package io.openliberty.data.internal.v1_1;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -294,8 +295,8 @@ public class Data_1_1 implements DataVersionCompatibility {
 
     @Override
     @Trivial
-    public String[] getSelections(Method method) {
-        Annotation select = method.getAnnotation(Select.class);
+    public String[] getSelections(AnnotatedElement element) {
+        Annotation select = element.getAnnotation(Select.class);
         return select == null ? null : ((Select) select).value();
     }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3075,8 +3075,14 @@ public class QueryInfo {
 
                     String[] names = new String[recordComponents.length];
                     for (int i = 0; i < recordComponents.length; i++) {
-                        // 1.1 TODO first check for Select annotation on record component
-                        names[i] = recordComponents[i].getName();
+                        String[] select = entityInfo.builder.provider.compat //
+                                        .getSelections(recordComponents[i]);
+                        if (select == null || select.length == 0)
+                            names[i] = recordComponents[i].getName();
+                        else if (select.length == 1)
+                            names[i] = select[0];
+                        else
+                            throw new UnsupportedOperationException("@Select " + Arrays.toString(select)); // 1.1 TODO
                     }
 
                     try {

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -13,6 +13,7 @@
 package io.openliberty.data.internal.version;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Set;
 
@@ -84,14 +85,14 @@ public interface DataVersionCompatibility {
     Annotation getExistsAnnotation(Method method);
 
     /**
-     * Obtains the value of the Select annotation if present on the method.
-     * Otherwise null.
+     * Obtains the value of the Select annotation if present on the method
+     * or record component. Otherwise null.
      *
-     * @param method repository method. Must not be null.
+     * @param element repository method or record component. Must not be null.
      * @return values of the Select annotation indicating the columns to select,
      *         otherwise null.
      */
-    String[] getSelections(Method method);
+    String[] getSelections(AnnotatedElement element);
 
     /**
      * Return a 2-element array where the first element is the entity attribute name

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -2885,11 +2886,12 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Query that matches multiple entities and returns a stream of results
-     * where each result has a ManyToMany association.
+     * Query that matches multiple entities that have a ManyToMany relation.
+     * Verify that the data within the ManyToMany relations of the results
+     * is correct.
      */
     @Test
-    public void testManyToManyReturnsCombinedCollectionFromMany() {
+    public void testManyToManyIncludedInResults() {
 
         List<String> addresses = customers.findByPhoneIn(List.of(5075552444L,
                                                                  5075550101L))
@@ -2912,11 +2914,12 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Query that matches a single entity, from which the corresponding collection
-     * from its ManyToMany association can be accessed.
+     * Query that matches a single entity that has a ManyToMany relation.
+     * Verify that the data within the ManyToMany relation of the result
+     * is correct.
      */
     @Test
-    public void testManyToManyReturnsOneWithSetOfMany() {
+    public void testManyToManyIncludedInSingleResult() {
         Set<DeliveryLocation> locations = customers //
                         .findByEmail("Maximilian@tests.openliberty.io")
                         .orElseThrow().deliveryLocations;
@@ -2939,7 +2942,6 @@ public class DataJPATestServlet extends FATServlet {
         assertNotNull(loc3.street);
         assertEquals(2800, loc3.houseNum);
         assertEquals("37th St", loc3.street.name);
-        assertEquals("NW", loc3.street.direction);
 
         assertNotNull(locations.toString(), loc4);
         assertEquals(DeliveryLocation.Type.HOME, loc4.type);
@@ -3018,6 +3020,27 @@ public class DataJPATestServlet extends FATServlet {
         assertIterableEquals(List.of("Monica@tests.openliberty.io",
                                      "martin@tests.openliberty.io"),
                              creditCards.findByExpiresOnBetween(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31)));
+    }
+
+    /**
+     * Query that matches based on an attribute of the One of a ManyToOne relation.
+     */
+    @Test
+    public void testManyToOneSubAttribute() {
+
+        Stream<CreditCard> cards = customers//
+                        .findCardsByDebtorEmailEndsWith("an@tests.openliberty.io");
+        List<Long> cardNumbers = cards
+                        .map(card -> card.number)
+                        .collect(Collectors.toList());
+
+        // Customer 5's card numbers must come before Customer 4's card numbers
+        // due to the ordering on Customer.phone.
+        assertEquals(Set.of(5000921051110001L, 5000921052220002L),
+                     new HashSet<>(cardNumbers.subList(0, 2)));
+
+        assertEquals(Set.of(4000921041110001L, 4000921042220002L),
+                     new HashSet<>(cardNumbers.subList(2, 4)));
     }
 
     /**
@@ -3212,28 +3235,6 @@ public class DataJPATestServlet extends FATServlet {
                                      "Maximilian@tests.openliberty.io",
                                      "Megan@tests.openliberty.io"),
                              customers.withCardIssuer(Issuer.MonsterCard));
-    }
-
-    /**
-     * Query that matches multiple entities and returns a combined collection of results across matches for the OneToMany association.
-     */
-    //@Test
-    // This test is currently incorrect because Email is an attribute of Customer (primary entity type), not CreditCard (result type).
-    // This would require a way to indicate that a projection is desired, meaning the return type indicates
-    // an attribute of the entity rather than the entity class itself.
-    // TODO Could this be achieved with @Select?
-    public void testOneToManyReturnsCombinedCollectionFromMany() {
-
-        List<Long> cardNumbers = customers.findCardsByDebtorEmailEndsWith("an@tests.openliberty.io")
-                        .map(card -> card.number)
-                        .collect(Collectors.toList());
-
-        // Customer 5's card numbers must come before Customer 4's card numbers due to the ordering on Customer.phone.
-        assertEquals(cardNumbers.toString(),
-                     true, cardNumbers.equals(List.of(5000921051110001L, 5000921052220002L, 4000921041110001L, 4000921042220002L)) ||
-                           cardNumbers.equals(List.of(5000921051110001L, 5000921052220002L, 4000921042220002L, 4000921041110001L)) ||
-                           cardNumbers.equals(List.of(5000921052220002L, 5000921051110001L, 4000921042220002L, 4000921041110001L)) ||
-                           cardNumbers.equals(List.of(5000921052220002L, 5000921051110001L, 4000921041110001L, 4000921042220002L)));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/WorkAddresses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/WorkAddresses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import jakarta.data.repository.Repository;
 /**
  * The only purpose of this repository is to make the Jakarta Data provider aware
  * of the existence of the WorkAddress entity as a subtype of the ShippingAddress entity.
- * TODO is there a way to figure this out automatically?
+ * The Find(entityclass) annotation value in Data 1.1 should make this unnecessary.
  */
 @Repository
 public interface WorkAddresses extends DataRepository<WorkAddress, Long> {


### PR DESCRIPTION
We have some code that is assuming the Select annotation can only come from a Method, but it can also come from a record component.  This PR updates to use a common supertype of both (AnnotatedElement).
Also, a second commit under this PR addresses various TODOs in tests.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
