### PR TITLE
fix: cloudant allowable ffdc from IBM JDK

### DIFF
--- a/dev/com.ibm.ws.cloudant_fat/fat/src/com/ibm/ws/cloudant/fat/CloudantTest.java
+++ b/dev/com.ibm.ws.cloudant_fat/fat/src/com/ibm/ws/cloudant/fat/CloudantTest.java
@@ -147,7 +147,8 @@ public class CloudantTest extends FATServletClient {
 
     @Test
     @AllowedFFDC({ "java.security.cert.CertPathBuilderException",
-                   "sun.security.validator.ValidatorException" })
+                   "sun.security.validator.ValidatorException",
+                   "com.ibm.security.cert.IBMCertPathBuilderException" })
     public void testInvalidSSL() throws Exception {
         runTest();
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- IBM JDK 8 throws a more specific `com.ibm.security.cert.IBMCertPathBuilderException` then the generic superclass `java.security.cert.CertPathBuilderException`
- Previously exploited during: https://github.com/OpenLiberty/open-liberty/pull/31134
