### PR TITLE
OrderBy clause that contains an entity attribute name with a reserved keyword

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1062,3 +1062,14 @@ CWWKD1104.empty.anno.value.explanation=The empty value for the String class is \
 CWWKD1104.empty.anno.value.useraction=If the annotation is not needed, \
  remove it from the repository method. Otherwise, specify a valid value for \
  the annotation.
+
+CWWKD1105.keyword.in.orderby=CWWKD1105E: The OrderBy clause of the {0} method \
+ of the {1} repository cannot be parsed because the {2} entity attribute of the \
+ {3} entity contains the {4} keyword of the Jakarta Data Query by Method Name \
+ pattern. Remove the OrderBy clause from the {0} method name and use the \
+ OrderBy annotation instead.
+CWWKD1105.keyword.in.orderby.explanation=Entity attribute names that contain \
+ Jakarta Data keywords cannot be used in the names of repository methods that \
+ follow the Jakarta Data Query by Method Name pattern.
+CWWKD1105.keyword.in.orderby.useraction=Rename the entity attribute or switch \
+ to the OrderBy annotation to specify the ordering.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -4991,6 +4991,25 @@ public class QueryInfo {
 
             String attribute = methodName.substring(i, endBefore);
 
+            if (attribute.length() == 0) {
+                // Error handling for missing attribute name due to Asc or Desc
+                // appearing within an attribute name that is used in the OrderBy
+                String lowerOrderBy = methodName.substring(orderBy + 7).toLowerCase();
+                for (String lowerAttrName : entityInfo.attributeNames.keySet()) {
+                    String keyword = lowerAttrName.contains("asc") ? "Asc" //
+                                    : lowerAttrName.contains("desc") ? "Desc" //
+                                                    : null;
+                    if (keyword != null && lowerOrderBy.contains(lowerAttrName))
+                        throw exc(MappingException.class,
+                                  "CWWKD1105.keyword.in.orderby",
+                                  methodName,
+                                  repositoryInterface.getName(),
+                                  entityInfo.attributeNames.get(lowerAttrName),
+                                  entityInfo.getType().getName(),
+                                  keyword);
+                }
+            }
+
             addSort(ignoreCase, attribute, descending);
 
             if (iNext > 0)

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -49,10 +49,6 @@ public class DataTest extends FATServletClient {
      */
     static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
-                                   "CWWKD1054E.*deleteByDescription",
-                                   "CWWKD1054E.*deleteFirst",
-                                   "CWWKD1054E.*findAsLongBetween",
-                                   "CWWKD1054E.*findByNumberIdBetween",
                                    "CWWKD1075E.*Apartment2",
                                    "CWWKD1075E.*Apartment3",
                                    // work around to prevent bad behavior from EclipseLink (see #30575)

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -49,10 +49,6 @@ public class DataTest extends FATServletClient {
      */
     static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
-                                   "CWWKD1046E.*minMaxSumCountAverageFloat",
-                                   "CWWKD1046E.*singleHexDigit",
-                                   "CWWKD1047E.*numberAsByte",
-                                   "CWWKD1049E.*countAsBooleanByNumberIdLessThan",
                                    "CWWKD1054E.*deleteByDescription",
                                    "CWWKD1054E.*deleteFirst",
                                    "CWWKD1054E.*findAsLongBetween",

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -577,22 +577,8 @@ public class DataTestServlet extends FATServlet {
         assertEquals((byte) 41,
                      primes.numberAsByte(41));
 
-        try {
-            byte result = primes.numberAsByte(4021);
-            fail("Should not convert long value 4021 to byte value " + result);
-        } catch (MappingException x) {
-            // expected - out of range
-        }
-
         assertEquals((byte) 37,
                      primes.numberAsByteWrapper(37).orElseThrow().byteValue());
-
-        try {
-            Optional<Byte> result = primes.numberAsByteWrapper(4019);
-            fail("Should not convert long value 4019 to Byte value " + result);
-        } catch (MappingException x) {
-            // expected - out of range
-        }
 
         assertEquals(4003.0, primes.numberAsDouble(4003), 0.01);
 
@@ -637,19 +623,6 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(false,
                      primes.singleHexDigit(12).isPresent());
-
-        try {
-            Optional<Character> found = primes.singleHexDigit(29);
-            fail("Should not be able to return hex 1D as a single character: " +
-                 found);
-        } catch (MappingException x) {
-            if (x.getMessage() != null &&
-                x.getMessage().startsWith("CWWKD1046E") &&
-                x.getMessage().contains("singleHexDigit"))
-                ; // pass
-            else
-                throw x;
-        }
     }
 
     /**
@@ -666,20 +639,6 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testCountAsBigInteger() {
         assertEquals(BigInteger.valueOf(13L), primes.countAsBigIntegerByNumberIdLessThan(43));
-    }
-
-    /**
-     * Repository method that returns the count as a boolean value,
-     * which is not an allowed return type. This must raise an error.
-     */
-    @Test
-    public void testCountAsBoolean() {
-        try {
-            boolean count = primes.countAsBooleanByNumberIdLessThan(42);
-            fail("Count queries cannot have a boolean return type: " + count);
-        } catch (MappingException x) {
-            // expected
-        }
     }
 
     /**
@@ -3677,18 +3636,6 @@ public class DataTestServlet extends FATServlet {
         assertEquals(197, ints[2]); // sum
         assertEquals(12, ints[3]); // count
         assertEquals(16, ints[4]); // average
-
-        try {
-            float[] floats = primes.minMaxSumCountAverageFloat(35);
-            fail("Allowed unsafe conversion from double to float: " +
-                 Arrays.toString(floats));
-        } catch (MappingException x) {
-            if (x.getMessage().startsWith("CWWKD1046E") &&
-                x.getMessage().contains("float[]"))
-                ; // unsafe to convert double to float
-            else
-                throw x;
-        }
 
         List<Long> list = primes.minMaxSumCountAverageList(30);
         assertEquals(Long.valueOf(2L), list.get(0)); // minimum

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -67,7 +67,6 @@ import jakarta.data.Sort;
 import jakarta.data.exceptions.EmptyResultException;
 import jakarta.data.exceptions.EntityExistsException;
 import jakarta.data.exceptions.MappingException;
-import jakarta.data.exceptions.NonUniqueResultException;
 import jakarta.data.exceptions.OptimisticLockingFailureException;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
@@ -1046,14 +1045,6 @@ public class DataTestServlet extends FATServlet {
         packages.save(new Package(10003, 12.0f, 11.0f, 4.0f, "testDeleteIgnoresFirstKeywork#10003"));
         packages.save(new Package(10004, 13.0f, 10.0f, 4.0f, "testDeleteIgnoresFirstKeywork#10004"));
 
-        try {
-            Optional<Package> pkg = packages.deleteFirst();
-            fail("Expected packages.deleteFirst() to ignore the 'first' keyword" +
-                 " and fail to return a signular result. Instead returned: " + pkg);
-        } catch (NonUniqueResultException e) {
-            // pass
-        }
-
         Package pkg = packages.deleteFirst5ByWidthLessThan(10.5f);
         assertEquals(10004, pkg.id);
 
@@ -1597,13 +1588,6 @@ public class DataTestServlet extends FATServlet {
         assertEquals(14.0f, p1.width, 0.01f);
         assertEquals(4.0f, p1.height, 0.01f);
         assertEquals("testFindAndDelete#40001", p1.description);
-
-        try {
-            Optional<Package> p = packages.deleteByDescription("testFindAndDelete#4001x");
-            fail("Should get NonUniqueResultException when there are multiple results but a singular return type. Instead, result is: " + p);
-        } catch (NonUniqueResultException x) {
-            // expected
-        }
 
         String jdbcJarName = System.getenv().getOrDefault("DB_DRIVER", "UNKNOWN");
         boolean supportsOrderByForUpdate = !jdbcJarName.startsWith("derby");
@@ -5163,43 +5147,11 @@ public class DataTestServlet extends FATServlet {
         Prime p = primes.findByNumberIdBetween(14L, 18L);
         assertEquals(17L, p.numberId);
 
-        // No result must raise EmptyResultException:
-        try {
-            p = primes.findByNumberIdBetween(24L, 28L);
-            fail("Unexpected prime " + p);
-        } catch (EmptyResultException x) {
-            // expected
-        }
-
-        // Multiple results must raise NonUniqueResultException:
-        try {
-            p = primes.findByNumberIdBetween(34L, 48L);
-            fail("Should find more primes than " + p);
-        } catch (NonUniqueResultException x) {
-            // expected
-        }
-
         // With custom return type:
 
         // Single result is fine:
         long n = primes.findAsLongBetween(12L, 16L);
         assertEquals(13L, n);
-
-        // No result must raise EmptyResultException:
-        try {
-            n = primes.findAsLongBetween(32L, 36L);
-            fail("Unexpected prime number " + n);
-        } catch (EmptyResultException x) {
-            // expected
-        }
-
-        // Multiple results must raise NonUniqueResultException:
-        try {
-            n = primes.findAsLongBetween(22L, 42L);
-            fail("Should find more prime numbers than " + n);
-        } catch (NonUniqueResultException x) {
-            // expected
-        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -63,8 +63,6 @@ public interface Packages extends BasicRepository<Package, Integer> {
 
     Package deleteFirst5ByWidthLessThan(float maxWidth); // 'first5' should be ignored and the number of results should be limited by the condition
 
-    Optional<Package> deleteFirst(); // 'first' should be ignored and this should delete all entities (expect failure since the result will be non-unique)
-
     @Delete
     Object[] destroy(Limit limit, Sort<Package> sort);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -79,9 +79,6 @@ public interface Primes {
 
     BigInteger countAsBigIntegerByNumberIdLessThan(long number);
 
-    // boolean return type is not allowed for count methods
-    boolean countAsBooleanByNumberIdLessThan(long number);
-
     int countAsIntByNumberIdLessThan(long number);
 
     Integer countAsIntegerByNumberIdBetween(long first, long last);
@@ -307,11 +304,6 @@ public interface Primes {
            "       COUNT(o.numberId), AVG(o.numberId) " +
            "  FROM Prime o WHERE o.numberId < ?1")
     Deque<Double> minMaxSumCountAverageDeque(long numBelow);
-
-    @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId)," +
-           "       COUNT(o.numberId), CAST(AVG(o.numberId) AS FLOAT)" +
-           "  FROM Prime o WHERE o.numberId < ?1")
-    float[] minMaxSumCountAverageFloat(long numBelow);
 
     @Query("SELECT MIN(o.numberId), MAX(o.numberId), SUM(o.numberId)," +
            "       COUNT(o.numberId), CAST(AVG(o.numberId) AS INTEGER)" +

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -85,6 +85,10 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1047E.*ssnAsByte", // unsafe conversion to byte
                                    "CWWKD1049E.*countAsBooleanBySSNLessThan", // count returning boolean
                                    "CWWKD1049E.*countByBirthday", // count returning Page<Long>
+                                   "CWWKD1054E.*deleteByNameStartsWith", // NonUniqueResultException
+                                   "CWWKD1054E.*deleteFirst", // NonUniqueResultException
+                                   "CWWKD1054E.*findBySSNBetweenAndNameNotNull", // NonUniqueResultException
+                                   "CWWKD1054E.*findSSNAsLongBetween", // NonUniqueResultException
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",
                                    "CWWKD1078E.*test.jakarta.data.errpaths.web.InvalidNonJNDIRepo",
                                    "CWWKD1079E.*test.jakarta.data.errpaths.web.InvalidJNDIRepo",

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -115,7 +115,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1099E.*findFirst3", // PageRequest incompatible with First
                                    "CWWKD1100E.*selectByLastName", // CursoredPage with ORDER BY clause
                                    "CWWKD1101E.*nameAndZipCode", // Record return type with invalid attribute name
-                                   "CWWKD1104E.*inWard" // @Param with empty string value
+                                   "CWWKD1104E.*inWard", // @Param with empty string value
+                                   "CWWKD1105E.*findByNameNotNullOrderByDescriptionAsc" // keyword in OrderBy
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -80,7 +80,11 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1037E.*findByBirthdayOrderBySSN", // CursoredPage of non-entity
                                    "CWWKD1037E.*registrations", // CursoredPage of non-entity
                                    "CWWKD1041E.*findBySsnBetweenAnd.*NotNull", // CursoredPage without PageRequest
-                                   "CWWKD1049E.*countByBirthday", // exists method returning Page<Long>
+                                   "CWWKD1046E.*firstLetterOfName", // unsafe conversion to Character
+                                   "CWWKD1046E.*minMaxSumCountAverageFloat", // unsafe conversion to float
+                                   "CWWKD1047E.*ssnAsByte", // unsafe conversion to byte
+                                   "CWWKD1049E.*countAsBooleanBySSNLessThan", // count returning boolean
+                                   "CWWKD1049E.*countByBirthday", // count returning Page<Long>
                                    "CWWKD1077E.*test.jakarta.data.errpaths.web.RepoWithoutDataStore",
                                    "CWWKD1078E.*test.jakarta.data.errpaths.web.InvalidNonJNDIRepo",
                                    "CWWKD1079E.*test.jakarta.data.errpaths.web.InvalidJNDIRepo",

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -169,6 +169,82 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Verify an error is raised when a value cannot be safely converted to byte.
+     */
+    @Test
+    public void testConvertToByte() {
+        try {
+            byte result = voters.ssnAsByte(123445678);
+            fail("Should not convert int value 123445678 to byte value " + result);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
+
+        try {
+            Optional<Byte> result = voters.ssnAsByteWrapper(987665432);
+            fail("Should not convert int value 987665432 to Byte value " + result);
+        } catch (MappingException x) {
+            // expected - out of range
+        }
+    }
+
+    /**
+     * Verify an error is raised when a String cannot be safely converted to char
+     * because it contains more than 1 character.
+     */
+    @Test
+    public void testConvertToChar() {
+        try {
+            Optional<Character> found = voters.firstLetterOfName(987665432);
+            fail("Should not be able to return a 6 character String as a" +
+                 " single character: " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() != null &&
+                x.getMessage().startsWith("CWWKD1046E") &&
+                x.getMessage().contains("firstLetterOfName"))
+                ; // pass
+            else
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised when a value cannot be safely converted to float.
+     */
+    @Test
+    public void testConvertToFloat() {
+        try {
+            float[] floats = voters.minMaxSumCountAverageFloat(999999999);
+            fail("Allowed unsafe conversion from integer to float: " +
+                 Arrays.toString(floats));
+        } catch (MappingException x) {
+            if (x.getMessage().startsWith("CWWKD1046E") &&
+                x.getMessage().contains("float[]"))
+                ; // unsafe to convert double to float
+            else
+                throw x;
+        }
+    }
+
+    /**
+     * Repository method that returns the count as a boolean value,
+     * which is not an allowed return type. This must raise an error.
+     */
+    @Test
+    public void testCountAsBoolean() {
+        try {
+            boolean count = voters.countAsBooleanBySSNLessThan(420000000);
+            fail("Count queries cannot have a boolean return type: " + count);
+        } catch (MappingException x) {
+            if (x.getMessage().startsWith("CWWKD1049E") &&
+                x.getMessage().contains("boolean"))
+                ; // cannot convert number to boolean
+            else
+                throw x;
+        }
+    }
+
+    /**
      * Verify an error is raised when a count Query by Method Name method
      * tries to return a long value as a Page of Long.
      */

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -1891,6 +1891,27 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Verify that an appropriate error is raised when a repository method name for
+     * Query by Method Name includes a reserved keyword in the OrderBy part of the
+     * method name.
+     */
+    @Test
+    public void testReservedKeywordInOrderByOfMethodName() {
+        try {
+            List<Voter> found = voters.findByNameNotNullOrderByDescriptionAsc();
+            fail("Should not be able to OrderBy an entity attribute name that" +
+                 " contains a reserved keyword. Found: " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() != null &&
+                x.getMessage().startsWith("CWWKD1105E") &&
+                x.getMessage().contains("findByNameNotNullOrderByDescriptionAsc"))
+                ; // expected
+            else
+                throw x;
+        }
+    }
+
+    /**
      * Tests an error path where a repository method attempts to return a subset of
      * an entity as a record where the record component names do not all match the
      * entity attribute names.

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voter.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,8 @@ public class Voter {
     @Column(nullable = false)
     public LocalDate birthday;
 
+    public String description;
+
     @Id
     @Column(nullable = false)
     public int ssn;
@@ -44,6 +46,7 @@ public class Voter {
         this.name = name;
         this.birthday = birthday;
         this.address = address;
+        this.description = name + " born on " + birthday + " and living at " + address;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -124,6 +124,11 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     void changeNothing();
 
     /**
+     * Boolean return type is not allowed for count methods.
+     */
+    boolean countAsBooleanBySSNLessThan(long ssnBelow);
+
+    /**
      * Invalid return type Boolean is not the entity or Id.
      */
     Page<Boolean> deleteReturnBooleanByAddress(String address,
@@ -265,6 +270,12 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                                     String address);
 
     /**
+     * This method is invalid for all names with more than 1 character.
+     */
+    @Query("SELECT name WHERE ssn=?1")
+    Optional<Character> firstLetterOfName(int ssn);
+
+    /**
      * This invalid method defines an ordering for results of a delete operation
      * but has a return type that disallows returning results.
      */
@@ -359,6 +370,16 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     List<Voter> livingOn(@Param("street") String street,
                          @Param("city") String city, // extra, unused Param
                          @Param("state") String stateCode); // extra, unused Param
+
+    /**
+     * This invalid method returns values that cannot all be converted to float.
+     */
+    @Query("""
+                    SELECT MIN(o.ssn), MAX(o.ssn), SUM(o.ssn),
+                           COUNT(o.ssn), CAST(AVG(o.ssn) AS FLOAT)
+                      FROM Voter o WHERE o.ssn < ?1
+                    """)
+    float[] minMaxSumCountAverageFloat(long numBelow);
 
     /**
      * Find method that returns a record instead of an entity,
@@ -480,6 +501,18 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     @OrderBy("birthday")
     @OrderBy("zipcode")
     List<Voter> sortedByZipCode();
+
+    /**
+     * Invalid method for 9 digit SSN.
+     */
+    @Query("SELECT ssn WHERE ssn=?1")
+    byte ssnAsByte(long ssn);
+
+    /**
+     * Invalid method for 9 digit SSN.
+     */
+    @Query("SELECT ssn WHERE ssn=:s")
+    Optional<Byte> ssnAsByteWrapper(@Param("s") long ssn);
 
     /**
      * Invalid method. A method with a life cycle annotation must have exactly

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -238,6 +238,12 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     List<Voter> findByIgnoreCaseContains(String address);
 
     /**
+     * This invalid method name contains an entity attribute name "Description"
+     * that contains a reserved keyword, "Desc".
+     */
+    List<Voter> findByNameNotNullOrderByDescriptionAsc();
+
+    /**
      * Unsupported pattern: lacks PageRequest parameter.
      */
     @OrderBy("ssn")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -129,6 +129,17 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     boolean countAsBooleanBySSNLessThan(long ssnBelow);
 
     /**
+     * Fails if more than one match.
+     */
+    Optional<Voter> deleteByNameStartsWith(String namePrefix);
+
+    /**
+     * 'first' should be ignored and this should delete all entities
+     * or cause failure if when the result would be non-unique
+     */
+    Optional<Voter> deleteFirst();
+
+    /**
      * Invalid return type Boolean is not the entity or Id.
      */
     Page<Boolean> deleteReturnBooleanByAddress(String address,
@@ -242,6 +253,11 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                                                            int max,
                                                            Sort<?>... orderBy);
 
+    /**
+     * Only valid when the range has exactly 1 result.
+     */
+    Voter findBySSNBetweenAndNameNotNull(long min, long max);
+
     List<Voter> findBySsnLessThanEqualOrderBySsnDesc(int max, Limit limit);
 
     /**
@@ -274,6 +290,12 @@ public interface Voters extends BasicRepository<Voter, Integer> {
      */
     @Query("SELECT name WHERE ssn=?1")
     Optional<Character> firstLetterOfName(int ssn);
+
+    /**
+     * Only valid when the range has exactly 1 result.
+     */
+    @Query("SELECT v.ssn FROM Voter v WHERE v.ssn >= ?1 AND v.ssn <= ?2")
+    long findSSNAsLongBetween(long min, long max);
 
     /**
      * This invalid method defines an ordering for results of a delete operation


### PR DESCRIPTION
This PR adds error handling (and a test case) for a Query by Method Name OrderBy clausing containing an entity attribute name that contains a reserved keyword like Desc or Asc.  Previously this was detected as a missing entity attribute name with a message that is very confusing to the user.  The new message explains the problem better and indicates how it can be fixed.

Also, two commits under this PR move error path testing out of the core Data bucket and into the error paths bucket.  These are split out for ease of reviewing.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
