### PR TITLE
Skip check_defaultLogging_AUTOCOMPLETE_OFF_VIEW_STATE for EE8 and later

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFSimpleHtmlUnit.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFSimpleHtmlUnit.java
@@ -250,12 +250,12 @@ public class JSFSimpleHtmlUnit {
     /**
      * Create a testcase 169346: Port MYFACES-3949, javax.faces.ViewState autocomplete
      * 
-     * In Faces 4.1 and 2.3.11, AUTOCOMPLETE_OFF_VIEW_STATE changed to false -- see MYFACES-4659 
+     * AUTOCOMPLETE_OFF_VIEW_STATE changed to false (2.3.11, 3.0,3, 4.0.3, and 4.1.0) -- see MYFACES-4659 
      *
      * @throws Exception
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE8_FEATURES) // parameter change in 2.3.11
+    @SkipForRepeat(SkipForRepeat.EE8_OR_LATER_FEATURES) // parameter change in 2.3.11
     public void check_defaultLogging_AUTOCOMPLETE_OFF_VIEW_STATE() throws Exception {
         try (WebClient webClient = new WebClient()) {
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

To avoid merge conflicts as we update the JSF/Faces releases! The default changed, so this test no longer applies except for EE7 (jsf-2.2)

Follow up issue: #31116