### PR TITLE
disabled test for ServletContextListener scenario

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataServletContextListener.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataServletContextListener.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+
+/**
+ * Servlet context listener that uses Jakarta Data to pre-populate the table
+ * that is used by the Prime entity.
+ */
+@WebListener
+public class DataServletContextListener implements ServletContextListener {
+
+    @Inject
+    private Primes primes;
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+    }
+
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+        System.out.println("DataServletContextListener.contextInitialized:" +
+                           " populate tables for " + // primes.toString());
+                           " TODO: primes.toString()");
+
+        // TODO move code to here from DataTestServlet.init()
+    }
+
+}

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreServletContextListener.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreServletContextListener.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.datastore.web;
+
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+
+/**
+ * Servlet context listener that uses Jakarta Data to pre-populate the table
+ * that is used by the ServerDSResRefRepo entity.
+ */
+@WebListener
+public class DataStoreServletContextListener implements ServletContextListener {
+
+    @Inject
+    ServerDSResRefRepo serverDSResRefRepo;
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+    }
+
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+        System.out.println("DataStoreServletContextListener.contextInitialized:" +
+                           " populate tables for " + // serverDSResRefRepo.toString());
+                           " TODO: serverDSResRefRepo.toString()");
+
+        // TODO add code to write values here
+        // and include test in servlet to read them
+    }
+
+}


### PR DESCRIPTION
I tried adding ServletContextListener that injects a Jakarta Data repository and invokes an operation on it (for now, just .toString to obtain the bean instance).  It deadlocks, so I disabled the toString for now.

The ServletContextListener thread attempting to use the repository (toString),
```
"Default Executor-thread-4" #58 [64515] daemon prio=5 os_prio=31 cpu=61.89ms elapsed=54.86s tid=0x000000011e949400 nid=64515 waiting on condition  [0x0000000176481000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@21/Native Method)
	- parking to wait for  <0x0000000607b01b48> (a java.util.concurrent.CompletableFuture$Signaller)
	at java.util.concurrent.locks.LockSupport.park(java.base@21/LockSupport.java:221)
	at java.util.concurrent.CompletableFuture$Signaller.block(java.base@21/CompletableFuture.java:1864)
	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@21/ForkJoinPool.java:3780)
	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@21/ForkJoinPool.java:3725)
	at java.util.concurrent.CompletableFuture.waitingGet(java.base@21/CompletableFuture.java:1898)
	at java.util.concurrent.CompletableFuture.join(java.base@21/CompletableFuture.java:2117) <--- deadlocked
	at io.openliberty.data.internal.persistence.RepositoryImpl.<init>(RepositoryImpl.java:88)
	at io.openliberty.data.internal.persistence.cdi.RepositoryProducer.produce(RepositoryProducer.java:234)
	at org.jboss.weld.bean.SyntheticProducerBean.create(SyntheticProducerBean.java:45)
	at org.jboss.weld.contexts.AbstractContext.get(AbstractContext.java:96)
	at org.jboss.weld.bean.ContextualInstanceStrategy$DefaultContextualInstanceStrategy.get(ContextualInstanceStrategy.java:106)
	at org.jboss.weld.bean.ContextualInstance.get(ContextualInstance.java:50)
	at org.jboss.weld.bean.proxy.ContextBeanInstance.getInstance(ContextBeanInstance.java:101)
	at org.jboss.weld.bean.proxy.ProxyMethodHandler.getInstance(ProxyMethodHandler.java:136)
	at test.jakarta.data.web.Primes$1501238887$Proxy$_$$_WeldClientProxy.toString(Unknown Source)
	at java.lang.String.valueOf(java.base@21/String.java:4461)
	at test.jakarta.data.web.DataServletContextListener.contextInitialized(DataServletContextListener.java:38)
	at com.ibm.ws.webcontainer.webapp.WebApp.notifyServletContextCreated(WebApp.java:2464)
	at com.ibm.ws.webcontainer31.osgi.webapp.WebApp31.notifyServletContextCreated(WebApp31.java:512)
	at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:1062)
	at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:6722)
	- locked <0x0000000601af27c0> (a com.ibm.ws.webcontainer.webapp.WebApp$1) <--- obtains lock here
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApp(DynamicVirtualHost.java:484)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApplication(DynamicVirtualHost.java:479)
	at com.ibm.ws.webcontainer.osgi.WebContainer.startWebApplication(WebContainer.java:1208)
	at com.ibm.ws.webcontainer.osgi.WebContainer.access$100(WebContainer.java:113)
	at com.ibm.ws.webcontainer.osgi.WebContainer$3.run(WebContainer.java:996)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:298)
	at java.util.concurrent.Executors$RunnableAdapter.call(java.base@21/Executors.java:572)
	at java.util.concurrent.FutureTask.run(java.base@21/FutureTask.java:317)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21/ThreadPoolExecutor.java:1144)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21/ThreadPoolExecutor.java:642)
	at java.lang.Thread.runWith(java.base@21/Thread.java:1596)
	at java.lang.Thread.run(java.base@21/Thread.java:1583)
```

Executor thread that runs futureEMBuilder.createEMBuilder to complete the initialization that the other thread waits for, but is blocked on the lock held above,
```
"Default Executor-thread-3" #57 [64771] daemon prio=5 os_prio=31 cpu=45.65ms elapsed=55.29s tid=0x000000014b2cde00 nid=64771 waiting for monitor entry  [0x0000000176276000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:6721)
	- waiting to lock <0x0000000601af27c0> (a com.ibm.ws.webcontainer.webapp.WebApp$1)
	at com.ibm.ws.webcontainer.osgi.WebContainerListener.initialize(WebContainerListener.java:213)
	at com.ibm.ws.container.service.metadata.internal.MetaDataServiceImpl.getMetaData(MetaDataServiceImpl.java:274)
	at io.openliberty.data.internal.persistence.cdi.FutureEMBuilder.createEMBuilder(FutureEMBuilder.java:311)
	at io.openliberty.data.internal.persistence.DataProvider$$Lambda/0x000000c0014fd800.get(Unknown Source)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(java.base@21/CompletableFuture.java:1768)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:298)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21/ThreadPoolExecutor.java:1144)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21/ThreadPoolExecutor.java:642)
	at java.lang.Thread.runWith(java.base@21/Thread.java:1596)
	at java.lang.Thread.run(java.base@21/Thread.java:1583)
```

I have some ideas for fixing this, but first I'll get the scenario documented here and the start of a test.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

