### PR TITLE
Update Java 24 FAT with GA WAR

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -65,7 +65,7 @@ io.openliberty:java-apps:20.0.0
 io.openliberty:java-apps:21.0.0
 io.openliberty:java-apps:22.1.0
 io.openliberty:java-apps:23.1.0
-io.openliberty:java-apps:24.0.0
+io.openliberty:java-apps:24.1.0
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0

--- a/dev/io.openliberty.java.internal_fat/build.gradle
+++ b/dev/io.openliberty.java.internal_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2024 IBM Corporation and others.
+ * Copyright (c) 2017,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ configurations {
     app21 'io.openliberty:java-apps:21.0.0'
     app22 'io.openliberty:java-apps:22.1.0'
     app23 'io.openliberty:java-apps:23.1.0'
-    app24 'io.openliberty:java-apps:24.0.0'
+    app24 'io.openliberty:java-apps:24.1.0'
  }
 
 task copyKernelService(type: Copy) {


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

The Java 24 specific FAT was compiled against the EA version of Java 24. Now that Java 24 has become GA, we have recompiled the FAT with the GA version and need to update it in our repositories.

Note:
```
io.openliberty:java-apps:24.0.0 -> WAR file compiled with EA version of Java 24
io.openliberty:java-apps:24.1.0 -> WAR file compiled with GA version of Java 24
```
