### PR TITLE
Update to latest Semeru Java 21

### DIFF
--- a/.ci-orchestrator/jvms/dev/checkpoint_linux_x86_64.properties
+++ b/.ci-orchestrator/jvms/dev/checkpoint_linux_x86_64.properties
@@ -1,3 +1,3 @@
 reportingJVM=IBM_SEMERU_OPEN_JDK_17
 jvmUnderTestPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-17.0.10+7_openj9-0.43.0/jdk-17.0.10+7.tar.gz
-jvmFrameworkPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-21.0.2+13_openj9-0.43.0/jdk-21.0.2+13.tar.gz
+jvmFrameworkPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-21.0.6+7_openj9-0.49.0/jdk-21.0.6+7.tar.gz

--- a/.ci-orchestrator/jvms/dev/linux_x86_64.properties
+++ b/.ci-orchestrator/jvms/dev/linux_x86_64.properties
@@ -1,3 +1,3 @@
-reportingJVM=ORACLE_OPEN_JDK_21
-jvmUnderTestPath=/liberty/jvms/linux_x64/Oracle_Hotspot_openjdk-21-ga/jdk-21.tar.gz
-jvmFrameworkPath=/liberty/jvms/linux_x64/Oracle_Hotspot_openjdk-21-ga/jdk-21.tar.gz
+reportingJVM=IBM_SEMERU_OPEN_JDK_21
+jvmUnderTestPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-21.0.6+7_openj9-0.49.0/jdk-21.0.6+7.tar.gz
+jvmFrameworkPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-21.0.6+7_openj9-0.49.0/jdk-21.0.6+7.tar.gz


### PR DESCRIPTION
At @gjwatts's request, this change is to cover upgrading the following builds to use Semeru Java 21 for child builds (executing FAT tests).
- OL PB

To upgrade the personal pipelines, I've made changes to `.ci-orchestrator/jvms/dev/linux_x86_64.properties`. This is the file that is included into those pipeline's config.
```
reportingJVM=IBM_SEMERU_OPEN_JDK_21
jvmUnderTestPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-21.0.6+7_openj9-0.49.0/jdk-21.0.6+7.tar.gz
jvmFrameworkPath=/liberty/jvms/linux_x86_64/ibm-semerujdk-21.0.6+7_openj9-0.49.0/jdk-21.0.6+7.tar.gz
```