### PR TITLE
Detect invalid use of persistence annotations

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1094,3 +1094,21 @@ CWWKD1107.init.timed.out.checkpoint.explanation=Applications cannot use \
  repositories before completion of a checkpoint.
 CWWKD1107.init.timed.out.checkpoint.useraction=Avoid using the repository \
  until after the checkpoint completes.
+
+CWWKD1108.missing.entity.anno=CWWKD1108E: The {0} entity class requires the \
+ {1} annotation because the {2} annotation is applied to the {3} member of \
+ the entity class.
+CWWKD1108.missing.entity.anno.explanation=Entity classes that use annotations
+ from the jakarta.persistence package must also be annotated with the Entity
+ annotation from the Jakarta Persistence specification.
+CWWKD1108.missing.entity.anno.useraction=Apply the Entity annotation to the
+ entity class or remove the Jakarta Persistence annotations from its members.
+
+CWWKD1109.jpa.anno.on.record=CWWKD1109E: The {0} annotation is not allowed \
+ on the {1} method of the {2} entity class because the {2} entity class is \
+ a Java record.
+CWWKD1109.jpa.anno.on.record.explanation=Jakarta Persistence annotations \
+ are not allowed on Java records.
+CWWKD1109.jpa.anno.on.record.useraction=Switch to a Jakarta Persistence \
+ entity class or remove the Jakarta Persistence annotation from the \
+ Java record.

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -116,7 +116,9 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1100E.*selectByLastName", // CursoredPage with ORDER BY clause
                                    "CWWKD1101E.*nameAndZipCode", // Record return type with invalid attribute name
                                    "CWWKD1104E.*inWard", // @Param with empty string value
-                                   "CWWKD1105E.*findByNameNotNullOrderByDescriptionAsc" // keyword in OrderBy
+                                   "CWWKD1105E.*findByNameNotNullOrderByDescriptionAsc", // keyword in OrderBy
+                                   "CWWKD1108E.*Invitation", // JPA entity lacks @Entity
+                                   "CWWKD1109E.*Investment" // Record entity has JPA anno
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.stream.Stream;
 
 import jakarta.annotation.Resource;
@@ -773,7 +772,7 @@ public class DataErrPathsTestServlet extends FATServlet {
 
             fail("Used an entity that has Jakarta Persistence annotations on" +
                  " members, but lacks the Entity annotation.");
-        } catch (CompletionException x) {
+        } catch (MappingException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1108E:") ||
                 !x.getMessage().contains("jakarta.persistence.Entity"))
@@ -1824,7 +1823,7 @@ public class DataErrPathsTestServlet extends FATServlet {
 
             fail("Used a record entity that has a Jakarta Persistence annotation" +
                  " on a record component.");
-        } catch (CompletionException x) {
+        } catch (MappingException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1109E:") ||
                 !x.getMessage().contains("jakarta.persistence.Column"))
@@ -1861,7 +1860,7 @@ public class DataErrPathsTestServlet extends FATServlet {
                             .bornOn(LocalDate.of(1977, Month.SEPTEMBER, 26));
             fail("Should not be able to use repository that sets the dataStore " +
                  "to a JNDI name that does not exist. Found: " + found);
-        } catch (CompletionException x) {
+        } catch (DataException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1079E:") ||
                 !x.getMessage().contains("<persistence-unit name=\"MyPersistenceUnit\">"))
@@ -1883,7 +1882,7 @@ public class DataErrPathsTestServlet extends FATServlet {
                                             "5455 W River Rd NW, Rochester, MN 55901"));
             fail("Should not be able to use repository that sets the dataStore " +
                  "to a name that does not exist. Added: " + added);
-        } catch (CompletionException x) {
+        } catch (DataException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1078E:") ||
                 !x.getMessage().contains("<dataSource id=\"MyDataSource\" jndiName=\"jdbc/ds\""))
@@ -1903,7 +1902,7 @@ public class DataErrPathsTestServlet extends FATServlet {
             fail("Should not be able to use repository that sets the dataStore" +
                  " to a DataSource that is configured to use a database that does" +
                  " not exist. Found: " + found);
-        } catch (CompletionException x) {
+        } catch (DataException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1080E:") ||
                 !x.getMessage().contains(InvalidDatabaseRepo.class.getName()))
@@ -1922,7 +1921,7 @@ public class DataErrPathsTestServlet extends FATServlet {
                             .save(new Invention(1, 2, "Perpetual Motion Machine"));
             fail("Should not be able to use a repository operation for an entity" +
                  " that is not valid because it has no Id attribute. Saved: " + i);
-        } catch (CompletionException x) {
+        } catch (DataException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1080E:") ||
                 !x.getMessage().contains(Invention.class.getName()))
@@ -1943,7 +1942,7 @@ public class DataErrPathsTestServlet extends FATServlet {
             found = errDefaultDataSourceNotConfigured.findById(123445678);
             fail("Should not be able to use repository without DefaultDataSource " +
                  "being configured. Found: " + found);
-        } catch (CompletionException x) {
+        } catch (DataException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1077E:") ||
                 !x.getMessage().contains("<dataSource id=\"DefaultDataSource\""))

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Investment.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Investment.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import jakarta.persistence.Column;
+
+/**
+ * An invalid record entity - because it has a Jakarta Persistence annotation
+ * on a method.
+ */
+public record Investment(long id, float amount, String symbol) {
+
+    /**
+     * Invalid attempt to add a Jakarta Persistence annotation to a record component
+     */
+    @Column(nullable = false)
+    public String symbol() {
+        return symbol;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Investments.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Investments.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for an invalid recprd entity that tries to put a Jakarta Persistence
+ * annotation on a record component.
+ */
+@Repository(dataStore = "java:app/jdbc/env/DSForInvalidEntityRecordWithJPAAnnoRef")
+public interface Investments extends DataRepository<Investment, Long> {
+    @Insert
+    void invest(Investment inv);
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Invitation.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Invitation.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+
+/**
+ * An invalid entity - because it has Jakarta Persistence annotations
+ * but lacks an Entity annotation
+ */
+// intentionally lacks @Entity to test error path
+public class Invitation {
+
+    @Id
+    public long id;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    public Set<String> invitees = new HashSet<>();
+
+    @Column(nullable = false)
+    public String place;
+
+    @Column(nullable = false)
+    public LocalDateTime time;
+
+    @Override
+    public String toString() {
+        return "Invitation#" + id + " @" + time + " in " + place + " for " + invitees;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Invitations.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Invitations.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for an invalid entity type that has Jakarta Persistence
+ * annotations on members but lacks an Entity annotation.
+ */
+@Repository(dataStore = "java:comp/jdbc/env/DSForInvalidEntityClassWithoutAnnoRef")
+public interface Invitations {
+    @Insert
+    public void invite(Invitation newInvitation);
+
+    @Delete
+    public void uninvite(Invitation invitationToRemove);
+}


### PR DESCRIPTION
Detect invalid use of persistence annotations (on records, or without `@Entity)
and ensure that respository methods raise DataException, a subclass, or an appropriate runtime exception such as UnsupportedOperationException rather than CompletionException, and update the error paths test.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

