### PR TITLE
nonbinding on qualifier for Concurrency resources

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -253,4 +253,9 @@ public class ConcurrentCDITest extends FATServletClient {
     public void testSelectManagedThreadFactoryQualified() throws Exception {
         runTest(server, APP_NAME, testName);
     }
+
+    @Test
+    public void testSelectNonbinding() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/resources/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="6.0"
+<web-app version="6.1"
     xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
     id="WebApp_ID">
 
   <display-name>Concurrent CDI FAT</display-name>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -1410,4 +1410,30 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
         assertEquals("value2", future2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
     }
+
+    /**
+     * Use CDI.current() to select an instance of ContextService where the value of
+     * a nonbinding field of the qualifier annotation differs.
+     */
+    public void testSelectNonbinding() {
+        Annotation annoWithNonbinding = WithLocationContext.Literal.with(TRANSACTION);
+        Instance<ContextService> instance = CDI.current()
+                        .select(ContextService.class, annoWithNonbinding);
+
+        Supplier<String> getLocation;
+        ContextService contextSvc = instance.get();
+        try {
+            Location.set("2800 37th St NW, Rochester, MN 55901");
+            getLocation = contextSvc.contextualSupplier(Location::get);
+        } finally {
+            Location.clear();
+        }
+
+        assertEquals(null, Location.get());
+
+        assertEquals("2800 37th St NW, Rochester, MN 55901",
+                     getLocation.get());
+
+        assertEquals(null, Location.get());
+    }
 }


### PR DESCRIPTION
Cover the scenario where CDI.current().select() is used to find an instance of a Concurrency resource with the specified qualifier annotation, where the qualifier has a nonbinding field with non-default values that do not match those used on the definition annotation. It should still match because nonbinding prevents the field from being considered.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
