### PR TITLE
Cleanup and performance improvements in App ClassLoader logic

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011,2024 IBM Corporation and others.
+ * Copyright (c) 2011,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1271,27 +1271,36 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
         if ( (location < 0) && !normalized ) {
             // Try again after forcing the path to be normalized.
+            String normalizedPath = PathUtils.normalizeUnixStylePath(entryPath);
 
-            entryPath = PathUtils.normalizeUnixStylePath(entryPath);
-            pathLen = entryPath.length();
-
-            if ( (pathLen == 0) || (pathLen == 1) && (entryPath.charAt(0) == '/') ) {
-                return null; // "" and "/" reach the root; the root container has no entry.
-            }
-
-            if ( !PathUtils.isNormalizedPathAbsolute(entryPath) ) {
-                return null; // Leading ".." or "/.."; the path reaches outside of this container.
-            }
-
-            if ( entryPath.charAt(0) == '/' ) {
-                a_entryPath = entryPath;
-                r_entryPath = entryPath.substring(1); // The entries table uses relative paths.
+            // If the entryPath was already normalized we only have to do the one check.
+            // All other state remains the same and we do not need to do locatePath again since the entryPath is exactly the same
+            if (normalizedPath == entryPath) {
+                if ( !PathUtils.isNormalizedPathAbsolute(entryPath) ) {
+                    return null; // Leading ".." or "/.."; the path reaches outside of this container.
+                }
             } else {
-                a_entryPath = null; // Maybe won't need it.
-                r_entryPath = entryPath; // The path is already relative.
-            }
+                entryPath = normalizedPath;
+                pathLen = entryPath.length();
 
-            location = locatePath(r_entryPath);
+                if ( (pathLen == 0) || (pathLen == 1) && (entryPath.charAt(0) == '/') ) {
+                    return null; // "" and "/" reach the root; the root container has no entry.
+                }
+
+                if ( !PathUtils.isNormalizedPathAbsolute(entryPath) ) {
+                    return null; // Leading ".." or "/.."; the path reaches outside of this container.
+                }
+
+                if ( entryPath.charAt(0) == '/' ) {
+                    a_entryPath = entryPath;
+                    r_entryPath = entryPath.substring(1); // The entries table uses relative paths.
+                } else {
+                    a_entryPath = null; // Maybe won't need it.
+                    r_entryPath = entryPath; // The path is already relative.
+                }
+
+                location = locatePath(r_entryPath);
+            }
         }
 
         ZipEntryData useZipEntryData;

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
@@ -505,18 +505,6 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
         }
     }
 
-    final ByteResourceInformation findClassBytes(String className, String resourceName) {
-        try {
-            return findClassBytesImpl(className, resourceName);
-        } catch (IOException e) {
-            Tr.error(tc, "cls.class.file.not.readable", className, resourceName);
-            String message = String.format("Could not read class '%s' as resource '%s'", className, resourceName);
-            ClassFormatError error = new ClassFormatError(message);
-            error.initCause(e);
-            throw error;
-        }
-    }
-
     @Override
     @Trivial
     protected final Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
@@ -61,17 +61,12 @@ public class LibertyClassLoaderTest {
 
     @Test
     public void testClassFormatError() throws Exception {
-        Container c = buildMockContainer("testClasses", getOtherClassesURL(ClassSource.A));
+        Container c = buildMockContainer("testClasses", getOtherClassesURL(ClassSource.A), true);
 
-        loader = new AppClassLoader(loader.getParent(), loader.config, Arrays.asList(c), (DeclaredApiAccess) (loader.getParent()), null, null, new GlobalClassloadingConfiguration(), Collections.emptyList()) {
-            @Override
-            protected com.ibm.ws.classloading.internal.AppClassLoader.ByteResourceInformation findClassBytesImpl(String className, String resourceName) throws IOException {
-                throw new IOException();
-            }
-        };
+        loader = new AppClassLoader(loader.getParent(), loader.config, Arrays.asList(c), (DeclaredApiAccess) (loader.getParent()), null, null, new GlobalClassloadingConfiguration(), Collections.emptyList());
 
         try {
-            loader.findClassBytes("test", "test.class");
+            loader.findClassBytes("test.DummyServlet", "test/DummyServlet.class");
             fail("call should have thrown an exception");
         } catch (ClassFormatError e) {
             assertTrue("Should have traced an error", outputManager.checkForStandardErr("CWWKL0002E"));

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/ProtectionDomainTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/ProtectionDomainTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -74,11 +74,11 @@ public class ProtectionDomainTest {
         config.setProtectionDomain(new ProtectionDomain(new CodeSource(new File(".").toURI().toURL(), (Certificate[]) null), null));
 
         List<Container> containers = new ArrayList<Container>();
-        MockContainer testJarContainer = new MockContainer("testJar", getTestJarURL());
+        Container testJarContainer = TestUtil.buildMockContainer("testJar", getTestJarURL());
         containers.add(testJarContainer);
 
         URL thisClassURL = this.getClass().getProtectionDomain().getCodeSource().getLocation();
-        MockContainer unittestClassDir = new MockContainer("unittestClassDir", thisClassURL);
+        Container unittestClassDir = TestUtil.buildMockContainer("unittestClassDir", thisClassURL);
         containers.add(unittestClassDir);
 
         DeclaredApiAccess access = new DeclaredApiAccess() {
@@ -113,11 +113,11 @@ public class ProtectionDomainTest {
         config.setId(id);
 
         List<Container> containers = new ArrayList<Container>();
-        MockContainer testJarContainer = new MockContainer("testJar", getTestJarURL());
+        Container testJarContainer = TestUtil.buildMockContainer("testJar", getTestJarURL());
         containers.add(testJarContainer);
 
         URL thisClassURL = this.getClass().getProtectionDomain().getCodeSource().getLocation();
-        MockContainer unittestClassDir = new MockContainer("unittestClassDir", thisClassURL);
+        Container unittestClassDir = TestUtil.buildMockContainer("unittestClassDir", thisClassURL);
         containers.add(unittestClassDir);
 
         DeclaredApiAccess access = new DeclaredApiAccess() {

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/TestUtil.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/TestUtil.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -61,7 +61,11 @@ final class TestUtil {
     static final String SERVLET_JAR_LOCATION = "servlet.jar.location";
 
     static final Container buildMockContainer(final String name, final URL url) {
-        return new MockContainer(name, url);
+        return buildMockContainer(name, url, false);
+    }
+
+    static final Container buildMockContainer(final String name, final URL url, boolean throwException) {
+        return new MockContainer(name, url, throwException);
     }
 
     static synchronized ClassLoadingServiceImpl getClassLoadingService(ClassLoader parentClassLoader) throws BundleException, InvalidSyntaxException {

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/TransformerTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/TransformerTest.java
@@ -19,22 +19,30 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
 import com.ibm.ws.classloading.internal.ClassLoadingServiceImpl.ClassFileTransformerAdapter;
 import com.ibm.ws.classloading.internal.ContainerClassLoader.ByteResourceInformation;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
+import com.ibm.ws.classloading.internal.ContainerClassLoader.ContainerURL;
+import com.ibm.ws.classloading.internal.ContainerClassLoader.UniversalContainer;
+import com.ibm.ws.kernel.boot.classloader.ClassLoaderHook;
 import com.ibm.wsspi.classloading.ClassTransformer;
 
 import test.common.SharedOutputManager;
@@ -47,11 +55,6 @@ public class TransformerTest {
 
     @Rule
     public SharedOutputManager outputManager = SharedOutputManager.getInstance();
-
-    @After
-    public void removeBetaFlag() {
-        System.getProperties().remove(ProductInfo.BETA_EDITION_JVM_PROPERTY);
-    }
 
     @Test
     public void testTransformerRegistration() throws Exception {
@@ -69,6 +72,52 @@ public class TransformerTest {
         assertFalse("Should not be able to remove newly added transformer adapter twice", loader.removeTransformer(transformer1));
     }
 
+    private static UniversalContainer testContainer = new UniversalContainer() {
+
+        private final URL url;
+
+        {
+            URL urlToSet;
+            try {
+                urlToSet = new File(System.getProperty("user.dir")).toURI().toURL();
+            } catch (MalformedURLException e) {
+                urlToSet = null;
+            }
+            url = urlToSet;
+        }
+
+        @Override
+        public UniversalResource getResource(String name) {
+            return null;
+        }
+
+        @Override
+        public void updatePackageMap(Map<Integer, List<UniversalContainer>> map) {
+
+        }
+
+        @Override
+        public Collection<URL> getContainerURLs() {
+            return null;
+        }
+
+        @Override
+        public void definePackage(String packageName, LibertyLoader loader, ContainerURL sealBase) {
+
+        }
+
+        @Override
+        public ContainerURL getContainerURL(UniversalResource resource) {
+            return new ContainerURL(url);
+        }
+
+        @Override
+        public URL getSharedClassCacheURL(UniversalResource resource) {
+            return url;
+        }
+
+    };
+
     @Test
     public void testTransformerReturnsNull() throws Exception {
         doTestTransformerReturnsNull(false);
@@ -80,10 +129,6 @@ public class TransformerTest {
     }
 
     private void doTestTransformerReturnsNull(boolean systemTransformer) throws Exception {
-        if (systemTransformer) {
-            System.setProperty(ProductInfo.BETA_EDITION_JVM_PROPERTY, Boolean.TRUE.toString());
-        }
-
         final AtomicBoolean transformerInvoked = new AtomicBoolean(false);
         ClassFileTransformer transformer = new ClassFileTransformer() {
 
@@ -97,7 +142,7 @@ public class TransformerTest {
         AppClassLoader loader = createAppClassloaderTransformer(transformer, systemTransformer);
 
         byte[] originalBytes = "Hello!".getBytes();
-        ByteResourceInformation toTransform = new ByteResourceInformation(originalBytes, null, null, null, false, () -> originalBytes, null);
+        ByteResourceInformation toTransform = new ByteResourceInformation(testContainer, null, null, () -> originalBytes, null);
         byte[] transformedBytes = loader.transformClassBytes("hello", toTransform);
 
         assertTrue(transformerInvoked.get());
@@ -125,10 +170,6 @@ public class TransformerTest {
     }
 
     private void doTestTransformerReturnsSameBytes(boolean systemTransformer) throws Exception {
-        if (systemTransformer) {
-            System.setProperty(ProductInfo.BETA_EDITION_JVM_PROPERTY, Boolean.TRUE.toString());
-        }
-
         final AtomicBoolean transformerInvoked = new AtomicBoolean(false);
         ClassFileTransformer transformer = new ClassFileTransformer() {
 
@@ -143,7 +184,7 @@ public class TransformerTest {
         AppClassLoader loader = createAppClassloaderTransformer(transformer, systemTransformer);
 
         byte[] originalBytes = "Goodbye!".getBytes();
-        ByteResourceInformation toTransform = new ByteResourceInformation(originalBytes, null, null, null, false, () -> originalBytes, null);
+        ByteResourceInformation toTransform = new ByteResourceInformation(testContainer, null, null, () -> originalBytes, null);
         byte[] transformedBytes = loader.transformClassBytes("goodbye", toTransform);
 
         assertTrue(transformerInvoked.get());
@@ -162,10 +203,6 @@ public class TransformerTest {
     }
 
     private void doTestTransformerReturnsTransformedBytes(boolean systemTransformer) throws Exception {
-        if (systemTransformer) {
-            System.setProperty(ProductInfo.BETA_EDITION_JVM_PROPERTY, Boolean.TRUE.toString());
-        }
-
         final AtomicBoolean transformerInvoked = new AtomicBoolean(false);
         ClassFileTransformer transformer = new ClassFileTransformer() {
 
@@ -181,7 +218,7 @@ public class TransformerTest {
         AppClassLoader loader = createAppClassloaderTransformer(transformer, systemTransformer);
 
         byte[] originalBytes = "Greetings".getBytes();
-        ByteResourceInformation toTransform = new ByteResourceInformation(originalBytes, null, null, null, false, () -> originalBytes, null);
+        ByteResourceInformation toTransform = new ByteResourceInformation(testContainer, null, null, () -> originalBytes, null);
         byte[] transformedBytes = loader.transformClassBytes("greetings", toTransform);
 
         assertTrue(transformerInvoked.get());
@@ -214,25 +251,42 @@ public class TransformerTest {
         };
         AppClassLoader loader = createAppClassloaderTransformer(transformer, systemTransformer);
 
+        final AtomicBoolean hookLoadClassInvoked = new AtomicBoolean(false);
         byte[] originalBytes = "Greetings".getBytes();
-        final boolean fromCached = true;
-        ByteResourceInformation toTransform = new ByteResourceInformation(originalBytes, null, null, null, fromCached, () -> originalBytes, null);
+        ClassLoaderHook hook = new ClassLoaderHook() {
+
+            @Override
+            public byte[] loadClass(URL arg0, String arg1) {
+                hookLoadClassInvoked.set(true);
+                return originalBytes;
+            }
+
+            @Override
+            public void storeClass(URL arg0, Class<?> arg1) {
+                // do nothing
+            }
+
+        };
+        AtomicInteger supplierCalled = new AtomicInteger(0);
+        Supplier<byte[]> supplier = new Supplier<byte[]>() {
+
+            @Override
+            public byte[] get() {
+                supplierCalled.incrementAndGet();
+                return originalBytes;
+            }
+
+        };
+
+        ByteResourceInformation toTransform = new ByteResourceInformation(testContainer, null, null, supplier, hook);
+        assertTrue(hookLoadClassInvoked.get());
+        assertTrue(toTransform.foundInClassCache());
         byte[] transformedBytes = loader.transformClassBytes("greetings", toTransform);
 
-        if (systemTransformer) {
-            // System transformers invoke in beta-editions, only
-            assertTrue(transformerInvoked.get());
-            assertFalse(Arrays.equals(originalBytes, transformedBytes));
-            assertEquals("Greetings and salutations!", new String(transformedBytes));
-        } else if (systemTransformer) {
-            assertFalse(transformerInvoked.get());
-            assertTrue(Arrays.equals(originalBytes, transformedBytes));
-            assertEquals("Greetings", new String(transformedBytes));
-        } else {
-            // Transformers invoke
-            assertTrue(transformerInvoked.get());
-            assertFalse(Arrays.equals(originalBytes, transformedBytes));
-            assertEquals("Greetings and salutations!", new String(transformedBytes));
-        }
+        assertTrue(transformerInvoked.get());
+        assertFalse(Arrays.equals(originalBytes, transformedBytes));
+        assertEquals("Greetings and salutations!", new String(transformedBytes));
+        // If supplier is called twice it means we did not use hook to get the bytes.
+        assertEquals(1, supplierCalled.get());
     }
 }


### PR DESCRIPTION
- Consolidate some function into method to avoid duplication of code
- In ZipFileContainer.getEntry() do not call locatePath twice for a not found entry if the entryPath was already normalized
- Don't call Policy to get PermissionsCollection if SecurityManager is not enabled when setting up ProtectionDomain and the classloader config PermissionCollection is null.  See #30277 where similar logic was done.
- Have getContainerURL return a ContainerURL class to avoid having to do the expensive URL.toString() when getting Class specific ProtectionDomain
- Move getClassBytesFromHook() logic to the ByteResourceInformation constructor to consolidate the Class bytes logic
- Remove unneeded getClassLoaderHook method from ContainerClassLoader
- Update TransformerTest for the new changes and remove the old beta checking in the test that is no longer needed
- Do the todo to remove the Impl method and update test to actually throw an IOException in the Entry InputStream like would normally happen to generate a ClassFormatException

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
