### PR TITLE
Test Bug: Update Content Length for Java 24 Builds in JSP Test

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestServlet.war/resources/Servlet31RequestResponseTest.jsp
+++ b/dev/com.ibm.ws.jsp.2.3_fat/test-applications/TestServlet.war/resources/Servlet31RequestResponseTest.jsp
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2015 IBM Corporation and others.
+    Copyright (c) 2015, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@
 	<%	
 	
 		// Testing the response.setContentLengthLong method
-		long length = 10000;
+		long length = 2165; // (Actual content length) If too large, a "java.io.IOException: Premature EOF" occurs on Java 24. (See JDK-8335135)
 		response.setContentLengthLong(length);
 		
 		sos.print("Testing SC_NOT_FOUND static field from HttpServletResponse (Expected: 404): " + HttpServletResponse.SC_NOT_FOUND + "<br/>");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


Caused by https://bugs.openjdk.org/browse/JDK-8335135