### PR TITLE
fix: restore config when suite is extended by test class

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
@@ -63,7 +63,6 @@ import com.ibm.ws.security.acme.utils.AcmeFatUtils;
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
-import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -72,7 +71,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 @RunWith(FATRunner.class)
 @SkipForRepeat({ SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES }) // No value added
-public class AcmeCaRestHandlerTest extends TestContainerSuite {
+public class AcmeCaRestHandlerTest {
     @Server("com.ibm.ws.security.acme.fat.rest")
     public static LibertyServer server;
 

--- a/dev/fattest.simplicity/src/componenttest/containers/TestContainerSuite.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/TestContainerSuite.java
@@ -73,7 +73,7 @@ public class TestContainerSuite {
         @Override
         protected void after() {
             Log.info(TestContainerSuite.class, "after", "Tearing down testcontainers");
-            restoreConfig();
+//          restoreConfig(); //TODO re-enable once WL tests are updated to only extend TestContainerSuite on suite classes and not test classes
             ImageVerifier.assertImages();
         }
     };
@@ -115,7 +115,7 @@ public class TestContainerSuite {
     /**
      * Moves existing ~/.testcontainers.properties file (if present) to a backup location.
      * Then generates a new ~/.testcontainers.properties file in it's place.
-	 * 
+     *
      * The new properties file will be configured with only the image name substitutor or
      * the properties necessary to connect and use a remote docker host if one is required
      * by the {@link #useRemoteDocker()} method.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Disables feature added by #30990
When calling `restoreConfig()` in the `after()` method of a `@ClassRule` my assumption was that all test buckets only extended the `TestContainerSuite` in their `FATSuite` class and not by individual test classes. 

It seems there are some test buckets that do not follow this standard practice and as such we cannot simply restore the previous configuration since the after method will be called between test classes. 
