### PR TITLE
fix: ignore warning caused by CWWKD1080E

### DIFF
--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataCoreTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -46,6 +46,7 @@ public class DataCoreTckLauncher {
                                                   "CWWKD0202E", // TODO : https://github.com/OpenLiberty/open-liberty/issues/30155
                                                   "CWWKD1054E", // tested error path
                                                   "CWWKD1080E", // TODO : https://github.com/OpenLiberty/open-liberty/issues/30155
+                                                  "CWWKZ0014W", // TODO : https://github.com/OpenLiberty/open-liberty/issues/30155 (seen alongside CWWKD1080E)
                                                   "CWWKE0955E" //websphere.java.security java 18+
         };
         if (persistenceServer.isStarted()) {

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataFullTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataFullTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -53,6 +53,7 @@ public class DataFullTckLauncher {
                           "CWWKD0202E", // TODO : https://github.com/OpenLiberty/open-liberty/issues/30155
                           "CWWKD1054E", // tested error path
                           "CWWKD1080E", // TODO : https://github.com/OpenLiberty/open-liberty/issues/30155
+                          "CWWKZ0014W", // TODO : https://github.com/OpenLiberty/open-liberty/issues/30155 (seen alongside CWWKD1080E)
                           "CWWKE0955E" //websphere.java.security java 18+
         );
     }

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/DataWebTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,7 @@ public class DataWebTckLauncher {
                           "CWWKD0202E", // TODO : https://github.com/OpenLiberty/open-liberty/issues/30155
                           "CWWKD1054E", // tested error path
                           "CWWKD1080E", // TODO : https://github.com/OpenLiberty/open-liberty/issues/30155
+                          "CWWKZ0014W", // TODO : https://github.com/OpenLiberty/open-liberty/issues/30155 (seen alongside CWWKD1080E)
                           "CWWKE0955E" //websphere.java.security java 18+
         );
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Ignore the warning CWWKZ0014W which can be caused by the existing known bug CWWKD1080E where the application is stopped before the asynchronous threads complete.