### PR TITLE
log archive name in scanForBeanDefiningAnnotations

### DIFF
--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/BeanDeploymentArchiveImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/BeanDeploymentArchiveImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -192,6 +192,10 @@ public class BeanDeploymentArchiveImpl implements WebSphereBeanDeploymentArchive
     @Override
     public Set<String> scanForBeanDefiningAnnotations(boolean includeAccessible) throws CDIException {
 
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
+            Tr.entry(tc, "scanForBeanDefiningAnnotations [ " + getHumanReadableName() + " ] includeAccessible: " + includeAccessible);
+        }
+
         Set<String> beanDefiningAnnotations = new HashSet<String>(this.additionalBeanDefiningAnnotations);
 
         //these are the annotations directly in this BDA
@@ -219,6 +223,10 @@ public class BeanDeploymentArchiveImpl implements WebSphereBeanDeploymentArchive
             beanDefiningAnnotations.addAll(this.accessibleBeanDefiningAnnotations);
         }
 
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
+            Tr.exit(tc, "scanForBeanDefiningAnnotations [ " + getHumanReadableName() + " ] { " + beanDefiningAnnotations + " }");
+        }
+
         return beanDefiningAnnotations;
     }
 
@@ -242,7 +250,7 @@ public class BeanDeploymentArchiveImpl implements WebSphereBeanDeploymentArchive
                 // If the server.xml has the configuration of enableImplicitBeanArchives sets to false, we will not scan the implicit bean archives
                 beanDiscoveryMode = BeanDiscoveryMode.NONE;
             } else if (archive.getType() == ArchiveType.RUNTIME_EXTENSION) {
-                // Runtime extensions default to none as they are extension archives (and this means that only classes explicitly returned by getBeans() will be a bean. 
+                // Runtime extensions default to none as they are extension archives (and this means that only classes explicitly returned by getBeans() will be a bean.
                 // But if another component has added a beans.xml we will honour their request.
                 beanDiscoveryMode = BeanDiscoveryMode.NONE;
             }
@@ -300,7 +308,8 @@ public class BeanDeploymentArchiveImpl implements WebSphereBeanDeploymentArchive
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             String debugClassesString = this.beanClasses.entrySet().stream().filter(Objects::nonNull).map(entry -> entry.getKey() + " = "
-                                                                                                                   + entry.getValue().toString()).collect(Collectors.joining(", "));
+                                                                                                                   + entry.getValue().toString())
+                                                        .collect(Collectors.joining(", "));
             Tr.debug(tc, "scan [ " + getHumanReadableName() + " ] AFTER SCAN. Bean classes: { " + debugClassesString + "}");
         }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This adds some extra logging that would have helped the web container team in https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=301662