### PR TITLE
Jakarta Data repositories in ServletContextListener

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -85,6 +85,10 @@ public class RepositoryImpl<R> implements InvocationHandler {
                           Map<Class<?>, List<QueryInfo>> queriesPerEntityClass) {
         EntityManagerBuilder builder;
         try {
+            // TODO add a timeout. If it times out, determine if checkpoint is
+            // in progress and raise an error indicating that something might be
+            // incompatible with checkpoint (such as a ServletContextListener
+            // using Jakarta Data).
             builder = futureEMBuilder.join();
         } catch (CompletionException x) {
             // The CompletionException does not have the current stack. Replace it.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -353,7 +353,21 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                 accessor.beginContext(metadata);
             try {
                 if (namespace != null) {
-                    Object resource = InitialContext.doLookup(dataStore);
+                    //Object resource = InitialContext.doLookup(dataStore);
+                    // TODO use the above instead of the following temporary workaround
+                    Object resource = null;
+                    NamingException failure = null;
+                    for (long start = System.nanoTime(); //
+                                    resource == null && System.nanoTime() - start < TimeUnit.SECONDS.toNanos(30); //
+                                    TimeUnit.SECONDS.sleep(2))
+                        try {
+                            resource = InitialContext.doLookup(dataStore);
+                        } catch (NamingException namingX) {
+                            failure = namingX;
+                        }
+                    if (failure != null && resource == null)
+                        throw failure;
+                    // end of code to replace
 
                     if (trace && tc.isDebugEnabled())
                         Tr.debug(this, tc, dataStore + " is the JNDI name for " + resource);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -602,7 +602,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
 
     /**
      * Obtains the module name in which the repository interface is defined,
-     * or lacking that, the name of the application in which is is defined or used.
+     * or lacking that, the name of the application in which it is defined or used.
      *
      * @param repositoryInterface   the repository interface.
      * @param repositoryClassLoader class loader of the repository interface.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -88,10 +88,12 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
     public final boolean inWebModule;
 
     /**
-     * Module name in which the repository interface is defined.
-     * If not defined in a module, only the application name part is included.
+     * Application artifact name (typically a module name) in which the repository
+     * interface is defined. If not defined in a module, only the application name
+     * part is included. If not defined in an application either, the name of the
+     * application that uses the repository is used instead.
      */
-    final J2EEName moduleName;
+    final J2EEName jeeName;
 
     /**
      * Namespace prefix (such as java:module) of the Repository dataStore.
@@ -129,23 +131,23 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         this.provider = provider;
         this.repositoryClassLoader = repositoryClassLoader;
         this.dataStore = dataStore;
-        this.moduleName = getModuleName(repositoryInterface, repositoryClassLoader, provider);
+        this.jeeName = getArtifactName(repositoryInterface, repositoryClassLoader, provider);
         this.namespace = Namespace.of(dataStore);
 
         if (Namespace.APP.isMoreGranularThan(namespace)) { // java:global or none
             application = null;
             module = null;
         } else { // java:app, java:module, or java:comp
-            application = moduleName.getApplication();
+            application = jeeName.getApplication();
             if (Namespace.MODULE.isMoreGranularThan(namespace)) { // java:app
                 module = null;
             } else { // java:module or java:comp
-                module = moduleName.getModule();
+                module = jeeName.getModule();
                 if (module == null)
                     throw exc(IllegalArgumentException.class,
                               "CWWKD1060.name.out.of.scope",
                               repositoryInterface.getName(),
-                              moduleName.getApplication(),
+                              jeeName.getApplication(),
                               dataStore,
                               "dataStore",
                               namespace,
@@ -291,10 +293,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
      */
     @FFDCIgnore({ NamingException.class, Throwable.class })
     public EntityManagerBuilder createEMBuilder() {
-        // metadata of DataExtension thread (runs from an application module)
-        ComponentMetaData extMetadata = null;
-        // metadata of the class loader of the repository interface
-        ComponentMetaData repoMetadata = null;
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
         try {
             String resourceName = dataStore;
             String metadataIdentifier = getMetadataIdentifier();
@@ -304,33 +303,41 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
             // EJB#MyApp#MyEJBModule.jar#MyEJB
             // DATA#MyApp
 
-            ComponentMetaDataAccessorImpl accessor = ComponentMetaDataAccessorImpl //
-                            .getComponentMetaDataAccessor();
-            extMetadata = accessor.getComponentMetaData();
-            repoMetadata = (ComponentMetaData) provider.metadataIdSvc //
-                            .getMetaData(metadataIdentifier);
-            boolean switchMetadata = repoMetadata != null && //
-                                     (extMetadata == null || //
-                                      !extMetadata.getJ2EEName().equals(repoMetadata.getJ2EEName()));
-
             if (namespace == Namespace.COMP && metadataIdentifier.startsWith("EJB#"))
                 throw exc(DataException.class,
                           "CWWKD1061.comp.name.in.ejb",
                           getClassNames(repositoryInterfaces),
-                          repoMetadata.getJ2EEName().getModule(),
-                          repoMetadata.getJ2EEName().getApplication(),
+                          jeeName.getModule(),
+                          jeeName.getApplication(),
                           resourceName,
                           "dataStore",
                           "java:comp",
                           List.of("java:app", "java:module"));
 
-            if (switchMetadata)
-                accessor.beginContext(repoMetadata);
+            // Avoid a web container deadlock (#31106) on metadataIdSvc.getMetaData
+            // by first checking for ComponentMetaData that was observed by our
+            // ComponentMetaDataListener:
+            ComponentMetaData metadata = //
+                            provider.componentMetadatasForModules.get(jeeName);
+
+            if (metadata == null)
+                metadata = (ComponentMetaData) provider.metadataIdSvc //
+                                .getMetaData(metadataIdentifier);
+
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(this, tc, "using metadata: " + metadata);
+
+            ComponentMetaDataAccessorImpl accessor = ComponentMetaDataAccessorImpl //
+                            .getComponentMetaDataAccessor();
+            if (metadata == null)
+                accessor.beginDefaultContext();
+            else
+                accessor.beginContext(metadata);
             try {
                 if (namespace != null) {
                     Object resource = InitialContext.doLookup(dataStore);
 
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    if (trace && tc.isDebugEnabled())
                         Tr.debug(this, tc, dataStore + " is the JNDI name for " + resource);
 
                     if (resource instanceof EntityManagerFactory)
@@ -339,7 +346,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                                         repositoryInterfaces, //
                                         (EntityManagerFactory) resource, //
                                         resourceName, //
-                                        metadataIdentifier, //
+                                        metadata, //
                                         entityTypes);
                 } else {
                     // Check for resource references and persistence unit references where java:comp/env/ is omitted:
@@ -347,7 +354,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                     try {
                         Object resource = InitialContext.doLookup(javaCompName);
 
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                        if (trace && tc.isDebugEnabled())
                             Tr.debug(this, tc, javaCompName + " is the JNDI name for " + resource);
 
                         if (resource instanceof EntityManagerFactory)
@@ -356,24 +363,22 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                                             repositoryInterfaces, //
                                             (EntityManagerFactory) resource, //
                                             javaCompName, //
-                                            metadataIdentifier, //
+                                            metadata, //
                                             entityTypes);
 
                         if (resource instanceof DataSource)
                             resourceName = javaCompName;
                     } catch (NamingException x) {
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                        if (trace && tc.isDebugEnabled())
                             Tr.debug(this, tc, javaCompName + " is not available in JNDI, ensure dataStore = "
                                                + resourceName + " refers to a resource reference or persistence unit reference. "
                                                + "Otherwise, we will assume this property refers to a datasource.");
                     }
                 }
             } finally {
-                if (switchMetadata)
-                    accessor.endContext();
+                accessor.endContext();
             }
 
-            J2EEName jeeName = repoMetadata == null ? null : repoMetadata.getJ2EEName();
             boolean javacolon = namespace != null || // any java: namespace
                                 resourceName != dataStore; // implicit java:comp
 
@@ -382,28 +387,24 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                             repositoryInterfaces, //
                             resourceName, //
                             javacolon, //
-                            metadataIdentifier, //
-                            jeeName, //
+                            metadata, //
                             entityTypes);
         } catch (Throwable x) {
             // The error is logged to Tr.error rather than FFDC
-            ComponentMetaData metadata = repoMetadata == null //
-                            ? extMetadata //
-                            : repoMetadata;
             if (x instanceof DataException) { // already logged
                 throw (DataException) x;
             } else if (x instanceof NamingException) {
                 if (namespace == null)
-                    throw excDataStoreNotFound(metadata, x);
+                    throw excDataStoreNotFound(jeeName, x);
                 else if (DataExtension.DEFAULT_DATA_SOURCE.equals(dataStore))
-                    throw excDefaultDataSourceNotFound(metadata, x);
+                    throw excDefaultDataSourceNotFound(jeeName, x);
                 else
-                    throw excJNDINameNotFound(metadata, x);
+                    throw excJNDINameNotFound(jeeName, x);
             } else {
                 throw (DataException) exc(DataException.class,
                                           "CWWKD1080.datastore.general.err",
                                           getClassNames(repositoryInterfaces),
-                                          metadata.getJ2EEName(),
+                                          jeeName,
                                           dataStore,
                                           x).initCause(x);
             }
@@ -426,13 +427,12 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
      * value that is not found as an id or JNDI name, or is not accessible,
      * or the resource is misconfigured.
      *
-     * @param metadata metadata that is on the thread.
-     * @param cause    cause for the exception.
+     * @param jeeName name of the application artifact containing the repository.
+     * @param cause   cause for the exception.
      * @return DataException.
      */
     @Trivial
-    private DataException excDataStoreNotFound(ComponentMetaData metadata,
-                                               Throwable cause) {
+    private DataException excDataStoreNotFound(J2EEName jeeName, Throwable cause) {
         Class<?> primary = DataExtension.getPrimaryEntityType(repositoryInterfaces.stream().findFirst().get());
         String exampleEntityClassName = primary == null //
                         ? "org.example.MyEntity" //
@@ -472,7 +472,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         DataException x = exc(DataException.class,
                               "CWWKD1078.datastore.not.found",
                               getClassNames(repositoryInterfaces),
-                              metadata.getJ2EEName(),
+                              jeeName,
                               dataStore,
                               dataSourceConfigExample,
                               databaseStoreConfigExample,
@@ -488,12 +488,12 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
      * Creates an exception for a Repository that uses java:comp/DefaultDataSource
      * (the default if unspecified) but it is not configured.
      *
-     * @param metadata metadata that is on the thread.
-     * @param cause    cause for the exception, typically NamingException.
+     * @param jeeName name of the application artifact containing the repository.
+     * @param cause   cause for the exception, typically NamingException.
      * @return DataException.
      */
     @Trivial
-    private DataException excDefaultDataSourceNotFound(ComponentMetaData metadata,
+    private DataException excDefaultDataSourceNotFound(J2EEName jeeName,
                                                        Throwable cause) {
         Class<?> primary = DataExtension.getPrimaryEntityType(repositoryInterfaces.stream().findFirst().get());
         String exampleEntityClassName = primary == null //
@@ -533,7 +533,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
 
         DataException x = exc(DataException.class,
                               "CWWKD1077.defaultds.not.found",
-                              metadata.getJ2EEName(),
+                              jeeName,
                               getClassNames(repositoryInterfaces),
                               dataStore,
                               dataSourceConfigExample,
@@ -551,13 +551,12 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
      * JNDI name that is not found, not accessible, or the resource is
      * misconfigured.
      *
-     * @param metadata metadata that is on the thread.
-     * @param cause    cause for the exception, typically NamingException.
+     * @param jeeName name of the application artifact containing the repository.
+     * @param cause   cause for the exception, typically NamingException.
      * @return DataException.
      */
     @Trivial
-    private DataException excJNDINameNotFound(ComponentMetaData metadata,
-                                              Throwable cause) {
+    private DataException excJNDINameNotFound(J2EEName jeeName, Throwable cause) {
         Class<?> primary = DataExtension.getPrimaryEntityType(repositoryInterfaces.stream().findFirst().get());
         String exampleEntityClassName = primary == null //
                         ? "org.example.MyEntity" //
@@ -590,7 +589,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         DataException x = exc(DataException.class,
                               "CWWKD1079.jndi.not.found",
                               getClassNames(repositoryInterfaces),
-                              metadata.getJ2EEName(),
+                              jeeName,
                               dataStore,
                               "@Resource(name=\"java:app/env/jdbc/dsRef\",lookup=\"jdbc/ds\")",
                               "jndiName=\"jdbc/ds\"",
@@ -599,6 +598,42 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                               dataSourceConfigExample);
 
         return (DataException) x.initCause(cause);
+    }
+
+    /**
+     * Obtains the module name in which the repository interface is defined,
+     * or lacking that, the name of the application in which is is defined or used.
+     *
+     * @param repositoryInterface   the repository interface.
+     * @param repositoryClassLoader class loader of the repository interface.
+     * @param provider              OSGi service that provides the CDI extension.
+     * @return AppName[#ModuleName] with only the application name if not defined
+     *         in a module.
+     * @throws IllegalStateException if not running on an application thread.
+     */
+    private J2EEName getArtifactName(Class<?> repositoryInterface,
+                                     ClassLoader repositoryClassLoader,
+                                     DataProvider provider) {
+        J2EEName artifactName;
+
+        Optional<J2EEName> moduleNameOptional = //
+                        provider.cdiService.getModuleNameForClass(repositoryInterface);
+
+        if (moduleNameOptional.isPresent()) {
+            artifactName = moduleNameOptional.get();
+        } else {
+            // create component and module metadata based on the application metadata
+            ComponentMetaData cdata = ComponentMetaDataAccessorImpl //
+                            .getComponentMetaDataAccessor().getComponentMetaData();
+            if (cdata == null) // internal error - used outside of an application
+                throw new IllegalStateException();
+            ApplicationMetaData adata = //
+                            cdata.getModuleMetaData().getApplicationMetaData();
+            cdata = provider.createComponentMetadata(adata, repositoryClassLoader);
+            artifactName = cdata.getModuleMetaData().getJ2EEName();
+        }
+
+        return artifactName;
     }
 
     /**
@@ -612,48 +647,19 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
     private String getMetadataIdentifier() {
         String mdIdentifier;
 
-        if (moduleName.getModule() == null) {
-            mdIdentifier = provider.getMetaDataIdentifier(moduleName.getApplication(),
-                                                          moduleName.getModule(),
+        if (jeeName.getModule() == null) {
+            mdIdentifier = provider.getMetaDataIdentifier(jeeName.getApplication(),
+                                                          jeeName.getModule(),
                                                           null);
         } else {
             mdIdentifier = provider.metadataIdSvc //
                             .getMetaDataIdentifier(inWebModule ? "WEB" : "EJB",
-                                                   moduleName.getApplication(),
-                                                   moduleName.getModule(),
+                                                   jeeName.getApplication(),
+                                                   jeeName.getModule(),
                                                    null);
         }
 
         return mdIdentifier;
-    }
-
-    /**
-     * Obtains the module name in which the repository interface is defined.
-     *
-     * @param repositoryInterface   the repository interface.
-     * @param repositoryClassLoader class loader of the repository interface.
-     * @param provider              OSGi service that provides the CDI extension.
-     * @return AppName[#ModuleName] with only the application name if not defined
-     *         in a module.
-     */
-    private J2EEName getModuleName(Class<?> repositoryInterface,
-                                   ClassLoader repositoryClassLoader,
-                                   DataProvider provider) {
-        J2EEName moduleName;
-
-        Optional<J2EEName> moduleNameOptional = provider.cdiService.getModuleNameForClass(repositoryInterface);
-
-        if (moduleNameOptional.isPresent()) {
-            moduleName = moduleNameOptional.get();
-        } else {
-            // create component and module metadata based on the application metadata
-            ComponentMetaData cdata = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-            ApplicationMetaData adata = cdata == null ? null : cdata.getModuleMetaData().getApplicationMetaData();
-            cdata = provider.createComponentMetadata(adata, repositoryClassLoader);
-            moduleName = cdata.getModuleMetaData().getJ2EEName();
-        }
-
-        return moduleName;
     }
 
     @Override
@@ -680,7 +686,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         writer.println(indent + "  namespace: " + namespace);
         writer.println(indent + "    application: " + application);
         writer.println(indent + "    module: " + module);
-        writer.println(indent + "  defining artifact: " + moduleName);
+        writer.println(indent + "  defining artifact: " + jeeName);
         writer.println(indent + "  repository class loader: " + repositoryClassLoader);
 
         repositoryInterfaces.forEach(r -> {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -82,7 +82,7 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
         this.provider = provider;
         this.queriesPerEntityClass = queriesPerEntityClass;
         this.repositoryInterface = repositoryInterface;
-        provider.producerCreated(futureEMBuilder.moduleName.getApplication(), this);
+        provider.producerCreated(futureEMBuilder.jeeName.getApplication(), this);
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
@@ -24,6 +24,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
 
 import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.EntityManagerBuilder;
@@ -48,7 +49,8 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
      * @param repositoryInterfaces  repository interfaces that use the entities.
      * @param emf                   entity manager factory.
      * @param pesistenceUnitRef     persistence unit reference.
-     * @param metaDataIdentifier    metadata identifier for the class loader of the repository interface.
+     * @param metadata              metadata of the application artifact that
+     *                                  contains the repository interface.
      * @param entityTypes           entity classes as known by the user, not generated.
      * @throws Exception if an error occurs.
      */
@@ -57,7 +59,7 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
                           Set<Class<?>> repositoryInterfaces,
                           EntityManagerFactory emf,
                           String persistenceUnitRef,
-                          String metadataIdentifier,
+                          ComponentMetaData metadata,
                           Set<Class<?>> entityTypes) throws Exception {
         super(provider, //
               repositoryClassLoader, //

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -60,6 +60,7 @@ import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 import com.ibm.wsspi.persistence.DDLGenerationParticipant;
 import com.ibm.wsspi.persistence.DatabaseStore;
@@ -130,9 +131,10 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
      * @param repositoryInterfaces  repository interfaces that use the entities.
      * @param dataStore             dataStore value from the Repository annotation,
      *                                  or the value with java:comp/env added.
-     * @param isJNDIName            indicates if the dataStore name is a JNDI name (begins with java: or is inferred to be java:comp/env/...)
-     * @param metaDataIdentifier    metadata identifier for the class loader of the repository interface.
-     * @param jeeName               application/module/component in which the repository interface is defined.
+     * @param isJNDIName            indicates if the dataStore name is a JNDI name
+     *                                  (begins with java: or is inferred to be java:comp/env/...)
+     * @param metadata              metadata of the application artifact that
+     *                                  contains the repository interface.
      *                                  Module and component might be null or absent.
      * @param entityTypes           entity classes as known by the user, not generated.
      * @throws Exception if an error occurs.
@@ -142,14 +144,14 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
                             Set<Class<?>> repositoryInterfaces,
                             String dataStore,
                             boolean isJNDIName,
-                            String metadataIdentifier,
-                            J2EEName jeeName,
+                            ComponentMetaData metadata,
                             Set<Class<?>> entityTypes) throws Exception {
         super(provider, repositoryClassLoader, repositoryInterfaces, dataStore);
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         String qualifiedName = null;
         boolean javaApp = false, javaModule = false, javaComp = false;
+        J2EEName jeeName = metadata.getJ2EEName();
         String application = jeeName == null ? null : jeeName.getApplication();
         String module = jeeName == null ? null : jeeName.getModule();
 
@@ -222,7 +224,7 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
             }
             if (dbStoreId == null) {
                 // Create a ResourceFactory that can delegate back to a resource reference lookup
-                ResourceFactory delegator = new ResRefDelegator(dataStore, metadataIdentifier, provider);
+                ResourceFactory delegator = new ResRefDelegator(dataStore, metadata);
                 Hashtable<String, Object> svcProps = new Hashtable<String, Object>();
                 dbStoreId = isJNDIName ? qualifiedName : ("application[" + application + "]/databaseStore[" + dataStore + ']');
                 String id = dbStoreId + "/ResourceFactory";

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/ResRefDelegator.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/ResRefDelegator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,29 +19,24 @@ import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.resource.ResourceFactory;
 import com.ibm.wsspi.resource.ResourceInfo;
 
-import io.openliberty.data.internal.persistence.DataProvider;
-
 /**
  * A resource factory that delegates to a resource reference JNDI name that was
  * specified as the dataStore for a Repository.
  */
 class ResRefDelegator implements ResourceFactory {
-    private final String identifier;
     private final String jndiName;
-    private final DataProvider provider;
+    private final ComponentMetaData metadata;
 
     /**
      * Construct a new instance.
      *
      * @param jndiName resource reference JNDI name to look up.
-     * @param metadata metadata identifier for the application artifact
+     * @param metadata metadata for the application artifact
      *                     that defines the repository interface.
-     * @param provider OSGi service that provides the CDI extension.
      */
-    ResRefDelegator(String jndiName, String identifier, DataProvider provider) {
+    ResRefDelegator(String jndiName, ComponentMetaData metadata) {
         this.jndiName = jndiName;
-        this.identifier = identifier;
-        this.provider = provider;
+        this.metadata = metadata;
     }
 
     /**
@@ -54,8 +49,6 @@ class ResRefDelegator implements ResourceFactory {
      */
     @Override
     public Object createResource(ResourceInfo info) throws Exception {
-        ComponentMetaData metadata = (ComponentMetaData) provider.metadataIdSvc.getMetaData(identifier);
-
         ComponentMetaDataAccessorImpl accessor = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor();
         if (metadata == null)
             accessor.beginDefaultContext();

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -46,7 +46,7 @@ import test.jakarta.data.web.DataTestServlet;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
-@CheckpointTest
+@CheckpointTest(alwaysRun = false) // true to run locally
 public class DataTestCheckpoint extends FATServletClient {
     @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataServletContextListener.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataServletContextListener.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.web;
+
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+
+/**
+ * Servlet context listener that uses Jakarta Data to pre-populate the table
+ * that is used by the Prime entity.
+ */
+@WebListener
+public class DataServletContextListener implements ServletContextListener {
+
+    @Inject
+    private Primes primes;
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+    }
+
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+        System.out.println("DataServletContextListener.contextInitialized:" +
+                           " populate tables for " + // primes.toString());
+                           " TODO: primes.toString()");
+
+        // TODO move code to here from DataTestServlet.init()
+    }
+
+}

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataServletContextListener.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataServletContextListener.java
@@ -34,37 +34,10 @@ public class DataServletContextListener implements ServletContextListener {
     @Override
     public void contextInitialized(ServletContextEvent event) {
         System.out.println("DataServletContextListener.contextInitialized:" +
-                           " populate tables for " + primes.toString());
-
-        // Do not add or remove from this data in tests.
-        // Tests must be able to rely on this data always being present.
-        primes.persist(new Prime(2, "2", "10", 1, "II", "two"),
-                       new Prime(3, "3", "11", 2, "III", "three"),
-                       new Prime(5, "5", "101", 2, "V", "five"),
-                       new Prime(7, "7", "111", 3, "VII", "seven"),
-                       new Prime(11, "B", "1011", 3, "XI", "eleven"),
-                       new Prime(13, "D", "1101", 3, "XIII", "thirteen"),
-                       new Prime(17, "11", "10001", 2, "XVII", "seventeen"),
-                       new Prime(19, "13", "10011", 3, "XIX", "nineteen"),
-                       new Prime(23, "17", "10111", 4, "XXIII", "twenty-three"),
-                       new Prime(29, "1D", "11101", 4, "XXIX", "twenty-nine"),
-                       new Prime(31, "1F", "11111", 5, "XXXI", "thirty-one"),
-                       new Prime(37, "25", "100101", 3, "XXXVII", "thirty-seven"),
-                       new Prime(41, "29", "101001", 3, "XLI", "forty-one"),
-                       new Prime(43, "2B", "101011", 4, "XLIII", "forty-three"),
-                       new Prime(47, "2F", "101111", 5, "XLVII", "forty-seven"),
-                       // romanNumeralSymbols null:
-                       new Prime(4001, "FA1", "111110100001", 7, null, "four thousand one"),
-                       // romanNumeralSymbols null:
-                       new Prime(4003, "FA3", "111110100011", 8, null, "four thousand three"),
-                       // romanNumeralSymbols null:
-                       new Prime(4007, "Fa7", "111110100111", 9, null, "four thousand seven"),
-                       // empty list of romanNumeralSymbols:
-                       new Prime(4013, "FAD", "111110101101", 9, "", "Four Thousand Thirteen"),
-                       // empty list of romanNumeralSymbols:
-                       new Prime(4019, "FB3", "111110110011", 9, "", "four thousand nineteen"),
-                       // extra blank space at beginning and end:
-                       new Prime(4021, "FB5", "111110110101", 9, "", " Four thousand twenty-one "));
+                           " populate tables for " + //primes.toString());
+                           " TODO: enable the above to reproduce deadlock due to" +
+                           " Checkpoint delaying the initialization that the" +
+                           " repository waits when first used.");
     }
 
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataServletContextListener.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataServletContextListener.java
@@ -34,10 +34,37 @@ public class DataServletContextListener implements ServletContextListener {
     @Override
     public void contextInitialized(ServletContextEvent event) {
         System.out.println("DataServletContextListener.contextInitialized:" +
-                           " populate tables for " + // primes.toString());
-                           " TODO: primes.toString()");
+                           " populate tables for " + primes.toString());
 
-        // TODO move code to here from DataTestServlet.init()
+        // Do not add or remove from this data in tests.
+        // Tests must be able to rely on this data always being present.
+        primes.persist(new Prime(2, "2", "10", 1, "II", "two"),
+                       new Prime(3, "3", "11", 2, "III", "three"),
+                       new Prime(5, "5", "101", 2, "V", "five"),
+                       new Prime(7, "7", "111", 3, "VII", "seven"),
+                       new Prime(11, "B", "1011", 3, "XI", "eleven"),
+                       new Prime(13, "D", "1101", 3, "XIII", "thirteen"),
+                       new Prime(17, "11", "10001", 2, "XVII", "seventeen"),
+                       new Prime(19, "13", "10011", 3, "XIX", "nineteen"),
+                       new Prime(23, "17", "10111", 4, "XXIII", "twenty-three"),
+                       new Prime(29, "1D", "11101", 4, "XXIX", "twenty-nine"),
+                       new Prime(31, "1F", "11111", 5, "XXXI", "thirty-one"),
+                       new Prime(37, "25", "100101", 3, "XXXVII", "thirty-seven"),
+                       new Prime(41, "29", "101001", 3, "XLI", "forty-one"),
+                       new Prime(43, "2B", "101011", 4, "XLIII", "forty-three"),
+                       new Prime(47, "2F", "101111", 5, "XLVII", "forty-seven"),
+                       // romanNumeralSymbols null:
+                       new Prime(4001, "FA1", "111110100001", 7, null, "four thousand one"),
+                       // romanNumeralSymbols null:
+                       new Prime(4003, "FA3", "111110100011", 8, null, "four thousand three"),
+                       // romanNumeralSymbols null:
+                       new Prime(4007, "Fa7", "111110100111", 9, null, "four thousand seven"),
+                       // empty list of romanNumeralSymbols:
+                       new Prime(4013, "FAD", "111110101101", 9, "", "Four Thousand Thirteen"),
+                       // empty list of romanNumeralSymbols:
+                       new Prime(4019, "FB3", "111110110011", 9, "", "four thousand nineteen"),
+                       // extra blank space at beginning and end:
+                       new Prime(4021, "FB5", "111110110101", 9, "", " Four thousand twenty-one "));
     }
 
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -170,29 +170,6 @@ public class DataTestServlet extends FATServlet {
 
     @Override
     public void init(ServletConfig config) throws ServletException {
-        // Do not add or remove from this data in tests.
-        // Tests must be able to rely on this data always being present.
-        primes.persist(new Prime(2, "2", "10", 1, "II", "two"),
-                       new Prime(3, "3", "11", 2, "III", "three"),
-                       new Prime(5, "5", "101", 2, "V", "five"),
-                       new Prime(7, "7", "111", 3, "VII", "seven"),
-                       new Prime(11, "B", "1011", 3, "XI", "eleven"),
-                       new Prime(13, "D", "1101", 3, "XIII", "thirteen"),
-                       new Prime(17, "11", "10001", 2, "XVII", "seventeen"),
-                       new Prime(19, "13", "10011", 3, "XIX", "nineteen"),
-                       new Prime(23, "17", "10111", 4, "XXIII", "twenty-three"),
-                       new Prime(29, "1D", "11101", 4, "XXIX", "twenty-nine"),
-                       new Prime(31, "1F", "11111", 5, "XXXI", "thirty-one"),
-                       new Prime(37, "25", "100101", 3, "XXXVII", "thirty-seven"),
-                       new Prime(41, "29", "101001", 3, "XLI", "forty-one"),
-                       new Prime(43, "2B", "101011", 4, "XLIII", "forty-three"),
-                       new Prime(47, "2F", "101111", 5, "XLVII", "forty-seven"),
-                       new Prime(4001, "FA1", "111110100001", 7, null, "four thousand one"), // romanNumeralSymbols null
-                       new Prime(4003, "FA3", "111110100011", 8, null, "four thousand three"), // romanNumeralSymbols null
-                       new Prime(4007, "Fa7", "111110100111", 9, null, "four thousand seven"), // romanNumeralSymbols null
-                       new Prime(4013, "FAD", "111110101101", 9, "", "Four Thousand Thirteen"), // empty list of romanNumeralSymbols
-                       new Prime(4019, "FB3", "111110110011", 9, "", "four thousand nineteen"), // empty list of romanNumeralSymbols
-                       new Prime(4021, "FB5", "111110110101", 9, "", " Four thousand twenty-one ")); // extra blank space at beginning and end
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -170,6 +170,35 @@ public class DataTestServlet extends FATServlet {
 
     @Override
     public void init(ServletConfig config) throws ServletException {
+        // Do not add or remove from this data in tests.
+        // Tests must be able to rely on this data always being present.
+        primes.persist(new Prime(2, "2", "10", 1, "II", "two"),
+                       new Prime(3, "3", "11", 2, "III", "three"),
+                       new Prime(5, "5", "101", 2, "V", "five"),
+                       new Prime(7, "7", "111", 3, "VII", "seven"),
+                       new Prime(11, "B", "1011", 3, "XI", "eleven"),
+                       new Prime(13, "D", "1101", 3, "XIII", "thirteen"),
+                       new Prime(17, "11", "10001", 2, "XVII", "seventeen"),
+                       new Prime(19, "13", "10011", 3, "XIX", "nineteen"),
+                       new Prime(23, "17", "10111", 4, "XXIII", "twenty-three"),
+                       new Prime(29, "1D", "11101", 4, "XXIX", "twenty-nine"),
+                       new Prime(31, "1F", "11111", 5, "XXXI", "thirty-one"),
+                       new Prime(37, "25", "100101", 3, "XXXVII", "thirty-seven"),
+                       new Prime(41, "29", "101001", 3, "XLI", "forty-one"),
+                       new Prime(43, "2B", "101011", 4, "XLIII", "forty-three"),
+                       new Prime(47, "2F", "101111", 5, "XLVII", "forty-seven"),
+                       // romanNumeralSymbols null:
+                       new Prime(4001, "FA1", "111110100001", 7, null, "four thousand one"),
+                       // romanNumeralSymbols null:
+                       new Prime(4003, "FA3", "111110100011", 8, null, "four thousand three"),
+                       // romanNumeralSymbols null:
+                       new Prime(4007, "Fa7", "111110100111", 9, null, "four thousand seven"),
+                       // empty list of romanNumeralSymbols:
+                       new Prime(4013, "FAD", "111110101101", 9, "", "Four Thousand Thirteen"),
+                       // empty list of romanNumeralSymbols:
+                       new Prime(4019, "FB3", "111110110011", 9, "", "four thousand nineteen"),
+                       // extra blank space at beginning and end:
+                       new Prime(4021, "FB5", "111110110101", 9, "", " Four thousand twenty-one "));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/ejb/StartupSingletonEJB.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/ejb/StartupSingletonEJB.java
@@ -15,6 +15,7 @@ package test.jakarta.data.datastore.ejb;
 import jakarta.annotation.PostConstruct;
 import jakarta.ejb.Singleton;
 import jakarta.ejb.Startup;
+import jakarta.inject.Inject;
 
 @Startup
 @Singleton
@@ -22,11 +23,11 @@ public class StartupSingletonEJB {
 
     //TODO Renable when  javax.naming.NameNotFoundException is fixed
     //FutureEMBuilder: InitialContext.doLookup(dataStore)
-    //@Inject
-    //EJBModuleDSDRepo repo;
+    @Inject
+    EJBModuleDSDRepo repo;
 
     @PostConstruct
     public void init() {
-        //    repo.acquire(0);
+        repo.acquire(0);
     }
 }

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreServletContextListener.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreServletContextListener.java
@@ -17,6 +17,8 @@ import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 import jakarta.servlet.annotation.WebListener;
 
+import test.jakarta.data.datastore.lib.ServerDSEntity;
+
 /**
  * Servlet context listener that uses Jakarta Data to pre-populate the table
  * that is used by the ServerDSResRefRepo entity.
@@ -34,11 +36,10 @@ public class DataStoreServletContextListener implements ServletContextListener {
     @Override
     public void contextInitialized(ServletContextEvent event) {
         System.out.println("DataStoreServletContextListener.contextInitialized:" +
-                           " populate tables for " + // serverDSResRefRepo.toString());
-                           " TODO: serverDSResRefRepo.toString()");
+                           " populate tables for " + serverDSResRefRepo.toString());
 
-        // TODO add code to write values here
-        // and include test in servlet to read them
+        serverDSResRefRepo.write(ServerDSEntity.of("DSSCL-one", 1));
+        serverDSResRefRepo.write(ServerDSEntity.of("DSSCL-two", 2));
     }
 
 }

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreServletContextListener.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreServletContextListener.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.datastore.web;
+
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+
+/**
+ * Servlet context listener that uses Jakarta Data to pre-populate the table
+ * that is used by the ServerDSResRefRepo entity.
+ */
+@WebListener
+public class DataStoreServletContextListener implements ServletContextListener {
+
+    @Inject
+    ServerDSResRefRepo serverDSResRefRepo;
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+    }
+
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+        System.out.println("DataStoreServletContextListener.contextInitialized:" +
+                           " populate tables for " + // serverDSResRefRepo.toString());
+                           " TODO: serverDSResRefRepo.toString()");
+
+        // TODO add code to write values here
+        // and include test in servlet to read them
+    }
+
+}

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreTestServlet.java
@@ -404,4 +404,19 @@ public class DataStoreTestServlet extends FATServlet {
     public void testDataSourceDefinitionInWARModuleFromEJB() throws SQLException {
         testEJB.testDataSourceDefinitionInWARModuleFromEJB();
     }
+
+    /**
+     * Verify that ServletContextListener can inject a Jakarta Data repository
+     * and use it to initialize data.
+     */
+    @Test
+    public void testServletContextListenerPopulatesDatabase() {
+        ServerDSEntity one = serverDSResRefRepo.read("DSSCL-one").orElseThrow();
+        assertEquals("DSSCL-one", one.id);
+        assertEquals(1, one.value);
+
+        ServerDSEntity two = serverDSResRefRepo.read("DSSCL-two").orElseThrow();
+        assertEquals("DSSCL-two", two.id);
+        assertEquals(2, two.value);
+    }
 }


### PR DESCRIPTION
Enables Jakarta Data repositories to be used within a ServletContextInitializer.
Adds tests of using ServletContextInitializer to pre-populate data with a Jakarta Data repository.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
