### PR TITLE
Ensure multiple TLS sipEndpoints can be started 

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
@@ -374,6 +374,13 @@ public class GenericEndpointImpl {
 			if (c_logger.isTraceDebugEnabled()){
 				c_logger.traceDebug("INFO: defaultSipEndpoint endpoint won't be activated as other sipendpoint is configured on the server!!!");
 			}
+			
+			//Do not remove defaultSipEndpont ID from configuration
+			//when other sipEndpoints are configured.
+			//By removing the defaultSipEndpointId from configuretions we
+			//also remove the ssl configuration, which results in
+			//TLS endpoints not coming online
+			//see open-liberty issue #30874
 
 			//isForcedDefaultEndpointIdDeactivate = true;
 			//removeDefaultSipEndpointIdFromConfiguration();

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
@@ -372,10 +372,10 @@ public class GenericEndpointImpl {
 		else {
 			isForcedDefaultEndpointIdDeactivate = true;
 			if (c_logger.isTraceDebugEnabled()){
-				c_logger.traceDebug("defaultSipEndpoint endpoint wasn't activated since was configured other sipendpoint");
+				c_logger.traceDebug("EYECATCHER: defaultSipEndpoint endpoint wasn't activated - we have other sipendpoint configured!!!");
 			}
 			
-			removeDefaultSipEndpointIdFromConfiguration();
+			//removeDefaultSipEndpointIdFromConfiguration();
 		}
 	}
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
@@ -370,11 +370,12 @@ public class GenericEndpointImpl {
 			} 
 		}
 		else {
-			isForcedDefaultEndpointIdDeactivate = true;
-			if (c_logger.isTraceDebugEnabled()){
-				c_logger.traceDebug("EYECATCHER: defaultSipEndpoint endpoint wasn't activated - we have other sipendpoint configured!!!");
-			}
 			
+			if (c_logger.isTraceDebugEnabled()){
+				c_logger.traceDebug("INFO: defaultSipEndpoint endpoint won't be activated as other sipendpoint is configured on the server!!!");
+			}
+
+			//isForcedDefaultEndpointIdDeactivate = true;
 			//removeDefaultSipEndpointIdFromConfiguration();
 		}
 	}

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
When custom sipEndpoints are configured it might happen that the sipcontainer will attempt to start the default SIP Endpoint first, versus the custom sipEndpoint defined in the server.xml. The sipcontainer will then realize that a custom sipEndpoint is configured and will shut down the defaultSipEndpoint. This behavior will result in the removal of sslConfig, which in turn will prevent TLS transport chains from starting up - even when the custom sipEndpoint is configured with a valid sipTLSPort.  