### PR TITLE
Added changes for max streams refused property with Netty

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyHttpConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyHttpConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyHttpConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyHttpConstants.java
@@ -34,5 +34,6 @@ public class NettyHttpConstants {
     public static final AttributeKey<Boolean> HANDLING_REQUEST = AttributeKey.valueOf("handlingRequest");
     public static final AttributeKey<Boolean> THROW_FFDC = AttributeKey.valueOf("throwFFDC");
     public static final AttributeKey<Integer> NUMBER_OF_HTTP_REQUESTS = AttributeKey.valueOf("numberOfHttpRequests");
+    public static final AttributeKey<Integer> STREAMS_REFUSED = AttributeKey.valueOf("streamsRefused");
 
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/http2/LibertyUpgradeCodec.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/http2/LibertyUpgradeCodec.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/http2/LibertyUpgradeCodec.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/http2/LibertyUpgradeCodec.java
@@ -65,7 +65,6 @@ public class LibertyUpgradeCodec implements UpgradeCodecFactory {
 
         @Override
         public void logRstStream(Direction direction, ChannelHandlerContext ctx, int streamId, long errorCode) {
-            new Exception().printStackTrace();
             super.logRstStream(direction, ctx, streamId, errorCode);
         };
     };

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
@@ -5252,7 +5252,7 @@ public class H2FATDriverServlet extends FATServlet {
         CountDownLatch blockUntilConnectionIsDone = new CountDownLatch(1);
         Http2Client h2Client = getDefaultH2Client(request, response, blockUntilConnectionIsDone);
 
-        FrameGoAway errorFrame = new FrameGoAway(0, "too many client-initiated streams have been refused; closing the connection".getBytes(), ENHANCE_YOUR_CALM_ERROR, 1, false);
+        FrameGoAway errorFrame = new FrameGoAway(0, "too many client-initiated streams have been refused; closing the connection".getBytes(), ENHANCE_YOUR_CALM_ERROR, USING_NETTY ? 201 : 1, false);
         h2Client.addExpectedFrame(errorFrame);
 
         setupDefaultUpgradedConnection(h2Client, HEADERS_ONLY_URI);

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -735,6 +735,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             }
         }
         
+        // Liberty override to notify down the pipeline this specific error to manage it
         if (http2Ex.getMessage().startsWith("Maximum active streams violated for this endpoint")) {
         	ctx.fireExceptionCaught(cause);
         }

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -734,6 +734,10 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                 }
             }
         }
+        
+        if (http2Ex.getMessage().startsWith("Maximum active streams violated for this endpoint")) {
+        	ctx.fireExceptionCaught(cause);
+        }
 
         if (stream == null) {
             if (!outbound || connection().local().mayHaveCreatedStream(streamId)) {


### PR DESCRIPTION
Changes in the overlayed Http2ConnectionHandler class to pass through the pipeline the error when exceeding the configured max stream to be able to shut down the connection appropriately