### PR TITLE
Align with latest spec updates to the Select annotation

### DIFF
--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -100,7 +100,7 @@ public class Data_1_0 implements DataVersionCompatibility {
     @Override
     @Trivial
     public String[] getSelections(AnnotatedElement element) {
-        return null;
+        return NO_SELECTIONS;
     }
 
     @Override

--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -302,8 +302,13 @@ public class Data_1_1 implements DataVersionCompatibility {
     @Override
     @Trivial
     public String[] getSelections(AnnotatedElement element) {
-        Annotation select = element.getAnnotation(Select.class);
-        return select == null ? null : ((Select) select).value();
+        Select[] selects = element.getAnnotationsByType(Select.class);
+        if (selects.length == 0)
+            return NO_SELECTIONS;
+        String[] values = new String[selects.length];
+        for (int i = 0; i < selects.length; i++)
+            values[i] = selects[i].value();
+        return values;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2984,7 +2984,7 @@ public class QueryInfo {
         String o_ = entityVar_;
 
         String[] cols, selections = entityInfo.builder.provider.compat.getSelections(method);
-        if (selections == null || selections.length == 0) {
+        if (selections.length == 0) {
             cols = null;
         } else if (type == Type.FIND_AND_DELETE) {
             // Unreachable in version 1.0 and uncertain what will be added to
@@ -2993,7 +2993,8 @@ public class QueryInfo {
             ("The " + method.getName() + " method of the " +
              repositoryInterface.getName() + " repository has a " +
              method.getGenericReturnType().getTypeName() + " return type and" +
-             " specifies to return the " + selections + " entity attributes," +
+             " specifies to return the " +
+             Arrays.toString(selections) + " entity attributes," +
              " but delete operations can only return void, a deletion count," +
              " a boolean deletion indicator, or the removed entities.");
         } else {

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -24,6 +24,11 @@ import jakarta.data.repository.Find;
  */
 public interface DataVersionCompatibility {
     /**
+     * Size 0 array indicating no Select annotations are present.
+     */
+    final String[] NO_SELECTIONS = new String[0];
+
+    /**
      * Append a condition such as o.myAttribute < ?1 to the JPQL query.
      *
      * @param q            JPQL query to which to append.
@@ -96,12 +101,13 @@ public interface DataVersionCompatibility {
     Annotation getExistsAnnotation(Method method);
 
     /**
-     * Obtains the value of the Select annotation if present on the method
-     * or record component. Otherwise null.
+     * Obtains the values of Select annotations if present on the method
+     * or record component. The order for values is the same as the order in
+     * which the annotations are listed. Otherwise a size 0 array.
      *
      * @param element repository method or record component. Must not be null.
-     * @return values of the Select annotation indicating the columns to select,
-     *         otherwise null.
+     * @return values of the Select annotations indicating the columns to select,
+     *         otherwise a size 0 array to indicate no Select annotation is present.
      */
     String[] getSelections(AnnotatedElement element);
 

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
@@ -147,7 +147,8 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
 
     // Use a stream of record as the return type
     @Find
-    @Select({ "start", "stop" })
+    @Select("start")
+    @Select("stop")
     Stream<ReservedTimeSlot> findByStoppingAtAnyOf(@By("stop") OffsetDateTime stop1,
                                                    @Or @By("stop") OffsetDateTime stop2,
                                                    @Or @By("stop") OffsetDateTime stop3);
@@ -165,7 +166,8 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
 
     // Use a record as the return type
     @Find
-    @Select({ "start", "stop" })
+    @Select("start")
+    @Select("stop")
     @OrderBy("start")
     ReservedTimeSlot[] findTimeSlotWithin(String location,
                                           @By("start") @Is(GreaterThanEqual) OffsetDateTime startAfter,

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/Select.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/Select.java
@@ -14,6 +14,7 @@ package jakarta.data.repository;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -22,9 +23,17 @@ import java.lang.annotation.Target;
  * Copied from Jakarta Data.
  */
 @Documented
+@Repeatable(Select.List.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.RECORD_COMPONENT })
 public @interface Select {
 
-    String[] value();
+    String value();
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface List {
+        Select[] value();
+    }
 }


### PR DESCRIPTION
Align with specification updates where the Select annotation where repeatable annotations are now used instead of an array-typed value.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
