### PR TITLE
error messages for timeout obtaining EntityManagerBuilder

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1073,3 +1073,23 @@ CWWKD1105.keyword.in.orderby.explanation=Entity attribute names that contain \
  follow the Jakarta Data Query by Method Name pattern.
 CWWKD1105.keyword.in.orderby.useraction=Rename the entity attribute or switch \
  to the OrderBy annotation to specify the ordering.
+
+CWWKD1106.init.timed.out=CWWKD1106E: The {0} repository that requires the \
+ {1} dataStore and is provided or used by the {2} application artifact did not \
+ become available within {3} seconds. Confirm that the {2} application artifact \
+ starts and that the {1} dataStore is configured correctly and is accessible to \
+ the application artifact at the point when the {0} repository is first accessed.
+CWWKD1106.init.timed.out.explanation=A repository did not become available \
+ within the allotted amount of time.
+CWWKD1106.init.timed.out.useraction=Check the configuration of the dataStore \
+ and that is it accessible to application artifacts that define and use the \
+ repository. Also confirm that the application and all of its modules start \
+ successfully.
+
+CWWKD1107.init.timed.out.checkpoint=CWWKD1107E: The {0} application artifact \
+ accessed the {1} repository before a checkpoint of the application completed. \
+ Update the {0} application to avoid using the repository before a checkpoint.
+CWWKD1107.init.timed.out.checkpoint.explanation=Repositories are not available \
+ to be used by applications before completion of a checkpoint.
+CWWKD1107.init.timed.out.checkpoint.useraction=Avoid using the repository \
+ until after the checkpoint completes.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1075,21 +1075,22 @@ CWWKD1105.keyword.in.orderby.useraction=Rename the entity attribute or switch \
  to the OrderBy annotation to specify the ordering.
 
 CWWKD1106.init.timed.out=CWWKD1106E: The {0} repository that requires the \
- {1} dataStore and is provided or used by the {2} application artifact did not \
+ {1} data store and is provided or used by the {2} application artifact did not \
  become available within {3} seconds. Confirm that the {2} application artifact \
- starts and that the {1} dataStore is configured correctly and is accessible to \
+ starts and that the {1} data store resource that is specified as the dataStore \
+ value of the Repository annotation is configured correctly and is accessible to \
  the application artifact at the point when the {0} repository is first accessed.
 CWWKD1106.init.timed.out.explanation=A repository did not become available \
  within the allotted amount of time.
 CWWKD1106.init.timed.out.useraction=Check the configuration of the dataStore \
- and that is it accessible to application artifacts that define and use the \
- repository. Also confirm that the application and all of its modules start \
+ and confirm that it is accessible to application artifacts that define and use \
+ the repository. Also confirm that the application and all of its modules start \
  successfully.
 
 CWWKD1107.init.timed.out.checkpoint=CWWKD1107E: The {0} application artifact \
  accessed the {1} repository before a checkpoint of the application completed. \
  Update the {0} application to avoid using the repository before a checkpoint.
-CWWKD1107.init.timed.out.checkpoint.explanation=Repositories are not available \
- to be used by applications before completion of a checkpoint.
+CWWKD1107.init.timed.out.checkpoint.explanation=Applications cannot use \
+ repositories before completion of a checkpoint.
 CWWKD1107.init.timed.out.checkpoint.useraction=Avoid using the repository \
  until after the checkpoint completes.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -47,7 +47,6 @@ import com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource;
 
 import io.openliberty.data.internal.persistence.QueryInfo.Type;
 import io.openliberty.data.internal.persistence.cdi.DataExtension;
-import io.openliberty.data.internal.persistence.cdi.FutureEMBuilder;
 import io.openliberty.data.internal.persistence.service.DBStoreEMBuilder;
 import jakarta.data.exceptions.DataConnectionException;
 import jakarta.data.exceptions.DataException;
@@ -76,27 +75,12 @@ public class RepositoryImpl<R> implements InvocationHandler {
     final Class<R> repositoryInterface;
     final EntityValidator validator;
 
-    @FFDCIgnore(CompletionException.class)
     public RepositoryImpl(DataProvider provider,
                           DataExtension extension,
-                          FutureEMBuilder futureEMBuilder,
+                          EntityManagerBuilder builder,
                           Class<R> repositoryInterface,
                           Class<?> primaryEntityClass,
                           Map<Class<?>, List<QueryInfo>> queriesPerEntityClass) {
-        EntityManagerBuilder builder;
-        try {
-            // TODO add a timeout. If it times out, determine if checkpoint is
-            // in progress and raise an error indicating that something might be
-            // incompatible with checkpoint (such as a ServletContextListener
-            // using Jakarta Data).
-            builder = futureEMBuilder.join();
-        } catch (CompletionException x) {
-            // The CompletionException does not have the current stack. Replace it.
-            Throwable cause = x.getCause();
-            if (cause != null)
-                x = new CompletionException(cause.getMessage(), cause);
-            throw x;
-        }
 
         // EntityManagerBuilder implementations guarantee that the future
         // in the following map will be completed even if an error occurs

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -75,7 +75,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
      * or that value prefixed with java:comp,
      * or if unspecified, then java:comp/DefaultDataSource.
      */
-    private final String dataStore;
+    final String dataStore;
 
     /**
      * Entity classes as seen by the user, not generated entity classes for records.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -126,19 +126,21 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
      * EntityManagerBuilder.
      *
      * @param repositoryInterface the repository interface.
-     * @param exception           the TimeoutException.
+     * @param cause               the TimeoutException.
      * @return DataException with an appropriate error message.
      */
     @Trivial
-    private DataException excTimedOut(Class<?> repositoryInterface, Throwable exception) {
+    private DataException excTimedOut(Class<?> repositoryInterface,
+                                      Throwable cause) {
+        DataException x;
         if (CheckpointPhase.getPhase().restored()) {
             // No checkpoint in progress
-            return exc(DataException.class,
-                       "CWWKD1106.init.timed.out",
-                       repositoryInterface.getName(),
-                       futureEMBuilder.dataStore,
-                       futureEMBuilder.jeeName,
-                       INIT_TIMEOUT_SEC);
+            x = exc(DataException.class,
+                    "CWWKD1106.init.timed.out",
+                    repositoryInterface.getName(),
+                    futureEMBuilder.dataStore,
+                    futureEMBuilder.jeeName,
+                    INIT_TIMEOUT_SEC);
         } else { // during checkpoint
             ComponentMetaData metadata = ComponentMetaDataAccessorImpl //
                             .getComponentMetaDataAccessor() //
@@ -147,11 +149,13 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
                             ? futureEMBuilder.jeeName //
                             : metadata.getJ2EEName();
 
-            return exc(DataException.class,
-                       "CWWKD1107.init.timed.out.checkpoint",
-                       jeeName,
-                       repositoryInterface.getName());
+            x = exc(DataException.class,
+                    "CWWKD1107.init.timed.out.checkpoint",
+                    jeeName,
+                    repositoryInterface.getName());
         }
+        x.initCause(cause);
+        return x;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -131,7 +131,7 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
      */
     @Trivial
     private DataException excTimedOut(Class<?> repositoryInterface, Throwable exception) {
-        if (CheckpointPhase.getPhase() == CheckpointPhase.INACTIVE) {
+        if (CheckpointPhase.getPhase().restored()) {
             // No checkpoint in progress
             return exc(DataException.class,
                        "CWWKD1106.init.timed.out",

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence.cdi;
 
+import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
+
 import java.io.PrintWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Proxy;
@@ -22,15 +24,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 import io.openliberty.data.internal.persistence.DataProvider;
+import io.openliberty.data.internal.persistence.EntityManagerBuilder;
 import io.openliberty.data.internal.persistence.QueryInfo;
 import io.openliberty.data.internal.persistence.RepositoryImpl;
 import io.openliberty.data.internal.persistence.Util;
@@ -58,7 +69,14 @@ import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
 public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, BeanAttributes<R> {
     private final static TraceComponent tc = Tr.register(RepositoryProducer.class);
 
-    private static final Set<Annotation> QUALIFIERS = Set.of(Any.Literal.INSTANCE, Default.Literal.INSTANCE);
+    /**
+     * Amount of time in seconds to wait for an EntityManagerBuilder to become
+     * available.
+     */
+    private static final long INIT_TIMEOUT_SEC = TimeUnit.MINUTES.toSeconds(5);
+
+    private static final Set<Annotation> QUALIFIERS = //
+                    Set.of(Any.Literal.INSTANCE, Default.Literal.INSTANCE);
 
     private final BeanManager beanMgr;
     private final Set<Type> beanTypes;
@@ -101,6 +119,39 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
         RepositoryImpl<?> handler = (RepositoryImpl<?>) Proxy.getInvocationHandler(repository);
         repositoryImplRef.compareAndSet(handler, null);
         handler.beanDisposed();
+    }
+
+    /**
+     * Error handling for a timeout that occurs when attempting to obtain an
+     * EntityManagerBuilder.
+     *
+     * @param repositoryInterface the repository interface.
+     * @param exception           the TimeoutException.
+     * @return DataException with an appropriate error message.
+     */
+    @Trivial
+    private DataException excTimedOut(Class<?> repositoryInterface, Throwable exception) {
+        if (CheckpointPhase.getPhase() == CheckpointPhase.INACTIVE) {
+            // No checkpoint in progress
+            return exc(DataException.class,
+                       "CWWKD1106.init.timed.out",
+                       repositoryInterface.getName(),
+                       futureEMBuilder.dataStore,
+                       futureEMBuilder.jeeName,
+                       INIT_TIMEOUT_SEC);
+        } else { // during checkpoint
+            ComponentMetaData metadata = ComponentMetaDataAccessorImpl //
+                            .getComponentMetaDataAccessor() //
+                            .getComponentMetaData();
+            J2EEName jeeName = metadata == null //
+                            ? futureEMBuilder.jeeName //
+                            : metadata.getJ2EEName();
+
+            return exc(DataException.class,
+                       "CWWKD1107.init.timed.out.checkpoint",
+                       jeeName,
+                       repositoryInterface.getName());
+        }
     }
 
     @Override
@@ -231,7 +282,10 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
                             Tr.debug(this, tc, "add " + anno + " for " + method.getAnnotated().getJavaMember());
                     }
 
-            RepositoryImpl<?> handler = new RepositoryImpl<>(provider, extension, futureEMBuilder, //
+            EntityManagerBuilder builder = futureEMBuilder.get(INIT_TIMEOUT_SEC, //
+                                                               TimeUnit.SECONDS);
+
+            RepositoryImpl<?> handler = new RepositoryImpl<>(provider, extension, builder, //
                             repositoryInterface, primaryEntityClass, queriesPerEntityClass);
 
             R instance = repositoryInterface.cast(Proxy.newProxyInstance(repositoryInterface.getClassLoader(),
@@ -250,7 +304,8 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
                 Tr.exit(this, tc, "produce", instance.toString());
             return instance;
         } catch (Throwable x) {
-            if (x instanceof DataException || x.getCause() instanceof DataException)
+            Throwable cause = x.getCause();
+            if (x instanceof DataException || cause instanceof DataException)
                 ; // already logged the error
             else
                 Tr.error(tc, "CWWKD1095.repo.err",
@@ -258,9 +313,24 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
                          repositoryInterface.getAnnotation(Repository.class),
                          primaryEntityClass == null ? null : primaryEntityClass.getName(),
                          x);
-            if (trace && tc.isEntryEnabled())
-                Tr.exit(this, tc, "produce", x);
-            throw x;
+
+            if (x instanceof TimeoutException) {
+                DataException dx = excTimedOut(repositoryInterface, x);
+                if (trace && tc.isEntryEnabled())
+                    Tr.exit(this, tc, "produce", DataException.class);
+                throw dx;
+            } else {
+                if (trace && tc.isEntryEnabled())
+                    Tr.exit(this, tc, "produce", x);
+                if (x instanceof RuntimeException)
+                    throw (RuntimeException) x;
+                else if (x instanceof Error)
+                    throw (Error) x;
+                else if (x instanceof ExecutionException)
+                    throw new CompletionException(cause.getMessage(), cause);
+                else // InterruptedException
+                    throw new DataException(x);
+            }
         }
     }
 }


### PR DESCRIPTION
Time out the attempt to obtain EntityManagerBuilder instead of waiting forever.
Detect whether it is during checkpoint and log appropriate messages.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
