### PR TITLE
debug: add debugging when config.json is malformed

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/containers/registry/ArtifactoryRegistry.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/registry/ArtifactoryRegistry.java
@@ -54,7 +54,7 @@ public class ArtifactoryRegistry extends Registry {
         REGISTRY_MIRRORS.put("quay.io", "wasliberty-quay-docker-remote");
     }
 
-    private static File configDir = new File(System.getProperty("user.home"), ".docker");
+    private static File CONFIG_DIR = DEFAULT_CONFIG_DIR;
 
     private String registry = ""; //Blank registry is the default setting
     private String authToken; // TODO remove
@@ -144,7 +144,7 @@ public class ArtifactoryRegistry extends Registry {
         // -- Create it by persisting the generated auth token
         if (Objects.isNull(foundAuthToken)) {
             try {
-                configFile = persistAuthToken(registry, generatedAuthToken, configDir);
+                configFile = persistAuthToken(registry, generatedAuthToken, CONFIG_DIR);
                 authToken = generatedAuthToken;
                 isArtifactoryAvailable = true;
                 return;
@@ -162,7 +162,7 @@ public class ArtifactoryRegistry extends Registry {
         // -- Attempt to persist auth token.
         // the persist method will check for matching tokens
         try {
-            configFile = persistAuthToken(registry, generatedAuthToken, configDir);
+            configFile = persistAuthToken(registry, generatedAuthToken, CONFIG_DIR);
             authToken = generatedAuthToken;
             isArtifactoryAvailable = true;
             return;

--- a/dev/fattest.simplicity/src/componenttest/containers/registry/InternalRegistry.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/registry/InternalRegistry.java
@@ -49,7 +49,7 @@ public class InternalRegistry extends Registry {
         REGISTRY_MIRRORS.put("localhost", "wasliberty-internal-docker-local"); // images we build
     }
 
-    private static File configDir = new File(System.getProperty("user.home"), ".docker");
+    private static File CONFIG_DIR = DEFAULT_CONFIG_DIR;
 
     private String registry;
     private Optional<File> configFile;
@@ -126,7 +126,7 @@ public class InternalRegistry extends Registry {
         // -- Create it by persisting the generated auth token
         if (Objects.isNull(foundAuthToken)) {
             try {
-                configFile = persistAuthToken(registry, generatedAuthToken, configDir);
+                configFile = persistAuthToken(registry, generatedAuthToken, CONFIG_DIR);
                 isRegistryAvailable = true;
                 return;
             } catch (Throwable t) {
@@ -142,7 +142,7 @@ public class InternalRegistry extends Registry {
 
         // -- Attempt to persist auth token.
         try {
-            configFile = persistAuthToken(registry, generatedAuthToken, configDir);
+            configFile = persistAuthToken(registry, generatedAuthToken, CONFIG_DIR);
             isRegistryAvailable = true;
             return;
         } catch (Throwable t) {

--- a/dev/fattest.simplicity/src/componenttest/containers/registry/Registry.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/registry/Registry.java
@@ -39,6 +39,8 @@ import com.ibm.websphere.simplicity.log.Log;
  */
 public abstract class Registry {
 
+    public static final File DEFAULT_CONFIG_DIR = new File(System.getProperty("user.home"), ".docker");
+
     private static final Class<?> c = Registry.class;
 
     /**

--- a/dev/fattest.simplicity/test/componenttest/containers/registry/ArtifactoryRegistryTest.java
+++ b/dev/fattest.simplicity/test/componenttest/containers/registry/ArtifactoryRegistryTest.java
@@ -45,7 +45,7 @@ public class ArtifactoryRegistryTest {
         // Avoid writing to the developers docker config
         File testdir = new File(System.getProperty("java.io.tmpdir"), ".docker");
 
-        Field configDir = ArtifactoryRegistry.class.getDeclaredField("configDir");
+        Field configDir = ArtifactoryRegistry.class.getDeclaredField("CONFIG_DIR");
         configDir.setAccessible(true);
         configDir.set(null, testdir);
     }

--- a/dev/fattest.simplicity/test/componenttest/containers/registry/InternalRegistryTest.java
+++ b/dev/fattest.simplicity/test/componenttest/containers/registry/InternalRegistryTest.java
@@ -43,7 +43,7 @@ public class InternalRegistryTest {
         // Avoid writing to the developers docker config
         File testdir = new File(System.getProperty("java.io.tmpdir"), ".docker");
 
-        Field configDir = InternalRegistry.class.getDeclaredField("configDir");
+        Field configDir = InternalRegistry.class.getDeclaredField("CONFIG_DIR");
         configDir.setAccessible(true);
         configDir.set(null, testdir);
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fail fast, or recover when a corrupted or malformed docker config.json file is found on a developers system or our build systems. 
