### PR TITLE
feat: introduce docker config file getter for registries

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/containers/registry/Registry.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/registry/Registry.java
@@ -49,6 +49,16 @@ public abstract class Registry {
     public abstract String getRegistry();
 
     /**
+     * Get the auth config file if it exists and is known to
+     * contain the auth data as an encoded token.
+     *
+     * @return Optional - empty if the file does not exist
+     *         or does not contain the auth data for this registry
+     *         or the auth data for this registry is not an encoded token.
+     */
+    public abstract Optional<File> getAuthConfigFile();
+
+    /**
      * If this registry in unavailable this method
      * will return the exception that made the registry
      * unavailable.
@@ -172,11 +182,13 @@ public abstract class Registry {
      * First, find or create a config file (config.json) in the provided configDir location.
      *
      * Then, search the config file, and perform one of the following actions for the provided registry:
-     * - Append: If no auth element existed for this registry,
-     *           then add a new auth element with this authToken
+     * - Append:  If no auth element existed for this registry,
+     *            then add a new auth element with this authToken
      * - Replace: If an auth element existed for this registry but the auth tokens do not match,
      *            then replace it with the one provided to this method.
-     * - Return: If an auth element existed for this registry and the auth tokens match,
+     * - Return:  If an auth element existed for this registry and the auth tokens match,
+     *            then return without making any changes.
+     * - Skip:    If an auth element exists for this registry and no auth token is configured,
      *            then return without making any changes.
      * </pre>
      *
@@ -185,8 +197,11 @@ public abstract class Registry {
      * @param  configDir The directory where an config.json file should be located.
      *
      * @throws Exception For issues parsing the config file.
+     *
+     * @return           Optional of an auth config file if we Append, Replace, or Return.
+     *                   Empty if we Skip
      */
-    protected static File persistAuthToken(final String registry, final String authToken, final File configDir) throws Exception {
+    protected static Optional<File> persistAuthToken(final String registry, final String authToken, final File configDir) throws Exception {
 
         final String m = "persistAuthToken";
 
@@ -215,13 +230,13 @@ public abstract class Registry {
                 Optional<String> found = findExistingConfig(root, registry);
                 if (found.isPresent() && found.get().equals(authToken)) {
                     Log.info(c, m, "Config already contains the correct auth token for registry: " + registry);
-                    return configFile;
+                    return Optional.of(configFile); //RETURN
                 }
 
                 // Config contained registry, but not auth data, therefore do not attempt to store auth data, return original file.
                 if (found.isPresent() && found.get().isEmpty()) {
                     Log.info(c, m, "Config contains the registry with no auth data, cannot persist new auth data for registry: " + registry);
-                    return configFile;
+                    return Optional.empty(); //SKIP
                 }
             } catch (Exception e) {
                 Log.error(c, m, e);
@@ -238,9 +253,9 @@ public abstract class Registry {
         //Get existing nodes
         ObjectNode authsObject = root.has("auths") ? (ObjectNode) root.get("auths") : mapper.createObjectNode();
         ObjectNode registryObject = authsObject.has(registry) ? (ObjectNode) authsObject.get(registry) : mapper.createObjectNode();
-        TextNode registryAuthObject = TextNode.valueOf(authToken); //Replace existing auth token with this one.
+        TextNode registryAuthObject = TextNode.valueOf(authToken); //replace/append auth token with this one.
 
-        //Replace nodes with updated/new configuration
+        //replace/append nodes with updated/new configuration
         registryObject.replace("auth", registryAuthObject);
         authsObject.replace(registry, registryObject);
         root.set("auths", authsObject);
@@ -250,7 +265,7 @@ public abstract class Registry {
         logConfigContents(m, "New config.json contents are", newContent);
         writeFile(configFile, newContent);
 
-        return configFile;
+        return Optional.of(configFile); //APPEND or REPLACE
     }
 
     /**
@@ -395,6 +410,7 @@ public abstract class Registry {
     @Override
     public String toString() {
         return this.getClass().getName() + " [getRegistry=" + this.getRegistry() + ", isRegistryAvailable=" + this.isRegistryAvailable() +
+               ", getAuthConfigFile=" + (this.getAuthConfigFile().isPresent() ? this.getAuthConfigFile().get().getAbsolutePath() : "empty") +
                ", getSetupException=" + this.getSetupException() + "]";
     }
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Allow test buckets access to the docker config file which is modified by the Artifactory and Internal registry objects in fattest.simplicity.
