### PR TITLE
Spec version detection for Jakarta Data

### DIFF
--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -75,6 +75,12 @@ public class Data_1_0 implements DataVersionCompatibility {
 
     @Override
     @Trivial
+    public boolean atLeast(int major, int minor) {
+        return major == 1 && minor == 0;
+    }
+
+    @Override
+    @Trivial
     public Annotation getCountAnnotation(Method method) {
         return null;
     }

--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -277,6 +277,12 @@ public class Data_1_1 implements DataVersionCompatibility {
 
     @Override
     @Trivial
+    public boolean atLeast(int major, int minor) {
+        return major == 1 && minor <= 1;
+    }
+
+    @Override
+    @Trivial
     public Annotation getCountAnnotation(Method method) {
         return method.getAnnotation(Count.class);
     }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -4252,14 +4252,23 @@ public class QueryInfo {
 
             StringBuilder q;
             if (selectLen > 0) {
-                q = new StringBuilder(ql.length() + (selectLen >= 0 ? 0 : 50) + (fromLen >= 0 ? 0 : 50) + 2);
                 String selection = ql.substring(select0, select0 + selectLen);
+                q = new StringBuilder(ql.length() + (selectLen >= 0 ? 0 : 50) + (fromLen >= 0 ? 0 : 50) + 2);
+                q.append("SELECT");
+                // TODO 1.1 use Jakarta Persistence enhancement issue 420 instead of
+                // editing the query
+                boolean insertConstructor = compat.atLeast(1, 1) &&
+                                            singleType.isRecord() &&
+                                            !selection.toUpperCase().contains(" NEW ");
+                if (insertConstructor)
+                    q.append(" NEW ").append(singleType.getName()).append('(');
                 if (insertEntityVar) {
-                    q.append("SELECT");
                     appendWithIdentifierName(ql, select0, select0 + selectLen, entityVar_, q);
                 } else {
-                    q.append("SELECT").append(selection);
+                    q.append(selection);
                 }
+                if (insertConstructor)
+                    q.append(") ");
                 if (fromLen == 0 && whereLen == 0 && orderLen == 0 &&
                     !Character.isWhitespace(q.charAt(q.length() - 1)))
                     q.append(' ');

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -61,6 +61,17 @@ public interface DataVersionCompatibility {
                                              Annotation[] annos);
 
     /**
+     * Indicates whether the enabled version of Jakarta Data is at the requested
+     * level or higher.
+     *
+     * @param major major version of Jakarta Data specification. Must be >= 1.
+     * @param minor minor version of Jakarta Data specification. Must be >= 0.
+     * @return true if at the requested level of Jakarta Data or higher,
+     *         otherwise false.
+     */
+    boolean atLeast(int major, int minor);
+
+    /**
      * Obtains the Count annotation if present on the method. Otherwise null.
      *
      * @param method repository method. Must not be null.

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -826,6 +826,15 @@ public class DataExperimentalServlet extends FATServlet {
     }
 
     /**
+     * Query method that selects multiple entity attributes and returns a record.
+     */
+    @Test
+    public void testQuerySelectsRecord() {
+        assertEquals(new Hexadecimal("2F", 47L),
+                     primes.toHexadecimal(47L).orElseThrow());
+    }
+
+    /**
      * Use the provided methods of a Repository<T, K> interface that is a copy of Jakarta NoSQL's.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Hexadecimal.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Hexadecimal.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.experimental.web;
+
+/**
+ * A record to use as a result type for selecting attributes of the Prime entity.
+ */
+public record Hexadecimal(
+                String numerals,
+                long decimalValue) {
+    /**
+     * Format in an easy way for tests to compare results.
+     */
+    @Override
+    public String toString() {
+        return "Hexadecimal " + numerals + " (" + decimalValue + ")";
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/PrimeNumbers.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/PrimeNumbers.java
@@ -31,6 +31,7 @@ import jakarta.data.repository.By;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Select;
 
@@ -86,6 +87,9 @@ public interface PrimeNumbers {
 
     @Count
     int numEvenWithSumOfBits(int sumOfBits, boolean even);
+
+    @Query("SELECT hex, numberId WHERE numberId = ?1")
+    Optional<Hexadecimal> toHexadecimal(long decimalValue);
 
     @Find
     @OrderBy("name")


### PR DESCRIPTION
Add specification version detection to the compatibility classes of Jakarta Data.
Use this to ensure multi-SELECT returning record fails in Data 1.0, so that we preserve the ability to implement it properly in Data 1.1 once API is added in Jakarta Persistence vNext for it.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
