### PR TITLE
Stricter test for version string

### DIFF
--- a/dev/io.openliberty.org.testcontainers/src/io/openliberty/org/testcontainers/generate/Dockerfile.java
+++ b/dev/io.openliberty.org.testcontainers/src/io/openliberty/org/testcontainers/generate/Dockerfile.java
@@ -106,11 +106,8 @@ public class Dockerfile implements Comparable<Dockerfile> {
     /**
      * Similar logic to ImageBuilder.findBaseImageFrom(resource)
      * 
-     * However, in this case we can only use the ArtifactoryMirrorSubstitutor so we
-     * have to manually put in the Artifactory registry (when available)
-     * 
      * @param location of Dockerfile the resource path of the Dockerfile
-     * @return The substituted docker image of the BASE_IMAGE argument
+     * @return The docker image of the BASE_IMAGE argument
      */
     private DockerImageName findBaseImageFrom(Path location) {
         final String BASE_IMAGE_PREFIX = "ARG BASE_IMAGE=\"";

--- a/dev/io.openliberty.org.testcontainers/src/io/openliberty/org/testcontainers/generate/Dockerfile.java
+++ b/dev/io.openliberty.org.testcontainers/src/io/openliberty/org/testcontainers/generate/Dockerfile.java
@@ -71,8 +71,8 @@ public class Dockerfile implements Comparable<Dockerfile> {
         final String version = fullPath.substring(start, end);
 
         // Find repository (between "resources/" and version)
+        end = start - 1; //End where the version started (exclude the path separator)
         start = fullPath.lastIndexOf("resources/") + 10;
-        end = fullPath.indexOf(version) - 1;
         final String repository = fullPath.substring(start, end);
 
         // Construct and return name


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

IBM IT set my username on my laptop to my employee ID number. This means that if the version string is a single digit it may match the /home/<ID-Number> part of the path.