### PR TITLE
Empty string values for Param/OrderBy/By annotations

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1051,9 +1051,13 @@ CWWKD1103.incompat.query.result.useraction=If the type of entity attributes that
  allows. If the type of entity attributes that the method selects is allowed, \
  check for other causes of incompatibility.
 
-CWWKD1104.empty.anno.value=CWWKD1104E: The empty String is not a valid value for \
- the {0} annotation that is used on the {1} method of the {2} repository.
-CWWKD1104.empty.anno.value.explanation=The empty String is not a supported value.
+CWWKD1104.empty.anno.value=CWWKD1104E: The empty value for the String class is \
+ not a valid value for the {0} annotation that is used on the {1} method of the \
+ {2} repository.
+CWWKD1104.empty.anno.value.explanation=The empty value for the String class is \
+ not a supported value. For example, if the annotation is a Param annotation, \
+ then valid values are the named parameter names that are used within the Query \
+ annotation value.
 CWWKD1104.empty.anno.value.useraction=If the annotation is not needed, \
  remove it from the repository method. Otherwise, specify a valid value for \
  the annotation.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1055,9 +1055,10 @@ CWWKD1104.empty.anno.value=CWWKD1104E: The empty value for the String class is \
  not a valid value for the {0} annotation that is used on the {1} method of the \
  {2} repository.
 CWWKD1104.empty.anno.value.explanation=The empty value for the String class is \
- not a supported value. For example, if the annotation is a Param annotation, \
- then valid values are the named parameter names that are used within the Query \
- annotation value.
+ not a supported value. What the supported value is depends on the type of \
+ annotation. For example, if the annotation is a Param annotation, then valid \
+ values are the named parameter names that are used within the Query annotation \
+ value.
 CWWKD1104.empty.anno.value.useraction=If the annotation is not needed, \
  remove it from the repository method. Otherwise, specify a valid value for \
  the annotation.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1050,3 +1050,10 @@ CWWKD1103.incompat.query.result.useraction=If the type of entity attributes that
  or a different set of entity attributes that the Jakarta Persistence provider \
  allows. If the type of entity attributes that the method selects is allowed, \
  check for other causes of incompatibility.
+
+CWWKD1104.empty.anno.value=CWWKD1104E: The empty String is not a valid value for \
+ the {0} annotation that is used on the {1} method of the {2} repository.
+CWWKD1104.empty.anno.value.explanation=The empty String is not a supported value.
+CWWKD1104.empty.anno.value.useraction=If the annotation is not needed, \
+ remove it from the repository method. Otherwise, specify a valid value for \
+ the annotation.

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -70,6 +70,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1019E.*livingAt", // mix of named/positional parameters
                                    "CWWKD1019E.*residingAt", // unused parameters
                                    "CWWKD1022E.*discardPage", // Delete operation with a PageRequest
+                                   "CWWKD1024E.*inPrecinct", // @By with empty string value
+                                   "CWWKD1024E.*inTownship", // @OrderBy with empty string value
                                    "CWWKD1033E.*selectByFirstName", // CursoredPage with ORDER BY in Query
                                    "CWWKD1037E.*findByBirthdayOrderBySSN", // CursoredPage of non-entity
                                    "CWWKD1037E.*registrations", // CursoredPage of non-entity
@@ -99,7 +101,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1099E.*findFirst2", // Limit incompatible with First
                                    "CWWKD1099E.*findFirst3", // PageRequest incompatible with First
                                    "CWWKD1100E.*selectByLastName", // CursoredPage with ORDER BY clause
-                                   "CWWKD1101E.*nameAndZipCode" // Record return type with invalid attribute name
+                                   "CWWKD1101E.*nameAndZipCode", // Record return type with invalid attribute name
+                                   "CWWKD1104E.*inWard" // @Param with empty string value
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -481,6 +481,23 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Verify MappingException is raised if attempting to supply an empty string
+     * value instead of a valid entity attribute name to the By annotation.
+     */
+    @Test
+    public void testEmptyBy() {
+        try {
+            List<Voter> found = voters.inPrecinct(2);
+            fail("Queried on an empty string attribute name and found " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1024E:") ||
+                !x.getMessage().contains("inPrecinct"))
+                throw x;
+        }
+    }
+
+    /**
      * Verify IllegalArgumentException is raised if you attempt to delete an
      * empty list of entities.
      */
@@ -510,6 +527,40 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1092E:") ||
                 !x.getMessage().contains("register"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify MappingException is raised if attempting to supply an empty string
+     * value instead of a valid entity attribute name to the OrderBy annotation.
+     */
+    @Test
+    public void testEmptyOrderBy() {
+        try {
+            List<Voter> found = voters.inTownship("Haverhill");
+            fail("Ordered by an empty string attribute name and returned " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1024E:") ||
+                !x.getMessage().contains("inTownship"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify MappingException is raised if attempting to supply an empty string
+     * value instead of a valid named parameter name to the Param annotation.
+     */
+    @Test
+    public void testEmptyParam() {
+        try {
+            List<Voter> found = voters.inWard(3);
+            fail("Queried with an empty string named parameter and found " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1104E:") ||
+                !x.getMessage().contains("inWard"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -231,6 +231,30 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                            PageRequest pageReq);
 
     /**
+     * This invalid method has a By annotation where the value is an empty string
+     * instead of a valid entity attribute name.
+     */
+    @Find
+    List<Voter> inPrecinct(@By("") int precinct);
+
+    /**
+     * This invalid method has an OrderBy annotation where the value is an
+     * empty string instead of a valid entity attribute name.
+     */
+    @Query("WHERE address LIKE CONCAT('%;TOWNSHIP:', ?1, ';%')")
+    @OrderBy("address")
+    @OrderBy("")
+    @OrderBy("ssn")
+    List<Voter> inTownship(String name);
+
+    /**
+     * This invalid method has a Param annotation where the value is an empty string
+     * instead of a valid named parameter name.
+     */
+    @Query("WHERE address IS NOT NULL")
+    List<Voter> inWard(@Param("") int ward);
+
+    /**
      * This invalid method has 2 Limit parameters.
      */
     @Find


### PR DESCRIPTION
Error handling for when an empty string is supplied as the value for the Param, OrderBy, and By annotations.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
