### PR TITLE
Fix ldap_fat.krb5.2 and 3 by adding container port check

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.2/override/autoFVT/src/ant/launch-overrides.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.2/override/autoFVT/src/ant/launch-overrides.xml
@@ -1,0 +1,12 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project>
+    <property name="fat.test.docker.host.port" value="88"/>
+</project>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.3/override/autoFVT/src/ant/launch-overrides.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.3/override/autoFVT/src/ant/launch-overrides.xml
@@ -1,0 +1,12 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project>
+    <property name="fat.test.docker.host.port" value="88"/>
+</project>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Should completely fix RTC defect 299994

**Explanation**
We had fixed ldap_fat.krb5.1 already, but we forgot to add the same fix to ldap_fat.krb5.2 and .3
Same Fix as: https://github.com/OpenLiberty/open-liberty/pull/30951 added to other applicable FATs.


Tested locally by running
```
./gradlew com.ibm.ws.security.wim.adapter.ldap_fat.krb5.2:buildandrun
./gradlew com.ibm.ws.security.wim.adapter.ldap_fat.krb5.3:buildandrun
```
and confirmed the new check was added
```
[03/18/2025 11:08:03:006 CDT] 001 ExternalDockerClientFilter     isMatched                      I Checking if Docker host tcp://9.99.999.999:2376 is available and healthy...
[03/18/2025 11:08:05:512 CDT] 001 ExternalDockerClientFilter     isPortAvailable                I Port 88 is available on host 9.99.999.999
```