### PR TITLE
Use new viewstate pattern matching

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestProtectedServlet.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestProtectedServlet.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 package com.ibm.ws.security.javaeesec.fat;
@@ -577,11 +574,11 @@ public class EJBModuleTestProtectedServlet extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("[\\s\\S]*value=\"(.+)\".*autocomplete[\\s\\S]*");
+        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {
-            viewState = m.group(1);
+            viewState = m.group(2);
         }
         return viewState;
     }

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestProtectedServlet.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestProtectedServlet.java
@@ -574,7 +574,7 @@ public class EJBModuleTestProtectedServlet extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
+        Pattern p = Pattern.compile("[\\s\\S]*id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"[\\s\\S]*");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestUnprotectedServlet.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestUnprotectedServlet.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 package com.ibm.ws.security.javaeesec.fat;
@@ -422,11 +419,11 @@ public class EJBModuleTestUnprotectedServlet extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("[\\s\\S]*value=\"(.+)\".*autocomplete[\\s\\S]*");
+        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {
-            viewState = m.group(1);
+            viewState = m.group(2);
         }
         return viewState;
     }

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestUnprotectedServlet.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestUnprotectedServlet.java
@@ -419,7 +419,7 @@ public class EJBModuleTestUnprotectedServlet extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
+        Pattern p = Pattern.compile("[\\s\\S]*id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"[\\s\\S]*");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FeatureTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FeatureTest.java
@@ -300,7 +300,7 @@ public class FeatureTest extends JavaEESecTestBase {
 
     /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
+        Pattern p = Pattern.compile("[\\s\\S]*id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"[\\s\\S]*");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FeatureTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FeatureTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.javaeesec.fat;
 
@@ -303,11 +300,11 @@ public class FeatureTest extends JavaEESecTestBase {
 
     /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("[\\s\\S]*value=\"(.+)\".*autocomplete[\\s\\S]*");
+        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {
-            viewState = m.group(1);
+            viewState = m.group(2);
         }
         return viewState;
     }

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormPostTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormPostTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.javaeesec.fat;
 
@@ -361,11 +358,11 @@ public class MultipleIdentityStoreCustomFormPostTest extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("[\\s\\S]*value=\"(.+)\".*autocomplete[\\s\\S]*");
+        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {
-            viewState = m.group(1);
+            viewState = m.group(2);
         }
         return viewState;
     }

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormPostTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormPostTest.java
@@ -358,7 +358,7 @@ public class MultipleIdentityStoreCustomFormPostTest extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
+        Pattern p = Pattern.compile("[\\s\\S]*id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"[\\s\\S]*");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.javaeesec.fat;
 
@@ -458,11 +455,11 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("[\\s\\S]*value=\"(.+)\".*autocomplete[\\s\\S]*");
+        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {
-            viewState = m.group(1);
+            viewState = m.group(2);
         }
         return viewState;
     }

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormTest.java
@@ -455,8 +455,9 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
+        Pattern p = Pattern.compile("[\\s\\S]*id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"[\\s\\S]*");
         Matcher m = p.matcher(form);
+        m.matches();
         String viewState = null;
         if (m.matches()) {
             viewState = m.group(2);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleExpandTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleExpandTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.javaeesec.fat;
 
@@ -584,11 +581,11 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("[\\s\\S]*value=\"(.+)\".*autocomplete[\\s\\S]*");
+        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {
-            viewState = m.group(1);
+            viewState = m.group(2);
         }
         return viewState;
     }

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleExpandTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleExpandTest.java
@@ -581,7 +581,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
+        Pattern p = Pattern.compile("[\\s\\S]*id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"[\\s\\S]*");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleNoExpandTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleNoExpandTest.java
@@ -573,7 +573,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
+        Pattern p = Pattern.compile("[\\s\\S]*id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"[\\s\\S]*");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleNoExpandTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleNoExpandTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.javaeesec.fat;
 
@@ -576,11 +573,11 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
 
 /* ------------------------ support methods ---------------------- */
     protected String getViewState(String form) {
-        Pattern p = Pattern.compile("[\\s\\S]*value=\"(.+)\".*autocomplete[\\s\\S]*");
+        Pattern p = Pattern.compile("id=.*(javax.faces.ViewState|jakarta.faces.ViewState).*value=\"(.*?)\"(\\s)*?(autocomplete=)?");
         Matcher m = p.matcher(form);
         String viewState = null;
         if (m.matches()) {
-            viewState = m.group(1);
+            viewState = m.group(2);
         }
         return viewState;
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


This new pattern matching should work regardless of the jakarta or javax namespace and regardlesss of whether autocomplete is included in the string or not.   