### PR TITLE
add aes-128 encoding option for #31105

### DIFF
--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/PasswordUtil.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/PasswordUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2024 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -744,8 +744,9 @@ public class PasswordUtil {
                     }
                 }
             }
-
-            buffer.append(crypto_algorithm);
+            // if "aes-128" or "aes-256" is used we want to make the tag "aes" instead so it will be usable on Liberty servers older than 25.0.0.4
+            String normalizedCryptoAlgorithm = crypto_algorithm.contains("aes") ? "aes" : crypto_algorithm;
+            buffer.append(normalizedCryptoAlgorithm);
             String alias = (null == info) ? null : info.getKeyAlias();
             if (alias != null && 0 < alias.length()) {
                 buffer.append(':').append(alias);

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/PasswordCipherUtil.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/PasswordCipherUtil.java
@@ -77,11 +77,13 @@ public class PasswordCipherUtil {
     private static final String CUSTOM_COLON = "custom:";
     private static final String XOR = "xor";
     private static final String AES = "aes";
+    private static final String AES_128 = "aes-128";
+    private static final String AES_256 = "aes-256";
     private static final String HASH = "hash";
 
     private static final byte XOR_MASK = 0x5F;
 
-    private static final String[] SUPPORTED_CRYPTO_ALGORITHMS_DEFAULT = new String[] { XOR, AES, HASH };
+    private static final String[] SUPPORTED_CRYPTO_ALGORITHMS_DEFAULT = new String[] { XOR, AES, AES_128, AES_256, HASH };
     private static final String[] SUPPORTED_CRYPTO_ALGORITHMS_CUSTOM = new String[] { XOR, AES, HASH, CUSTOM };
     private static String[] SUPPORTED_CRYPTO_ALGORITHMS = SUPPORTED_CRYPTO_ALGORITHMS_DEFAULT;
     private static String[] SUPPORTED_HASH_ALGORITHMS = new String[] { HASH };
@@ -216,7 +218,7 @@ public class PasswordCipherUtil {
 
         byte[] decrypted_bytes = null;
 
-        if (AES.equalsIgnoreCase(crypto_algorithm)) {
+        if (AES.equalsIgnoreCase(crypto_algorithm) || AES_128.equalsIgnoreCase(crypto_algorithm) || AES_256.equalsIgnoreCase(crypto_algorithm)) {
             decrypted_bytes = aesDecipher(encrypted_bytes);
         } else if (XOR.equalsIgnoreCase(crypto_algorithm)) {
             decrypted_bytes = xor(encrypted_bytes);
@@ -370,13 +372,19 @@ public class PasswordCipherUtil {
         EncryptedInfo info = null;
         byte[] encrypted_bytes = null;
 
-        if (AES.equalsIgnoreCase(crypto_algorithm)) {
+        if (AES.equalsIgnoreCase(crypto_algorithm) || AES_256.equalsIgnoreCase(crypto_algorithm)) {
             String cryptoKey = null;
             if (properties != null) {
                 cryptoKey = properties.get(PasswordUtil.PROPERTY_CRYPTO_KEY);
             }
             info = aesEncipherV1(decrypted_bytes, cryptoKey);
 
+        } else if (AES_128.equalsIgnoreCase(crypto_algorithm)) {
+            String cryptoKey = null;
+            if (properties != null) {
+                cryptoKey = properties.get(PasswordUtil.PROPERTY_CRYPTO_KEY);
+            }
+            info = aesEncipherV0(decrypted_bytes, cryptoKey, info, encrypted_bytes);
         } else if (XOR.equalsIgnoreCase(crypto_algorithm)) {
             encrypted_bytes = xor(decrypted_bytes);
             if (encrypted_bytes != null)

--- a/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
+++ b/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010, 2024 IBM Corporation and others.
+# Copyright (c) 2010, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -70,8 +70,9 @@ encode.option-desc.text=\
 encode.option-key.encoding=\
 \ \ \ \ --encoding=[xor|aes|hash{1}]
 encode.option-desc.encoding=\
-\tSpecify how to encode the password. Supported encodings are xor, aes,\n\
-\tand hash. The default encoding is xor. {2}
+\tSpecify how to encode the password. Supported encodings are xor, aes, aes-128,\n\
+\tand hash. The default encoding is xor. Aes encrypts by using an aes-256 bit key.\n\
+\taes-128 can be used for compatibility with server versions before 25.0.0.2. {2}
 encode.option-key.key=\
 \ \ \ \ --key=[key]
 encode.option-desc.key=\


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
Added a new option to specify a secret to be encrypted with AES-128 instead of AES-256.
This fixes https://github.com/OpenLiberty/open-liberty/issues/31105

AES-256 (default) Example:
```
wlp\bin>securityUtility encode --encoding=aes bobspassword
{aes}ARDXxxhGF8nybRZ3X8EUSDMBDXCdPwU4MPk5BCiIcdTc7+/m6pcGfWee+cNJDSSt2KPlpA8fZa26shATKdVVv+72coYnZcWi9KmPAXxKT2HRl+U1r7c0Sfk5yuYuYhZDoaiF71NadnIfTrVBu1UP
```
AES-128 Example:
```
wlp\bin>securityUtility encode --encoding=aes-128 bobspassword
{aes}AAg34RFqVJHScH2n5cRx+Tagt1xpbgU8ENZiy1U5FcJ+EB6C+B7X+NuIYlKo6XLe7w==
```