### PR TITLE
Netty keep alive properties

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -2289,16 +2289,11 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
             String closeNonUpgraded = (String) (this.myVC.getStateMap().get(TransportConstants.CLOSE_NON_UPGRADED_STREAMS));
             // Shouldn't close upgraded requests
             boolean upgradedRequest = closeNonUpgraded != null && closeNonUpgraded.equalsIgnoreCase("true");
-            if (!upgradedRequest && (!myChannelConfig.isKeepAliveEnabled() || nettyContext.channel().attr(NettyHttpConstants.NUMBER_OF_HTTP_REQUESTS).get() >= myChannelConfig.getMaximumPersistentRequests())) {
+            if (!upgradedRequest && (!myChannelConfig.isKeepAliveEnabled() || (myChannelConfig.getMaximumPersistentRequests() != -1 && nettyContext.channel().attr(NettyHttpConstants.NUMBER_OF_HTTP_REQUESTS).get() >= myChannelConfig.getMaximumPersistentRequests()))) {
                 // Keep alive disabled or exceeded maximum number of keep alive requests
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "sendHeaders: Adding close connection header due to keep alive disabled or exceeded number of maximum persistent requests");
                 }
-                System.out.println("sendHeaders: Adding close connection header due to keep alive disabled or exceeded number of maximum persistent requests");
-                System.out.println("VC Map content: ");
-                myVC.getStateMap().forEach((key, value) -> {
-                    System.out.println(key + "->" + value);
-                });
                 response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
             }
             if (HttpUtil.isContentLengthSet(response)) {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyHttpConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyHttpConstants.java
@@ -33,5 +33,6 @@ public class NettyHttpConstants {
     public static final AttributeKey<String> ENDPOINT_PID = AttributeKey.valueOf("endpointPID");
     public static final AttributeKey<Boolean> HANDLING_REQUEST = AttributeKey.valueOf("handlingRequest");
     public static final AttributeKey<Boolean> THROW_FFDC = AttributeKey.valueOf("throwFFDC");
+    public static final AttributeKey<Integer> NUMBER_OF_HTTP_REQUESTS = AttributeKey.valueOf("numberOfHttpRequests");
 
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/HttpDispatcherHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/HttpDispatcherHandler.java
@@ -65,6 +65,7 @@ public class HttpDispatcherHandler extends SimpleChannelInboundHandler<FullHttpR
     public void handlerAdded(ChannelHandlerContext ctx) {
         // Store the context for later use
         context = ctx;
+        context.channel().attr(NettyHttpConstants.NUMBER_OF_HTTP_REQUESTS).set(0);
     }
 
     // Method to allow direct invocation
@@ -218,6 +219,8 @@ public class HttpDispatcherHandler extends SimpleChannelInboundHandler<FullHttpR
             context.channel().attr(NettyHttpConstants.CONTENT_LENGTH).set(null);
 
         }
+        int numberOfRequests = context.channel().attr(NettyHttpConstants.NUMBER_OF_HTTP_REQUESTS).get();
+        context.channel().attr(NettyHttpConstants.NUMBER_OF_HTTP_REQUESTS).set(numberOfRequests+1);
         link.init(context, request, config);
         link.ready();
     }


### PR DESCRIPTION
Added logic for keep alive http options in Netty. Fixes `maxKeepAliveRequests` and `keepAliveEnabled` not implemented