### PR TITLE
Converter on mapped superclass attributes and embedded entity attributes

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Address.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Address.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Address.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Address.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
 
@@ -30,7 +31,8 @@ public class Address {
     @Embedded
     public Street street;
 
-    public int zip;
+    @Convert(converter = ZipCodeConverter.class)
+    public ZipCode zip;
 
     public Address() {
     }
@@ -38,7 +40,7 @@ public class Address {
     Address(String city, String state, int zip, int houseNum, Street street) {
         this.city = city;
         this.state = state;
-        this.zip = zip;
+        this.zip = ZipCode.of(zip);
         this.houseNum = houseNum;
         this.street = street;
     }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -76,19 +76,19 @@ public interface Businesses extends BasicRepository<Business, Integer> {
     // embeddable as result type
     @OrderBy("location.address.street")
     @OrderBy("location.address.houseNum")
-    Stream<Location> findByLocationAddressZip(int zipCode);
+    Stream<Location> findByLocationAddressZip(ZipCode zipCode);
 
     // embeddable 2 levels deep
     @OrderBy(value = "location.address.city", descending = true)
     @OrderBy("location.address.zip")
     @OrderBy("location.address.houseNum")
     @OrderBy("id")
-    CursoredPage<Business> findByLocationAddressZipIn(Iterable<Integer> zipCodes, PageRequest pagination);
+    CursoredPage<Business> findByLocationAddressZipIn(Iterable<ZipCode> zipCodes, PageRequest pagination);
 
     // embeddable 3 levels deep as result type
     @OrderBy("location.address.street")
     @OrderBy("location.address.houseNum")
-    Stream<Street> findByLocationAddressZipNotAndLocationAddressCity(int excludeZipCode, String city);
+    Stream<Street> findByLocationAddressZipNotAndLocationAddressCity(ZipCode excludeZipCode, String city);
 
     @OrderBy("id")
     Business findFirstByName(String name);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2363,7 +2363,7 @@ public class DataJPATestServlet extends FATServlet {
         o2 = orders.findById(o2.id).get();
 
         assertEquals(168.89f, o2.total, 0.01f);
-        assertEquals(o2.purchasedOn, OffsetDateTime.of(2022, 6, 1, 14, 0, 0, 0, MDT));
+        assertEquals(OffsetDateTime.of(2022, 6, 1, 14, 0, 0, 0, MDT), o2.purchasedOn);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -157,6 +157,9 @@ public class DataJPATestServlet extends FATServlet {
     Orders orders;
 
     @Inject
+    Purchases purchases;
+
+    @Inject
     Rebates rebates;
 
     @Inject
@@ -635,6 +638,66 @@ public class DataJPATestServlet extends FATServlet {
         } catch (MappingException x) {
             // expected - out of range
         }
+    }
+
+    /**
+     * Tests that repository methods can query and sort based on an entity attribute
+     * that has a Converter that is specified on a MappedSuperclass.
+     */
+    @Test
+    public void testConverterOnMappedSuperclass() {
+        PurchaseTime mondayAt6AM = new PurchaseTime( //
+                        LocalTime.of(6, 0, 0), LocalDate.of(2025, 3, 17));
+
+        PurchaseTime mondayAt3PM = new PurchaseTime( //
+                        LocalTime.of(15, 0, 0), LocalDate.of(2025, 3, 17));
+
+        PurchaseTime wednesdayAt6PM = new PurchaseTime( //
+                        LocalTime.of(18, 0, 0), LocalDate.of(2025, 3, 19));
+
+        PurchaseTime thursdayAt10PM = new PurchaseTime( //
+                        LocalTime.of(22, 0, 0), LocalDate.of(2025, 3, 20));
+
+        PurchaseTime fridayAt9AM = new PurchaseTime(//
+                        LocalTime.of(9, 0, 0), LocalDate.of(2025, 3, 21));
+
+        PurchaseTime fridayAtNoon = new PurchaseTime(//
+                        LocalTime.of(12, 0, 0), LocalDate.of(2025, 3, 21));
+
+        PurchaseTime fridayAt10PM = new PurchaseTime(//
+                        LocalTime.of(22, 0, 0), LocalDate.of(2025, 3, 21));
+
+        purchases.removeByTimeOfPurchaseBetween(mondayAt6AM, fridayAt10PM);
+
+        purchases.make(Purchase.of((short) 101,
+                                   "TestAutoApplyConverter-1",
+                                   mondayAt3PM,
+                                   17.89f));
+
+        purchases.make(Purchase.of((short) 102,
+                                   "TestAutoApplyConverter-2",
+                                   thursdayAt10PM,
+                                   22.95f));
+
+        purchases.make(Purchase.of((short) 103,
+                                   "TestAutoApplyConverter-3",
+                                   wednesdayAt6PM,
+                                   30.39f));
+
+        purchases.make(Purchase.of((short) 104,
+                                   "TestAutoApplyConverter-4",
+                                   fridayAtNoon,
+                                   14.49f));
+
+        assertEquals(List.of("TestAutoApplyConverter-1",
+                             "TestAutoApplyConverter-3",
+                             "TestAutoApplyConverter-2"),
+                     purchases.findByTimeOfPurchaseBetween(mondayAt6AM, fridayAt9AM)
+                                     .stream()
+                                     .map(p -> p.itemName)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(4, purchases.removeByTimeOfPurchaseBetween(mondayAt6AM, fridayAt10PM));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1461,7 +1461,11 @@ public class DataJPATestServlet extends FATServlet {
     @Test
     public void testEmbeddableDepth2() {
         CursoredPage<Business> page;
-        List<Integer> zipCodes = List.of(55906, 55902, 55901, 55976, 55905);
+        List<ZipCode> zipCodes = List.of(ZipCode.of(55906),
+                                         ZipCode.of(55902),
+                                         ZipCode.of(55901),
+                                         ZipCode.of(55976),
+                                         ZipCode.of(55905));
 
         page = businesses.findByLocationAddressZipIn(zipCodes, PageRequest.ofSize(4).withoutTotal());
 
@@ -1622,7 +1626,7 @@ public class DataJPATestServlet extends FATServlet {
                                      "NW Lakeridge Pl",
                                      "NW Members Parkway",
                                      "W Highway 14"),
-                             businesses.findByLocationAddressZip(55901)
+                             businesses.findByLocationAddressZip(ZipCode.of(55901))
                                              .map(loc -> loc.address.street.direction + " " + loc.address.street.name)
                                              .collect(Collectors.toList()));
     }
@@ -1638,7 +1642,8 @@ public class DataJPATestServlet extends FATServlet {
                                      "SW 1st St",
                                      "SW Enterprise Dr",
                                      "SW Greenview Dr"),
-                             businesses.findByLocationAddressZipNotAndLocationAddressCity(55901, "Rochester")
+                             businesses.findByLocationAddressZipNotAndLocationAddressCity(ZipCode.of(55901),
+                                                                                          "Rochester")
                                              .map(street -> street.direction + " " + street.name)
                                              .collect(Collectors.toList()));
     }
@@ -3622,7 +3627,11 @@ public class DataJPATestServlet extends FATServlet {
     @Test
     public void testParenthesisInsertionForCursorPagination() {
         PageRequest page1Request = PageRequest.ofSize(3);
-        CursoredPage<Business> page1 = mixed.withZipCodeIn(55901, 55904, page1Request, Sort.asc("name"), Sort.asc(ID));
+        CursoredPage<Business> page1 = mixed.withZipCodeIn(ZipCode.of(55901),
+                                                           ZipCode.of(55904),
+                                                           page1Request,
+                                                           Sort.asc("name"),
+                                                           Sort.asc(ID));
 
         assertEquals(List.of("Benike Construction", "Crenlo", "Home Federal Savings Bank"),
                      page1.stream()
@@ -3631,7 +3640,11 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, page1.hasNext());
 
-        CursoredPage<Business> page2 = mixed.withZipCodeIn(55901, 55904, page1.nextPageRequest(), Sort.asc("name"), Sort.asc(ID));
+        CursoredPage<Business> page2 = mixed.withZipCodeIn(ZipCode.of(55901),
+                                                           ZipCode.of(55904),
+                                                           page1.nextPageRequest(),
+                                                           Sort.asc("name"),
+                                                           Sort.asc(ID));
 
         assertEquals(List.of("IBM", "Metafile", "Olmsted Medical"),
                      page2.stream()
@@ -3640,7 +3653,11 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(true, page1.hasNext());
 
-        CursoredPage<Business> page3 = mixed.withZipCodeIn(55901, 55904, page2.nextPageRequest(), Sort.asc("name"), Sort.asc(ID));
+        CursoredPage<Business> page3 = mixed.withZipCodeIn(ZipCode.of(55901),
+                                                           ZipCode.of(55904),
+                                                           page2.nextPageRequest(),
+                                                           Sort.asc("name"),
+                                                           Sort.asc(ID));
 
         assertEquals(List.of("RAC", "Think Bank"),
                      page3.stream()
@@ -4760,7 +4777,7 @@ public class DataJPATestServlet extends FATServlet {
             assertEquals("N", ibm.location.address.street.direction);
             assertEquals("Rochester", ibm.location.address.city);
             assertEquals("MN", ibm.location.address.state);
-            assertEquals(55901, ibm.location.address.zip);
+            assertEquals(ZipCode.of(55901), ibm.location.address.zip);
         } finally {
             // restore original values
             ibm.location.latitude = originalLatitude;
@@ -4783,7 +4800,7 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals("NW", ibm.location.address.street.direction);
         assertEquals("Rochester", ibm.location.address.city);
         assertEquals("MN", ibm.location.address.state);
-        assertEquals(55901, ibm.location.address.zip);
+        assertEquals(ZipCode.of(55901), ibm.location.address.zip);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MixedRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,5 +56,8 @@ public interface MixedRepository { // Do not inherit from a supertype
     CursoredPage<Business> locatedIn(String city, String state, PageRequest pageRequest, Order<Business> order);
 
     @Query("FROM Business WHERE location.address.zip=?1 OR location.address.zip=?2")
-    CursoredPage<Business> withZipCodeIn(int zip1, int zip2, PageRequest pageRequest, Sort<?>... sorts);
+    CursoredPage<Business> withZipCodeIn(ZipCode zip1,
+                                         ZipCode zip2,
+                                         PageRequest pageRequest,
+                                         Sort<?>... sorts);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Purchase.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Purchase.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * An entity with an attribute that requires a Converter that is specified
+ * on an attribute of the MappedSuperclass.
+ */
+@Entity
+public class Purchase extends PurchaseInfo {
+
+    @Id
+    public short identifier;
+
+    public String itemName;
+
+    public float total;
+
+    static Purchase of(short identifier,
+                       String itemName,
+                       PurchaseTime timeOfPurchase,
+                       float total) {
+        Purchase p = new Purchase();
+        p.identifier = identifier;
+        p.itemName = itemName;
+        p.timeOfPurchase = timeOfPurchase;
+        p.total = total;
+        return p;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseInfo.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseInfo.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.Convert;
+import jakarta.persistence.MappedSuperclass;
+
+/**
+ * MappedSuperclass for the Purchase entity
+ */
+@MappedSuperclass
+public class PurchaseInfo {
+
+    @Convert(converter = PurchaseTimeConverter.class)
+    public PurchaseTime timeOfPurchase;
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseOrder.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseOrder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,8 @@ import jakarta.persistence.Version;
 /**
  * An entity with a generated id value.
  */
+@Convert(attributeName = "purchasedOn",
+         converter = OffsetDateTimeToStringConverter.class)
 @Entity(name = "Orders") // overrides the default name PurchaseOrder
 public class PurchaseOrder {
 
@@ -34,7 +36,6 @@ public class PurchaseOrder {
 
     public String purchasedBy;
 
-    @Convert(converter = OffsetDateTimeToStringConverter.class)
     public OffsetDateTime purchasedOn;
 
     public float total;

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseTime.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseTime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,10 @@ import java.time.LocalTime;
 
 /**
  * Java record that has a subset of fields of the Rebate entity.
+ *
+ * It is also an entity attribute of the Purchase entity, where the attribute
+ * is sortable because it has an automatic converter (PurchaseTimeConverter)
+ * to a sortable LocalDateTime value.
  */
 public record PurchaseTime(
                 LocalTime purchaseMadeAt,

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseTimeConverter.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/PurchaseTimeConverter.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * A converter between PurchaseTime and LocalDateTime.
+ */
+@Converter
+public class PurchaseTimeConverter implements AttributeConverter<PurchaseTime, LocalDateTime> {
+
+    @Override
+    public LocalDateTime convertToDatabaseColumn(PurchaseTime pt) {
+        return LocalDateTime.of(pt.purchaseMadeOn(), pt.purchaseMadeAt());
+    }
+
+    @Override
+    public PurchaseTime convertToEntityAttribute(LocalDateTime dt) {
+        return new PurchaseTime(dt.toLocalTime(), dt.toLocalDate());
+    }
+
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Purchases.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Purchases.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import java.util.List;
+
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for the Purchase entity that has a Converter that is specified
+ * on an attribute of the MappedSuperclass.
+ */
+@Repository
+public interface Purchases {
+
+    @OrderBy("timeOfPurchase")
+    List<Purchase> findByTimeOfPurchaseBetween(PurchaseTime min,
+                                               PurchaseTime max);
+
+    @Insert
+    void make(Purchase purchase);
+
+    int removeByTimeOfPurchaseBetween(PurchaseTime min,
+                                      PurchaseTime max);
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ZipCode.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ZipCode.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+/**
+ * Java class that needs an AttributeConverter to allow for comparisons of
+ * order and sorting.
+ */
+public class ZipCode {
+    final int digits;
+
+    private ZipCode(int digits) {
+        this.digits = digits;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof ZipCode z && digits == z.digits;
+    }
+
+    @Override
+    public int hashCode() {
+        return digits;
+    }
+
+    static ZipCode of(int digits) {
+        return new ZipCode(digits);
+    }
+
+    @Override
+    public String toString() {
+        return Integer.toString(digits);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ZipCodeConverter.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ZipCodeConverter.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * A converter between ZipCode and Integer.
+ */
+@Converter
+public class ZipCodeConverter implements AttributeConverter<ZipCode, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(ZipCode z) {
+        return z.digits;
+    }
+
+    @Override
+    public ZipCode convertToEntityAttribute(Integer i) {
+        return ZipCode.of(i);
+    }
+
+}


### PR DESCRIPTION
AttributeConverter can be used with Jakarta Data on attributes inherited from a MappedSuperclass and embedded entity attributes from an Embeddable.  Include test coverage for both of these scenarios.  Also cover Convert being specified on an entity class with the `attributeName` listed for a specific entity attribute.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
