### PR TITLE
fix: dockerfile path parsing

### DIFF
--- a/dev/io.openliberty.org.testcontainers/src/io/openliberty/org/testcontainers/generate/CacheFiles.java
+++ b/dev/io.openliberty.org.testcontainers/src/io/openliberty/org/testcontainers/generate/CacheFiles.java
@@ -30,11 +30,11 @@ import org.testcontainers.utility.ImageNameSubstitutor;
 
 public class CacheFiles {
 	
-	/**
-	 * Always maintain generated files with a new line separator to avoid git 
-	 * from complaining about carriage returns on windows. 
-	 */
-	private static final String LINE_SEPERATOR = "\n";
+    /**
+     * Always maintain generated files with a new line separator to avoid git 
+     * from complaining about carriage returns on windows. 
+     */
+    private static final String LINE_SEPERATOR = "\n";
     
     public static void main(String[] args) {
         long start = System.currentTimeMillis();

--- a/dev/io.openliberty.org.testcontainers/src/io/openliberty/org/testcontainers/generate/Dockerfile.java
+++ b/dev/io.openliberty.org.testcontainers/src/io/openliberty/org/testcontainers/generate/Dockerfile.java
@@ -59,15 +59,17 @@ public class Dockerfile implements Comparable<Dockerfile> {
      * @return The DockerImageName for this Dockerfile
      */
     private static DockerImageName constructImageName(Path location) {
+        
+        final String SEPARATOR = "/";
 
         // io.openliberty.org.testcontainers/resources/openliberty/testcontainers/[repository]/[version]/Dockerfile
-        final String fullPath = location.toString();
+        final String fullPath = location.toString().replace("\\", SEPARATOR);
         
         System.out.println("Full path to dockerfile is: " + fullPath);
 
         // Find version (between the last two separator characters)
-        int end = fullPath.lastIndexOf(File.separator);
-        int start = fullPath.substring(0, end).lastIndexOf(File.separator) + 1;
+        int end = fullPath.lastIndexOf(SEPARATOR);
+        int start = fullPath.substring(0, end).lastIndexOf(SEPARATOR) + 1;
         final String version = fullPath.substring(start, end);
 
         // Find repository (between "resources/" and version)


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Handle the case where a path has a mix of `/` and `\` file separators. 
