### PR TITLE
Treat DNS response with rcode: 8 as a lookup failure

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/dns/impl/chfw/Dns.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/dns/impl/chfw/Dns.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2015 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -82,8 +82,7 @@ public final class Dns {
 	  public static final int NOT_IMPL    = 4;
 	  public static final int REFUSED     = 5;
 	  public static final int TRY_TCP     = 6;
-	  /** 6-15 reserved for future use */
-	  
+	  public static final int NOT_AUTH    = 8; 
 	 
 }
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/dns/impl/chfw/Dns.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/dns/impl/chfw/Dns.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2015 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/dns/impl/netty/Dns.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/dns/impl/netty/Dns.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -79,8 +79,7 @@ public final class Dns {
 	  public static final int NOT_IMPL    = 4;
 	  public static final int REFUSED     = 5;
 	  public static final int TRY_TCP     = 6;
-	  /** 6-15 reserved for future use */
-	  
+	  public static final int NOT_AUTH    = 8; 
 	 
 }
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/chfw/SipResolver.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/chfw/SipResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2014 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -471,9 +471,10 @@ public class SipResolver implements SipResolverTransportListener {
                     break;
 
                     
-				case Dns.FORM_ERROR:
-				case Dns.NOT_IMPL:
+		case Dns.FORM_ERROR:
+		case Dns.NOT_IMPL:
                 case Dns.REFUSED:
+		case Dns.NOT_AUTH:
                     event = new SipResolverEvent();
                     
                     if (c_logger.isTraceDebugEnabled())

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolver.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -517,6 +517,7 @@ public class SipResolver implements SipResolverTransportListener {
                 case Dns.FORM_ERROR:
                 case Dns.NOT_IMPL:
                 case Dns.REFUSED:
+		case Dns.NOT_AUTH:
                     event = new SipResolverEvent();
 
                     if (c_logger.isTraceDebugEnabled())


### PR DESCRIPTION
A DNS response with rcode: 8 does not return an IP address. We need to handle it as a DNS lookup failure.