### PR TITLE
Revert "Ensure multiple TLS sipEndpoints can be started "

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2025 IBM Corporation and others.
+ * Copyright (c) 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -370,20 +370,12 @@ public class GenericEndpointImpl {
 			} 
 		}
 		else {
-			
+			isForcedDefaultEndpointIdDeactivate = true;
 			if (c_logger.isTraceDebugEnabled()){
-				c_logger.traceDebug("INFO: defaultSipEndpoint endpoint won't be activated as other sipendpoint is configured on the server!!!");
+				c_logger.traceDebug("defaultSipEndpoint endpoint wasn't activated since was configured other sipendpoint");
 			}
 			
-			//Do not remove defaultSipEndpont ID from configuration
-			//when other sipEndpoints are configured.
-			//By removing the defaultSipEndpointId from configuretions we
-			//also remove the ssl configuration, which results in
-			//TLS endpoints not coming online
-			//see open-liberty issue #30874
-
-			//isForcedDefaultEndpointIdDeactivate = true;
-			//removeDefaultSipEndpointIdFromConfiguration();
+			removeDefaultSipEndpointIdFromConfiguration();
 		}
 	}
 


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#30939 as it caused an unforeseen exception: [3/8/25, 7:43:01:040 PST] 0000008a LogService-87-com.ibm.ws.sipcontainer                        E CWWKE0701E: bundle com.ibm.ws.sipcontainer:1.0.99.cl250320250307-1902 (87)[com.ibm.ws.sip.stack.transport.GenericEndpointImpl(249)] : The deactivate method has thrown an exception org.osgi.service.component.ComponentException: Removing SIP endpoint from virtual host failed.
    at componenttest.topology.impl.LibertyServer.checkLogsForErrorsAndWarnings(LibertyServer.java:3505)
    at componenttest.topology.impl.WSLibertyServer.checkLogsForErrorsAndWarnings(WSLibertyServer.java:767)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3326)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3163)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3157)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3133)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3042)
    at test.rtcomm.connector.FATTest.stopServerIgnoreFailover(FATTest.java:158)
    at test.rtcomm.connector.FATTest.serverOperations(FATTest.java:178)
    at test.rtcomm.connector.FATTest.testWebrtcGwInternalInvite(FATTest.java:200)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:216)
    at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:381)
    at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:185)
