### PR TITLE
Checkpoint compatability for file-based health checks in mpHealth-40

### DIFF
--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2024 IBM Corporation and others.
+# Copyright (c) 2022, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -219,6 +219,7 @@ tested.features: \
 	com.ibm.websphere.org.eclipse.microprofile.openapi.1.0;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.config.1.2.1;version=latest,\
 	io.openliberty.com.fasterxml.jackson,\
-	com.fasterxml.jackson.core.jackson-databind
+	com.fasterxml.jackson.core.jackson-databind,\
+	io.openliberty.microprofile.health.internal_fat.common
 
 -sub: *.bnd

--- a/dev/io.openliberty.checkpoint_fat/build.gradle
+++ b/dev/io.openliberty.checkpoint_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -74,6 +74,7 @@ dependencies {
   requiredLibs project(':com.ibm.ws.microprofile.openapi')
   requiredLibs project(':io.openliberty.org.eclipse.microprofile')
   requiredLibs project(path: ':com.ibm.websphere.org.eclipse.microprofile', configuration: 'openapi10')
+  requiredLibs project(':io.openliberty.microprofile.health.internal_fat.common')
 }
 
 autoFVT {

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -49,6 +49,7 @@ import componenttest.rules.repeater.RepeatActions.EEVersion;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
+import io.openliberty.microprofile.health.internal_fat.shared.HealthActions;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -82,6 +83,7 @@ import componenttest.topology.impl.LibertyServer;
                 MPTelemetryTest.class,
                 WebProfileEARtest.class,
                 MPHealthTest.class,
+                MPHealthTestFileBased.class, // Testing new
                 SlowAppStartTest.class,
                 JsonbTest.class,
                 JsonpTest.class,
@@ -233,6 +235,17 @@ public class FATSuite {
                                           MicroProfileActions.MP61, // rest are FULL mode
                                           MicroProfileActions.MP41,
                                           MicroProfileActions.MP50);
+    }
+
+    public static RepeatTests MPHealthFileBasedRepeat(String serverName) {
+        return MicroProfileActions.repeat(serverName,
+                                          MicroProfileActions.MP70_EE10, // First test in LITE mode
+                                          // Nothing specific for EE 11 that we should repeat for checkpoint
+                                          // MicroProfileActions.MP70_EE11,
+                                          MicroProfileActions.MP61, // rest are FULL mode
+                                          MicroProfileActions.MP50,
+                                          HealthActions.MP41_MPHEALTH40); //  mpHealth-4.0 FULL w/ MP41 EE8
+
     }
 
     public static final String MP50_MPTEL11_ID = MicroProfileActions.MP50_ID + "_MPTEL11";

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPHealthTestFileBased.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/MPHealthTestFileBased.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.checkpoint.fat;
+
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethod;
+import static io.openliberty.checkpoint.fat.FATSuite.getTestMethodNameOnly;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.CheckpointTest;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.checkpoint.fat.utils.HealthFileUtils;
+import io.openliberty.checkpoint.spi.CheckpointPhase;
+
+@RunWith(FATRunner.class)
+@CheckpointTest
+public class MPHealthTestFileBased extends FATServletClient {
+
+    @Server("checkpointMPHealthFileBased")
+    public static LibertyServer server;
+
+    private static final String APP_NAME = "mphealth";
+
+    private static final String MESSAGE_LOG = "logs/messages.log";
+
+    public TestMethod testMethod;
+
+    @ClassRule
+    public static RepeatTests repeatTest = FATSuite.MPHealthFileBasedRepeat("checkpointMPHealthFileBased");
+
+    @BeforeClass
+    public static void copyAppToDropins() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.OVERWRITE }, APP_NAME);
+        FATSuite.copyAppsAppToDropins(server, APP_NAME);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        testMethod = getTestMethod(TestMethod.class, testName);
+        configureBeforeCheckpoint();
+        server.setCheckpoint(getCheckpointPhase(), true,
+                             server -> {
+                                 configureBeforeRestore();
+                             });
+        server.setConsoleLogName(getTestMethod(TestMethod.class, testName) + ".log");
+        server.startServer(true, false); // Do not validate apps since we have a delayed startup.
+    }
+
+    private CheckpointPhase getCheckpointPhase() {
+        CheckpointPhase phase = CheckpointPhase.AFTER_APP_START;
+        switch (testMethod) {
+            default:
+                break;
+        }
+        return phase;
+    }
+
+    private void configureBeforeCheckpoint() {
+        try {
+            server.saveServerConfiguration();
+            Log.info(getClass(), testName.getMethodName(), "Configuring during checkpoint: " + testMethod);
+            switch (testMethod) {
+                default:
+                    Log.info(getClass(), testName.getMethodName(), "No configuration required: " + testMethod);
+                    break;
+            }
+        } catch (Exception e) {
+            throw new AssertionError("Unexpected error configuring test.", e);
+        }
+    }
+
+    @Test
+    public void testDefaultFileBasedHealthChecks() throws Exception {
+        String name = getTestMethodNameOnly(testName);
+
+        String serverRoot = server.getServerRoot();
+        File serverRootDirFile = new File(serverRoot);
+
+        /*
+         * Check that the startFileHealthCheckProcesses entry trace exists.
+         * This indicates that the health files haven't been created before the checkpoint.
+         * The files are created for the first time in this method and the timer process kicks off as well.
+         * This is also the method that called as part of the CheckpointPhase.onRestore().
+         * The restore immediately starts the already started application and by the time this test starts
+         * the health files would have been created after resuming the process.
+         *
+         * Checking the trace that the method entry happens after restore is the only way to validate
+         * that the health files were not created before restore.
+         */
+        Log.info(getClass(), "testDefaultFileBasedHealthChecks", "Testing that startFileHealthCheckProcesses entry trace exists in the trace after restore");
+        List<String> myLines = server.findStringsInTrace("startFileHealthCheckProcesses Entry");
+        assertEquals("StartFileHealthCheckProcesses has not been found", 1, myLines.size());
+
+        /*
+         * Ensure that the Application has started message exists (CWWKZ0001I) and then check that the files are there.
+         */
+
+        List<String> lines = server.findStringsInFileInLibertyServerRoot("CWWKZ0001I:", MESSAGE_LOG);
+        assertEquals("The CWWKZ0001I Application started message did not appear in messages.log", 1, lines.size());
+
+        /*
+         * The started and live files should now have been created in the /health directory.
+         * The ready file is not created because the health check returns DOWN.
+         *
+         * Expect:
+         * [X] /health dir
+         * [X] Started
+         * [ ] Ready
+         * [X] Live
+         * Don't need to check health dir and live again. Already created from above.
+         */
+        assertTrue(HealthFileUtils.HEALTH_DIR_SHOULD_HAVE, HealthFileUtils.getHealthDirFile(serverRootDirFile).exists());
+        assertTrue(HealthFileUtils.STARTED_SHOULD_HAVE, HealthFileUtils.getStartFile(serverRootDirFile).exists());
+        assertTrue(HealthFileUtils.LIVE_SHOULD_HAVE, HealthFileUtils.getLiveFile(serverRootDirFile).exists());
+        assertFalse(HealthFileUtils.READY_SHOULD_NOT_HAVE, HealthFileUtils.getReadyFile(serverRootDirFile).exists());
+
+    }
+
+    private void configureBeforeRestore() {
+        try {
+            Log.info(getClass(), testName.getMethodName(), "Configuring during restore: " + testMethod);
+            switch (testMethod) {
+                default:
+                    Log.info(getClass(), testName.getMethodName(), "No configuration required: " + testMethod);
+                    break;
+            }
+
+        } catch (Exception e) {
+            throw new AssertionError("Unexpected error configuring test.", e);
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stopServer("CWMMH0052W");
+        server.restoreServerConfiguration();
+    }
+
+    static enum TestMethod {
+        testDefaultFileBasedHealthChecks,
+        unknown
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/utils/HealthFileUtils.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/utils/HealthFileUtils.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.checkpoint.fat.utils;
+
+import java.io.File;
+import java.time.Duration;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+/**
+ *
+ */
+public class HealthFileUtils {
+
+    public static final String SHOULD_HAVE = " should have been created.";
+    public static final String SHOULD_NOT_HAVE = " should not have been created.";
+
+    public static final String HEALTH_DIR_SHOULD_HAVE = "/health" + SHOULD_HAVE;
+
+    public static final String LIVE_SHOULD_HAVE = "/health/live" + SHOULD_HAVE;
+    public static final String LIVE_SHOULD_NOT_HAVE = "/health/live" + SHOULD_NOT_HAVE;
+
+    public static final String STARTED_SHOULD_HAVE = "/health/started" + SHOULD_HAVE;
+    public static final String STARTED_SHOULD_NOT_HAVE = "/health/started" + SHOULD_NOT_HAVE;
+
+    public static final String READY_SHOULD_HAVE = "/health/ready" + SHOULD_HAVE;
+    public static final String READY_SHOULD_NOT_HAVE = "/health/ready" + SHOULD_NOT_HAVE;
+
+    private static void log(String method, String msg) {
+        Log.info(HealthFileUtils.class, method, msg);
+    }
+
+    public static long getLastModifiedTime(File file) {
+        final String METHOD_NAME = "getLastModifiedTime";
+
+        if (!file.exists()) {
+            log(METHOD_NAME, String.format("File %s does not exist", file.getAbsolutePath()));
+            return -1;
+        }
+
+        return file.lastModified();
+
+    }
+
+    public static boolean isLastModifiedTimeWithinLast(File file, Duration duration) {
+        final String METHOD_NAME = "isLastModifiedTimeWithinLast";
+
+        if (!file.exists()) {
+            log(METHOD_NAME, String.format("File %s does not exist", file.getAbsolutePath()));
+            return false;
+        }
+
+        long currTimeMilli = System.currentTimeMillis();
+        long lastMod = getLastModifiedTime(file);
+        long diff = (currTimeMilli - lastMod);
+
+        log(METHOD_NAME, String.format("The current time is [%d]. The last modified time was [%d]. The differene is [%d]", currTimeMilli, lastMod, diff));
+
+        return diff <= duration.toMillis();
+
+    }
+
+    public static File getHealthDirFile(File serverRootDirFile) {
+
+        File healthDirFile = new File(serverRootDirFile, "health");
+
+        return healthDirFile;
+    }
+
+    public static File getStartFile(File serverRootDirFile) {
+
+        File startedFile = new File(getHealthDirFile(serverRootDirFile), HealthCheckFileName.STARTED_FILE.getFileName());
+
+        return startedFile;
+    }
+
+    public static File getReadyFile(File serverRootDirFile) {
+
+        File readyFile = new File(getHealthDirFile(serverRootDirFile), HealthCheckFileName.READY_FILE.getFileName());
+
+        return readyFile;
+    }
+
+    public static File getLiveFile(File serverRootDirFile) {
+
+        File liveFile = new File(getHealthDirFile(serverRootDirFile), HealthCheckFileName.LIVE_FILE.getFileName());
+
+        return liveFile;
+    }
+
+    enum HealthCheckFileName {
+        STARTED_FILE("started"),
+        READY_FILE("ready"),
+        LIVE_FILE("live");
+
+        private final String fileName;
+
+        HealthCheckFileName(String fileName) {
+            this.fileName = fileName;
+        }
+
+        String getFileName() {
+            return fileName;
+        }
+    }
+}

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPHealthFileBased/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPHealthFileBased/bootstrap.properties
@@ -12,6 +12,4 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 websphere.java.security.exempt=true
-com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
-
-com.ibm.ws.logging.trace.specification=com.ibm.ws.security.*=all:com.ibm.ws.webcontainer.security.*=all:HEALTH=all
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all:HEALTH=all

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPHealthFileBased/bootstrap.properties
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPHealthFileBased/bootstrap.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+websphere.java.security.exempt=true
+com.ibm.ws.logging.trace.specification=*=info:checkpoint=all
+
+com.ibm.ws.logging.trace.specification=com.ibm.ws.security.*=all:com.ibm.ws.webcontainer.security.*=all:HEALTH=all

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPHealthFileBased/jvm.options
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPHealthFileBased/jvm.options
@@ -1,0 +1,2 @@
+-Xdump:java:events=throw+systhrow,filter=org/eclipse/openj9/criu/JVMCheckpointException,request=exclusive+preempt
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPHealthFileBased/server.xml
+++ b/dev/io.openliberty.checkpoint_fat/publish/servers/checkpointMPHealthFileBased/server.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <applicationManager startTimeout="90s"/>
+    <featureManager>
+        <feature>mpHealth-4.0</feature>
+        <feature>cdi-3.0</feature>
+        <feature>servlet-5.0</feature>
+        <feature>mpConfig-3.0</feature>
+        <feature>componenttest-1.0</feature>
+    </featureManager>
+    
+    <mpHealth fileUpdateInterval="5s" />
+    
+    <include location="../fatTestPorts.xml" />
+</server>

--- a/dev/io.openliberty.microprofile.health.4.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.4.0.internal/bnd.bnd
@@ -67,17 +67,13 @@ testsrc: test/src
 
 -buildpath: \
         com.ibm.websphere.javaee.annotation.1.2;version=latest,\
-        com.ibm.ws.kernel.boot.core;version=latest,\
-        com.ibm.ws.app.manager;version=latest,\
-        com.ibm.websphere.javaee.servlet.3.1; version=latest,\
         com.ibm.websphere.javaee.cdi.1.2;version=latest,\
-        io.openliberty.org.eclipse.microprofile.health.3.1;version=latest,\
-        io.openliberty.microprofile.health.3.1.internal,\
+        com.ibm.websphere.javaee.servlet.3.1; version=latest,\
         com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
-        com.ibm.ws.adaptable.module;version=latest,\
         com.ibm.websphere.org.osgi.core;version=latest,\
         com.ibm.websphere.org.osgi.service.component;version=latest,\
-        com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+        com.ibm.ws.adaptable.module;version=latest,\
+        com.ibm.ws.app.manager;version=latest,\
         com.ibm.ws.cdi.interfaces;version=latest,\
         com.ibm.ws.classloader.context;version=latest,\
         com.ibm.ws.classloading;version=latest,\
@@ -86,15 +82,20 @@ testsrc: test/src
         com.ibm.ws.context;version=latest,\
         com.ibm.ws.javaee.metadata.context;version=latest,\
         com.ibm.ws.javaee.version;version=latest,\
-        com.ibm.ws.kernel.service;version=latest,\
+        com.ibm.ws.kernel.boot.common,\
+        com.ibm.ws.kernel.boot.core;version=latest,\
         com.ibm.ws.kernel.security.thread;version=latest,\
+        com.ibm.ws.kernel.service;version=latest,\
         com.ibm.ws.logging;version=latest,\
+        com.ibm.ws.org.apache.commons.lang3;version=latest,\
         com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
         com.ibm.ws.threading;version=latest,\
         com.ibm.ws.webcontainer;version=latest,\
-        com.ibm.ws.org.apache.commons.lang3;version=latest,\
-        org.eclipse.osgi;version=latest,\
-        io.openliberty.microprofile.health.3.0.internal;version=latest
+        com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+        io.openliberty.microprofile.health.3.0.internal;version=latest,\
+        io.openliberty.microprofile.health.3.1.internal,\
+        io.openliberty.org.eclipse.microprofile.health.3.1;version=latest,\
+        org.eclipse.osgi;version=latest
 
 -testpath: \
         ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthCheck40ServiceImpl.java
+++ b/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthCheck40ServiceImpl.java
@@ -277,7 +277,6 @@ public class HealthCheck40ServiceImpl implements HealthCheck40Service {
     /** {@inheritDoc} */
     @Override
     public void startFileHealthCheckProcesses() {
-
         /*
          * If we got here, that means we've been restored (or this is a normal run)
          */

--- a/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthCheck40ServiceImpl.java
+++ b/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthCheck40ServiceImpl.java
@@ -73,6 +73,8 @@ public class HealthCheck40ServiceImpl implements HealthCheck40Service {
      */
     private volatile int fileUpdateIntevalMilliseconds = -1;
 
+    protected volatile boolean isCheckPointFinished = false;
+
     /**
      *
      * Instead of relying on checking if fileUpdateIntevalMilliseconds is > 0,
@@ -277,6 +279,11 @@ public class HealthCheck40ServiceImpl implements HealthCheck40Service {
     public void startFileHealthCheckProcesses() {
 
         /*
+         * If we got here, that means we've been restored (or this is a normal run)
+         */
+        isCheckPointFinished = true;
+
+        /*
          * Last flag in the if is the beta guard
          */
         if (isValidSystemForFileHealthCheck && isFileHealthCheckingEnabled() && ProductInfo.getBetaEdition()) {
@@ -393,6 +400,27 @@ public class HealthCheck40ServiceImpl implements HealthCheck40Service {
 
     @Override
     public Status performFileHealthCheck(File file, String healthCheckProcedure) {
+
+        /*
+         * For a checkpoint/restore environment.
+         * If an application image is ever built with more than one app,
+         * we need to make sure those immediate startup/started checks
+         * from application started don't ever get called.
+         *
+         * There may a configuration where the `started` file is created
+         * before all apps report "started".
+         *
+         * Example:
+         * Apps: A, B ,C.
+         * 1. App A starts. (async call held for starting health processes)
+         * 2. App B starts. Startup status is UP.
+         * - App C is not started, so this would traditionally return a overall DOWN Status
+         * - But if MP Config is set for default START (by accident), then overall Status is UP.
+         * - resulting in `started` file created for the checkpoint image.
+         */
+        if (!isCheckPointFinished) {
+            return null;
+        }
 
         /*
          * Entry point through AppTracker40Impl, needs to verify that system is valid, and we're enabled


### PR DESCRIPTION
PR introduces a flag to avoid creating a started file for the `afterAppStart` checkpoint image. No issues with `beforeAppStart` scenario.

Fixes #30927 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

