### PR TITLE
Update where the OIDC Provider is set in thread

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/AccessTokenAuthenticator.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/AccessTokenAuthenticator.java
@@ -70,7 +70,6 @@ public class AccessTokenAuthenticator {
     private static final String JWT_SEGMENTS = "-segments";
     private static final String JWT_SEGMENT_INDEX = "-";
     private static final String BEARER_SCHEME = "Bearer ";
-    public static ThreadLocal<String> threadClientID = new ThreadLocal<String>();
 
     OidcClientUtil oidcClientUtil = new OidcClientUtil();
     SSLSupport sslSupport = null;
@@ -106,8 +105,6 @@ public class AccessTokenAuthenticator {
         oidcClientRequest.setTokenType(OidcClientRequest.TYPE_ACCESS_TOKEN);
         ProviderAuthenticationResult oidcResult = new ProviderAuthenticationResult(AuthResult.FAILURE, HttpServletResponse.SC_UNAUTHORIZED);
         String accessToken = null;
-
-        setThreadClientId(clientConfig.getClientId());
 
         if (clientConfig.getAccessTokenInLtpaCookie()) {
             accessToken = getAccessTokenFromReqAsAttribute(req, true);
@@ -1107,12 +1104,5 @@ public class AccessTokenAuthenticator {
                 Tr.debug(tc, "Not setting new RS fail message since one was already found: " + existingFailMsg);
             }
         }
-    }
-    private void setThreadClientId(String clientID) {
-        threadClientID.set(clientID);
-    }
-
-    public static String getThreadClientId() {
-        return threadClientID.get();
     }
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
@@ -48,7 +48,6 @@ public class OIDCClientAuthenticatorUtil {
     SSLSupport sslSupport = null;
     private Jose4jUtil jose4jUtil = null;
     private static int badStateCount = 0;
-    public static ThreadLocal<String> threadClientID = new ThreadLocal<String>();
     public static final String[] OIDC_COOKIES = { OidcClientStorageConstants.WAS_OIDC_STATE_KEY, OidcClientStorageConstants.WAS_REQ_URL_OIDC,
             ClientConstants.WAS_OIDC_CODE, OidcClientStorageConstants.WAS_OIDC_NONCE };
 
@@ -89,8 +88,6 @@ public class OIDCClientAuthenticatorUtil {
             Tr.error(tc, "OIDC_CLIENT_NULL_AUTH_ENDPOINT", clientConfig.getClientId());
             return new ProviderAuthenticationResult(AuthResult.SEND_401, HttpServletResponse.SC_UNAUTHORIZED);
         }
-
-        setThreadClientId(clientConfig.getClientId());
 
         boolean isImplicit = Constants.IMPLICIT.equals(clientConfig.getGrantType());
 
@@ -487,14 +484,6 @@ public class OIDCClientAuthenticatorUtil {
             }
         }
         return issuer;
-    }
-
-    private void setThreadClientId(String clientID) {
-        threadClientID.set(clientID);
-    }
-
-    public static String getThreadClientId() {
-        return threadClientID.get();
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientRequest.java
@@ -63,6 +63,7 @@ public class OidcClientRequest extends OidcCommonClientRequest {
 
     protected String tokenType = TYPE_ID_TOKEN;
     protected String tokenTypeNoSpace = Constants.TOKEN_TYPE_ID_TOKEN;
+    public static ThreadLocal<String> threadClientID = new ThreadLocal<String>();
 
     OidcClientRequest() {
         // for FAT, make its scope package only
@@ -78,10 +79,12 @@ public class OidcClientRequest extends OidcCommonClientRequest {
         this.request = request;
         this.response = response;
         OidcClientUtil.setReferrerURLCookieHandler(referrerURLCookieHandler);
-
+                 
         clientConfigId = convergedClientConfig.getId();
         authnSessionDisabled = convergedClientConfig.isAuthnSessionDisabled_propagation();
         inboundValue = convergedClientConfig.getInboundPropagation();
+        
+        setThreadClientId(this.oidcClientConfig.getClientId());
 
         request.setAttribute(AUTHN_SESSION_DISABLED, Boolean.valueOf(authnSessionDisabled));
         request.setAttribute(INBOUND_PROPAGATION_VALUE, inboundValue);
@@ -379,6 +382,14 @@ public class OidcClientRequest extends OidcCommonClientRequest {
     @Override
     public boolean disableIssChecking() {
         return oidcClientConfig.disableIssChecking();
+    }
+
+    private void setThreadClientId(String clientID) {
+        threadClientID.set(clientID);
+    }
+
+    public static String getThreadClientId() {
+        return threadClientID.get();
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientRequest.java
@@ -63,7 +63,6 @@ public class OidcClientRequest extends OidcCommonClientRequest {
 
     protected String tokenType = TYPE_ID_TOKEN;
     protected String tokenTypeNoSpace = Constants.TOKEN_TYPE_ID_TOKEN;
-    public static ThreadLocal<String> threadClientID = new ThreadLocal<String>();
 
     OidcClientRequest() {
         // for FAT, make its scope package only
@@ -79,12 +78,9 @@ public class OidcClientRequest extends OidcCommonClientRequest {
         this.request = request;
         this.response = response;
         OidcClientUtil.setReferrerURLCookieHandler(referrerURLCookieHandler);
-                 
         clientConfigId = convergedClientConfig.getId();
         authnSessionDisabled = convergedClientConfig.isAuthnSessionDisabled_propagation();
         inboundValue = convergedClientConfig.getInboundPropagation();
-        
-        setThreadClientId(this.oidcClientConfig.getClientId());
 
         request.setAttribute(AUTHN_SESSION_DISABLED, Boolean.valueOf(authnSessionDisabled));
         request.setAttribute(INBOUND_PROPAGATION_VALUE, inboundValue);
@@ -382,14 +378,6 @@ public class OidcClientRequest extends OidcCommonClientRequest {
     @Override
     public boolean disableIssChecking() {
         return oidcClientConfig.disableIssChecking();
-    }
-
-    private void setThreadClientId(String clientID) {
-        threadClientID.set(clientID);
-    }
-
-    public static String getThreadClientId() {
-        return threadClientID.get();
     }
 
 }


### PR DESCRIPTION
We want to improve how the OIDC Provider is set in the threat. This will serve as a quality improvement for other features.
Instead of setting it directly in the OIDC Classes (which leads to duplicating the code in multiple places) we can accomplish the same thing if we set it in `dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebProviderAuthenticatorProxy.java`

- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
