### PR TITLE
Test of Converter with autoapply, temporarily disabled

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -157,6 +157,9 @@ public class DataJPATestServlet extends FATServlet {
     Orders orders;
 
     @Inject
+    Purchases purchases;
+
+    @Inject
     Rebates rebates;
 
     @Inject
@@ -294,6 +297,66 @@ public class DataJPATestServlet extends FATServlet {
         assertNotNull(found);
         assertEquals("Found " + found.toString(), 1, found.size());
         assertEquals("IBM", found.get(0).name);
+    }
+
+    /**
+     * Tests that repository methods can query and sort based on an entity attribute
+     * that has a Converter with autoApply=true.
+     */
+    @Test
+    public void testAutoApplyConverter() {
+        PurchaseTime mondayAt6AM = new PurchaseTime( //
+                        LocalTime.of(6, 0, 0), LocalDate.of(2025, 3, 17));
+
+        PurchaseTime mondayAt3PM = new PurchaseTime( //
+                        LocalTime.of(15, 0, 0), LocalDate.of(2025, 3, 17));
+
+        PurchaseTime wednesdayAt6PM = new PurchaseTime( //
+                        LocalTime.of(18, 0, 0), LocalDate.of(2025, 3, 19));
+
+        PurchaseTime thursdayAt10PM = new PurchaseTime( //
+                        LocalTime.of(22, 0, 0), LocalDate.of(2025, 3, 20));
+
+        PurchaseTime fridayAt9AM = new PurchaseTime(//
+                        LocalTime.of(9, 0, 0), LocalDate.of(2025, 3, 21));
+
+        PurchaseTime fridayAtNoon = new PurchaseTime(//
+                        LocalTime.of(12, 0, 0), LocalDate.of(2025, 3, 21));
+
+        PurchaseTime fridayAt10PM = new PurchaseTime(//
+                        LocalTime.of(22, 0, 0), LocalDate.of(2025, 3, 21));
+
+        purchases.removeByTimeOfPurchaseBetween(mondayAt6AM, fridayAt10PM);
+
+        purchases.make(Purchase.of((short) 101,
+                                   "TestAutoApplyConverter-1",
+                                   mondayAt3PM,
+                                   17.89f));
+
+        purchases.make(Purchase.of((short) 102,
+                                   "TestAutoApplyConverter-2",
+                                   thursdayAt10PM,
+                                   22.95f));
+
+        purchases.make(Purchase.of((short) 103,
+                                   "TestAutoApplyConverter-3",
+                                   wednesdayAt6PM,
+                                   30.39f));
+
+        purchases.make(Purchase.of((short) 104,
+                                   "TestAutoApplyConverter-4",
+                                   fridayAtNoon,
+                                   14.49f));
+
+        assertEquals(List.of("TestAutoApplyConverter-1",
+                             "TestAutoApplyConverter-3",
+                             "TestAutoApplyConverter-2"),
+                     purchases.findByTimeOfPurchaseBetween(mondayAt6AM, fridayAt9AM)
+                                     .stream()
+                                     .map(p -> p.itemName)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(4, purchases.removeByTimeOfPurchaseBetween(mondayAt6AM, fridayAt10PM));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Purchase.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Purchase.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * An entity with an attribute that requires a Converter with autoApply = true
+ */
+@Entity
+public class Purchase {
+
+    @Id
+    public short identifier;
+
+    public String itemName;
+
+    @Convert(converter = PurchaseTimeConverter.class) // TODO remove this and rely on autoApply
+    public PurchaseTime timeOfPurchase; // has Converter with autoApply = true
+
+    public float total;
+
+    static Purchase of(short identifier,
+                       String itemName,
+                       PurchaseTime timeOfPurchase,
+                       float total) {
+        Purchase p = new Purchase();
+        p.identifier = identifier;
+        p.itemName = itemName;
+        p.timeOfPurchase = timeOfPurchase;
+        p.total = total;
+        return p;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseTime.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseTime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,10 @@ import java.time.LocalTime;
 
 /**
  * Java record that has a subset of fields of the Rebate entity.
+ *
+ * It is also an entity attribute of the Purchase entity, where the attribute
+ * is sortable because it has an automatic converter (PurchaseTimeConverter)
+ * to a sortable LocalDateTime value.
  */
 public record PurchaseTime(
                 LocalTime purchaseMadeAt,

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseTimeConverter.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseTimeConverter.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * A converter between PurchaseTime and LocalDateTime.
+ */
+@Converter(autoApply = true)
+public class PurchaseTimeConverter implements AttributeConverter<PurchaseTime, LocalDateTime> {
+
+    @Override
+    public LocalDateTime convertToDatabaseColumn(PurchaseTime pt) {
+        return LocalDateTime.of(pt.purchaseMadeOn(), pt.purchaseMadeAt());
+    }
+
+    @Override
+    public PurchaseTime convertToEntityAttribute(LocalDateTime dt) {
+        return new PurchaseTime(dt.toLocalTime(), dt.toLocalDate());
+    }
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Purchases.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Purchases.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.List;
+
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for the Purchase entity that has a Converter with autoApply = true
+ */
+@Repository
+public interface Purchases {
+
+    @OrderBy("timeOfPurchase")
+    List<Purchase> findByTimeOfPurchaseBetween(PurchaseTime min,
+                                               PurchaseTime max);
+
+    @Insert
+    void make(Purchase purchase);
+
+    int removeByTimeOfPurchaseBetween(PurchaseTime min,
+                                      PurchaseTime max);
+}


### PR DESCRIPTION
Test case for a Converter with autoApply=true, but currently with a workaround the specify the Converter on the entity attribute because more work is needed for this scenario.  A TODO  comment indicate how to fully enable the test.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
