### PR TITLE
fix: testcontainer error paths

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/containers/registry/InternalRegistry.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/registry/InternalRegistry.java
@@ -38,6 +38,8 @@ public class InternalRegistry extends Registry {
 
     private static final String DEFAULT_REGISTRY = ""; //Blank registry is the default setting
 
+    private static final String REGISTRY_REGEX = ".*fyre\\.ibm\\.com:\\d{4}";
+
     private static final HashMap<String, String> REGISTRY_MIRRORS = new HashMap<>();
     static {
         REGISTRY_MIRRORS.put("NONE", "wasliberty-infrastructure-docker"); // images we cache (from sources like dockerhub)
@@ -71,6 +73,12 @@ public class InternalRegistry extends Registry {
             registry = DEFAULT_REGISTRY;
             isRegistryAvailable = false;
             setupException = t;
+            return;
+        }
+
+        if (!validRegistryName(registry)) {
+            isRegistryAvailable = false;
+            setupException = new IllegalStateException("The configured Internal registry was invalid and should have matched the regex: " + REGISTRY_REGEX);
             return;
         }
 
@@ -176,6 +184,20 @@ public class InternalRegistry extends Registry {
                         .filter(mirror -> modified.getRepository().startsWith(mirror))
                         .findAny()
                         .isPresent();
+    }
+
+    @Override
+    public boolean validRegistryName(String registry) {
+        return registry.matches(REGISTRY_REGEX);
+    }
+
+    @Override
+    public boolean validDockerImageName(DockerImageName image) {
+        if (image.getRegistry() == null || image.getRegistry().isEmpty()) {
+            return false;
+        }
+
+        return validRegistryName(image.getRegistry());
     }
 
     @Override

--- a/dev/fattest.simplicity/src/componenttest/containers/registry/Registry.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/registry/Registry.java
@@ -96,6 +96,22 @@ public abstract class Registry {
      */
     public abstract String getMirrorRepository(DockerImageName original) throws IllegalArgumentException;
 
+    /**
+     * Validates the name of the registry to ensure it was configured correctly.
+     *
+     * @param  registry the name of the registry that has been found
+     * @return          true if valid, false otherwise
+     */
+    public abstract boolean validRegistryName(String registry);
+
+    /**
+     * Validates the docker image name has a registry, and that the registry name is valid.
+     *
+     * @param  image the image name
+     * @return       true iff the docker image name has a registry and that registry is valid, false otherwise.
+     */
+    public abstract boolean validDockerImageName(DockerImageName image);
+
     // SETUP METHODS
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/containers/substitution/LibertyImageNameSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/substitution/LibertyImageNameSubstitutor.java
@@ -53,9 +53,9 @@ public class LibertyImageNameSubstitutor extends ImageNameSubstitutor {
             // Priority 2a: If the image is known to only exist in an Artifactory organization
             // This is now handled directly by the MIRROR substitutor
 
-            // Priority 2b: If the image is known to only exist in an Artifactory registry
-            if (original.getRegistry() != null && original.getRegistry().contains("artifactory.swg-devops.com")) {
-                throw new RuntimeException("Not all developers of Open Liberty have access to artifactory, must use a public registry.");
+            // Priority 2b: If the image is known to only exist in the Artifactory or Internal registry
+            if (ArtifactoryRegistry.instance().validDockerImageName(original) || InternalRegistry.instance().validDockerImageName(original)) {
+                throw new RuntimeException("Not all developers of Open Liberty have access to the Artifactory or Internal registries, must use a public registry.");
             }
 
             // Priority 3: If a public registry was explicitly set on an image, do not substitute

--- a/dev/fattest.simplicity/test/componenttest/containers/registry/ArtifactoryRegistryTest.java
+++ b/dev/fattest.simplicity/test/componenttest/containers/registry/ArtifactoryRegistryTest.java
@@ -108,6 +108,16 @@ public class ArtifactoryRegistryTest {
 
         assertFalse("Registry should not have been available", registry.isRegistryAvailable());
 
+        // invalid registry
+        System.setProperty(REGISTRY, "example.com");
+        registry = getConstructor().newInstance();
+
+        t = registry.getSetupException();
+        assertNotNull(t);
+        assertTrue("Throwable should have been an IllegalStateException", t instanceof IllegalStateException);
+
+        assertFalse("Registry should not have been available", registry.isRegistryAvailable());
+
         // no user
         System.setProperty(REGISTRY, "artifactory.swg-devops.com");
         registry = getConstructor().newInstance();

--- a/dev/fattest.simplicity/test/componenttest/containers/registry/InternalRegistryTest.java
+++ b/dev/fattest.simplicity/test/componenttest/containers/registry/InternalRegistryTest.java
@@ -87,8 +87,18 @@ public class InternalRegistryTest {
 
         assertFalse("Registry should not have been available", registry.isRegistryAvailable());
 
+        // invalid registry
+        System.setProperty(REGISTRY, "example.com");
+        registry = getConstructor().newInstance();
+
+        t = registry.getSetupException();
+        assertNotNull(t);
+        assertTrue("Throwable should have been an IllegalStateException", t instanceof IllegalStateException);
+
+        assertFalse("Registry should not have been available", registry.isRegistryAvailable());
+
         // no user
-        System.setProperty(REGISTRY, "127.0.0.1");
+        System.setProperty(REGISTRY, "example.fyre.ibm.com:0000");
         registry = getConstructor().newInstance();
 
         t = registry.getSetupException();

--- a/dev/io.openliberty.org.testcontainers/resources/openliberty/testcontainers/db2-krb5/12.1.1.0/Dockerfile
+++ b/dev/io.openliberty.org.testcontainers/resources/openliberty/testcontainers/db2-krb5/12.1.1.0/Dockerfile
@@ -26,5 +26,5 @@ RUN yum -y install krb5-workstation krb5-libs
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-//TODO This currently does not work need to do more debugging to figure out
-//why the database cannot be restarted after enabling kerberos
+# TODO This currently does not work need to do more debugging to figure out
+# why the database cannot be restarted after enabling kerberos

--- a/dev/io.openliberty.org.testcontainers/resources/openliberty/testcontainers/postgres-ssl/17/Dockerfile
+++ b/dev/io.openliberty.org.testcontainers/resources/openliberty/testcontainers/postgres-ssl/17/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_IMAGE="public.ecr.aws/docker/library/postgres:17"
 
 FROM ${BASE_IMAGE}
 
-COPY startup/db2_startup.sh /tmp/db2_startup.sh
+COPY startup/postgre_startup.sh /tmp/postgre_startup.sh
 RUN chmod 777 /tmp/postgre_startup.sh && /tmp/postgre_startup.sh
 
 # Passing locally 02/21/2024


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Fix testcontainer config errors that could occur when tests run back to back with new/old configures.
- Validate the registry name for Artifactory and Internal registries to ensure developers actually read setup instructions and configure these correctly.
- Fix failures reported for custom docker image build failures