### PR TITLE
Resolving 298906 for IBM i systems

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.1/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.1/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,6 +36,7 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.LDAPFatUtils;
+import componenttest.annotation.SkipIfSysProp;
 
 /**
  * Tests Kerberos bind (GSSAPI) for Ldap, using primarily the krb5TicketCache.
@@ -124,6 +125,7 @@ public class TicketCacheBindTest extends CommonBindTest {
      */
     @AllowedFFDC({ "javax.naming.NamingException", "javax.security.auth.login.LoginException" })
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to readOnly setting not applied correctly on those systems
     public void readOnlyTicketCache() throws Exception {
         /*
          * Setting the file to unreadable only works on *nix systems.

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.2/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.2/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,6 +36,7 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.LDAPFatUtils;
+import componenttest.annotation.SkipIfSysProp;
 
 /**
  * Tests Kerberos bind (GSSAPI) for Ldap, using primarily the krb5TicketCache.
@@ -124,6 +125,7 @@ public class TicketCacheBindTest extends CommonBindTest {
      */
     @AllowedFFDC({ "javax.naming.NamingException", "javax.security.auth.login.LoginException" })
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to readOnly setting not applied correctly on those systems
     public void readOnlyTicketCache() throws Exception {
         /*
          * Setting the file to unreadable only works on *nix systems.

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSpnegoAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSpnegoAuthenticationCacheTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
RTC Defect: https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=298906

It is a negative testcase, expecting a failure when using a read only ticket cache.
It seems on IBM I, the failure does not occur, perhaps the readOnly setting is not applied correctly on IBM I.
Disabling the tests on those systems.