### PR TITLE
fix wim.core_FAT - add stopServer CWWKE1102W to ignore server quiesce timeouts

### DIFF
--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/ConfigManagerFeatureTest.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/ConfigManagerFeatureTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -62,7 +62,7 @@ public class ConfigManagerFeatureTest {
     public static void tearDown() throws Exception {
         Log.info(c, "tearDown", "Stopping the server...");
 
-        server.stopServer();
+        server.stopServer("CWWKE1102W"); //ignore server quiesce timeouts due to slow test machines
 
         server.uninstallUserBundle("com.ibm.ws.security.wim.repository_test.custom_1.0");
         server.uninstallUserFeature("customRepositorySample-1.0");

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/ConfigManagerInitModifyTest.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/ConfigManagerInitModifyTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -58,7 +58,8 @@ public class ConfigManagerInitModifyTest {
     public static void tearDown() throws Exception {
         Log.info(c, "tearDown", "Stopping the server...");
 
-        server.stopServer("CWIMK0004E");
+        server.stopServer("CWIMK0004E", "CWWKE1102W");
+        //added "CWWKE1102W" to ignore server quiesce timeouts due to slow test machines
 
     }
 

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/DynamicUpdateTest.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/DynamicUpdateTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -107,7 +107,8 @@ public class DynamicUpdateTest {
         Log.info(c, "tearDown", "Stopping the server...");
 
         try {
-            server.stopServer("CWIML1018E", "CWIML4538E", "CWWKG0027W");
+            server.stopServer("CWIML1018E", "CWIML4538E", "CWWKG0027W", "CWWKE1102W");
+            //added "CWWKE1102W" to ignore server quiesce timeouts due to slow test machines
         } finally {
             server.removeInstalledAppForValidation("userRegistry");
             server.deleteFileFromLibertyInstallRoot("lib/features/internalfeatures/securitylibertyinternals-1.0.mf");

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/InvalidBaseEntryInRealmTest.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/InvalidBaseEntryInRealmTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -92,7 +92,8 @@ public class InvalidBaseEntryInRealmTest {
         Log.info(c, "tearDown", "Stopping the server...");
 
         try {
-            server.stopServer("CWIML0515E");
+            server.stopServer("CWIML0515E", "CWWKE1102W");
+            //added "CWWKE1102W" to ignore server quiesce timeouts due to slow test machines
         } finally {
             server.removeInstalledAppForValidation("userRegistry");
             server.deleteFileFromLibertyInstallRoot("lib/features/internalfeatures/securitylibertyinternals-1.0.mf");

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/MaxSearchResultTest.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/MaxSearchResultTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -82,7 +82,8 @@ public class MaxSearchResultTest {
         Log.info(c, "tearDown", "Stopping the server...");
 
         try {
-            server.stopServer("CWIML1018E");
+            server.stopServer("CWIML1018E", "CWWKE1102W");
+            //added "CWWKE1102W" to ignore server quiesce timeouts due to slow test machines
         } finally {
             server.removeInstalledAppForValidation("userRegistry");
             server.deleteFileFromLibertyInstallRoot("lib/features/internalfeatures/securitylibertyinternals-1.0.mf");

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/NoRegistryConfiguredTest.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/NoRegistryConfiguredTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -87,7 +87,8 @@ public class NoRegistryConfiguredTest {
         Log.info(c, "tearDown", "Stopping the server...");
 
         try {
-            server.stopServer("CWWKG0032W", "CWWKG0058E", "CWIMK0011E");
+            server.stopServer("CWWKG0032W", "CWWKG0058E", "CWIMK0011E", "CWWKE1102W");
+            //added "CWWKE1102W" to ignore server quiesce timeouts due to slow test machines
         } finally {
             server.removeInstalledAppForValidation("userRegistry");
             server.deleteFileFromLibertyInstallRoot("lib/features/internalfeatures/securitylibertyinternals-1.0.mf");

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/WimCoreRegressionTest.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/WimCoreRegressionTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -79,7 +79,8 @@ public class WimCoreRegressionTest {
     public static void teardownClass() throws Exception {
         try {
             if (libertyServer != null) {
-                libertyServer.stopServer();
+                libertyServer.stopServer("CWWKE1102W");
+                //added "CWWKE1102W" to ignore server quiesce timeouts due to slow test machines
             }
         } finally {
             try {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Fixes RTC 302821

It is common issue across all FATs when tests are run on a slow test machine more prone to timeouts

Fix: ignore the timeout warning
`server.stopServer("CWWKE1102W"); //ignore server quiesce timeouts due to slow test machines`

Tested locally: ./gradlew com.ibm.ws.security.wim.core_fat:buildandrun