### PR TITLE
Update to use Charset APIs instead of String API

### DIFF
--- a/dev/com.ibm.json4j/src/com/ibm/json/java/JSON.java
+++ b/dev/com.ibm.json4j/src/com/ibm/json/java/JSON.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2008 IBM Corporation and others.
+ * Copyright (c) 2008, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,14 +13,15 @@
 
 package com.ibm.json.java;
 
+import java.io.BufferedReader;
+import java.io.CharArrayReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
-import java.io.PushbackReader;
-import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.PushbackReader;
+import java.io.Reader;
 import java.io.StringReader;
-import java.io.CharArrayReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Helper class that does generic parsing of a JSON stream and returns the appropriate 
@@ -130,7 +131,7 @@ public class JSON {
         if (is != null) {
             BufferedReader reader = null;
             try {
-                reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+                reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             } catch (Exception ex) {
                 IOException iox = new IOException("Could not construct UTF-8 character reader for the InputStream");
                 iox.initCause(ex);

--- a/dev/com.ibm.json4j/src/com/ibm/json/java/JSONArray.java
+++ b/dev/com.ibm.json4j/src/com/ibm/json/java/JSONArray.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2006 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,19 +13,18 @@
 
 package com.ibm.json.java;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.Reader;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Writer;
 import java.io.BufferedWriter;
 import java.io.CharArrayWriter;
-import java.io.OutputStreamWriter;
-import java.io.StringWriter;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
-
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -124,7 +123,7 @@ public class JSONArray extends ArrayList implements JSONArtifact
         InputStreamReader isr = null;
         try
         {
-            isr = new InputStreamReader(is, "UTF-8");
+            isr = new InputStreamReader(is, StandardCharsets.UTF_8);
         }
         catch (Exception ex)
         {
@@ -197,17 +196,7 @@ public class JSONArray extends ArrayList implements JSONArtifact
      * @throws IOException Thrown on IO errors during serialization.
      */
     public void serialize(OutputStream os, boolean verbose) throws IOException {
-        Writer writer = null;
-        try
-        {
-            writer = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-        }
-        catch (UnsupportedEncodingException uex)
-        {
-            IOException iox = new IOException(uex.toString());
-            iox.initCause(uex);
-            throw iox;
-        }
+        Writer writer = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
         serialize(writer, verbose);
     }
 

--- a/dev/com.ibm.json4j/src/com/ibm/json/java/JSONObject.java
+++ b/dev/com.ibm.json4j/src/com/ibm/json/java/JSONObject.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2006 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,17 +14,17 @@
 package com.ibm.json.java;
 
 import java.io.BufferedWriter;
+import java.io.CharArrayWriter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.StringReader;
-import java.io.InputStreamReader;
-import java.io.InputStream;
-import java.io.Writer;
-import java.io.OutputStreamWriter;
-import java.io.OutputStream;
 import java.io.StringWriter;
-import java.io.CharArrayWriter;
-import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import com.ibm.json.java.internal.Parser;
@@ -106,7 +106,7 @@ public class JSONObject extends HashMap  implements JSONArtifact
         InputStreamReader isr = null;
         try
         {
-            isr = new InputStreamReader(is, "UTF-8");
+            isr = new InputStreamReader(is, StandardCharsets.UTF_8);
         }
         catch (Exception ex)
         {
@@ -144,17 +144,7 @@ public class JSONObject extends HashMap  implements JSONArtifact
      * @throws IOException Thrown on IO errors during serialization.
      */
     public void serialize(OutputStream os, boolean verbose) throws IOException {
-        Writer writer = null;
-        try
-        {
-            writer = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-        }
-        catch (UnsupportedEncodingException uex)
-        {
-            IOException iox = new IOException(uex.toString());
-            iox.initCause(uex);
-            throw iox;
-        }
+        Writer writer = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
         serialize(writer, verbose);
     }
 

--- a/dev/com.ibm.json4j/src/com/ibm/json/java/OrderedJSONObject.java
+++ b/dev/com.ibm.json4j/src/com/ibm/json/java/OrderedJSONObject.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2006 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,24 +14,16 @@
 package com.ibm.json.java;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-import java.io.InputStreamReader;
-import java.io.InputStream;
-import java.io.Writer;
-import java.io.OutputStreamWriter;
-import java.io.OutputStream;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 
 import com.ibm.json.java.internal.Parser;
-import com.ibm.json.java.internal.Serializer;
-import com.ibm.json.java.internal.SerializerVerbose;
 
 /**
  * Extension of the basic JSONObject.  This class allows control of the serialization order of attributes.  
@@ -92,7 +84,7 @@ public class OrderedJSONObject extends JSONObject
         InputStreamReader isr = null;
         try
         {
-            isr = new InputStreamReader(is, "UTF-8");
+            isr = new InputStreamReader(is, StandardCharsets.UTF_8);
         }
         catch (Exception ex)
         {

--- a/dev/com.ibm.json4j/src/com/ibm/json/xml/internal/JSONSAXHandler.java
+++ b/dev/com.ibm.json4j/src/com/ibm/json/xml/internal/JSONSAXHandler.java
@@ -1,7 +1,7 @@
 package com.ibm.json.xml.internal;
 
 /*******************************************************************************
- * Copyright (c) 2006 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import java.util.StringTokenizer;
 import java.util.Properties;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 
 
@@ -72,7 +73,7 @@ public class JSONSAXHandler extends DefaultHandler
     {
         if (logger.isLoggable(Level.FINER)) logger.entering(className, "JSONHander(OutputStream) <constructor>");
         
-        this.osWriter = new OutputStreamWriter(os,"UTF-8");
+        this.osWriter = new OutputStreamWriter(os, StandardCharsets.UTF_8);
         this.compact  = true;
         
         if (logger.isLoggable(Level.FINER)) logger.exiting(className, "JSONHander(OutputStream) <constructor>");
@@ -89,7 +90,7 @@ public class JSONSAXHandler extends DefaultHandler
     {
         if (logger.isLoggable(Level.FINER)) logger.entering(className, "JSONHander(OutputStream, boolean) <constructor>");
         
-        this.osWriter = new OutputStreamWriter(os,"UTF-8");
+        this.osWriter = new OutputStreamWriter(os, StandardCharsets.UTF_8);
         this.compact  = !verbose;
         
         if (logger.isLoggable(Level.FINER)) logger.exiting(className, "JSONHander(OutputStream, boolean) <constructor>");

--- a/dev/com.ibm.websphere.security.wim.base/src/com/ibm/websphere/security/wim/util/PasswordUtil.java
+++ b/dev/com.ibm.websphere.security.wim.base/src/com/ibm/websphere/security/wim/util/PasswordUtil.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,13 +12,12 @@
  *******************************************************************************/
 package com.ibm.websphere.security.wim.util;
 
+import java.nio.charset.StandardCharsets;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.websphere.security.wim.ras.WIMMessageHelper;
-import com.ibm.websphere.security.wim.ras.WIMMessageKey;
-import com.ibm.wsspi.security.wim.exception.WIMSystemException;
 
 /**
  * The utility which provides helper functions related with password.
@@ -35,23 +34,8 @@ public class PasswordUtil {
      * @return the byte array representation of the text string
      */
     @Sensitive
-    public static byte[] getByteArrayPassword(@Sensitive String password) throws WIMSystemException {
-        String METHODNAME = "getByteArrayPassword";
-        try {
-            if (password != null) {
-                return password.getBytes("UTF-8");
-            } else {
-                return null;
-            }
-        } catch (java.io.UnsupportedEncodingException e) {
-            if (tc.isErrorEnabled()) {
-                Tr.error(tc, WIMMessageKey.GENERIC, WIMMessageHelper.generateMsgParms(e.toString()));
-            }
-            throw new WIMSystemException(WIMMessageKey.GENERIC, Tr.formatMessage(
-                                                                                 tc,
-                                                                                 WIMMessageKey.GENERIC,
-                                                                                 WIMMessageHelper.generateMsgParms(e.toString())));
-        }
+    public static byte[] getByteArrayPassword(@Sensitive String password) {
+        return password == null ? null : password.getBytes(StandardCharsets.UTF_8);
     }
 
     /**

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_Factory.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_Factory.java
@@ -17,7 +17,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -314,22 +313,13 @@ public class TargetCacheImpl_Factory implements TargetCache_Factory, TargetCache
     }
 
     protected TargetCacheImpl_Reader createReader(String path, InputStream stream) {
-        try {
-            return new TargetCacheImpl_Reader(this, path, stream, TargetCache_InternalConstants.SERIALIZATION_ENCODING);
-        } catch ( UnsupportedEncodingException e ) {
-            return null; // FFDC
-        }
+        return new TargetCacheImpl_Reader(this, path, stream, TargetCache_InternalConstants.SERIALIZATION_ENCODING);
     }
 
     protected TargetCacheImpl_Writer createWriter(String path, OutputStream stream) {
-        try {
-            return new TargetCacheImpl_Writer(this,
-                path, stream,
-                TargetCache_InternalConstants.SERIALIZATION_ENCODING);
-
-        } catch ( UnsupportedEncodingException e ) {
-            return null; // FFDC
-        }
+        return new TargetCacheImpl_Writer(this,
+            path, stream,
+            TargetCache_InternalConstants.SERIALIZATION_ENCODING);
     }
 
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_Reader.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_Reader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-  * Copyright (c) 2014, 2019 IBM Corporation and others.
+  * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -48,7 +48,7 @@ public class TargetCacheImpl_Reader implements TargetCache_Reader, TargetCache_I
 
     public TargetCacheImpl_Reader(TargetCacheImpl_Factory factory,
                                   String path, InputStream stream,
-                                  String encoding) throws UnsupportedEncodingException {
+                                  Charset charset) {
         super();
 
         this.factory = factory;
@@ -56,9 +56,9 @@ public class TargetCacheImpl_Reader implements TargetCache_Reader, TargetCache_I
         this.path = path;
         this.stream = stream;
 
-        this.encoding = encoding;
+        this.charset = charset;
 
-        this.reader = new InputStreamReader(stream, encoding); // throws UnsupportedEncodingException
+        this.reader = new InputStreamReader(stream, charset);
         this.bufferedReader = new BufferedReader(reader);
 
         //
@@ -86,7 +86,7 @@ public class TargetCacheImpl_Reader implements TargetCache_Reader, TargetCache_I
     protected final String path;
     protected final InputStream stream;
 
-    protected final String encoding;
+    protected final Charset charset;
     protected final InputStreamReader reader;
     protected final BufferedReader bufferedReader;
 
@@ -102,7 +102,7 @@ public class TargetCacheImpl_Reader implements TargetCache_Reader, TargetCache_I
 
     @Trivial
     public String getEncoding() {
-        return encoding;
+        return charset.name();
     }
 
     @Trivial

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_ReaderBinary.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_ReaderBinary.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-  * Copyright (c) 2014, 2019 IBM Corporation and others.
+  * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package com.ibm.ws.annocache.targets.cache.internal;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,13 +53,13 @@ public class TargetCacheImpl_ReaderBinary implements TargetCache_BinaryConstants
 
     public TargetCacheImpl_ReaderBinary(
         TargetCacheImpl_Factory factory,
-        String path, String encoding,
+        String path, Charset charset,
         boolean readStrings, boolean readFull) throws IOException {
 
         this.factory = factory;
 
         if ( readFull ) {
-            this.bufInput = new UtilImpl_ReadBufferFull(path, encoding);
+            this.bufInput = new UtilImpl_ReadBufferFull(path, charset);
             if ( readStrings ) {
                 this.strings = readStrings();
                 // 'readStrings' finishes by seeking to offset 0.
@@ -66,7 +67,7 @@ public class TargetCacheImpl_ReaderBinary implements TargetCache_BinaryConstants
                 this.strings = null;
             }
         } else {
-            this.bufInput = new UtilImpl_ReadBufferPartial(path, TargetCacheImpl_WriterBinary.STAMP_SIZE, encoding);
+            this.bufInput = new UtilImpl_ReadBufferPartial(path, TargetCacheImpl_WriterBinary.STAMP_SIZE, charset);
             this.strings = null; // Do not read strings unless doing a fully buffered read.
         }
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_Writer.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_Writer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 // import java.util.ConcurrentModificationException;
 import java.util.Collection;
 import java.util.IdentityHashMap;
@@ -99,7 +99,7 @@ public class TargetCacheImpl_Writer implements TargetCache_InternalConstants {
     public TargetCacheImpl_Writer(TargetCacheImpl_Factory factory,
                                   String path,
                                   OutputStream stream,
-                                  String encoding) throws UnsupportedEncodingException {
+                                  Charset charset) {
         super();
 
         this.factory = factory;
@@ -107,8 +107,8 @@ public class TargetCacheImpl_Writer implements TargetCache_InternalConstants {
         this.path = path;
         this.stream = stream;
 
-        this.encoding = encoding;
-        this.writer = new OutputStreamWriter(stream, encoding); // throws UnsupportedEncodingException
+        this.charset = charset;
+        this.writer = new OutputStreamWriter(stream, charset);
         this.bufferedWriter = new BufferedWriter(writer);
     }
 
@@ -126,7 +126,7 @@ public class TargetCacheImpl_Writer implements TargetCache_InternalConstants {
     protected final String path;
     protected final OutputStream stream;
 
-    protected final String encoding;
+    protected final Charset charset;
     protected final OutputStreamWriter writer;
     protected final BufferedWriter bufferedWriter;
 
@@ -142,7 +142,7 @@ public class TargetCacheImpl_Writer implements TargetCache_InternalConstants {
 
     @Trivial
     public String getEncoding() {
-        return encoding;
+        return charset.name();
     }
 
     @Trivial

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_WriterBinary.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/cache/internal/TargetCacheImpl_WriterBinary.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ package com.ibm.ws.annocache.targets.cache.internal;
 
 import java.io.IOException;
 import java.io.OutputStream;
-
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
@@ -55,10 +55,10 @@ public class TargetCacheImpl_WriterBinary implements TargetCache_BinaryConstants
     public TargetCacheImpl_WriterBinary(
         TargetCacheImpl_Factory factory,
         String path, OutputStream output,
-        String encoding) throws IOException {
+        Charset charset) throws IOException {
 
         this.factory = factory;
-        this.bufOutput = new UtilImpl_WriteBuffer(path, output, WRITE_BUFFER_SIZE, encoding);
+        this.bufOutput = new UtilImpl_WriteBuffer(path, output, WRITE_BUFFER_SIZE, charset);
         this.strings = new LinkedHashMap<String, Integer>();
     }
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_ReadBufferFull.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_ReadBufferFull.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,19 +43,18 @@ public final class UtilImpl_ReadBufferFull implements UtilImpl_ReadBuffer {
 
     //
 
-    private final String encoding;
     private final Charset charset;
 
     @Trivial
     public String getEncoding() {
-        return encoding;
+        return charset.name();
     }
 
     //
 
-    public static final String UTF_8 = UtilImpl_WriteBuffer.UTF_8;
+    public static final Charset UTF_8 = UtilImpl_WriteBuffer.UTF_8;
 
-    public UtilImpl_ReadBufferFull(String path, String encoding)
+    public UtilImpl_ReadBufferFull(String path, Charset charset)
         throws IOException {
 
         this.file = new File(path);
@@ -63,8 +62,7 @@ public final class UtilImpl_ReadBufferFull implements UtilImpl_ReadBuffer {
         this.buffer = UtilImpl_FileUtils.readFully(this.file);
         this.bufferFill = this.buffer.length;
 
-        this.encoding = encoding;
-        this.charset = Charset.forName(encoding);
+        this.charset = charset;
 
         this.bufferPos = 0;
         this.bufferAvail = this.bufferFill;

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_ReadBufferPartial.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_ReadBufferPartial.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -52,17 +52,16 @@ public final class UtilImpl_ReadBufferPartial implements UtilImpl_ReadBuffer {
     private int bufferPos;
     private int bufferAvail;
 
-    private final String encoding;
     private final Charset charset;
 
     @Trivial
     public String getEncoding() {
-        return encoding;
+        return charset.name();
     }
 
     //
 
-    public static final String UTF_8 = UtilImpl_WriteBuffer.UTF_8;
+    public static final Charset UTF_8 = UtilImpl_WriteBuffer.UTF_8;
 
     public UtilImpl_ReadBufferPartial(String path, int bufferSize)
         throws IOException {
@@ -74,13 +73,13 @@ public final class UtilImpl_ReadBufferPartial implements UtilImpl_ReadBuffer {
         this(path, file, bufferSize, UTF_8);
     }
 
-    public UtilImpl_ReadBufferPartial(String path, int bufferSize, String encoding)
+    public UtilImpl_ReadBufferPartial(String path, int bufferSize, Charset charset)
         throws IOException {
 
         this( path,
               new RandomAccessFile(path, "r"), // throws IOException
               bufferSize,
-              encoding);
+              charset);
     }
 
     /**
@@ -97,7 +96,7 @@ public final class UtilImpl_ReadBufferPartial implements UtilImpl_ReadBuffer {
      */
     public UtilImpl_ReadBufferPartial(
         String path, RandomAccessFile file, int bufferSize,
-        String encoding) throws IOException {
+        Charset charset) throws IOException {
 
         this.path = path;
         this.file = file;
@@ -111,8 +110,7 @@ public final class UtilImpl_ReadBufferPartial implements UtilImpl_ReadBuffer {
         }
         this.fileLength = (int) rawFileLength; 
 
-        this.encoding = encoding;
-        this.charset = Charset.forName(encoding);
+        this.charset = charset;
 
         if ( this.fileLength < bufferSize ) {
             this.bufferFill = this.fileLength;

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_WriteBuffer.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_WriteBuffer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ package com.ibm.ws.annocache.util.internal;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 
@@ -55,17 +56,16 @@ public final class UtilImpl_WriteBuffer {
 
     private int totalWritten;
 
-    private final String encoding;
     private final Charset charset;
 
     @Trivial
     public String getEncoding() {
-        return encoding;
+        return charset.name();
     }
 
     //
 
-    public static final String UTF_8 = "UTF-8";
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;;
 
     public UtilImpl_WriteBuffer(
             String path, OutputStream outputStream, int bufferSize)
@@ -77,7 +77,7 @@ public final class UtilImpl_WriteBuffer {
     @SuppressWarnings("unused") // Allow this to be thrown in the future.
     public UtilImpl_WriteBuffer(
         String path, OutputStream outputStream, int bufferSize,
-        String encoding)
+        Charset charset)
         throws IOException {
 
         this.path = path;
@@ -91,8 +91,7 @@ public final class UtilImpl_WriteBuffer {
 
         this.totalWritten = 0;
 
-        this.encoding = encoding;
-        this.charset = Charset.forName(encoding);
+        this.charset = charset;
     }
 
     /**

--- a/dev/com.ibm.ws.anno/src/com/ibm/wsspi/annocache/targets/cache/TargetCache_InternalConstants.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/wsspi/annocache/targets/cache/TargetCache_InternalConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,9 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.wsspi.annocache.targets.cache;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 // Save Format:
 //
@@ -153,7 +156,7 @@ public interface TargetCache_InternalConstants {
 
     // Common encoding:
 
-    String SERIALIZATION_ENCODING = "UTF-8";
+    Charset SERIALIZATION_ENCODING = StandardCharsets.UTF_8;
 
     // Common formatting tags:
 

--- a/dev/com.ibm.ws.classloading.bells/src/com/ibm/ws/classloading/bells/internal/Bell.java
+++ b/dev/com.ibm.ws.classloading.bells/src/com/ibm/ws/classloading/bells/internal/Bell.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,7 +22,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
@@ -75,7 +75,7 @@ import com.ibm.wsspi.library.LibraryChangeListener;
  */
 @Component(name = "com.ibm.ws.classloading.bell", configurationPolicy = ConfigurationPolicy.REQUIRE,
            property = { Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE })
- public class Bell implements LibraryChangeListener {
+public class Bell implements LibraryChangeListener {
 
     private static final TraceComponent tc = Tr.register(Bell.class);
     private static final char COMMENT_CHAR = '#';
@@ -349,7 +349,7 @@ import com.ibm.wsspi.library.LibraryChangeListener;
 
     private static BufferedReader createReader(final ArtifactEntry providerConfigFile) throws IOException {
         final InputStream is = providerConfigFile.getInputStream();
-        final InputStreamReader input = new InputStreamReader(is, Charset.forName("UTF8"));
+        final InputStreamReader input = new InputStreamReader(is, StandardCharsets.UTF_8);
         return new BufferedReader(input);
     }
 

--- a/dev/com.ibm.ws.collector/src/com/ibm/ws/lumberjack/LumberjackClient.java
+++ b/dev/com.ibm.ws.collector/src/com/ibm/ws/lumberjack/LumberjackClient.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.zip.Deflater;
@@ -45,7 +47,7 @@ public class LumberjackClient {
     private static final TraceComponent tc = Tr.register(LumberjackClient.class);
     private static TraceNLS nls = TraceNLS.getTraceNLS(LumberjackClient.class, TraceConstants.MESSAGE_BUNDLE);
 
-    protected final String UTF_8 = "UTF-8";
+    protected final Charset UTF_8 = StandardCharsets.UTF_8;
 
     /* Constants used in lumberjack protocol */
     private final static String PROTOCOL_VERSION = "1";

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/HashedData.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/HashedData.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,7 +15,6 @@ package com.ibm.ws.crypto.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -226,7 +225,7 @@ public class HashedData {
         return output;
     }
 
-    private String readString(ByteArrayInputStream input) throws InvalidPasswordCipherException, UnsupportedEncodingException {
+    private String readString(ByteArrayInputStream input) throws InvalidPasswordCipherException {
         String output = null;
         if (input != null) {
             int length = readInt(input);
@@ -264,7 +263,7 @@ public class HashedData {
         }
     }
 
-    private void writeString(ByteArrayOutputStream output, String value) throws InvalidPasswordCipherException, UnsupportedEncodingException {
+    private void writeString(ByteArrayOutputStream output, String value) throws InvalidPasswordCipherException {
         if (output != null && value != null) {
             byte[] b = toByte(value.length());
             output.write(b, 0, b.length);

--- a/dev/com.ibm.ws.dynacache.web/src/com/ibm/ws/cache/servlet/FragmentComposerMemento.java
+++ b/dev/com.ibm.ws.dynacache.web/src/com/ibm/ws/cache/servlet/FragmentComposerMemento.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2010 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
@@ -513,7 +514,7 @@ public class FragmentComposerMemento implements Serializable, GenerateContents {
            }
            if (object instanceof char[]) {
               try {
-                 OutputStreamWriter osw = new OutputStreamWriter(baos, "UTF8");
+                 OutputStreamWriter osw = new OutputStreamWriter(baos, StandardCharsets.UTF_8);
                  osw.write((char[]) object);
                  osw.flush();
               } catch (Exception e) {

--- a/dev/com.ibm.ws.dynacache/src/com/ibm/ws/cache/CacheEntry.java
+++ b/dev/com.ibm.ws.dynacache/src/com/ibm/ws/cache/CacheEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2012 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import java.io.ObjectOutput;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1111,7 +1112,7 @@ public class CacheEntry implements com.ibm.websphere.cache.CacheEntry, Invalidat
         byte[] returnme = null;
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            PrintWriter pw = new PrintWriter(new OutputStreamWriter(baos, "UTF8"));
+            PrintWriter pw = new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8));
             pw.print(dValue);
             pw.flush();
             returnme = baos.toByteArray();

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
@@ -19,11 +19,11 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -307,11 +307,7 @@ public class ArtifactDownloaderUtils {
     }
 
     private static String base64Encode(String userInfo) {
-        try {
-            return Base64.getEncoder().encodeToString(userInfo.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException encodingException) {
-            throw new RuntimeException("Failed to get bytes for user info using UTF-8.", encodingException);
-        }
+        return Base64.getEncoder().encodeToString(userInfo.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallLicenseImpl.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/InstallLicenseImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,7 +16,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.logging.Level;
@@ -124,7 +124,7 @@ public class InstallLicenseImpl implements InstallLicense {
         StringBuffer sb = new StringBuffer();
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(in, "UTF-16"));
+            reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_16));
             int i = 0;
             for (String line; (line = reader.readLine()) != null;) {
                 if (isAgreement) {
@@ -144,9 +144,6 @@ public class InstallLicenseImpl implements InstallLicense {
             }
             sb.append("\n");
             return sb.toString();
-        } catch (UnsupportedEncodingException e) {
-            logger.log(Level.FINEST, "InstallLicenseImpl.getLicense failed", e);
-            return "";
         } catch (IOException e) {
             logger.log(Level.FINEST, "InstallLicenseImpl.getLicense failed", e);
             return "";
@@ -158,7 +155,7 @@ public class InstallLicenseImpl implements InstallLicense {
     private void getProgramName(InputStream in) {
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(in, "UTF-16"));
+            reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_16));
             int i = 0;
             for (String line; (line = reader.readLine()) != null;) {
                 if (i < 6 && line.startsWith(PROGRAM_NAME)) {
@@ -167,8 +164,6 @@ public class InstallLicenseImpl implements InstallLicense {
                 }
                 i++;
             }
-        } catch (UnsupportedEncodingException e) {
-            logger.log(Level.FINEST, "InstallLicenseImpl.getProgramName failed", e);
         } catch (IOException e) {
             logger.log(Level.FINEST, "InstallLicenseImpl.getProgramName failed", e);
         } finally {
@@ -185,7 +180,7 @@ public class InstallLicenseImpl implements InstallLicense {
         StringBuffer sb = new StringBuffer();
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(is, "UTF-16"));
+            reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_16));
             for (String line; (line = reader.readLine()) != null;) {
                 sb.append(line + "\n");
             }

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/LicenseUpgradeUtility.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/LicenseUpgradeUtility.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -233,7 +234,7 @@ public class LicenseUpgradeUtility {
         BufferedReader reader = null;
         try {
             InputStream is = new FileInputStream(file);
-            reader = new BufferedReader(new InputStreamReader(is, "UTF-16"));
+            reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_16));
             for (String line; (line = reader.readLine()) != null;) {
                 sb.append(line + "\n");
             }
@@ -317,7 +318,7 @@ public class LicenseUpgradeUtility {
         BufferedReader reader = null;
         try {
             InputStream is = new FileInputStream(file);
-            reader = new BufferedReader(new InputStreamReader(is, "UTF-16"));
+            reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_16));
             boolean isProgramName = false;
             int firstTenLinesCounter = 0;
             for (String line; (line = reader.readLine()) != null;) {

--- a/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/dispatcher/BatchJmsDispatcher.java
+++ b/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/dispatcher/BatchJmsDispatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@
 package com.ibm.ws.jbatch.jms.internal.dispatcher;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;

--- a/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/bridge/BatchInternalDispatcherImpl.java
+++ b/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/bridge/BatchInternalDispatcherImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.jbatch.rest.bridge;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcTracer.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcTracer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corporation and others.
+ * Copyright (c) 2001, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,13 +17,13 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor; 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.sql.CallableStatement;
@@ -248,13 +248,7 @@ public class WSJdbcTracer implements InvocationHandler
         if (obj instanceof String) {
             String str = (String) obj;
             StringBuilder sb = new StringBuilder(str.length()).append('\"');
-            byte[] bytes;
-
-            try {
-                bytes = str.getBytes("UTF-16BE");
-            } catch (UnsupportedEncodingException x) {// No FFDC code needed
-                return new String(sb.append(str).append('\"'));
-            }
+            byte[] bytes = str.getBytes(StandardCharsets.UTF_16BE);
 
             for (int i = 0; i < bytes.length; i += 2) {
                 if (bytes[i] == 0 && (bytes[i + 1] & 0x80) == 0)

--- a/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/client/rest/internal/FileTransferClient.java
+++ b/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/client/rest/internal/FileTransferClient.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,6 +21,7 @@ import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -497,7 +498,7 @@ class FileTransferClient {
             if (logger.isLoggable(Level.FINER)) {
                 logger.logp(Level.FINER, logger.getName(), methodName, "Generated JSON: " + contentObject.toString());
             }
-            outStream.write(contentObject.toString().getBytes("UTF-8"));
+            outStream.write(contentObject.toString().getBytes(StandardCharsets.UTF_8));
             outStream.flush();
         } finally {
             tryToClose(outStream);

--- a/dev/com.ibm.ws.jmx.connector.server.rest/src/com/ibm/ws/jmx/connector/server/rest/RESTAppListener.java
+++ b/dev/com.ibm.ws.jmx.connector.server.rest/src/com/ibm/ws/jmx/connector/server/rest/RESTAppListener.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,6 +14,7 @@ package com.ibm.ws.jmx.connector.server.rest;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Hashtable;
 import java.util.Map;
 
@@ -162,12 +163,12 @@ public class RESTAppListener implements VirtualHostListener {
     /**
      * Called to create the work area resource. Only re-generate the file
      * if this is the first time or something in the url has changed.
-     * 
+     *
      * @param appPath standard url path received from the virtual host
      */
     private synchronized void createJMXWorkAreaResourceIfChanged(VirtualHost vhost) {
 
-        // Make sure our context root has been registered... 
+        // Make sure our context root has been registered...
         String contextRoot = registeredContextRoot;
         if (contextRoot != null) {
             // Make sure that we are dealing with the secure port before writing the file...
@@ -230,7 +231,7 @@ public class RESTAppListener implements VirtualHostListener {
      * Set the dynamic reference to the WsLocationAdmin service.
      * If the service is replaced, the new service will be set before
      * the old is removed.
-     * 
+     *
      * @param locationService
      */
     @Reference(service = WsLocationAdmin.class,
@@ -277,7 +278,7 @@ public class RESTAppListener implements VirtualHostListener {
                     resource.create();
                 }
                 OutputStream os = resource.putStream();
-                os.write(appURL.getBytes("UTF-8"));
+                os.write(appURL.getBytes(StandardCharsets.UTF_8));
                 os.flush();
                 os.close();
 

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/utils/SDEInstaller.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/utils/SDEInstaller.java
@@ -19,6 +19,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 public class SDEInstaller {
     private static final boolean verbose = false;
@@ -51,7 +52,7 @@ public class SDEInstaller {
 
         // get the bytes
         orig = readWhole(inClassFile);
-        sdeAttr = smapGenerator.toString().getBytes("UTF-8");
+        sdeAttr = smapGenerator.toString().getBytes(StandardCharsets.UTF_8);
         gen = new byte[orig.length + sdeAttr.length + 100];
 
         // do it
@@ -287,7 +288,7 @@ public class SDEInstaller {
                     int len = readU2();
                     writeU2(len);
                     byte[] utf8 = readBytes(len);
-                    String str = new String(utf8, "UTF-8");
+                    String str = new String(utf8, StandardCharsets.UTF_8);
                     if (verbose) {
                         System.out.println(i + " read class attr -- '" + str + "'");
                     }

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/smap/SmapVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/smap/SmapVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2004 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -126,7 +127,7 @@ public class SmapVisitor extends JspVisitor {
             try {
                 File outSmap = new File(generatedFiles.getClassFile().getPath() + ".smap");
                 fos = new FileOutputStream(outSmap);
-                so = new PrintWriter(new OutputStreamWriter(fos, "UTF-8"));
+                so = new PrintWriter(new OutputStreamWriter(fos, StandardCharsets.UTF_8));
                 so.print(smapGenerator.getString());
             }
             catch (IOException e) {

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/validator/PageDataImpl.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/validator/PageDataImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2004 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -146,7 +147,7 @@ public class PageDataImpl extends PageData {
 	            StringWriter writer = new StringWriter();
 	            Result result = new StreamResult(writer);
 	            serializer.transform(new DOMSource(jspDocument), result);
-	            is = new ByteArrayInputStream(writer.toString().getBytes("UTF-8"));
+	            is = new ByteArrayInputStream(writer.toString().getBytes(StandardCharsets.UTF_8));
         	}finally {
                 ThreadContextHelper.setClassLoader(oldLoader);		//PK26233
 			}
@@ -156,9 +157,6 @@ public class PageDataImpl extends PageData {
         }     
         catch (TransformerException e) {
 			logger.logp(Level.WARNING, CLASS_NAME, "_getInputStream", "failed to transform jspDocument", e);
-        }     
-        catch (IOException e) {
-			logger.logp(Level.WARNING, CLASS_NAME, "_getInputStream", "Failed to convert document to inputstream", e);
         }
 
         return (is);

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/HotSpotJavaDumperImpl.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/HotSpotJavaDumperImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -216,7 +217,7 @@ class HotSpotJavaDumperImpl extends JavaDumper {
                 }
 
                 output = new FileOutputStream(outputFile);
-                Writer writer = new OutputStreamWriter(output, "UTF-8");
+                Writer writer = new OutputStreamWriter(output, StandardCharsets.UTF_8);
                 writer.write(outputString);
                 writer.close();
             }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ProcessControlHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.EnumMap;
 import java.util.LinkedHashSet;
@@ -505,7 +506,7 @@ public class ProcessControlHelper {
         Map<JavaDumpAction, String> fileLocations = new EnumMap<JavaDumpAction, String>(JavaDumpAction.class);
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(new FileInputStream(javaDumpLocationFile), "UTF-8"));
+            reader = new BufferedReader(new InputStreamReader(new FileInputStream(javaDumpLocationFile), StandardCharsets.UTF_8));
             for (String line; (line = reader.readLine()) != null;) {
                 int index = line.indexOf('=');
                 String actionName = line.substring(0, index);

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ServerDumpPackager.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/ServerDumpPackager.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.PrivilegedAction;
@@ -175,7 +176,7 @@ public class ServerDumpPackager {
                             javacoreAscii.setWritable(true);
 
                             InputStreamReader reader = new InputStreamReader(new FileInputStream(javacoreEbcdic), Charset.forName("IBM-1047"));
-                            OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(javacoreAscii), Charset.forName("US-ASCII"));
+                            OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(javacoreAscii), StandardCharsets.US_ASCII);
                             int readInt;
                             while ((readInt = reader.read()) != -1) {
                                 writer.write(readInt);

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2024 IBM Corporation and others.
+ * Copyright (c) 2010, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ import java.io.Writer;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.MessageFormat;
@@ -1354,7 +1355,7 @@ public class FrameworkManager {
             PrintWriter pw = null;
             try {
                 out = new FileOutputStream(introspectionFile);
-                pw = new PrintWriter(new OutputStreamWriter(out, "UTF-8"));
+                pw = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
 
                 // write header
                 if (introspectionDesc != null && !introspectionDesc.isEmpty()) {
@@ -1403,7 +1404,7 @@ public class FrameworkManager {
 
         Writer writer = null;
         try {
-            writer = new OutputStreamWriter(new FileOutputStream(statusFile), "UTF-8");
+            writer = new OutputStreamWriter(new FileOutputStream(statusFile), StandardCharsets.UTF_8);
             for (JavaDumpAction javaDumpAction : javaDumpActions) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "Start javadump action " + javaDumpAction);

--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/cmdline/ThirdPartyLicenseProvider.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/cmdline/ThirdPartyLicenseProvider.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,7 +14,7 @@ package com.ibm.ws.kernel.feature.internal.cmdline;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import wlp.lib.extract.LicenseProvider;
 
@@ -75,10 +75,6 @@ public class ThirdPartyLicenseProvider implements LicenseProvider {
      * @return
      */
     private InputStream getInputStream() {
-        try {
-            return new ByteArrayInputStream(this.subsystemLicenseHeader.getBytes("UTF-16"));
-        } catch (UnsupportedEncodingException e) {
-            return new ByteArrayInputStream(this.subsystemLicenseHeader.getBytes());
-        }
+        return new ByteArrayInputStream(this.subsystemLicenseHeader.getBytes(StandardCharsets.UTF_16));
     }
 }

--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureList.java
@@ -14,12 +14,13 @@ package com.ibm.ws.kernel.feature.internal.generator;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.InputStreamReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -613,7 +614,7 @@ public class FeatureList {
             public Object run() {
                 try {
                     final File version = new File(getInstallDir(), "lib/versions/WebSphereApplicationServer.properties");
-                    Reader r = new InputStreamReader(new FileInputStream(version), "UTF-8");
+                    Reader r = new InputStreamReader(new FileInputStream(version), StandardCharsets.UTF_8);
                     props.load(r);
                     r.close();
                 } catch (IOException e) {

--- a/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureListWriter.java
+++ b/dev/com.ibm.ws.kernel.feature.cmdline/src/com/ibm/ws/kernel/feature/internal/generator/FeatureListWriter.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,7 +13,6 @@
 package com.ibm.ws.kernel.feature.internal.generator;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map;
 
@@ -24,7 +23,7 @@ public class FeatureListWriter {
     private final XMLStreamWriter writer;
     private final Indenter i;
 
-    public FeatureListWriter(FeatureListUtils utils) throws XMLStreamException, UnsupportedEncodingException {
+    public FeatureListWriter(FeatureListUtils utils) throws XMLStreamException {
         this.writer = utils.getXMLStreamWriter();
         this.i = utils.getIndenter();
     }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/util/ImageReader.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/util/ImageReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -75,7 +76,7 @@ public class ImageReader {
         List<String> features = new ArrayList<>();
 
         try (InputStream inputStream = new FileInputStream(imageFile);
-                        InputStreamReader baseReader = new InputStreamReader(inputStream, "UTF-8");
+                        InputStreamReader baseReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
                         BufferedReader reader = new BufferedReader(baseReader)) {
 
             String nextLine;

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/encoder/Base64Coder.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/encoder/Base64Coder.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,7 @@
 package com.ibm.ws.common.encoder;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -177,7 +178,7 @@ public final class Base64Coder {
      * Encode a byte array into a Base64-encoded String. The String is not
      * broken into 72 character lines.
      *
-     * @param data Byte data to be encoded
+     * @param data   Byte data to be encoded
      * @param offset Starting index within the byte data to be encoded
      * @param length Number of bytes to encode
      * @return Base64-encoded string.
@@ -278,6 +279,23 @@ public final class Base64Coder {
     }
 
     /**
+     * Converts a String with the given encoding Charset to a base64 encoded String.
+     *
+     * @param str
+     * @param charset
+     * @return
+     */
+    public static final String base64Decode(String str, Charset charset) {
+        if (str == null) {
+            return null;
+        } else {
+            byte data[] = getBytes(str);
+            return base64Decode(new String(data, charset));
+        }
+
+    }
+
+    /**
      * Converts a base64 encoded String to a decoded String.
      *
      * @param str String, may be {@code null}.
@@ -324,7 +342,7 @@ public final class Base64Coder {
      * Converts a String to a byte array by using UTF-8 character sets.
      * This code is needed even converting US-ASCII characters since there are some character sets which are not compatible with US-ASCII code area.
      * For example, CP-1399, which is z/OS Japanese EBCDIC character sets, is one.
-     * 
+     *
      * @param input String, may be {@code null}.
      * @return byte array representing the String or {@code null} if the String was null or contained non ASCII character.
      */

--- a/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/impl/JsApiHdrsImpl.java
+++ b/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/impl/JsApiHdrsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.sib.mfp.impl;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import com.ibm.ejs.ras.TraceNLS;
@@ -683,13 +684,7 @@ abstract class JsApiHdrsImpl extends JsMessageImpl {
             }
             /* Otherwise get the UTF8 byte encoding */
             else {
-                try {
-                    value = strValue.getBytes("UTF8");
-                } catch (java.io.UnsupportedEncodingException e) {
-                    /* No FFDC code needed */
-                    /* Falling back to the default encoding seems to be acceptable to JMS */
-                    value = strValue.getBytes();
-                }
+                value = strValue.getBytes(StandardCharsets.UTF_8);
             }
 
         }

--- a/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/impl/JsMessageFactoryImpl.java
+++ b/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/impl/JsMessageFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.sib.mfp.impl;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import com.ibm.ws.sib.comms.CommsConnection;
@@ -535,15 +535,7 @@ public final class JsMessageFactoryImpl extends JsMessageFactory {
       throw new IllegalArgumentException("Invalid buffer: classname length = 0");
     }
 
-    // The classname should be in UTF8, if that fails FFDC and default in the hope of carrying on.
-    String className;
-    try {
-      className = new String(buffer, offset, length, "UTF8"); // the class name itself
-    }
-    catch (UnsupportedEncodingException e) {
-      FFDCFilter.processException(e, "com.ibm.ws.sib.mfp.impl.JsMessageFactoryImpl.getClassName", "644");
-      className = new String(buffer, offset, length);
-    }
+    String className = new String(buffer, offset, length, StandardCharsets.UTF_8); // the class name itself
 
     if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.exit(tc, "getClassName", className);
     return className;

--- a/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/impl/JsMessageImpl.java
+++ b/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/impl/JsMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@
 package com.ibm.ws.sib.mfp.impl;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import com.ibm.websphere.ras.TraceComponent;
@@ -192,15 +193,7 @@ class JsMessageImpl extends JsHdrsImpl implements JsMessage, MatchSpaceKey {
 
   /* Get the flattened form of a classname                     SIB0112b.mfp.2 */
   static byte[] flattenClassName(String className) {
-    byte[] flattened;
-    try {
-      flattened = className.getBytes("UTF8");
-    }
-    catch (UnsupportedEncodingException e) {
-      FFDCFilter.processException(e, "com.ibm.ws.sib.mfp.impl.JsSdoMessageImpl.<clinit>", "50");
-      flattened = className.getBytes();
-    }
-    return flattened;
+      return className.getBytes(StandardCharsets.UTF_8);
   }
 
 

--- a/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/jmf/impl/JSchema.java
+++ b/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/jmf/impl/JSchema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@
 
 package com.ibm.ws.sib.mfp.jmf.impl;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
@@ -128,14 +128,7 @@ public class JSchema implements JMFSchema, HashedArray.Element {
     System.arraycopy(frame, offset, serialForm, 0, length);
     // Decode the name from the serialForm
     int namelen = ArrayUtil.readShort(frame, offset);
-    try {
-      name = new String(frame, offset + 2, namelen, "UTF8");
-    } catch (UnsupportedEncodingException e) {
-      FFDCFilter.processException(e, "<init>", "159");
-      IllegalArgumentException ex = new IllegalArgumentException();
-      ex.initCause(e);
-      throw ex;
-    }
+    name = new String(frame, offset + 2, namelen, StandardCharsets.UTF_8);
     // Decode the schema structure body
     int[] limits = new int[] { offset + 2 + namelen, offset + length };
     version = JSType.getCount(frame, limits);
@@ -569,20 +562,13 @@ public class JSchema implements JMFSchema, HashedArray.Element {
       name = jsTypeTree.getFeatureName();
       if (name == null)
         name = "";
-      try {
-        byte[] utfname = name.getBytes("UTF8");
+        byte[] utfname = name.getBytes(StandardCharsets.UTF_8);
         serialForm = new byte[2 + utfname.length + 2 + jsTypeTree.encodedTypeLength()];
         ArrayUtil.writeShort(serialForm, 0, (short)utfname.length);
         System.arraycopy(utfname, 0, serialForm, 2, utfname.length);
         int limits[] = new int[] { 2 + utfname.length, serialForm.length };
         JSType.setCount(serialForm, limits, version);
         jsTypeTree.encodeType(serialForm, limits);
-      } catch (UnsupportedEncodingException e) {
-        FFDCFilter.processException(e, "initialize", "604");
-        IllegalArgumentException ex = new IllegalArgumentException();
-        ex.initCause(e);
-        throw ex;
-      }
     }
 
     // Compute the schemaID, which is a 64-bit truncated SHA-1 hash over the serialForm.

--- a/dev/com.ibm.ws.messaging.jms.2.0/src/com/ibm/ws/sib/api/jms/impl/JmsJMSProducerImpl.java
+++ b/dev/com.ibm.ws.messaging.jms.2.0/src/com/ibm/ws/sib/api/jms/impl/JmsJMSProducerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package com.ibm.ws.sib.api.jms.impl;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -449,13 +450,7 @@ public class JmsJMSProducerImpl implements JmsJMSProducer {
             }
             /* Otherwise get the UTF8 byte encoding */
             else {
-                try {
-                    value = strValue.getBytes("UTF8");
-                } catch (java.io.UnsupportedEncodingException e) {
-                    /* No FFDC code needed */
-                    /* Falling back to the default encoding seems to be acceptable to JMS */
-                    value = strValue.getBytes();
-                }
+                value = strValue.getBytes(StandardCharsets.UTF_8);
             }
 
         }

--- a/dev/com.ibm.ws.messaging.runtime/src/com/ibm/ws/sib/admin/internal/BaseMessagingEngineImpl.java
+++ b/dev/com.ibm.ws.messaging.runtime/src/com/ibm/ws/sib/admin/internal/BaseMessagingEngineImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -1890,7 +1891,7 @@ public class BaseMessagingEngineImpl implements JsEngineComponent, LWMConfig, Co
                 dumpFilePath = new StringBuilder(String.valueOf(dumpDir)).append(dumpFile).toString();
             }
             FileOutputStream fos = new FileOutputStream(dumpFilePath);
-            OutputStreamWriter osw = new OutputStreamWriter(fos, "UTF-8");
+            OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
             fw = new FormattedWriter(osw);
         }
         catch(IOException e)

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/OpenAPIUIBundlesUpdater.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/OpenAPIUIBundlesUpdater.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2023 IBM Corporation and others.
+ * Copyright (c) 2017,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
@@ -67,7 +66,7 @@ public class OpenAPIUIBundlesUpdater {
         //Retrieve all OpenAPI-UI Bundles from the BundleContext
         final Set<Bundle> allOpenAPIUIBundles = getOpenAPIUIBundles();
         //check if bundles is empty, as can exit early as there is nothing to update
-        if(allOpenAPIUIBundles.isEmpty()){
+        if (allOpenAPIUIBundles.isEmpty()) {
             return;
         }
 
@@ -213,7 +212,7 @@ public class OpenAPIUIBundlesUpdater {
         return new ByteArrayInputStream(bytesOut.toByteArray());
     }
 
-    private static void processResource(String resourcePath, Object resourceContents, ZipOutputStream zos) throws UnsupportedEncodingException, IOException {
+    private static void processResource(String resourcePath, Object resourceContents, ZipOutputStream zos) throws IOException {
         if (resourceContents != null) {
             if (resourceContents instanceof String) {
                 zos.write(((String) resourceContents).getBytes(StandardCharsets.UTF_8));
@@ -303,7 +302,7 @@ public class OpenAPIUIBundlesUpdater {
             BundleContext bundleContext = FrameworkUtil.getBundle(OpenAPIUIBundlesUpdater.class).getBundleContext();
             // If the bundle context null, then the bundle is in a STOPPED state and we should not be waiting for other
             // bundles if this is STOPPED. Returning false, means we stop any unnecessary processing
-            if(bundleContext != null){
+            if (bundleContext != null) {
                 new OpenAPIUIBundlesListener(openAPIUIBundles, bundleContext).await();
             } else {
                 return false;

--- a/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/customization/OpenAPIUIBundlesUpdater.java
+++ b/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/customization/OpenAPIUIBundlesUpdater.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2023 IBM Corporation and others.
+ * Copyright (c) 2018,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
@@ -64,7 +63,7 @@ public class OpenAPIUIBundlesUpdater {
 
         //Retrieve all OpenAPI-UI Bundles from the BundleContext
         final Set<Bundle> allOpenAPIUIBundles = getOpenAPIUIBundles();
-        if(allOpenAPIUIBundles.isEmpty()){
+        if (allOpenAPIUIBundles.isEmpty()) {
             return;
         }
 
@@ -210,7 +209,7 @@ public class OpenAPIUIBundlesUpdater {
         return new ByteArrayInputStream(bytesOut.toByteArray());
     }
 
-    private static void processResource(String resourcePath, Object resourceContents, ZipOutputStream zos) throws UnsupportedEncodingException, IOException {
+    private static void processResource(String resourcePath, Object resourceContents, ZipOutputStream zos) throws IOException {
         if (resourceContents != null) {
             if (resourceContents instanceof String) {
                 zos.write(((String) resourceContents).getBytes(StandardCharsets.UTF_8));
@@ -300,7 +299,7 @@ public class OpenAPIUIBundlesUpdater {
             BundleContext bundleContext = FrameworkUtil.getBundle(OpenAPIUIBundlesUpdater.class).getBundleContext();
             // If the bundle context null, then the bundle is in a STOPPED state and we should not be waiting for other
             // bundles if this is STOPPED. Returning false, means we stop any unnecessary processing
-            if(bundleContext != null){
+            if (bundleContext != null) {
                 new OpenAPIUIBundlesListener(openAPIUIBundles, bundleContext).await();
             } else {
                 return false;

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/utils/UriEncoder.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/utils/UriEncoder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ package com.ibm.ws.jaxrs20.utils;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
@@ -22,7 +23,7 @@ import java.util.Arrays;
  */
 public final class UriEncoder {
 
-    private static final Charset CHARSET_UTF_8 = Charset.forName("UTF-8"); //$NON-NLS-1$
+    private static final Charset CHARSET_UTF_8 = StandardCharsets.UTF_8; //$NON-NLS-1$
 
     private UriEncoder() {
         // no instances

--- a/dev/com.ibm.ws.persistence.mbean/src/com/ibm/ws/persistence/mbean/internal/DDLGenerationMBeanImpl.java
+++ b/dev/com.ibm.ws.persistence.mbean/src/com/ibm/ws/persistence/mbean/internal/DDLGenerationMBeanImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -208,7 +209,7 @@ public class DDLGenerationMBeanImpl extends StandardMBean implements DDLGenerati
             try {
                 TextFileOutputStreamFactory f = TrConfigurator.getFileOutputStreamFactory();
                 OutputStream os = f.createOutputStream(ddlOutputResource.asFile(), false);
-                BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+                BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
                 DDLGenerationWriter out = new DDLGenerationWriter(bw);
 
                 // Iterate over treeset in natural order (ascending)

--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.wsspi.persistence.internal;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.sql.DataSource;
@@ -310,10 +309,10 @@ public class DatabaseStoreImpl implements DatabaseStore {
         List<InMemoryMappingFile> inMemoryFiles;
         if (entitySet.equals(SpecialEntitySet.PERSISTENT_EXECUTOR)) {
             String ormFileContents = createOrmFileContentsForPersistentExecutor(strategy);
-            inMemoryFiles = Collections.singletonList(new InMemoryMappingFile(ormFileContents.getBytes("UTF-8")));
+            inMemoryFiles = Collections.singletonList(new InMemoryMappingFile(ormFileContents.getBytes(StandardCharsets.UTF_8)));
         } else if (entitySet.equals(SpecialEntitySet.BATCH)) {
             String ormFileContents = createOrmFileContentsForBatch(entityClassNames, strategy);
-            inMemoryFiles = Collections.singletonList(new InMemoryMappingFile(ormFileContents.getBytes("UTF-8")));
+            inMemoryFiles = Collections.singletonList(new InMemoryMappingFile(ormFileContents.getBytes(StandardCharsets.UTF_8)));
         } else {
             // hidden internal non-ship property for experimenting with Jakarta Data
             @SuppressWarnings("unchecked") // TODO if persistence service could read @Table from the entity class, we could remove this hack
@@ -707,11 +706,10 @@ public class DatabaseStoreImpl implements DatabaseStore {
                                                 String tablePrefix,
                                                 LinkedHashSet<String> tableNames, // entries correspond to entityClassNames
                                                 String[] entityClassNames,
-                                                String[] entityClassEntries)
-                    throws UnsupportedEncodingException {
+                                                String[] entityClassEntries) {
         return ((entityClassNames == null || entityClassNames.length == 0) && (entityClassEntries == null || entityClassEntries.length == 0))
                         ? null
-                        : new InMemoryMappingFile(createOrm(schemaName, tablePrefix, tableNames, entityClassNames, entityClassEntries).getBytes("UTF-8"));
+                        : new InMemoryMappingFile(createOrm(schemaName, tablePrefix, tableNames, entityClassNames, entityClassEntries).getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/dev/com.ibm.ws.product.utility/src/com/ibm/ws/product/utility/LicenseUtility.java
+++ b/dev/com.ibm.ws.product.utility/src/com/ibm/ws/product/utility/LicenseUtility.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -89,7 +90,7 @@ public class LicenseUtility {
         List<String> lines = new ArrayList<String>();
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(in, "UTF-16"));
+            reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_16));
             for (String line; (line = reader.readLine()) != null;) {
                 wordWrap(line, lines);
             }

--- a/dev/com.ibm.ws.product.utility/src/com/ibm/ws/product/utility/extension/IFixCompareCommandTask.java
+++ b/dev/com.ibm.ws.product.utility/src/com/ibm/ws/product/utility/extension/IFixCompareCommandTask.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,6 +18,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -620,7 +621,7 @@ public class IFixCompareCommandTask extends BaseCommandTask {
                 }
             } else if (entryName.startsWith("wlp/lib/versions/") && entryName.endsWith(".properties")) {
                 try {
-                    ProductInfo pi = ProductInfo.parseProductInfo(new InputStreamReader(installZipFile.getInputStream(entry), "UTF-8"), null);
+                    ProductInfo pi = ProductInfo.parseProductInfo(new InputStreamReader(installZipFile.getInputStream(entry), StandardCharsets.UTF_8), null);
                     if (pi != null && "com.ibm.websphere.appserver".equals(pi.getId())) {
                         info = pi;
                     }

--- a/dev/com.ibm.ws.repository.liberty/src/com/ibm/ws/repository/connections/liberty/MainRepository.java
+++ b/dev/com.ibm.ws.repository.liberty/src/com/ibm/ws/repository/connections/liberty/MainRepository.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,6 +22,7 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -178,7 +179,7 @@ public class MainRepository {
 
                             checkHttpResponseCodeValid(connection);
 
-                            Reader reader = new InputStreamReader(connection.getInputStream(), "UTF-8");
+                            Reader reader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
 
                             props = new Properties();
                             try {
@@ -203,7 +204,7 @@ public class MainRepository {
 
                         checkHttpResponseCodeValid(connection);
 
-                        Reader reader = new InputStreamReader(propertiesFileURL.openStream(), "UTF-8");
+                        Reader reader = new InputStreamReader(propertiesFileURL.openStream(), StandardCharsets.UTF_8);
                         props = new Properties();
                         try {
                             props.load(reader);

--- a/dev/com.ibm.ws.repository.parsers/src/com/ibm/ws/repository/parsers/ParserBase.java
+++ b/dev/com.ibm.ws.repository.parsers/src/com/ibm/ws/repository/parsers/ParserBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -149,7 +150,7 @@ public abstract class ParserBase {
         Open("Open"),
         Open_Web("Open_Web");
 
-        private String _productEdition;
+        private final String _productEdition;
 
         private Edition(String productEdition) {
             _productEdition = productEdition;
@@ -992,7 +993,7 @@ public abstract class ParserBase {
 
                 // Now read in the long description
                 if (descriptionFile != null) {
-                    descriptionReader = new InputStreamReader(new FileInputStream(descriptionFile), "UTF-8");
+                    descriptionReader = new InputStreamReader(new FileInputStream(descriptionFile), StandardCharsets.UTF_8);
                     char[] buf = new char[1024];
                     StringBuilder builder = new StringBuilder();
                     int chars;

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/connections/SingleFileRepositoryConnection.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/connections/SingleFileRepositoryConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 
 import com.ibm.ws.repository.connections.internal.AbstractRepositoryConnection;
 import com.ibm.ws.repository.transport.client.RepositoryReadableClient;
@@ -62,7 +63,7 @@ public class SingleFileRepositoryConnection extends AbstractRepositoryConnection
 
         OutputStreamWriter writer = null;
         try {
-            writer = new OutputStreamWriter(new FileOutputStream(jsonFile), "UTF-8");
+            writer = new OutputStreamWriter(new FileOutputStream(jsonFile), StandardCharsets.UTF_8);
             writer.write("[]");
         } finally {
             if (writer != null) {

--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/RestClient.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/RestClient.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -29,6 +29,7 @@ import java.net.Proxy;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -276,7 +277,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
         ByteArrayOutputStream startOutputStream = new ByteArrayOutputStream();
 
         try {
-            OutputStreamWriter writer = new OutputStreamWriter(startOutputStream, Charset.forName("UTF-8"));
+            OutputStreamWriter writer = new OutputStreamWriter(startOutputStream, StandardCharsets.UTF_8);
             writer.write("--" + boundary + NEWLINE);
             writer.write("Content-Disposition: form-data; name=\"attachmentInfo\"" + NEWLINE);
             writer.write("Content-Type: application/json" + NEWLINE);
@@ -319,7 +320,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
         ByteArrayOutputStream endOutputStream = new ByteArrayOutputStream();
         // Data to stream after file is uploaded
         try {
-            OutputStreamWriter writer = new OutputStreamWriter(endOutputStream, Charset.forName("UTF-8"));
+            OutputStreamWriter writer = new OutputStreamWriter(endOutputStream, StandardCharsets.UTF_8);
             writer.write(NEWLINE);
             writer.write("--" + boundary + "--" + NEWLINE);
             writer.close();
@@ -482,7 +483,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
         if (attachment.getLinkType() == AttachmentLinkType.DIRECT) {
             if ((loginInfo.getAttachmentBasicAuthUserId() != null) && (loginInfo.getAttachmentBasicAuthPassword() != null)) {
                 String userpass = loginInfo.getAttachmentBasicAuthUserId() + ":" + loginInfo.getAttachmentBasicAuthPassword();
-                String basicAuth = "Basic " + encode(userpass.getBytes(Charset.forName("UTF-8")));
+                String basicAuth = "Basic " + encode(userpass.getBytes(StandardCharsets.UTF_8));
                 connection.setRequestProperty("Authorization", basicAuth);
             }
         }
@@ -742,7 +743,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
         }
 
         if (basicAuthUserPass != null) {
-            String basicAuth = "Basic " + encode(basicAuthUserPass.getBytes(Charset.forName("UTF-8")));
+            String basicAuth = "Basic " + encode(basicAuthUserPass.getBytes(StandardCharsets.UTF_8));
             connection.setRequestProperty("Authorization", basicAuth);
         }
 
@@ -1037,7 +1038,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
         }
         try {
             // Just use JsonObject parse directly instead of DataModelSerializer as we only want one attribute
-            InputStream inputStream = new ByteArrayInputStream(errorObject.getBytes(Charset.forName("UTF-8")));
+            InputStream inputStream = new ByteArrayInputStream(errorObject.getBytes(StandardCharsets.UTF_8));
             JsonReader jsonReader = Json.createReader(inputStream);
             JsonObject parsedObject = jsonReader.readObject();
             jsonReader.close();

--- a/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.config/src/com/ibm/ws/rest/handler/config/internal/ConfigRESTHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,6 +15,7 @@ package com.ibm.ws.rest.handler.config.internal;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Dictionary;
@@ -518,7 +519,7 @@ public class ConfigRESTHandler extends ConfigBasedRESTHandler {
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getOutputStream().write(jsonString.getBytes("UTF-8"));
+        response.getOutputStream().write(jsonString.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
+++ b/dev/com.ibm.ws.rest.handler.validator/src/com/ibm/ws/rest/handler/validator/internal/ValidatorRESTHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -367,7 +368,7 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getOutputStream().write(jsonString.getBytes("UTF-8"));
+        response.getOutputStream().write(jsonString.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -388,7 +389,7 @@ public class ValidatorRESTHandler extends ConfigBasedRESTHandler {
      * Populate JSON object for a top level exception or error.
      *
      * @param errorInfo additional information to append to exceptions and causes
-     * @param error the top level exception or error.
+     * @param error     the top level exception or error.
      * @return JSON object representing the Throwable.
      */
     @SuppressWarnings("unchecked")

--- a/dev/com.ibm.ws.security.audit.file/src/com/ibm/ws/security/audit/file/AuditFileHandler.java
+++ b/dev/com.ibm.ws.security.audit.file/src/com/ibm/ws/security/audit/file/AuditFileHandler.java
@@ -15,6 +15,7 @@ package com.ibm.ws.security.audit.file;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStoreException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -959,7 +960,7 @@ public class AuditFileHandler implements SynchronousHandler {
 
                             byte[] er = null;
                             byte[] encryptedAuditRecord = null;
-                            byte[] eventBytes = jsonEvent.getBytes("UTF-8");
+                            byte[] eventBytes = jsonEvent.getBytes(StandardCharsets.UTF_8);
                             String z = new String(eventBytes);
                             if (tc.isDebugEnabled())
                                 Tr.debug(tc, "eventBytes: " + z + "eventBytes.length: " + eventBytes.length);
@@ -1064,7 +1065,7 @@ public class AuditFileHandler implements SynchronousHandler {
 
                             String jsonEvent = mapToJSONString(event.getMap());
 
-                            byte[] eventBytes = jsonEvent.getBytes("UTF-8");
+                            byte[] eventBytes = jsonEvent.getBytes(StandardCharsets.UTF_8);
 
                             signedAuditRecord = as.sign(eventBytes, signedSharedKey);
 

--- a/dev/com.ibm.ws.security.audit.reader/src/com/ibm/ws/security/audit/reader/utils/FileUtility.java
+++ b/dev/com.ibm.ws.security.audit.reader/src/com/ibm/ws/security/audit/reader/utils/FileUtility.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,7 +17,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import com.ibm.ws.security.audit.reader.IFileUtility;
 
@@ -35,7 +35,7 @@ public class FileUtility implements IFileUtility {
      * <p>
      * The supported environment variables are: WLP_USER_DIR and WLP_OUTPUT_DIR
      *
-     * @param WLP_USER_DIR The value of WLP_USER_DIR environment variable. {@code null} is supported.
+     * @param WLP_USER_DIR   The value of WLP_USER_DIR environment variable. {@code null} is supported.
      * @param WLP_OUTPUT_DIR The value of WLP_OUTPUT_DIR environment variable. {@code null} is supported.
      */
     public FileUtility(String WLP_USER_DIR, String WLP_OUTPUT_DIR) {
@@ -129,7 +129,7 @@ public class FileUtility implements IFileUtility {
         FileOutputStream fos = null;
         try {
             fos = new FileOutputStream(outFile);
-            fos.write(toWrite.getBytes(Charset.forName("UTF-8")));
+            fos.write(toWrite.getBytes(StandardCharsets.UTF_8));
             fos.flush();
             return true;
         } catch (FileNotFoundException e) {

--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,9 +14,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.Key;
 import java.security.PrivateKey;
@@ -361,14 +361,12 @@ public class JwKRetriever {
     protected String getKeyAsString(InputStream fis) {
         StringBuilder sb = new StringBuilder();
         try {
-            InputStreamReader r = new InputStreamReader(fis, "UTF-8");
+            InputStreamReader r = new InputStreamReader(fis, StandardCharsets.UTF_8);
             int ch = r.read();
             while (ch >= 0) {
                 sb.append((char) ch);
                 ch = r.read();
             }
-        } catch (UnsupportedEncodingException UEE) {
-
         } catch (IOException ioe) {
         }
         return sb.toString();
@@ -691,8 +689,8 @@ public class JwKRetriever {
         jsonString = jsonString.trim();
         try {
             if (!jsonString.startsWith(JSON_START)) { //convert Base64 encoded String to JSON string
-                // jsonString=new String (Base64.getDecoder().decode(jsonString), "UTF-8");
-                jsonString = new String(Base64.decodeBase64(jsonString), "UTF-8");
+                // jsonString=new String (Base64.getDecoder().decode(jsonString), StandardCharsets.UTF_8);
+                jsonString = new String(Base64.decodeBase64(jsonString), StandardCharsets.UTF_8);
             }
             jsonObject = JSONObject.parse(jsonString);
         } catch (Exception e) {

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -283,7 +284,7 @@ public class HttpUtils {
     String extractResponseAsString(HttpResponse result, String url) throws IOException, AbstractHttpResponseException {
         StatusLine statusLine = result.getStatusLine();
         int iStatusCode = statusLine.getStatusCode();
-        String response = EntityUtils.toString(result.getEntity(), "UTF-8");
+        String response = EntityUtils.toString(result.getEntity(), StandardCharsets.UTF_8);
         if (iStatusCode == 200) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "Response: ", response);
@@ -338,7 +339,7 @@ public class HttpUtils {
         if (responseStream == null) {
             return null;
         }
-        BufferedReader in = new BufferedReader(new InputStreamReader(responseStream, "UTF-8"));
+        BufferedReader in = new BufferedReader(new InputStreamReader(responseStream, StandardCharsets.UTF_8));
         String line;
         String response = "";
         while ((line = in.readLine()) != null) {

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/jwk/utils/JsonUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/jwk/utils/JsonUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016,2023 IBM Corporation and others.
+ * Copyright (c) 2016,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.common.jwk.utils;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.text.SimpleDateFormat;
@@ -119,13 +119,7 @@ public class JsonUtils {
         if (source == null) {
             return null;
         }
-        try {
-            return StringUtils.newStringUtf8(source.getBytes("UTF8"));
-        } catch (UnsupportedEncodingException e) {
-            // TODO Auto-generated catch block
-            // e.printStackTrace();
-        }
-        return null;
+        return StringUtils.newStringUtf8(source.getBytes(StandardCharsets.UTF_8));
     }
 
     public static boolean isNullEmpty(String value) {

--- a/dev/com.ibm.ws.security.credentials/src/com/ibm/ws/security/credentials/wscred/WSCredentialImpl.java
+++ b/dev/com.ibm.ws.security.credentials/src/com/ibm/ws/security/credentials/wscred/WSCredentialImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.credentials.wscred;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Hashtable;
@@ -24,7 +24,6 @@ import javax.security.auth.login.CredentialExpiredException;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.security.auth.CredentialDestroyedException;
 import com.ibm.websphere.security.cred.WSCredential;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.credentials.ExpirableCredential;
 
 public class WSCredentialImpl implements WSCredential, ExpirableCredential {
@@ -59,11 +58,11 @@ public class WSCredentialImpl implements WSCredential, ExpirableCredential {
      * Constructor used by the registry code to create the original WSCredential.
      * This constructor is used by IMS to reduce overhead when compared with using a Hashtable
      * in the Subject's public credentials.
-     * 
+     *
      * This is an IBM private-in-use API.
-     * 
+     *
      * DO NOT change the signature or the implementation of this ctor.
-     * 
+     *
      * @ibm-private-in-use
      * @param realmName
      * @param securityName
@@ -71,7 +70,7 @@ public class WSCredentialImpl implements WSCredential, ExpirableCredential {
      * @param unauthenticatedUserid
      * @param primaryUniqueGroupAccessId
      * @param accessId
-     * @param roles ignored for now
+     * @param roles                      ignored for now
      * @param uniqueGroupAccessIds
      */
     public WSCredentialImpl(String realmName,
@@ -124,10 +123,8 @@ public class WSCredentialImpl implements WSCredential, ExpirableCredential {
         hashTable = new Hashtable<String, Object>(32);
     }
 
-    @FFDCIgnore(UnsupportedEncodingException.class)
     @Sensitive
     private static byte[] getConvertedBytes(@Sensitive String in_String) {
-        byte[] convertedBytes = null;
         if (in_String == null) {
             return null;
         }
@@ -136,12 +133,7 @@ public class WSCredentialImpl implements WSCredential, ExpirableCredential {
             return emptyByteArray;
         }
 
-        try {
-            convertedBytes = in_String.getBytes("UTF-8");
-        } catch (java.io.UnsupportedEncodingException e) {
-            // UTF-8 should always be supported.
-        }
-        return convertedBytes;
+        return in_String.getBytes(StandardCharsets.UTF_8);
     }
 
     /**
@@ -245,7 +237,7 @@ public class WSCredentialImpl implements WSCredential, ExpirableCredential {
 
     /**
      * Sets the expiration in milliseconds.
-     * 
+     *
      * @param expiration credential expiration in milliseconds.
      */
     @Override

--- a/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/security/config/css/CSSGSSUPMechConfigDynamic.java
+++ b/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/security/config/css/CSSGSSUPMechConfigDynamic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@
  * Some of the code was derived from code supplied by the Apache Software Foundation licensed under the Apache License, Version 2.0.
  */
 package com.ibm.ws.transport.iiop.security.config.css;
+
+import java.nio.charset.StandardCharsets;
 
 import javax.security.auth.Subject;
 
@@ -144,7 +146,7 @@ public class CSSGSSUPMechConfigDynamic implements CSSASMechConfig {
         // There must be a WSCredential in the subject, but check for null to satisfy findbugs
         if (wsCredential != null && wsCredential.isBasicAuth()) {
             try {
-                encoding = commonEncode(codec, wsCredential.getSecurityName(), new String(wsCredential.getCredentialToken(), "UTF-8"), targetName);
+                encoding = commonEncode(codec, wsCredential.getSecurityName(), new String(wsCredential.getCredentialToken(), StandardCharsets.UTF_8), targetName);
             } catch (Exception e) {
                 // This should never happen since a basic auth credential never expires and it is never in a destroyed state, but this exception needs to be caught.
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/security/config/tss/TSSUnknownServiceConfigurationConfig.java
+++ b/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/security/config/tss/TSSUnknownServiceConfigurationConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,12 +12,11 @@
  *******************************************************************************/
 package com.ibm.ws.transport.iiop.security.config.tss;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.omg.CSIIOP.ServiceConfiguration;
 
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.transport.iiop.security.config.ConfigException;
 
 /**
@@ -50,16 +49,12 @@ public class TSSUnknownServiceConfigurationConfig extends TSSServiceConfiguratio
 
     /** {@inheritDoc} */
     @Override
-    @FFDCIgnore(UnsupportedEncodingException.class)
     void toString(String spaces, StringBuilder buf) {
         String moreSpaces = spaces + "  ";
         buf.append(spaces).append("TSSUnknownServiceConfigurationConfig: [\n");
         buf.append(moreSpaces).append("syntax VMCID : ").append(Integer.toHexString(syntax >> 12)).append("\n");
         buf.append(moreSpaces).append("syntax organization-scoped syntax identifier : ").append(Integer.toHexString(syntax & 0XFFF)).append("\n");
-        try {
-            buf.append(moreSpaces).append("name: ").append(Arrays.asList(name)).append(" (").append(new String(name, "ISO-8859-1")).append(")\n");
-        } catch (UnsupportedEncodingException e) {
-        }
+        buf.append(moreSpaces).append("name: ").append(Arrays.asList(name)).append(" (").append(new String(name, StandardCharsets.ISO_8859_1)).append(")\n");
         buf.append(spaces).append("]\n");
     }
 

--- a/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/security/util/Util.java
+++ b/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/security/util/Util.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,11 +18,10 @@ package com.ibm.ws.transport.iiop.security.util;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.rmi.UnexpectedException;
@@ -229,7 +228,7 @@ public final class Util {
         try {
             byte[] oid_arr = encodeOID(oid);
             int oid_len = oid_arr.length;
-            byte[] name_arr = name.getBytes("UTF-8");
+            byte[] name_arr = name.getBytes(StandardCharsets.UTF_8);
             int name_len = name_arr.length;
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -314,10 +313,9 @@ public final class Util {
      * 
      * @param scopedNameBytes
      * @return
-     * @throws UnsupportedEncodingException
      */
-    public static String extractUserNameFromScopedName(byte[] scopedNameBytes) throws UnsupportedEncodingException {
-        String scopedUserName = new String(scopedNameBytes, "UTF8");
+    public static String extractUserNameFromScopedName(byte[] scopedNameBytes) {
+        String scopedUserName = new String(scopedNameBytes, StandardCharsets.UTF_8);
         return extractUserNameFromScopedName(scopedUserName);
     }
 
@@ -389,7 +387,7 @@ public final class Util {
         try {
             // create and encode a GSSUP initial context token
             InitialContextToken init_token = new InitialContextToken();
-            init_token.username = user.getBytes("UTF-8");
+            init_token.username = user.getBytes(StandardCharsets.UTF_8);
             init_token.password = getUTF8Bytes(pwd);
             init_token.target_name = encodeGSSExportName(GSSUPMechOID.value.substring(4), target);
 
@@ -500,8 +498,7 @@ public final class Util {
      */
     @Sensitive
     private static byte[] getUTF8Bytes(@Sensitive char[] pwd) {
-        Charset utf8 = Charset.forName("UTF-8");
-        ByteBuffer bb = utf8.encode(CharBuffer.wrap(pwd));
+        ByteBuffer bb = StandardCharsets.UTF_8.encode(CharBuffer.wrap(pwd));
         try {
             bb.rewind(); // not clear whether this is necessary
             byte[] bytes = new byte[bb.limit()];
@@ -533,7 +530,7 @@ public final class Util {
                     if (token != null) {
                         gssup_tok.username = token.username;
                         gssup_tok.password = token.password;
-                        gssup_tok.target_name = decodeGSSExportedName(token.target_name).getName().getBytes("UTF-8");
+                        gssup_tok.target_name = decodeGSSExportedName(token.target_name).getName().getBytes(StandardCharsets.UTF_8);
 
                         result = true;
                     }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.security.jwt.internal;
 
-import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.PublicKey;
@@ -209,16 +208,7 @@ public class ConsumerUtil {
             String msg = Tr.formatMessage(tc, "JWT_MISSING_SHARED_KEY");
             throw new KeyException(msg);
         }
-        try {
-            // TODO - use signature algorithm?
-            return new HmacKey(sharedKey.getBytes(Constants.UTF_8));
-        } catch (UnsupportedEncodingException e) {
-            // Should not happen - UTF-8 should be supported
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Caught exception getting shared key bytes: " + e.getLocalizedMessage());
-            }
-        }
-        return null;
+        return new HmacKey(sharedKey.getBytes(Constants.UTF_8));
     }
 
     boolean isPublicKeyPropsPresent(MpConfigProperties mpConfigProps) {

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/Constants.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/Constants.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package com.ibm.ws.security.jwt.utils;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 public class Constants {
 
-    public static final String UTF_8 = "UTF-8";
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;
 
     public static final String SIGNATURE_ALG_HS256 = "HS256";
     public static final String SIGNATURE_ALG_HS384 = "HS384";

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtData.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtData.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.jwt.utils;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyStoreException;
 import java.security.PublicKey;
@@ -160,14 +160,14 @@ public class JwtData {
         }
     }
 
-    void initSigningKeyUsingHSAlgorithm(JwtDataConfig config) throws UnsupportedEncodingException {
+    void initSigningKeyUsingHSAlgorithm(JwtDataConfig config) {
         String keyType = Constants.SIGNING_KEY_SECRET;
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, "hs256 Signing key type is " + keyType);
         }
         String sharedKey = config.sharedKey;
         if (!(sharedKey == null || sharedKey.isEmpty())) {
-            _signingKey = new HmacKey(sharedKey.getBytes("UTF-8"));
+            _signingKey = new HmacKey(sharedKey.getBytes(StandardCharsets.UTF_8));
         } else {
             _signingKey = null;
         }

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIJwtUtils.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIJwtUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt.tai;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -69,7 +69,7 @@ public class TAIJwtUtils {
 
     public static boolean isJwtPreviouslyLoggedOut(String rawToken) {
         if (loggedOutJwts.isEmpty()) {
-          return false;
+            return false;
         }
         boolean result = loggedOutJwts.get(getSha256Digest(rawToken)) != null;
         return result;
@@ -90,7 +90,7 @@ public class TAIJwtUtils {
         } catch (NoSuchAlgorithmException e) {
             return null; // and emit ffdc
         }
-        byte[] digest = md.digest(in.getBytes(Charset.forName("UTF-8")));
+        byte[] digest = md.digest(in.getBytes(StandardCharsets.UTF_8));
         return new String(digest);
     }
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/PkceMethodS256.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/pkce/PkceMethodS256.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,9 @@
  *******************************************************************************/
 package com.ibm.ws.security.oauth20.pkce;
 
+import java.nio.charset.StandardCharsets;
+
 import com.ibm.oauth.core.api.error.oauth20.InvalidGrantException;
-import com.ibm.oauth.core.internal.oauth20.OAuth20Constants;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.security.oauth20.util.HashUtils;
@@ -32,7 +33,7 @@ public class PkceMethodS256 extends ProofKeyForCodeExchangeMethod {
 
     @Override
     public String generateCodeChallenge(String codeVerifier) {
-        return HashUtils.encodedDigest(codeVerifier, CODE_CHALLENGE_ALG_METHOD, OAuth20Constants.CODE_VERIFIER_ASCCI);
+        return HashUtils.encodedDigest(codeVerifier, CODE_CHALLENGE_ALG_METHOD, StandardCharsets.US_ASCII);
     }
 
     @Override

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/HashUtils.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/HashUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.security.oauth20.util;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -26,7 +27,7 @@ import com.ibm.ws.common.encoder.Base64Coder;
 public class HashUtils {
     private static final TraceComponent tc = Tr.register(HashUtils.class);
     private static String DEFAULT_ALGORITHM = "SHA-256";
-    private static String DEFAULT_CHARSET = "UTF-8";
+    private static Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
     /**
      * generate hash code by using SHA-256
@@ -48,7 +49,7 @@ public class HashUtils {
      * generate hash code by using specified algorithm and character set.
      * If there is some error, log the error.
      */
-    protected static String digest(String input, String algorithm, String charset) {
+    protected static String digest(String input, String algorithm, Charset charset) {
         MessageDigest md;
         String output = null;
         if (input != null && input.length() > 0) {
@@ -61,21 +62,16 @@ public class HashUtils {
                     Tr.debug(tc, "Exception instanciating MessageDigest. The algorithm is " + algorithm + nsae);
                 }
                 throw new RuntimeException("Exception instanciating MessageDigest : " + nsae);
-            } catch (UnsupportedEncodingException uee) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Exception converting String object : " + uee);
-                }
-                throw new RuntimeException("Exception converting String object : " + uee);
             }
         }
         return output;
     }
-    
+
     /**
      * generate hash code by using specified algorithm and character set.
      * If there is some error, log the error.
      */
-    public static String encodedDigest(String code_verifier, String algorithm, String charset) {
+    public static String encodedDigest(String code_verifier, String algorithm, Charset charset) {
         MessageDigest md;
         String output = null;
         if (code_verifier != null && code_verifier.length() > 0) {
@@ -89,11 +85,6 @@ public class HashUtils {
                     Tr.debug(tc, "Exception instanciating MessageDigest. The algorithm is " + algorithm + nsae);
                 }
                 throw new RuntimeException("Exception instantiating MessageDigest : " + nsae);
-            } catch (UnsupportedEncodingException uee) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Exception converting String object : " + uee);
-                }
-                throw new RuntimeException("Exception converting String object : " + uee);
             }
         }
         return output;

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/RegistrationEndpointServices.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/RegistrationEndpointServices.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
@@ -168,7 +169,7 @@ public class RegistrationEndpointServices extends AbstractOidcEndpointServices {
         // Set response body for GET requests
         if (request.getMethod().equalsIgnoreCase(HTTP_METHOD_GET)) {
             decodeClientName(client);
-            byte[] b = GSON.toJson(client).toString().getBytes("UTF-8");
+            byte[] b = GSON.toJson(client).toString().getBytes(StandardCharsets.UTF_8);
             response.getOutputStream().write(b);
         }
 
@@ -213,7 +214,7 @@ public class RegistrationEndpointServices extends AbstractOidcEndpointServices {
 
             responseBody.add("data", GSON.toJsonTree(clientsAsJSON));
             // Write out in UTF-8 bytes format
-            response.getOutputStream().write(responseBody.toString().getBytes("UTF-8"));
+            response.getOutputStream().write(responseBody.toString().getBytes(StandardCharsets.UTF_8));
         }
 
         response.flushBuffer();
@@ -277,7 +278,7 @@ public class RegistrationEndpointServices extends AbstractOidcEndpointServices {
         );
 
         // Write out in UTF-8 bytes format
-        byte[] b = OidcOAuth20Util.GSON_RAW.toJson(savedClientWithDefaults).toString().getBytes("UTF-8");
+        byte[] b = OidcOAuth20Util.GSON_RAW.toJson(savedClientWithDefaults).toString().getBytes(StandardCharsets.UTF_8);
         response.getOutputStream().write(b);
         response.setStatus(HttpServletResponse.SC_CREATED);
         response.flushBuffer();
@@ -358,13 +359,13 @@ public class RegistrationEndpointServices extends AbstractOidcEndpointServices {
 
             if (clientSecretAction == ClientSecretAction.RETAIN && !OidcOAuth20Util.isNullEmpty(savedClientWithDefaults.getClientSecret())) {
                 // Mask client_secret with (*) because no new secret was generated
-                byte[] b = GSON.toJson(savedClientWithDefaults).toString().getBytes("UTF-8");
+                byte[] b = GSON.toJson(savedClientWithDefaults).toString().getBytes(StandardCharsets.UTF_8);
                 response.getOutputStream().write(b);
             } else {
                 // If 'NEW' client secret was generated or 'CLEAR', send unhashed secret back
                 savedClientWithDefaults.setClientSecret(tmpNewSecret);
 
-                byte[] b = OidcOAuth20Util.GSON_RAW.toJson(savedClientWithDefaults).toString().getBytes("UTF-8");
+                byte[] b = OidcOAuth20Util.GSON_RAW.toJson(savedClientWithDefaults).toString().getBytes(StandardCharsets.UTF_8);
                 response.getOutputStream().write(b);
             }
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/TokenExchange.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/TokenExchange.java
@@ -1,23 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
-
-/*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-2.0/
- * 
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -26,6 +13,7 @@
 package com.ibm.ws.security.oauth20.web;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -935,7 +923,7 @@ public class TokenExchange {
         response.setStatus(HttpServletResponse.SC_OK);
         try {
             // write out in UTF-8 bytes format
-            byte[] b = responseJson.getBytes("UTF-8");
+            byte[] b = responseJson.getBytes(StandardCharsets.UTF_8);
             response.getOutputStream().write(b);
             response.flushBuffer();
         } catch (IOException e) {

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/util/HashUtilsTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/util/HashUtilsTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,7 @@
 package com.ibm.ws.security.oauth20.util;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -80,7 +81,7 @@ public class HashUtilsTest {
         String code_verifier = getEncoded(code);
         String code_challenge = getDigest(code_verifier, "nourlsafe");
 
-        String challenge = HashUtils.encodedDigest(code_verifier, "SHA-256", "US-ASCII");
+        String challenge = HashUtils.encodedDigest(code_verifier, "SHA-256", StandardCharsets.US_ASCII);
 
         org.junit.Assert.assertNotSame("code verifier is encoded non url safe", challenge, code_challenge);
 
@@ -95,7 +96,7 @@ public class HashUtilsTest {
         String code_verifier = getEncodedUsingLocalEncoder(code);
         String code_challenge = getDigest(code_verifier, "local");
 
-        String challenge = HashUtils.encodedDigest(code_verifier, "SHA-256", "US-ASCII");
+        String challenge = HashUtils.encodedDigest(code_verifier, "SHA-256", StandardCharsets.US_ASCII);
 
         org.junit.Assert.assertNotSame("code verifier is encoded using local", challenge, code_challenge);
 
@@ -110,7 +111,7 @@ public class HashUtilsTest {
         String code_verifier = getUrlSafeEncoded(code);
         String code_challenge = getDigest(code_verifier, "urlsafe");
 
-        String challenge = HashUtils.encodedDigest(code_verifier, "SHA-256", "US-ASCII");
+        String challenge = HashUtils.encodedDigest(code_verifier, "SHA-256", StandardCharsets.US_ASCII);
 
         org.junit.Assert.assertEquals("code verifier is encoded and url safe and should be same", challenge, code_challenge);
 

--- a/dev/com.ibm.ws.security.openid/src/com/ibm/ws/security/openid20/tai/ClientAuthnData.java
+++ b/dev/com.ibm.ws.security.openid/src/com/ibm/ws/security/openid20/tai/ClientAuthnData.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2022 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,6 +12,8 @@
  *******************************************************************************/
 
 package com.ibm.ws.security.openid20.tai;
+
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -26,7 +28,7 @@ public class ClientAuthnData {
 
     public static final String Authorization_Header = "Authorization";
     public static final String AUTHORIZATION_ENCODING = "Authorization-Encoding";
-    public static final String BasicAuthEncoding = System.getProperty("com.ibm.websphere.security.BasicAuthEncoding", "UTF-8");
+    public static final String BasicAuthEncoding = System.getProperty("com.ibm.websphere.security.BasicAuthEncoding");
     String userName = null;
     String passWord = null;
     boolean authnData = false;
@@ -72,11 +74,16 @@ public class ClientAuthnData {
         if (encoding == null) {
             encoding = BasicAuthEncoding;
         }
-        try {
-            hdrValue = Base64Coder.base64Decode(hdrValue.substring(6), encoding);
-        } catch (Exception e) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Decoding fails with encoding:" + encoding, e.getMessage());
+        // If BasicAuthEncoding is not configured, use UTF8
+        if (encoding == null) {
+            hdrValue = Base64Coder.base64Decode(hdrValue.substring(6), StandardCharsets.UTF_8);
+        } else {
+            try {
+                hdrValue = Base64Coder.base64Decode(hdrValue.substring(6), encoding);
+            } catch (Exception e) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Decoding fails with encoding:" + encoding, e.getMessage());
+                }
             }
         }
 

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientCache.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientCache.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.internal;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +38,7 @@ import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
  */
 class OidcClientCache {
     private static final TraceComponent tc = Tr.register(OidcClientCache.class);
-    static final String UTF8 = "UTF-8";
+    static final Charset UTF8 = StandardCharsets.UTF_8;
 
     AuthCacheService authCache = null;
     OidcClientConfig clientCfg = null;

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client.jose4j.util;
 
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.Key;
 import java.security.PrivilegedAction;
@@ -42,7 +43,6 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.security.authentication.AuthenticationConstants;
 import com.ibm.ws.security.common.crypto.HashUtils;
 import com.ibm.ws.security.common.jwk.impl.JwKRetriever;
@@ -103,7 +103,7 @@ public class Jose4jUtil {
         String[] parts = accessTokenStr.split(Pattern.quote(".")); // split out the "parts" (header, payload and signature)
 
         if (parts.length > 1) {
-            String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[1]), "UTF-8");
+            String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[1]), StandardCharsets.UTF_8);
             jwtClaims = JwtClaims.parse(claimsAsJsonString);
         } else {
             // do nothing
@@ -400,7 +400,7 @@ public class Jose4jUtil {
         }
         if (signatureAlgorithm.startsWith(SIGNATURE_ALG_HS)) {
             //keyValue = Base64Coder.getBytes(clientConfig.getSharedKey());
-            keyValue = new HmacKey(clientConfig.getSharedKey().getBytes(ClientConstants.CHARSET));
+            keyValue = new HmacKey(clientConfig.getSharedKey().getBytes(StandardCharsets.UTF_8));
         } else if (signatureAlgorithm.startsWith(SIGNATURE_ALG_RS) || signatureAlgorithm.startsWith(SIGNATURE_ALG_ES)) {
             if (clientConfig.getJwkEndpointUrl() != null || clientConfig.getJsonWebKey() != null) {
                 JwKRetriever retriever = createJwkRetriever(clientConfig);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcAuthorizationRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@ package com.ibm.ws.security.openidconnect.clients.common;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
@@ -159,9 +158,6 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
                 storeOriginalRequestUrl(state);
             }
 
-        } catch (UnsupportedEncodingException e) {
-            Tr.error(tc, "OIDC_CLIENT_AUTHORIZE_ERR", new Object[] { clientId, e.getLocalizedMessage(), ClientConstants.CHARSET });
-            return new ProviderAuthenticationResult(AuthResult.SEND_401, HttpServletResponse.SC_UNAUTHORIZED);
         } catch (IOException ioe) {
             Tr.error(tc, "OIDC_CLIENT_AUTHORIZE_ERR", new Object[] { clientId, ioe.getLocalizedMessage(), ClientConstants.CHARSET });
             return new ProviderAuthenticationResult(AuthResult.SEND_401, HttpServletResponse.SC_UNAUTHORIZED);
@@ -190,7 +186,7 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
         return false;
     }
 
-    String buildAuthorizationUrlWithQuery(OidcClientRequest oidcClientRequest, String state, String redirect_url, String acr_values) throws UnsupportedEncodingException {
+    String buildAuthorizationUrlWithQuery(OidcClientRequest oidcClientRequest, String state, String redirect_url, String acr_values) {
         String strResponse_type = Constants.RESPONSE_TYPE_CODE; // default is asking for authorization code
         boolean isImplicit = false;
         if (Constants.IMPLICIT.equals(clientConfig.getGrantType())) {
@@ -207,7 +203,7 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
         return authzParameters.buildRequestUrl();
     }
 
-    void addOptionalParameters(AuthorizationRequestParameters authzParameters, OidcClientRequest oidcClientRequest, String state, String acr_values, boolean isImplicit) throws UnsupportedEncodingException {
+    void addOptionalParameters(AuthorizationRequestParameters authzParameters, OidcClientRequest oidcClientRequest, String state, String acr_values, boolean isImplicit) {
         if (clientConfig.isNonceEnabled() || isImplicit) {
             String nonceValue = requestUtils.generateNonceValue();
             storeNonceValue(nonceValue, state);
@@ -258,11 +254,11 @@ public class OidcAuthorizationRequest extends AuthorizationRequest {
         pkceHelper.generateAndAddPkceParametersToAuthzRequest(codeChallengeMethod, state, authzParameters);
     }
 
-    void addImplicitParameters(AuthorizationRequestParameters authzParameters) throws UnsupportedEncodingException {
+    void addImplicitParameters(AuthorizationRequestParameters authzParameters) {
         authzParameters.addParameter("response_mode", "form_post");
     }
 
-    String getResourcesParameter() throws UnsupportedEncodingException {
+    String getResourcesParameter() {
         String resources = OIDCClientAuthenticatorUtil.getResources(clientConfig);
         if (resources != null && !resources.isEmpty()) {
             return resources;

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,8 @@
 package com.ibm.ws.security.openidconnect.clients.common;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -148,7 +148,7 @@ public class OidcClientUtil {
             // Tr.error(tc, "SSL_PORT_IS_NULL");
             int port = req.getServerPort();
             // return whatever in the req
-            String httpSchema = ((javax.servlet.ServletRequest) req).getScheme();
+            String httpSchema = req.getScheme();
             return httpSchema + "://" + hostName + (port > 0 && port != 443 ? ":" + port : "") + entryPoint;
         } else {
             return "https://" + hostName + (httpsPort == null ? "" : ":" + httpsPort) + entryPoint;
@@ -255,15 +255,7 @@ public class OidcClientUtil {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "requestParameters:" + requestParameters);
         }
-        String encodedReqParams = null;
-        try {
-            encodedReqParams = Base64Coder.toString(Base64Coder.base64Encode(requestParameters.getBytes(ClientConstants.CHARSET)));
-        } catch (UnsupportedEncodingException e) {
-            //This should not happen, we are using UTF-8
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "get unexpected exception", e);
-            }
-        }
+        String encodedReqParams = Base64Coder.toString(Base64Coder.base64Encode(requestParameters.getBytes(StandardCharsets.UTF_8)));
 
         String encodedHash = null;
         if (encodedReqParams != null) {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/token/JWT.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/token/JWT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2024 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.token;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.SignatureException;
@@ -350,7 +350,7 @@ public class JWT {
 
     }
 
-    private String serializeAndSign(WSJsonToken token) throws InvalidKeyException, UnsupportedEncodingException, JoseException {
+    private String serializeAndSign(WSJsonToken token) throws InvalidKeyException, JoseException {
         JsonWebSignature jws = new JsonWebSignature();
         jws.setPayload(JsonTokenUtil.toJson(token.getPayload()));
         String alg = token.getHeader().get(ALGORITHM_HEADER).getAsString();
@@ -717,19 +717,18 @@ public class JWT {
      *
      * @param alg
      * @return
-     * @throws UnsupportedEncodingException
      * @throws InvalidKeyException
      */
     //@FFDCIgnore({InvalidKeyException.class})
     @Sensitive
-    private Key getKey(String alg) throws UnsupportedEncodingException, InvalidKeyException {
+    private Key getKey(String alg) throws InvalidKeyException {
         Key keyUsed = null;
         if ("RS256".equals(alg)) {
             keyUsed = (Key) getKey();
         } else if ("HS256".equals(alg)) {
             byte[] keyBytes = null;
             if (getKey() instanceof String) {
-                keyBytes = ((String) getKey()).getBytes("UTF-8"); //TODO
+                keyBytes = ((String) getKey()).getBytes(StandardCharsets.UTF_8); //TODO
             } else if (getKey() instanceof byte[]) {
                 keyBytes = (byte[]) getKey();
             } else {

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/token/impl/IdTokenImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/token/impl/IdTokenImpl.java
@@ -1,19 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.token.impl;
 
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -468,12 +468,7 @@ public class IdTokenImpl implements Serializable {
     //
 
     public String getAllClaimsAsJson() {
-        try {
-            return new String(idTokenPart2Bytes, Constants.UTF_8);
-        } catch (UnsupportedEncodingException e) {
-            // this should not happen
-            return new String(idTokenPart2Bytes);
-        }
+        return new String(idTokenPart2Bytes, StandardCharsets.UTF_8);
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.security.openidconnect.common/src/com/ibm/ws/security/openidconnect/common/cl/JWTVerifier.java
+++ b/dev/com.ibm.ws.security.openidconnect.common/src/com/ibm/ws/security/openidconnect/common/cl/JWTVerifier.java
@@ -1,18 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.common.cl;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.ArrayList;
 import java.util.List;
@@ -161,10 +161,7 @@ public class JWTVerifier {
         try {
             Key theKey = null;
             if (_key instanceof String) {
-                try {
-                    theKey = new HmacKey(((String) _key).getBytes("UTF-8"));
-                } catch (UnsupportedEncodingException e) {
-                }
+                theKey = new HmacKey(((String) _key).getBytes(StandardCharsets.UTF_8));
             } else if (_key instanceof byte[]) {
                 theKey = new HmacKey((byte[]) _key);
             } else if (_key instanceof Key) {
@@ -190,7 +187,7 @@ public class JWTVerifier {
 
     /**
      * @param tokenString
-     *            The original encoded representation of a JWT
+     *                        The original encoded representation of a JWT
      * @return Three components of the JWT as an array of strings
      */
     public String[] splitTokenString(String tokenString) throws InvalidGrantException {

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/HashUtils.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/internal/HashUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.server.internal;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -26,7 +27,7 @@ import com.ibm.ws.common.encoder.Base64Coder;
 public class HashUtils {
     private static final TraceComponent tc = Tr.register(HashUtils.class);
     private static String DEFAULT_ALGORITHM = "SHA-256";
-    private static String DEFAULT_CHARSET = "UTF-8";
+    private static Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
     /**
      * generate hash code by using SHA-256
@@ -48,7 +49,7 @@ public class HashUtils {
      * generate hash code by using specified algorithm and character set.
      * If there is some error, log the error.
      */
-    protected static String digest(String input, String algorithm, String charset) {
+    protected static String digest(String input, String algorithm, Charset charset) {
         MessageDigest md;
         String output = null;
         if (input != null && input.length() > 0) {
@@ -61,11 +62,6 @@ public class HashUtils {
                     Tr.debug(tc, "Exception instanciating MessageDigest. The algorithm is " + algorithm + nsae);
                 }
                 throw new RuntimeException("Exception instanciating MessageDigest : " + nsae);
-            } catch (UnsupportedEncodingException uee) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Exception converting String object : " + uee);
-                }
-                throw new RuntimeException("Exception converting String object : " + uee);
             }
         }
         return output;

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/IDTokenHandler.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/IDTokenHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.server.plugins;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.PrivateKey;
@@ -478,12 +478,7 @@ public class IDTokenHandler implements OAuth20TokenTypeHandler {
             keyId = jwk.getKeyID();
         } else {
             if (SIGNATURE_ALG_HS256.equals(signatureAlgorithm)) {
-                try {
-                    keyValue = new HmacKey(sharedKey.getBytes("UTF-8"));;
-                } catch (UnsupportedEncodingException e) {
-                    // TODO This won't happen since we hardcode as UTF-8
-                }
-
+                keyValue = new HmacKey(sharedKey.getBytes(StandardCharsets.UTF_8));
             } else if (SIGNATURE_ALG_RS256.equals(signatureAlgorithm)) {
                 try {
                     keyValue = oidcServerConfig.getPrivateKey();

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcSessionManagementUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcSessionManagementUtil.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.web;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 import com.ibm.oauth.core.internal.OAuthUtil;
@@ -26,7 +28,7 @@ import com.ibm.ws.common.encoder.Base64Coder;
 public class OidcSessionManagementUtil {
     private static final TraceComponent tc = Tr.register(OidcSessionManagementUtil.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
-    public final static String ENCODING = "UTF-8";
+    public final static Charset ENCODING = StandardCharsets.UTF_8;
     public final static int RANDOM_STATE_LENGTH = 40;
 
     /**
@@ -38,7 +40,7 @@ public class OidcSessionManagementUtil {
      * Inclusion of a salt provides sufficient randomness to prevent
      * identification of an end-user across successive calls to the
      * authorization endpoint and is recommended by the spec.
-     * 
+     *
      * @param clientId
      * @param state
      * @param salt

--- a/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/io/openliberty/security/openidconnect/backchannellogout/BackchannelLogoutRequest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package io.openliberty.security.openidconnect.backchannellogout;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -110,7 +110,7 @@ public class BackchannelLogoutRequest implements Callable<BackchannelLogoutReque
     private HttpEntity getHttpEntity() {
         List<NameValuePair> parameters = new ArrayList<>();
         parameters.add(new BasicNameValuePair(LOGOUT_TOKEN_PARAM_NAME, logoutToken));
-        return new UrlEncodedFormEntity(parameters, Charset.forName("UTF-8"));
+        return new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/server/internal/HashUtilsTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/server/internal/HashUtilsTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -74,25 +74,6 @@ public class HashUtilsTest {
         String message = "Exception instanciating MessageDigest :";
         try {
             HashUtils.digest(input, invalidAlgorithm);
-            fail("An exception should be caught");
-        } catch (RuntimeException re) {
-            // this is normal.
-            assertTrue(re.getMessage().startsWith(message));
-            return;
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(methodName, t);
-        }
-    }
-
-    @Test
-    public void testDigestInvalidEncoding() {
-        String methodName = "testDigestInvalidEncoding";
-        String input = "ThisIsASampleString.";
-        String invalidCharset = "UTF-3";
-        String message = "Exception converting String object :";
-
-        try {
-            HashUtils.digest(input, "SHA-256", invalidCharset);
             fail("An exception should be caught");
         } catch (RuntimeException re) {
             // this is normal.

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/impl/Saml20HTTPPostDecoder.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/impl/Saml20HTTPPostDecoder.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,14 +15,13 @@ package com.ibm.ws.security.saml.impl;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.http.HttpServletRequest;
 
 import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.messaging.decoder.MessageDecodingException;
 import org.opensaml.saml.saml2.binding.decoding.impl.HTTPPostDecoder;
-
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -55,12 +54,7 @@ public class Saml20HTTPPostDecoder extends HTTPPostDecoder {
                     byte[] bytes = new byte[iAvailable];
                     byteStream.read(bytes, 0, iAvailable);
                     byteStream.reset();
-                    try {
-                        Tr.debug(tc, "decoded saml response:" + new String(bytes, "UTF-8"));
-                    } catch (UnsupportedEncodingException e) {
-                        // ignore it
-                        Tr.debug(tc, "decoded saml response failed to converted to a String:" + e);
-                    }
+                    Tr.debug(tc, "decoded saml response:" + new String(bytes, StandardCharsets.UTF_8));
                 } else {
                     Tr.debug(tc, "decoded saml response has bytes count:" + iAvailable);
                 }

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/HashUtils.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/HashUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.security.saml.sso20.internal.utils;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -27,7 +28,7 @@ import com.ibm.ws.common.encoder.Base64Coder;
 public class HashUtils {
     private static final TraceComponent tc = Tr.register(HashUtils.class);
     private static String DEFAULT_ALGORITHM = "SHA-256";
-    private static String DEFAULT_CHARSET = "UTF-8";
+    private static Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
     /**
      * generate hash code by using SHA-256
@@ -52,7 +53,7 @@ public class HashUtils {
      * If there is some error, log the error.
      */
     @Sensitive
-    protected static String digest(String input, String algorithm, String charset) {
+    protected static String digest(String input, String algorithm, Charset charset) {
         MessageDigest md;
         String output = null;
         if (input != null && input.length() > 0) {
@@ -65,11 +66,6 @@ public class HashUtils {
                     Tr.debug(tc, "Exception instanciating MessageDigest. The algorithm is " + algorithm + nsae);
                 }
                 throw new RuntimeException("Exception instanciating MessageDigest : " + nsae);
-            } catch (UnsupportedEncodingException uee) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Exception converting String object : " + uee);
-                }
-                throw new RuntimeException("Exception converting String object : " + uee);
             }
         }
         return output;

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/HttpRequestInfo.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/HttpRequestInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -234,7 +235,7 @@ public class HttpRequestInfo implements Serializable {
      *
      * @param request
      * @param response
-     * @param cookieName --
+     * @param cookieName  --
      * @param cookieValue --
      * @throws SamlException
      */
@@ -447,14 +448,7 @@ public class HttpRequestInfo implements Serializable {
         if (savePostIdBytes == null || savePostIdBytes.length < 8) // length ought to be 12
             return; // no cookie found
 
-        String savePostId = null;
-        try {
-            savePostId = new String(savePostIdBytes, Constants.UTF8);
-        } catch (UnsupportedEncodingException e) {
-            //
-            throw new SamlException(e);
-            // This should not happen since the encoding is utf-8
-        }
+        String savePostId = new String(savePostIdBytes, StandardCharsets.UTF_8);
         String cacheKey = SamlUtil.hash(savePostId);
         HttpRequestInfo requestInfo = (HttpRequestInfo) postCache.get(cacheKey);
         if (tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/InitialRequest.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/InitialRequest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,7 +16,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -58,7 +59,7 @@ public class InitialRequest implements Serializable {
     public static final int LENGTH_INT = 4;
 
     private static final int OFFSET_DATA = 1;
-    private static final String CHARSET_NAME = "UTF-8";
+    private static final Charset CHARSET_NAME = StandardCharsets.UTF_8;
     private static final int postParamSaveSize = 16000;
 
     public InitialRequest(HttpServletRequest request, String reqUrl, String requestURL, String method, String inResponseTo, String formlogout,
@@ -157,7 +158,7 @@ public class InitialRequest implements Serializable {
      * The format of the data is as follows:
      * <based64 encoded data[0] from serializeInputStreamData()>.<base 64 encoded data[1]>. and so on.
      */
-    public String serializePostParams(IExtendedRequest req) throws IOException, UnsupportedEncodingException, IllegalStateException {
+    public String serializePostParams(IExtendedRequest req) throws IOException, IllegalStateException {
         String output = null;
 
         if (this.savedPostParams != null) {
@@ -196,7 +197,7 @@ public class InitialRequest implements Serializable {
      * deserialize Post parameters.
      * The code doesn't expect that the req, cookieValueBytes, or reqURL is null.
      */
-    private HashMap deserializePostParams(byte[] paramsbytes, IExtendedRequest req) throws IOException, UnsupportedEncodingException, IllegalStateException {
+    private HashMap deserializePostParams(byte[] paramsbytes, IExtendedRequest req) throws IOException, IllegalStateException {
         HashMap output = null;
         List<byte[]> data = splitBytes(paramsbytes, (byte) '.');
         int total = data.size();

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/RequestUtil.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/utils/RequestUtil.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,8 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.saml.sso20.internal.utils;
 
-
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
@@ -107,7 +106,7 @@ public class RequestUtil extends KnownSamlUrl {
                     Tr.debug(tc, "The redirect SSL port is null from request. Trying to get http port");
                 }
                 int port = req.getServerPort();
-                String httpSchema = ((javax.servlet.ServletRequest) req).getScheme();
+                String httpSchema = req.getScheme();
                 // return whatever in the req
                 return httpSchema + "://" + hostName + (port > 0 && port != 443 ? ":" + port : "") + samlCtxPath;
             } else {
@@ -160,7 +159,7 @@ public class RequestUtil extends KnownSamlUrl {
                                                          req);
         response.addCookie(c);
     }
-    
+
     public static void createCookie(HttpServletRequest req,
                                     HttpServletResponse response,
                                     String cookieName,
@@ -202,35 +201,18 @@ public class RequestUtil extends KnownSamlUrl {
         if (cookieValueBytes == null || cookieValueBytes.length == 0) {
             return null;
         }
-        String result = null;
-        try {
-            result = new String(cookieValueBytes, Constants.UTF8); // no need to do Base64 decode
-        } catch (UnsupportedEncodingException e) {
-            // This should not happen, since UTF8 is OK in almost all situations
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Unexpected exception, id:(" + e + ")");
-            }
-            throw new SamlException(e); // Let SamlException handle the unexpected Exception
-        }
-        return result;
+        return new String(cookieValueBytes, StandardCharsets.UTF_8); // no need to do Base64 decode
     }
 
     public static String convertBytesToString(byte[] bytes) {
-        String result = null;
-        try {
-            result = new String(bytes, Constants.UTF8); // no need to do Base64 decode
-        } catch (UnsupportedEncodingException e) {
-            // This ought to be OK
-            // The worst case is: The request is not handled
-        }
-        return result;
+        return new String(bytes, StandardCharsets.UTF_8); // no need to do Base64 decode
     }
 
     @FFDCIgnore({ SamlException.class })
     public static Credential getDecryptingCredential(SsoSamlService ssoService) throws SamlException {
         BasicX509Credential credential = null;
         try {
-            PrivateKey privateKey = ssoService.getPrivateKey();         
+            PrivateKey privateKey = ssoService.getPrivateKey();
             if (privateKey == null) {
                 // error handling
                 throw new SamlException("SAML20_NO_PRIVATE_KEY",
@@ -244,7 +226,7 @@ public class RequestUtil extends KnownSamlUrl {
                                 //SAML20_NO_CERT=CWWKS5074E: Cannot find a signature certificate from Service Provider [{0}].
                                 null, true, new Object[] { ssoService.getProviderId(), ssoService.getConfig().getKeyStoreRef() });
             }
-            credential = new BasicX509Credential((X509Certificate) certificate);           
+            credential = new BasicX509Credential((X509Certificate) certificate);
             credential.setPrivateKey(privateKey);
         } catch (SamlException e) { // declared exceptions: KeyStoreException,  CertificateException
             throw e;
@@ -274,7 +256,7 @@ public class RequestUtil extends KnownSamlUrl {
                                 null, true, new Object[] { ssoService.getProviderId(), ssoService.getConfig().getKeyStoreRef() });
             }
             credential = new BasicX509Credential((X509Certificate) certificate);
-            
+
             credential.setPrivateKey(privateKey);
 
         } catch (SamlException e) {

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/rs/RsSamlConsumer.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/rs/RsSamlConsumer.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,7 @@
 package com.ibm.ws.security.saml.sso20.rs;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,7 +36,6 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.security.saml.Constants;
 import com.ibm.ws.security.saml.SsoRequest;
 import com.ibm.ws.security.saml.SsoSamlService;
 import com.ibm.ws.security.saml.TraceConstants;
@@ -83,7 +83,7 @@ public class RsSamlConsumer<InboundMessageType extends SAMLObject, OutboundMessa
                 if (tc.isDebugEnabled()) {
                     Tr.debug(tc, "SAML assertion in header" );
                 }
-                bytes = headerContent.getBytes(Constants.UTF8);
+                bytes = headerContent.getBytes(StandardCharsets.UTF_8);
             } else {
                 if (tc.isDebugEnabled()) {
                     Tr.debug(tc, "Encoded SAML assertion in header" );

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/slo/IdPInitiatedSLO.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/slo/IdPInitiatedSLO.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021,2023 IBM Corporation and others.
+ * Copyright (c) 2021,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.saml.sso20.slo;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.servlet.ServletException;
@@ -36,8 +36,8 @@ import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.core.StatusResponseType;
 import org.opensaml.saml.saml2.core.impl.IssuerBuilder;
-import org.opensaml.saml.saml2.core.impl.LogoutResponseMarshaller;
 import org.opensaml.saml.saml2.core.impl.LogoutResponseBuilder;
+import org.opensaml.saml.saml2.core.impl.LogoutResponseMarshaller;
 import org.opensaml.saml.saml2.core.impl.StatusBuilder;
 import org.opensaml.saml.saml2.core.impl.StatusCodeBuilder;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
@@ -331,15 +331,7 @@ public class IdPInitiatedSLO {
                  String relayState,
                  String idpUrl) throws SamlException {
 
-        byte[] logoutResBytes = null;
-        try {
-            logoutResBytes = logoutResponse.getBytes(Constants.UTF8);
-        } catch (UnsupportedEncodingException e1) {
-            // error handling, UTF8 should not have errors
-            SamlException samlException = new SamlException(e1); // let the SamlException to handle the Exception
-
-            throw samlException;
-        }
+        byte[] logoutResBytes = logoutResponse.getBytes(StandardCharsets.UTF_8);
 
         String samlResponse = Base64Support.encode(logoutResBytes, Base64Support.UNCHUNKED); //v3
 

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/slo/SPInitiatedSLO.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/slo/SPInitiatedSLO.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.saml.sso20.slo;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
@@ -347,15 +347,7 @@ public class SPInitiatedSLO {
                       String idpUrl,
                       HttpRequestInfo cachingRequestInfo) throws SamlException {
 
-        byte[] logoutReqBytes = null;
-        try {
-            logoutReqBytes = logoutRequest.getBytes(Constants.UTF8);
-        } catch (UnsupportedEncodingException e1) {
-            // error handling, UTF8 should not have errors
-            SamlException samlException = new SamlException(e1); // let the SamlException to handle the Exception
-
-            throw samlException;
-        }
+        byte[] logoutReqBytes = logoutRequest.getBytes(StandardCharsets.UTF_8);
 
         String samlRequest = Base64Support.encode(logoutReqBytes, Base64Support.UNCHUNKED); //v3
 

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/sp/Solicited.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/sp/Solicited.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021,2024 IBM Corporation and others.
+ * Copyright (c) 2021,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.saml.sso20.sp;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -377,16 +377,7 @@ public class Solicited {
                       HttpRequestInfo cachingRequestInfo)
                     throws WebTrustAssociationFailedException {
 
-        byte[] authnReqBytes = null;
-        try {
-            authnReqBytes = AuthnRequest.getBytes(Constants.UTF8);
-        } catch (UnsupportedEncodingException e1) {
-            // error handling, UTF8 should not have errors
-            SamlException samlException = new SamlException(e1); // let the SamlException to handle the Exception
-            WebTrustAssociationFailedException wtfae = new WebTrustAssociationFailedException(samlException.getMessage());
-            wtfae.initCause(samlException);
-            throw wtfae;
-        }
+        byte[] authnReqBytes = AuthnRequest.getBytes(StandardCharsets.UTF_8);
 
         //String samlRequest = Base64.encodeBytes(authnReqBytes, Base64.DONT_BREAK_LINES);
         String samlRequest = Base64Support.encode(authnReqBytes, Base64Support.UNCHUNKED); //v3

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/token/Saml20TokenImpl.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/token/Saml20TokenImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,8 +15,8 @@ package com.ibm.ws.security.saml.sso20.token;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -620,7 +620,7 @@ public class Saml20TokenImpl implements Saml20Token, Serializable {
     public String toString() {
         String holderOfKey = "";
         try {
-            holderOfKey = new String(holderOfKeyBytes, Constants.UTF8);
+            holderOfKey = new String(holderOfKeyBytes, StandardCharsets.UTF_8);
         } catch (Exception e) {
 
         }

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/OAuthClientUtil.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/OAuthClientUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package com.ibm.ws.security.social.internal.utils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -438,7 +439,7 @@ public class OAuthClientUtil {
             params = new ArrayList<NameValuePair>();
         }
         //params.add(new BasicNameValuePair("format", "json"));
-        query = URLEncodedUtils.format(params, ClientConstants.CHARSET);
+        query = URLEncodedUtils.format(params, StandardCharsets.UTF_8);
 
         if (query != null && !query.isEmpty()) {
             if (!url.endsWith("?")) {

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/OpenShiftUserApiUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/OpenShiftUserApiUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -84,7 +85,7 @@ public class OpenShiftUserApiUtils {
         connection.setDoOutput(true);
 
         OutputStream outputStream = connection.getOutputStream();
-        OutputStreamWriter streamWriter = new OutputStreamWriter(outputStream, "UTF-8");
+        OutputStreamWriter streamWriter = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
 
         String bodyString = createUserApiRequestBody(accessToken);
         streamWriter.write(bodyString);

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAIEncryptionUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAIEncryptionUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package com.ibm.ws.security.social.tai;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.MessageDigest;
 import java.security.PrivateKey;
@@ -143,7 +144,7 @@ public class TAIEncryptionUtils {
         PublicKey publicKey = clientConfig.getPublicKey();
         if (publicKey != null) {
             cipher.init(Cipher.ENCRYPT_MODE, publicKey);
-            byte[] encryptedBytes = getBytes(cipher, accessToken.getBytes("UTF-8"), 53); // RSA takes 53 bytes max for encrypting.
+            byte[] encryptedBytes = getBytes(cipher, accessToken.getBytes(StandardCharsets.UTF_8), 53); // RSA takes 53 bytes max for encrypting.
             encryptedAccessToken = encodingUtils.bytesToHexString(encryptedBytes);
         }
         return encryptedAccessToken;
@@ -161,7 +162,7 @@ public class TAIEncryptionUtils {
         PrivateKey privateKey = clientConfig.getPrivateKey();
         cipher.init(Cipher.DECRYPT_MODE, privateKey);
         byte[] decryptedBytes = getBytes(cipher, hexStringToBytes(encryptedToken), 64); // RSA takes 64 bytes max for decrypting
-        return new String(decryptedBytes, "UTF-8");
+        return new String(decryptedBytes, StandardCharsets.UTF_8);
     }
 
     @Trivial
@@ -210,7 +211,7 @@ public class TAIEncryptionUtils {
             IvParameterSpec ivSpec = getIvSpec(clientConfig);
             Cipher cipher = Cipher.getInstance(TRANSFORMATION_AES);
             cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivSpec);
-            byte[] encryptedBytes = cipher.doFinal(accessToken.getBytes("UTF-8"));
+            byte[] encryptedBytes = cipher.doFinal(accessToken.getBytes(StandardCharsets.UTF_8));
             encryptedAccessToken = encodingUtils.bytesToHexString(encryptedBytes);
         }
         return encryptedAccessToken;
@@ -229,7 +230,7 @@ public class TAIEncryptionUtils {
         Cipher cipher = Cipher.getInstance(TRANSFORMATION_AES);
         cipher.init(Cipher.DECRYPT_MODE, secretKey, ivSpec);
         byte[] decryptedBytes = cipher.doFinal(hexStringToBytes(encryptedToken));
-        return new String(decryptedBytes, "UTF-8");
+        return new String(decryptedBytes, StandardCharsets.UTF_8);
     }
 
     Key getSecretKey(SocialLoginConfig config) throws Exception {
@@ -253,7 +254,7 @@ public class TAIEncryptionUtils {
             }
             return null;
         }
-        return md.digest(clientSecret.getBytes(Charset.forName("UTF-8")));
+        return md.digest(clientSecret.getBytes(StandardCharsets.UTF_8));
     }
 
     @FFDCIgnore(Exception.class)

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/twitter/TwitterEndpointServices.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/twitter/TwitterEndpointServices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.social.twitter;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -137,11 +137,6 @@ public class TwitterEndpointServices {
 
         } catch (GeneralSecurityException e) {
             Tr.warning(tc, "TWITTER_ERROR_CREATING_SIGNATURE", new Object[] { e.getLocalizedMessage() });
-        } catch (UnsupportedEncodingException e) {
-            // Should be using UTF-8 encoding, so this should be highly unlikely
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Caught unexpected exception: " + e.getLocalizedMessage(), e);
-            }
         }
 
         return signature;
@@ -154,19 +149,18 @@ public class TwitterEndpointServices {
      * @param keyString
      * @return
      * @throws GeneralSecurityException
-     * @throws UnsupportedEncodingException
      */
-    protected String computeSha1Signature(String baseString, @Sensitive String keyString) throws GeneralSecurityException, UnsupportedEncodingException {
+    protected String computeSha1Signature(String baseString, @Sensitive String keyString) throws GeneralSecurityException {
 
-        byte[] keyBytes = keyString.getBytes(CommonWebConstants.UTF_8);
+        byte[] keyBytes = keyString.getBytes(StandardCharsets.UTF_8);
         SecretKey secretKey = new SecretKeySpec(keyBytes, "HmacSHA1");
 
         Mac mac = Mac.getInstance("HmacSHA1");
         mac.init(secretKey);
 
-        byte[] text = baseString.getBytes(CommonWebConstants.UTF_8);
+        byte[] text = baseString.getBytes(StandardCharsets.UTF_8);
 
-        return new String(Base64.encodeBase64(mac.doFinal(text)), CommonWebConstants.UTF_8).trim();
+        return new String(Base64.encodeBase64(mac.doFinal(text)), StandardCharsets.UTF_8).trim();
     }
 
     /**

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/twitter/TwitterEndpointServicesTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/twitter/TwitterEndpointServicesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
@@ -104,7 +103,7 @@ public class TwitterEndpointServicesTest extends CommonTestClass {
     static final String MY_JSON_FAILURE_MSG = "JSON failure message. Something went wrong.";
 
     public interface MockInterface {
-        public String mockComputeSha1Signature() throws GeneralSecurityException, UnsupportedEncodingException;
+        public String mockComputeSha1Signature() throws GeneralSecurityException;
 
         public Map<String, Object> mockExecuteRequest();
 
@@ -199,7 +198,7 @@ public class TwitterEndpointServicesTest extends CommonTestClass {
     public void testComputeSignature_GeneralSecurityException() {
         TwitterEndpointServices mockTwitter = new TwitterEndpointServices() {
             @Override
-            protected String computeSha1Signature(String baseString, String keyString) throws GeneralSecurityException, UnsupportedEncodingException {
+            protected String computeSha1Signature(String baseString, String keyString) throws GeneralSecurityException {
                 return mockInterface.mockComputeSha1Signature();
             }
         };
@@ -217,41 +216,6 @@ public class TwitterEndpointServicesTest extends CommonTestClass {
 
             String logMsg = CWWKS5409E_ERROR_CREATING_SIGNATURE;
             assertTrue("Did not find [" + logMsg + "] message in messages.log", outputMgr.checkForMessages(logMsg));
-
-            checkForSecretsInTrace();
-
-        } catch (Throwable t) {
-            outputMgr.failWithThrowable(testName.getMethodName(), t);
-        }
-    }
-
-    /**
-     * Method(s) under test:
-     * <ul>
-     * <li>{@link TwitterEndpointServices#computeSignature(String, String, Map)}</li>
-     * </ul>
-     * Tests results when underlying {@link TwitterEndpointServices#computeSha1Signature(String, String)} method throws an
-     * UnsupportedEncodingException.
-     */
-    @Test
-    public void testComputeSignature_UnsupportedEncodingException() {
-        TwitterEndpointServices mockTwitter = new TwitterEndpointServices() {
-            @Override
-            protected String computeSha1Signature(String baseString, String keyString) throws GeneralSecurityException, UnsupportedEncodingException {
-                return mockInterface.mockComputeSha1Signature();
-            }
-        };
-
-        try {
-            mockery.checking(new Expectations() {
-                {
-                    one(mockInterface).mockComputeSha1Signature();
-                    will(throwException(new UnsupportedEncodingException()));
-                }
-            });
-
-            HashMap<String, String> params = populateSignatureParameters();
-            assertEquals("", mockTwitter.computeSignature(POST, BASE_URL, params));
 
             checkForSecretsInTrace();
 
@@ -300,7 +264,7 @@ public class TwitterEndpointServicesTest extends CommonTestClass {
      * {@link https://dev.twitter.com/oauth/overview/creating-signatures}.
      */
     @Test
-    public void testCreateSignatureBaseString() throws UnsupportedEncodingException {
+    public void testCreateSignatureBaseString() {
 
         assertEquals("POST&&", twitter.createSignatureBaseString(null, null, null));
         assertEquals("GET&&", twitter.createSignatureBaseString("get", null, null));

--- a/dev/com.ibm.ws.security.spnego/src/com/ibm/ws/security/spnego/PageLoader.java
+++ b/dev/com.ibm.ws.security.spnego/src/com/ibm/ws/security/spnego/PageLoader.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.StringTokenizer;
 
@@ -159,7 +160,7 @@ public class PageLoader {
      * The HTTP ContentType header looks like <code>"text/html;charset=UTF-8"</code>.
      * This method extracts the contentEncoding portion (<code>"UTF-8"</code>) from
      * within the HTTP ContentEncoding header.
-     * 
+     *
      * @param ct The complete HTTP ContentType header.
      * @return
      */
@@ -186,7 +187,7 @@ public class PageLoader {
      * <p>
      * The system default encoding is lazy evaluated. This unsynchronized
      * method gets the system default encoding the first time it is needed.
-     * 
+     *
      * @return The system default encoding.
      */
     protected final String getDefaultContentEncoding() {
@@ -228,7 +229,7 @@ public class PageLoader {
         BufferedReader br = null;
         try {
             in = pageURL.openStream();
-            isr = new InputStreamReader(in, "ISO-8859-1");
+            isr = new InputStreamReader(in, StandardCharsets.ISO_8859_1);
             br = new BufferedReader(isr);
             String line = null;
             while ((line = br.readLine()) != null) {
@@ -246,8 +247,6 @@ public class PageLoader {
                     break;
                 }
             }
-        } catch (UnsupportedEncodingException e) {
-            Tr.error(tc, "SPNEGO_CUSTOM_ERROR_PAGE_CONTENT_TYPE_ERROR", new Object[] { e.getMessage() == null ? "UnsupportedEncodingException" : e.getMessage() });
         } catch (IOException e) {
             Tr.error(tc, "SPNEGO_CUSTOM_ERROR_PAGE_CONTENT_TYPE_ERROR", new Object[] { e.getMessage() == null ? "IOException" : e.getMessage() });
         } finally {

--- a/dev/com.ibm.ws.security.sso.common/src/com/ibm/ws/security/sso/common/saml/propagation/PropagationHelperImpl.java
+++ b/dev/com.ibm.ws.security.sso.common/src/com/ibm/ws/security/sso/common/saml/propagation/PropagationHelperImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,7 +14,7 @@ package com.ibm.ws.security.sso.common.saml.propagation;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPOutputStream;
 
 import javax.security.auth.Subject;
@@ -58,14 +58,7 @@ public class PropagationHelperImpl {
                 byte[] compressedTokenBytes = compressSamlToken(samlString);
                 base64Saml = Base64Coder.base64EncodeToString(compressedTokenBytes);
             } else {
-                byte output[] = null;
-                try {
-                    output = samlString.getBytes("UTF-8");
-                } catch (UnsupportedEncodingException e) {
-                    // This should not happen.
-                    // If it happens, it would be some runtime or operating system issue, so just give up and return null.
-                    // ffdc data will be logged automatically.
-                }
+                byte output[] = samlString.getBytes(StandardCharsets.UTF_8);
                 if (output != null) {
                     base64Saml = Base64Coder.base64EncodeToString(output);
                 } else {
@@ -87,14 +80,8 @@ public class PropagationHelperImpl {
         try {
             gzip = new GZIPOutputStream(out);
             byte output[] = null;
-            try {
-                if (tokenString != null) {
-                    output = tokenString.getBytes("UTF-8");
-                }
-            } catch (UnsupportedEncodingException e) {
-                // This should not happen.
-                // If it happens, it would be some runtime or operating system issue, so just give up and return null.
-                // ffdc data will be logged automatically.
+            if (tokenString != null) {
+                output = tokenString.getBytes(StandardCharsets.UTF_8);
             }
             if (output != null) {
                 gzip.write(output);

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPAToken2.java
@@ -13,7 +13,7 @@
 package com.ibm.ws.security.token.ltpa.internal;
 
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Date;
@@ -473,15 +473,7 @@ public class LTPAToken2 implements Token, Serializable {
      * @return The UTF-8 String form
      */
     private static final String toUTF8String(byte[] b) {
-        String ns = null;
-        try {
-            ns = new String(b, "UTF8");
-        } catch (UnsupportedEncodingException e) {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "Error converting to string; " + e);
-            }
-        }
-        return ns;
+        return new String(b, StandardCharsets.UTF_8);
     }
 
     /**

--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/utils/FileUtility.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/utils/FileUtility.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,7 +17,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import com.ibm.ws.security.utility.IFileUtility;
 
@@ -35,7 +35,7 @@ public class FileUtility implements IFileUtility {
      * <p>
      * The supported environment variables are: WLP_USER_DIR and WLP_OUTPUT_DIR
      *
-     * @param WLP_USER_DIR The value of WLP_USER_DIR environment variable. {@code null} is supported.
+     * @param WLP_USER_DIR   The value of WLP_USER_DIR environment variable. {@code null} is supported.
      * @param WLP_OUTPUT_DIR The value of WLP_OUTPUT_DIR environment variable. {@code null} is supported.
      */
     public FileUtility(String WLP_USER_DIR, String WLP_OUTPUT_DIR) {
@@ -129,7 +129,7 @@ public class FileUtility implements IFileUtility {
         FileOutputStream fos = null;
         try {
             fos = new FileOutputStream(outFile);
-            fos.write(toWrite.getBytes(Charset.forName("UTF-8")));
+            fos.write(toWrite.getBytes(StandardCharsets.UTF_8));
             fos.flush();
             return true;
         } catch (FileNotFoundException e) {

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapHelper.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,6 +14,7 @@ package com.ibm.ws.security.wim.adapter.ldap;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.SoftReference;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -708,7 +709,7 @@ public class LdapHelper {
      */
     public static byte[] encodePassword(String password) throws WIMSystemException {
         try {
-            return ("\"" + password + "\"").getBytes("UTF-16LE");
+            return ("\"" + password + "\"").getBytes(StandardCharsets.UTF_16LE);
         } catch (Exception e) {
             String msg = Tr.formatMessage(tc, WIMMessageKey.GENERIC, WIMMessageHelper.generateMsgParms(e.getMessage()));
             throw new WIMSystemException(WIMMessageKey.GENERIC, msg, e);

--- a/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/adapter/urbridge/URBridge.java
+++ b/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/adapter/urbridge/URBridge.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,7 +13,7 @@
 package com.ibm.ws.security.wim.adapter.urbridge;
 
 import java.io.ByteArrayInputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.rmi.RemoteException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -992,13 +992,7 @@ public class URBridge implements Repository {
                         throw new PasswordCheckFailedException(WIMMessageKey.MISSING_OR_EMPTY_PASSWORD, Tr.formatMessage(tc, WIMMessageKey.MISSING_OR_EMPTY_PASSWORD));
                     }
 
-                    String passwordStr;
-                    try {
-                        passwordStr = new String(pwd, "UTF-8");
-                    } catch (UnsupportedEncodingException e1) {
-                        throw new WIMApplicationException(WIMMessageKey.CUSTOM_REGISTRY_EXCEPTION, Tr.formatMessage(tc, WIMMessageKey.CUSTOM_REGISTRY_EXCEPTION,
-                                                                                                                    WIMMessageHelper.generateMsgParms(reposId)));
-                    }
+                    String passwordStr = new String(pwd, StandardCharsets.UTF_8);
 
                     // first need to check if valid user or not
                     boolean isValidUser = false;

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/CertificateEnvHelper.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/CertificateEnvHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,7 +17,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.util.ArrayList;
@@ -93,7 +93,7 @@ public class CertificateEnvHelper {
 
         // If env_Value starts with the certificate tag assume a certificate otherwise treat like a file
         if (env_Value.startsWith(certBeginTag)) {
-            inputStream = new ByteArrayInputStream(env_Value.getBytes(Charset.forName("UTF-8")));
+            inputStream = new ByteArrayInputStream(env_Value.getBytes(StandardCharsets.UTF_8));
         } else {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
                 Tr.debug(this, tc, "The value from the environment did not start with -----BEGIN CERTIFICATE----- so treating it like a file");

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/hpack/IntegerRepresentation.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/hpack/IntegerRepresentation.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2017 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,7 +13,6 @@
 package com.ibm.ws.http.channel.h2internal.hpack;
 
 import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 
 import com.ibm.ws.http.channel.h2internal.exceptions.CompressionException;
 import com.ibm.ws.http.channel.h2internal.hpack.HpackConstants.ByteFormatType;
@@ -67,7 +66,7 @@ public class IntegerRepresentation {
      * based on implementation constraints.
      */
 
-    protected static byte[] encode(int I, LiteralIndexType type) throws CompressionException, UnsupportedEncodingException {
+    protected static byte[] encode(int I, LiteralIndexType type) throws CompressionException {
 
         ByteFormatType formatType;
         switch (type) {
@@ -90,7 +89,7 @@ public class IntegerRepresentation {
         return encode(I, formatType);
     }
 
-    protected static byte[] encode(int I, ByteFormatType type) throws CompressionException, UnsupportedEncodingException {
+    protected static byte[] encode(int I, ByteFormatType type) throws CompressionException {
         //First byte needs to have a special format. If it's the first byte
         //for a header, it will specify literal indexing type. If it is the
         //first byte for determining a header's key/value String length,
@@ -130,7 +129,7 @@ public class IntegerRepresentation {
 
     }
 
-    public static byte[] encode(int I, byte format, int N) throws UnsupportedEncodingException {
+    public static byte[] encode(int I, byte format, int N) {
         ByteArrayOutputStream ba = new ByteArrayOutputStream();
         if (I < (HpackUtils.ipow(2, N) - 1)) {
             //Integer fits within the bits reserved for integer representation for

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpBaseMessageImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpBaseMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2024 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -86,7 +86,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
     /** Static representation of a quote symbol */
     private static final byte QUOTE = '"';
     /** Default charset for ISO-8859-1 */
-    private static Charset DEF_CHARSET = null;
+    private static final Charset DEF_CHARSET = StandardCharsets.ISO_8859_1;
     /** Delimiters used while parsing cookies */
     private static final byte[] COOKIE_DELIMS = { COMMA, SEMICOLON };
 
@@ -1888,10 +1888,6 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
                 }
                 // continue below and return the default
             }
-        }
-        if (null == DEF_CHARSET) {
-            // lazily instantiate the default charset if need be
-            DEF_CHARSET = StandardCharsets.ISO_8859_1;
         }
         return DEF_CHARSET;
     }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2024 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
@@ -772,7 +772,7 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
 
         rMsg.setStatusCode(code);
         rMsg.setConnection(ConnectionValues.CLOSE);
-        rMsg.setCharset(Charset.forName("UTF-8"));
+        rMsg.setCharset(StandardCharsets.UTF_8);
         rMsg.setHeader("Content-Type", "text/html; charset=UTF-8");
     }
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/DefaultWelcomePage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/DefaultWelcomePage.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2014 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,8 +15,8 @@ package com.ibm.ws.http.internal;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -65,12 +65,7 @@ public class DefaultWelcomePage implements WelcomePage {
         }
         versionJs.append("\"\r\n");
         versionJs.append("}");
-        try {
-          return new ByteArrayInputStream(versionJs.toString().getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-          // This should never happen because UTF-8 is required in Java. #famouslastwords
-          return null;
-        }
+        return new ByteArrayInputStream(versionJs.toString().getBytes(StandardCharsets.UTF_8));
     } else {
       return safeOpen("/OSGI-INF/welcome" + url);
     }

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/persistence/FilePersistenceDebugger.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/persistence/FilePersistenceDebugger.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedAction;
 
 import com.ibm.websphere.ras.Tr;
@@ -33,7 +34,7 @@ public class FilePersistenceDebugger implements IPersistenceDebugger {
     /**
      * Try to close the Closeable object. This should never fail. If it does,
      * let it FFDC incase it matters down stream.
-     * 
+     *
      * @param c
      */
     private void tryClose(Closeable c) {
@@ -61,7 +62,7 @@ public class FilePersistenceDebugger implements IPersistenceDebugger {
                 BufferedReader br = null;
                 try {
                     fis = new FileInputStream(file);
-                    isr = new InputStreamReader(fis, "UTF-8");
+                    isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
                     br = new BufferedReader(isr);
 
                     String line = br.readLine();

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/persistence/FilePersistenceProvider.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/persistence/FilePersistenceProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ package com.ibm.ws.ui.internal.persistence;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -216,7 +217,7 @@ public class FilePersistenceProvider implements IPersistenceProvider {
         try {
             synchronized (file) {
                 createParentIfNeeded(file);
-                org.apache.commons.io.FileUtils.writeStringToFile(file, content, "UTF-8");
+                org.apache.commons.io.FileUtils.writeStringToFile(file, content, StandardCharsets.UTF_8);
             }
         } catch (IOException e) {
             Tr.error(tc, "FILE_PERSISTENCE_STORE_IO_ERROR", file.getAbsolutePath(), e.getMessage());
@@ -273,7 +274,7 @@ public class FilePersistenceProvider implements IPersistenceProvider {
         final File file = getPersistenceFileLockObj(name);
         try {
             synchronized (file) {
-                return org.apache.commons.io.FileUtils.readFileToString(file, "UTF-8");
+                return org.apache.commons.io.FileUtils.readFileToString(file, StandardCharsets.UTF_8);
             }
         } catch (FileNotFoundException e) {
             // This is an expected error flow, do not FFDC or log anything

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/CommonJSONRESTHandler.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/CommonJSONRESTHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,7 +15,7 @@ package com.ibm.ws.ui.internal.rest;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -275,13 +275,13 @@ public abstract class CommonJSONRESTHandler extends CommonRESTHandler {
             if (MEDIA_TYPE_TEXT_PLAIN.equals(contentType)) {
                 response.setStatus(e.getStatus());
                 response.setResponseHeader(HTTP_HEADER_CONTENT_TYPE, e.getContentType());
-                response.getOutputStream().write(e.getPayload().toString().getBytes(Charset.forName("UTF-8")));
+                response.getOutputStream().write(e.getPayload().toString().getBytes(StandardCharsets.UTF_8));
             } else if (contentType != null && contentType.indexOf(MEDIA_TYPE_APPLICATION_JSON_NO_CHARSET) > -1) {
                 setJSONResponse(response, e.getPayload(), e.getStatus());
             } else {
                 response.setStatus(HTTP_INTERNAL_ERROR);
                 response.setResponseHeader(HTTP_HEADER_CONTENT_TYPE, MEDIA_TYPE_TEXT_PLAIN);
-                response.getOutputStream().write(("An internal error occurred. RESTException had a set payload but did not specify content type").getBytes(Charset.forName("UTF-8")));
+                response.getOutputStream().write(("An internal error occurred. RESTException had a set payload but did not specify content type").getBytes(StandardCharsets.UTF_8));
             }
         } else {
             response.setStatus(e.getStatus());

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/CommonRESTHandler.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/CommonRESTHandler.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,7 +14,7 @@ package com.ibm.ws.ui.internal.rest;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -650,7 +650,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
 
         try {
             // Deserialize first. We need to know it will work before we set status
-            byte[] b = obj.toString().getBytes("UTF-8");
+            byte[] b = obj.toString().getBytes(StandardCharsets.UTF_8);
             response.setStatus(status);
             response.getOutputStream().write(b);
         } catch (IOException e) {
@@ -754,11 +754,11 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
             if (MEDIA_TYPE_TEXT_PLAIN.equals(contentType)) {
                 response.setStatus(e.getStatus());
                 response.setResponseHeader(HTTP_HEADER_CONTENT_TYPE, e.getContentType());
-                response.getOutputStream().write(e.getPayload().toString().getBytes(Charset.forName("UTF-8")));
+                response.getOutputStream().write(e.getPayload().toString().getBytes(StandardCharsets.UTF_8));
             } else {
                 response.setStatus(HTTP_INTERNAL_ERROR);
                 response.setResponseHeader(HTTP_HEADER_CONTENT_TYPE, MEDIA_TYPE_TEXT_PLAIN);
-                response.getOutputStream().write(("An internal error occurred. RESTException had a set payload but did not specify content type").getBytes(Charset.forName("UTF-8")));
+                response.getOutputStream().write(("An internal error occurred. RESTException had a set payload but did not specify content type").getBytes(StandardCharsets.UTF_8));
             }
         } else {
             response.setStatus(e.getStatus());
@@ -824,7 +824,7 @@ public class CommonRESTHandler implements AdminCenterRestHandler, APIConstants, 
                 Message error = new Message(HTTP_BAD_REQUEST, RequestNLS.formatMessage(tc, "POST_NO_PAYLOAD", maxSize));
                 throw new BadRequestException(MEDIA_TYPE_TEXT_PLAIN, error);
             }
-            return new String(buf, 0, read, "UTF-8");
+            return new String(buf, 0, read, StandardCharsets.UTF_8);
         } finally {
             input.close();
         }

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/utils/Utils.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/utils/Utils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,17 +12,18 @@
  *******************************************************************************/
 package com.ibm.ws.ui.internal.v1.utils;
 
-import com.google.gson.Gson;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 
+import com.google.gson.Gson;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
@@ -120,12 +121,11 @@ public class Utils {
      *
      * @param str The input string
      * @return The MD5 checksum of the given string.
-     * @throws UnsupportedEncodingException
      */
     public synchronized static String getMD5String(String str) {
         byte[] hash;
         try {
-            hash = messagedigest.digest(str.getBytes("UTF-8"));
+            hash = messagedigest.digest(str.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
             // Let this FFDC because we should never get here
             if (tc.isEventEnabled()) {
@@ -140,25 +140,24 @@ public class Utils {
         return sb.toString();
     }
 
-    
-
     /**
      * This method validates whether the input string is a valid JSON or not.
+     *
      * @param inputString, Input string
-     * @param prefix, Prefix string to be trimmed from input string
+     * @param prefix,      Prefix string to be trimmed from input string
      * @return Boolean, true if input string is valid JSON.
      */
     public static boolean isValidJsonString(String inputString, String prefix) {
-        if(!prefix.equals("")) {
+        if (!prefix.equals("")) {
             inputString = inputString.replace(prefix, "");
         }
 
         return isValidJsonString(inputString);
     }
-    
 
     /**
      * This method validates whether the input string is a valid JSON or not
+     *
      * @param inputString The input string
      * @return Boolean, true if input string is valid JSON.
      */

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/PostParameterHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/PostParameterHelper.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.webcontainer.security;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -300,12 +300,12 @@ public class PostParameterHelper {
      * The format of the data is as follows:
      * <base64 encoded byte array of the request URL>.<based64 encoded data[0] from serializeInputStreamData()>.<base 64 encoded data[1]>. and so on.
      */
-    private String serializePostParam(IExtendedRequest req, String reqURL, boolean keepInput) throws IOException, UnsupportedEncodingException, IllegalStateException {
+    private String serializePostParam(IExtendedRequest req, String reqURL, boolean keepInput) throws IOException, IllegalStateException {
         String output = null;
         HashMap params = getInputStreamData(req);
         if (params != null) {
             long size = req.sizeInputStreamData(params);
-            byte[] reqURLBytes = reqURL.getBytes("UTF-8");
+            byte[] reqURLBytes = reqURL.getBytes(StandardCharsets.UTF_8);
             long total = size + reqURLBytes.length + LENGTH_INT;
 
             long postParamSaveSize = webAppSecurityConfig.getPostParamCookieSize();
@@ -345,14 +345,14 @@ public class PostParameterHelper {
      * deserialize Post parameters.
      * The code doesn't expect that the req, cookieValueBytes, or reqURL is null.
      */
-    private HashMap deserializePostParam(IExtendedRequest req, byte[] cookieValueBytes, String reqURL) throws IOException, UnsupportedEncodingException, IllegalStateException {
+    private HashMap deserializePostParam(IExtendedRequest req, byte[] cookieValueBytes, String reqURL) throws IOException, IllegalStateException {
         HashMap output = null;
         List<byte[]> data = splitBytes(cookieValueBytes, (byte) '.');
         int total = data.size();
 
         if (total > OFFSET_DATA) {
             // url and at least one data. now deserializing the url.
-            String url = new String(Base64Coder.base64Decode(data.get(OFFSET_REQURL)), "UTF-8");
+            String url = new String(Base64Coder.base64Decode(data.get(OFFSET_REQURL)), StandardCharsets.UTF_8);
             if (url != null && url.equals(reqURL)) {
                 byte[][] bytes = new byte[total - OFFSET_DATA][];
                 for (int i = 0; i < (total - OFFSET_DATA); i++) {

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/LoggedOutJwtSsoCookieCache.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/LoggedOutJwtSsoCookieCache.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.security.internal;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -45,10 +45,7 @@ public class LoggedOutJwtSsoCookieCache {
     // store as digests to save space
     public static String toDigest(String input) {
         MessageDigest md = getMessageDigest();
-        try {
-            md.update(input.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-        }
+        md.update(input.getBytes(StandardCharsets.UTF_8));
         String result = com.ibm.ws.common.encoder.Base64Coder.base64EncodeToString(md.digest());
         return result;
     }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/srt/SRTServletRequest31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/srt/SRTServletRequest31.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@ package com.ibm.ws.webcontainer31.srt;
 
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
@@ -466,7 +466,7 @@ public class SRTServletRequest31 extends SRTServletRequest implements HttpServle
      * byte[3...] : byte array of INPUT_STREAM_CONTENT_DATA (it could be multiple for servlet31 on Liberty) byte[3] doesn't exist if the length is zero.
      */
     @SuppressWarnings("rawtypes")
-    public byte[][] serializeInputStreamData(Map isd) throws IOException, UnsupportedEncodingException, IllegalStateException {
+    public byte[][] serializeInputStreamData(Map isd) throws IOException, IllegalStateException {
         validateInputStreamData(isd);
 
         String type = (String)isd.get(INPUT_STREAM_CONTENT_TYPE);
@@ -481,7 +481,7 @@ public class SRTServletRequest31 extends SRTServletRequest implements HttpServle
         output[OFFSET_CONTENT_DATA_LENGTH] = longToBytes((long)length.intValue());
         if (type != null) {
             output[OFFSET_CONTENT_TYPE_LEN] = intToBytes(type.length());
-            output[OFFSET_CONTENT_TYPE_DATA] = type.getBytes("UTF-8"); 
+            output[OFFSET_CONTENT_TYPE_DATA] = type.getBytes(StandardCharsets.UTF_8);
         } else {
             output[OFFSET_CONTENT_TYPE_LEN] = intToBytes(0);
             output[OFFSET_CONTENT_TYPE_DATA] = new byte[1];
@@ -500,7 +500,7 @@ public class SRTServletRequest31 extends SRTServletRequest implements HttpServle
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public HashMap deserializeInputStreamData(byte[][] input) throws UnsupportedEncodingException, IllegalStateException {
+    public HashMap deserializeInputStreamData(byte[][] input) throws IllegalStateException {
         if (input == null || input.length < 2) {
             if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))
                 logger.logp(Level.FINE, CLASS_NAME,"deseriallizeInputStreamData", "The input data is null or fewer items than the expected. ");
@@ -511,7 +511,7 @@ public class SRTServletRequest31 extends SRTServletRequest implements HttpServle
         output.put(INPUT_STREAM_CONTENT_DATA_LENGTH, Long.valueOf(length));
         int typeLen = bytesToInt(input[OFFSET_CONTENT_TYPE_LEN]);
         if (typeLen > 0) {
-            output.put(INPUT_STREAM_CONTENT_TYPE, new String(input[OFFSET_CONTENT_TYPE_DATA], "UTF-8"));
+            output.put(INPUT_STREAM_CONTENT_TYPE, new String(input[OFFSET_CONTENT_TYPE_DATA], StandardCharsets.UTF_8));
         } else {
             output.put(INPUT_STREAM_CONTENT_TYPE, null);
         }
@@ -533,13 +533,13 @@ public class SRTServletRequest31 extends SRTServletRequest implements HttpServle
      * this code does not consider that the length in long overwraps. 
      */
     @SuppressWarnings("rawtypes")
-    public long sizeInputStreamData(Map isd) throws UnsupportedEncodingException, IllegalStateException {
+    public long sizeInputStreamData(Map isd) throws IllegalStateException {
         validateInputStreamData(isd);
         // The length of IMPUT_STREAM_CONTENT_TYPE won't exceed Integer.MAX_VALUE
         long size = LENGTH_INT + LENGTH_LONG;
         String type = (String)isd.get(INPUT_STREAM_CONTENT_TYPE);
         if (type != null) {
-            size += type.getBytes("UTF-8").length;
+            size += type.getBytes(StandardCharsets.UTF_8).length;
         } else {
             size +=1; // if the size is zero, one byte data will be used for placeholder.
         }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2024 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1078,7 +1078,7 @@ public abstract class WebContainer extends BaseContainer {
                 }
                 res.addHeader("Content-Type", "text/html;charset=UTF-8");
                 String output = webGroupVHostNotFound;
-                outBytes = output.getBytes("UTF-8"); // The custom property is stored in server.xml which is in UTF-8 and ISO-8859-1 is a subset of UTF-8 so it would work for anything in there.                  
+                outBytes = output.getBytes(StandardCharsets.UTF_8); // The custom property is stored in server.xml which is in UTF-8 and ISO-8859-1 is a subset of UTF-8 so it would work for anything in there.
 
             }
             //PK85685 End
@@ -1107,7 +1107,7 @@ public abstract class WebContainer extends BaseContainer {
                 }
 
                 res.addHeader("Content-Type", "text/html;charset=UTF-8");
-                outBytes = output.trim().getBytes("UTF-8");                  
+                outBytes = output.trim().getBytes(StandardCharsets.UTF_8);
             }
             else{
                 res.addHeader("Content-Type", "text/html");
@@ -1138,7 +1138,7 @@ public abstract class WebContainer extends BaseContainer {
                 }
 
                 res.addHeader("Content-Type", "text/html;charset=UTF-8");
-                outBytes = output.trim().getBytes("UTF-8");                
+                outBytes = output.trim().getBytes(StandardCharsets.UTF_8);
             }
             else {
                 res.addHeader("Content-Type", "text/html");
@@ -1172,7 +1172,7 @@ public abstract class WebContainer extends BaseContainer {
                 }
 
                 res.addHeader("Content-Type", "text/html;charset=UTF-8");
-                outBytes = output.trim().getBytes("UTF-8");                  
+                outBytes = output.trim().getBytes(StandardCharsets.UTF_8);
             }
             else { 
                 res.addHeader("Content-Type", "text/html");

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/extension/DefaultExtensionProcessor.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/extension/DefaultExtensionProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2008 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ package com.ibm.ws.webcontainer.extension;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessController;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2023 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.Principal;
 import java.security.PrivilegedActionException;
@@ -3230,16 +3231,6 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
     }
 
     // LIDB1234.6 - added method below
-    /**
-     * Overrides the name of the character encoding used in the body of this request.  This
-     * method must be called prior to reading request parameters or reading input using
-     * getReader().
-     * 
-     * @param encoding a String containing the name of the character encoding
-     * 
-     * @throws java.io.UnsupportedEncodingException if this is not a valid encoding
-     */
-
     public byte[] getSSLId()
     {
         if (WCCustomProperties.CHECK_REQUEST_OBJECT_IN_USE){
@@ -4185,7 +4176,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
      */
     @SuppressWarnings("rawtypes")
     @Override
-    public byte[][] serializeInputStreamData(Map isd) throws IOException, UnsupportedEncodingException, IllegalStateException {
+    public byte[][] serializeInputStreamData(Map isd) throws IOException, IllegalStateException {
         validateInputStreamData(isd);
 
         String type = (String)isd.get(INPUT_STREAM_CONTENT_TYPE);
@@ -4200,7 +4191,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
         output[OFFSET_CONTENT_DATA_LENGTH] = longToBytes((long)length.intValue());
         if (type != null) {
             output[OFFSET_CONTENT_TYPE_LEN] = intToBytes(type.length());
-            output[OFFSET_CONTENT_TYPE_DATA] = type.getBytes("UTF-8"); 
+            output[OFFSET_CONTENT_TYPE_DATA] = type.getBytes(StandardCharsets.UTF_8);
         } else {
             output[OFFSET_CONTENT_TYPE_LEN] = intToBytes(0);
             output[OFFSET_CONTENT_TYPE_DATA] = new byte[1];
@@ -4218,7 +4209,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
 
     @SuppressWarnings("rawtypes")
     @Override
-    public HashMap deserializeInputStreamData(byte[][] input) throws UnsupportedEncodingException, IllegalStateException {
+    public HashMap deserializeInputStreamData(byte[][] input) throws IllegalStateException {
         if (input == null || input.length < 2) {
             if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))
                 logger.logp(Level.FINE, CLASS_NAME,"deseriallizeInputStreamData", "The input data is null or fewer items than the expected. ");
@@ -4229,7 +4220,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
         output.put(INPUT_STREAM_CONTENT_DATA_LENGTH, Integer.valueOf((int)(length & 0xFFFF)));
         int typeLen = bytesToInt(input[OFFSET_CONTENT_TYPE_LEN]);
         if (typeLen > 0) {
-            output.put(INPUT_STREAM_CONTENT_TYPE, new String(input[OFFSET_CONTENT_TYPE_DATA], "UTF-8"));
+            output.put(INPUT_STREAM_CONTENT_TYPE, new String(input[OFFSET_CONTENT_TYPE_DATA], StandardCharsets.UTF_8));
         } else {
             output.put(INPUT_STREAM_CONTENT_TYPE, null);
         }
@@ -4248,13 +4239,13 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
      */
     @SuppressWarnings("rawtypes")
     @Override
-    public long sizeInputStreamData(Map isd) throws UnsupportedEncodingException, IllegalStateException {
+    public long sizeInputStreamData(Map isd) throws IllegalStateException {
         validateInputStreamData(isd);
         // The length of IMPUT_STREAM_CONTENT_TYPE won't exceed Integer.MAX_VALUE
         long size = LENGTH_INT + LENGTH_LONG;
         String type = (String)isd.get(INPUT_STREAM_CONTENT_TYPE);
         if (type != null) {
-            size += type.getBytes("UTF-8").length;
+            size += type.getBytes(StandardCharsets.UTF_8).length;
         } else {
             size +=1; // if the size is zero, one byte data will be used for placeholder.
         }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/util/ApplicationErrorUtils.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/util/ApplicationErrorUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ package com.ibm.ws.webcontainer.util;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import com.ibm.ejs.ras.TraceNLS;
 import com.ibm.websphere.ras.Tr;
@@ -56,7 +56,7 @@ public class ApplicationErrorUtils {
             } else {
                 errorHtml = "minimal-error.html";
             }
-            reader = new BufferedReader(new InputStreamReader(ApplicationErrorUtils.class.getResourceAsStream(errorHtml), "UTF-8"));
+            reader = new BufferedReader(new InputStreamReader(ApplicationErrorUtils.class.getResourceAsStream(errorHtml), StandardCharsets.UTF_8));
             for (String line = reader.readLine(); line != null; line = reader.readLine()) {
                 if (line.contains("{toolsLink}")) {
                     line = line.replace("{toolsLink}", "http://" + toolsLink + "/");
@@ -110,8 +110,6 @@ public class ApplicationErrorUtils {
                     buffer.append("\n</div>\n");
                 }
             }
-        } catch (UnsupportedEncodingException e) {
-            // This can't happen because JVMs are required to support UTF-8
         } catch (IOException e) {
             // TODO handle this
         } finally {

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/RequestUtils.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/RequestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2024 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package com.ibm.wsspi.webcontainer.util;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -604,10 +605,10 @@ public class RequestUtils {
                         if (!encoding_is_ShortEnglish) {
                             try {
                                 if (!qs.isKeySingleByteString()) {
-                                    key = new String(key.getBytes(SHORT_ENGLISH), encoding);
+                                    key = new String(key.getBytes(StandardCharsets.ISO_8859_1), encoding);
                                 }
                                 if (!qs.isValueSingleByteString()) {
-                                    value = new String(value.getBytes(SHORT_ENGLISH), encoding);
+                                    value = new String(value.getBytes(StandardCharsets.ISO_8859_1), encoding);
                                 }
                             } catch (UnsupportedEncodingException uee) {
                                 //No need to nls. SHORT_ENGLISH will always be supported

--- a/dev/com.ibm.ws.webserver.plugin.utility/src/com/ibm/ws/webserver/plugin/utility/utils/PluginMBeanConnection.java
+++ b/dev/com.ibm.ws.webserver.plugin.utility/src/com/ibm/ws/webserver/plugin/utility/utils/PluginMBeanConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
@@ -119,7 +120,7 @@ public class PluginMBeanConnection extends CommonMBeanConnection {
 	            String connectorAddr = null;
 	            BufferedReader br = null;
 	            try {
-	                br = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+	                br = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 	                connectorAddr = br.readLine();
 	            } catch (IOException e) {
 	                throw new IOException(CommandUtils.getMessage("jmx.local.connector.file.invalid", file.getAbsolutePath()));

--- a/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/HandshakeProcessor.java
+++ b/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/HandshakeProcessor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.wsoc;
 
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -440,8 +439,6 @@ public class HandshakeProcessor {
         try {
             acceptKey = Utils.makeAcceptResponseHeaderValue(headerSecWebSocketKey);
         } catch (NoSuchAlgorithmException e) {
-            // allow instrumented FFDC to be used here
-        } catch (UnsupportedEncodingException e) {
             // allow instrumented FFDC to be used here
         }
 

--- a/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/util/Utils.java
+++ b/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/util/Utils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.wsoc.util;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
@@ -463,7 +462,7 @@ public class Utils {
     }
 
     @Sensitive
-    public static String makeAcceptResponseHeaderValue(String key) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+    public static String makeAcceptResponseHeaderValue(String key) throws NoSuchAlgorithmException {
 
         String inputKey = key + Constants.GUID;
 

--- a/dev/io.openliberty.accesslists.internal/src/io/openliberty/accesslists/filterlist/FilterListFastStr.java
+++ b/dev/io.openliberty.accesslists.internal/src/io/openliberty/accesslists/filterlist/FilterListFastStr.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2021 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package io.openliberty.accesslists.filterlist;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -207,21 +207,11 @@ public class FilterListFastStr implements FilterListStr {
      * @return the Entry object created from this address.
      */
     private Entry convertToEntries(String newAddress) {
-        byte[] ba = null;
-
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.entry(tc, "convertToEntries");
         }
 
-        try {
-            ba = newAddress.getBytes("ISO-8859-1");
-        } catch (UnsupportedEncodingException x) {
-            // should never happen, log a message and use default encoding
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "ISO-8859-1 encoding not supported.  Exception: " + x);
-            }
-            ba = newAddress.getBytes();
-        }
+        byte[] ba = newAddress.getBytes(StandardCharsets.ISO_8859_1);
         int baLength = ba.length;
         int hashValue = 0;
         int hashLength = 0;

--- a/dev/io.openliberty.jsonsupport.internal/src/com/ibm/ws/jsonsupport/internal/JSONJacksonImpl.java
+++ b/dev/io.openliberty.jsonsupport.internal/src/com/ibm/ws/jsonsupport/internal/JSONJacksonImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,8 @@ package com.ibm.ws.jsonsupport.internal;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.JsonParseException;
@@ -71,11 +71,7 @@ public class JSONJacksonImpl implements JSON {
     /** {@inheritDoc} */
     @Override
     public byte[] asBytes(Object o) throws JSONMarshallException {
-        try {
-            return stringify(o).getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new JSONMarshallException("Encountered a JVM without UTF-8 support, this should never happen", e);
-        }
+        return stringify(o).getBytes(StandardCharsets.UTF_8);
     }
 
     /** {@inheritDoc} */

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/css/CustomCSSProcessor.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/css/CustomCSSProcessor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -270,7 +270,7 @@ public final class CustomCSSProcessor implements FileMonitor, ServerQuiesceListe
     }
 
     private String getContent(InputStream is) throws IOException {
-        try (Reader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8.name()))) {
+        try (Reader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
             final StringBuilder builder = new StringBuilder();
             int c;
             while ((c = reader.read()) != -1) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/css/OpenAPIUIBundlesUpdater.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/css/OpenAPIUIBundlesUpdater.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -66,7 +65,7 @@ public class OpenAPIUIBundlesUpdater {
 
         //Retrieve all OpenAPI-UI Bundles from the BundleContext
         final Set<Bundle> allOpenAPIUIBundles = getOpenAPIUIBundles();
-        if(allOpenAPIUIBundles.isEmpty()){
+        if (allOpenAPIUIBundles.isEmpty()) {
             return;
         }
 
@@ -212,10 +211,10 @@ public class OpenAPIUIBundlesUpdater {
         return new ByteArrayInputStream(bytesOut.toByteArray());
     }
 
-    private static void processResource(String resourcePath, Object resourceContents, ZipOutputStream zos) throws UnsupportedEncodingException, IOException {
+    private static void processResource(String resourcePath, Object resourceContents, ZipOutputStream zos) throws IOException {
         if (resourceContents != null) {
             if (resourceContents instanceof String) {
-                zos.write(((String) resourceContents).getBytes(StandardCharsets.UTF_8.name()));
+                zos.write(((String) resourceContents).getBytes(StandardCharsets.UTF_8));
                 if (LoggingUtils.isDebugEnabled(tc)) {
                     Tr.debug(tc, "Processed (String) resource at " + resourcePath);
                 }
@@ -260,7 +259,7 @@ public class OpenAPIUIBundlesUpdater {
         if (bundleResource != null) {
             BufferedReader br = null;
             try { // read the requested resource from the bundle
-                br = new BufferedReader(new InputStreamReader(bundleResource.openConnection().getInputStream(), StandardCharsets.UTF_8.name()));
+                br = new BufferedReader(new InputStreamReader(bundleResource.openConnection().getInputStream(), StandardCharsets.UTF_8));
                 while (br.ready()) {
                     responseString.append(br.readLine());
                 }
@@ -301,7 +300,7 @@ public class OpenAPIUIBundlesUpdater {
             BundleContext bundleContext = FrameworkUtil.getBundle(OpenAPIUIBundlesUpdater.class).getBundleContext();
             // If the bundle context null, then the bundle is in a STOPPED state and we should not be waiting for other
             // bundles if this is STOPPED. Returning false, means we stop any unnecessary processing
-            if(bundleContext != null){
+            if (bundleContext != null) {
                 new OpenAPIUIBundlesListener(openAPIUIBundles, bundleContext).await();
             } else {
                 return false;

--- a/dev/io.openliberty.security.common.jwt/src/io/openliberty/security/common/jwt/jws/JwsVerificationKeyHelper.java
+++ b/dev/io.openliberty.security.common.jwt/src/io/openliberty/security/common/jwt/jws/JwsVerificationKeyHelper.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.security.common.jwt.jws;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Collections;
 import java.util.HashSet;
@@ -96,12 +96,12 @@ public class JwsVerificationKeyHelper {
         throw new UnsupportedSignatureAlgorithmException(algorithm);
     }
 
-    Key getSharedKey() throws SharedKeyMissingException, UnsupportedEncodingException {
+    Key getSharedKey() throws SharedKeyMissingException {
         if (sharedSecret == null || sharedSecret.isEmpty()) {
             throw new SharedKeyMissingException();
         }
         String sharedSecretProtectedString = new String(sharedSecret.getChars());
-        return new HmacKey(sharedSecretProtectedString.getBytes("UTF-8"));
+        return new HmacKey(sharedSecretProtectedString.getBytes(StandardCharsets.UTF_8));
     }
 
     Key retrievePublicKey(JsonWebStructure jws, String signatureAlgorithmFromJws) throws IOException, Exception {

--- a/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal/src/io/openliberty/security/jakartasec/identitystore/OidcIdentityStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package io.openliberty.security.jakartasec.identitystore;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -157,11 +158,11 @@ public class OidcIdentityStore implements IdentityStore {
         if (parts.length > 1) {
             try {
                 try {
-                    String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[0]), "UTF-8");
+                    String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[0]), StandardCharsets.UTF_8);
                     org.jose4j.jwt.JwtClaims.parse(claimsAsJsonString).getClaimsMap();
                     isJWT = true;
                 } catch (Exception e1) {
-                    String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[1]), "UTF-8");
+                    String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[1]), StandardCharsets.UTF_8);
                     jwtClaims = org.jose4j.jwt.JwtClaims.parse(claimsAsJsonString).getClaimsMap();
                     isJWT = true;
                 }
@@ -175,7 +176,7 @@ public class OidcIdentityStore implements IdentityStore {
         if (isJWT) {
             if (jwtClaims == null) { // grab the claims map if we haven't already
                 try {
-                    String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[1]), "UTF-8");
+                    String claimsAsJsonString = new String(Base64.getDecoder().decode(parts[1]), StandardCharsets.UTF_8);
                     jwtClaims = org.jose4j.jwt.JwtClaims.parse(claimsAsJsonString).getClaimsMap();
                 } catch (Exception e1) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/HttpConstants.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/http/HttpConstants.java
@@ -1,16 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.security.oidcclientcore.http;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public interface HttpConstants {
 
@@ -21,7 +24,7 @@ public interface HttpConstants {
     public final static String BASIC = "Basic ";
     public final static String BEARER = "Bearer ";
 
-    public final static String UTF_8 = "UTF-8";
+    public final static Charset UTF_8 = StandardCharsets.UTF_8;
 
     public static final String ACCEPT = "Accept";
     public static final String APPLICATION_JSON = "application/json";

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/osgi/webapp/WebAppDispatcherContext61.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal/src/io/openliberty/webcontainer61/osgi/webapp/WebAppDispatcherContext61.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@ package io.openliberty.webcontainer61.osgi.webapp;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -71,7 +72,7 @@ public class WebAppDispatcherContext61 extends WebAppDispatcherContext40 {
 
                 try {
                     ServletOutputStream out = response.getOutputStream();
-                    out.write(hyperText.getBytes("UTF-8"));
+                    out.write(hyperText.getBytes(StandardCharsets.UTF_8));
                 } catch (IllegalStateException ise) {
                     PrintWriter writer = response.getWriter();
                     writer.print(hyperText);

--- a/dev/wlp-generateRepositoryContent/src/com/ibm/ws/wlp/repository/esa/GenerateEsas.java
+++ b/dev/wlp-generateRepositoryContent/src/com/ibm/ws/wlp/repository/esa/GenerateEsas.java
@@ -94,7 +94,7 @@ public class GenerateEsas extends DownloadXmlGenerator {
             File englishLI = new File(licenseRoot, "LI_en");
             BufferedReader licenseReader = null;
             try {
-                licenseReader = new BufferedReader(new InputStreamReader(new FileInputStream(englishLI), "UTF-16"));
+                licenseReader = new BufferedReader(new InputStreamReader(new FileInputStream(englishLI), StandardCharsets.UTF_16));
                 String line = null;
                 while ((line = licenseReader.readLine()) != null) {
                     if (line.startsWith("L/N:")) {

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/ContentLicenseProvider.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/ContentLicenseProvider.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,6 +16,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import wlp.lib.extract.Content.Entry;
 
@@ -97,7 +98,7 @@ public class ContentLicenseProvider implements LicenseProvider {
         BufferedReader r = null;
         try {
             // The license name is the sixth line in the LA file
-            r = new BufferedReader(new InputStreamReader(laEntry.getInputStream(), "UTF-16"));
+            r = new BufferedReader(new InputStreamReader(laEntry.getInputStream(), StandardCharsets.UTF_16));
             //read the first line
             String line = r.readLine();
             String sixTh_line = "";
@@ -132,7 +133,7 @@ public class ContentLicenseProvider implements LicenseProvider {
         try {
             // Look for the product name in the LI file -- within the first few lines
             int i = 0;
-            r = new BufferedReader(new InputStreamReader(liEnglishEntry.getInputStream(), "UTF-16"));
+            r = new BufferedReader(new InputStreamReader(liEnglishEntry.getInputStream(), StandardCharsets.UTF_16));
             do {
                 line = r.readLine();
                 if (line != null) {

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/MapBasedSelfExtractor.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/MapBasedSelfExtractor.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,8 +14,8 @@ package wlp.lib.extract;
 
 import java.io.File;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -137,6 +137,7 @@ public class MapBasedSelfExtractor implements Map {
         private List downloadSizeMonitor;
         private boolean canceled;
 
+        @Override
         public void downloadingFile(URL sourceUrl, File targetFile) {
             if (downloadedFiles != null) {
                 Map downloadInformation = new HashMap();
@@ -146,28 +147,38 @@ public class MapBasedSelfExtractor implements Map {
             }
         }
 
+        @Override
         public void dataDownloaded(int numBytes) {
             if (downloadSizeMonitor != null) {
                 downloadSizeMonitor.add(Integer.valueOf(numBytes));
             }
         }
 
+        @Override
         public void extractedFile(String f) {
             if (extractedFiles != null) {
                 canceled = !!!extractedFiles.add(f);
             }
         }
 
-        public void setFilesToExtract(int count) {}
+        @Override
+        public void setFilesToExtract(int count) {
+        }
 
-        public void commandRun(List args) {}
+        @Override
+        public void commandRun(List args) {
+        }
 
-        public void commandsToRun(int count) {}
+        @Override
+        public void commandsToRun(int count) {
+        }
 
+        @Override
         public boolean isCanceled() {
             return canceled;
         }
 
+        @Override
         public void skippedFile() {
             if (extractedFiles != null) {
                 canceled = !!!extractedFiles.add(INSTALL_VERSION_ONE);
@@ -194,6 +205,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#clear()
      */
+    @Override
     public void clear() {
         throw new UnsupportedOperationException();
     }
@@ -203,6 +215,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#containsKey(java.lang.Object)
      */
+    @Override
     public boolean containsKey(Object arg0) {
         return data.containsKey(arg0);
     }
@@ -212,6 +225,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#containsValue(java.lang.Object)
      */
+    @Override
     public boolean containsValue(Object arg0) {
         throw new UnsupportedOperationException();
     }
@@ -221,6 +235,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#entrySet()
      */
+    @Override
     public Set entrySet() {
         throw new UnsupportedOperationException();
     }
@@ -230,6 +245,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#get(java.lang.Object)
      */
+    @Override
     public Object get(Object arg0) {
         if (INSTALL_CODE.equals(arg0) && extract != null && installDir != null && (!extract.hasLicense() || licenseAccepted.booleanValue())) {
             ReturnCode rc = extract.validate(installDir);
@@ -239,17 +255,9 @@ public class MapBasedSelfExtractor implements Map {
             data.put(INSTALL_CODE, new Integer(rc.getCode()));
             data.put(INSTALL_ERROR_MESSAGE, rc.getErrorMessage());
         } else if (LICENSE_AGREEMENT.equals(arg0)) {
-            try {
-                return extract.hasLicense() ? new InputStreamReader(extract.getLicenseAgreement(), "UTF-16") : null;
-            } catch (UnsupportedEncodingException e) {
-                return null;
-            }
+            return extract.hasLicense() ? new InputStreamReader(extract.getLicenseAgreement(), StandardCharsets.UTF_16) : null;
         } else if (LICENSE_INFO.equals(arg0)) {
-            try {
-                return extract.hasLicense() ? new InputStreamReader(extract.getLicenseInformation(), "UTF-16") : null;
-            } catch (UnsupportedEncodingException e) {
-                return null;
-            }
+            return extract.hasLicense() ? new InputStreamReader(extract.getLicenseInformation(), StandardCharsets.UTF_16) : null;
         } else if (LICENSE_PRESENT.equals(arg0)) {
             return Boolean.valueOf(extract.hasLicense());
         } else if (HAS_EXTERNAL_DEPS.equals(arg0)) {
@@ -283,6 +291,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#isEmpty()
      */
+    @Override
     public boolean isEmpty() {
         return false;
     }
@@ -292,6 +301,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#keySet()
      */
+    @Override
     public Set keySet() {
         throw new UnsupportedOperationException();
     }
@@ -301,6 +311,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#put(java.lang.Object, java.lang.Object)
      */
+    @Override
     public Object put(Object arg0, Object arg1) {
         Object old = null;
         if (INSTALL_DIR.equals(arg0)) {
@@ -400,6 +411,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#putAll(java.util.Map)
      */
+    @Override
     public void putAll(Map arg0) {
         throw new UnsupportedOperationException();
     }
@@ -409,6 +421,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#remove(java.lang.Object)
      */
+    @Override
     public Object remove(Object arg0) {
         throw new UnsupportedOperationException();
     }
@@ -418,6 +431,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#size()
      */
+    @Override
     public int size() {
         throw new UnsupportedOperationException();
     }
@@ -427,6 +441,7 @@ public class MapBasedSelfExtractor implements Map {
      *
      * @see java.util.Map#values()
      */
+    @Override
     public Collection values() {
         throw new UnsupportedOperationException();
     }

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractRun.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractRun.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -199,7 +200,7 @@ public class SelfExtractRun extends SelfExtract {
             } else {
                 // read existing file content
 
-                br = new BufferedReader(new InputStreamReader(new FileInputStream(fileName), "UTF-8"));
+                br = new BufferedReader(new InputStreamReader(new FileInputStream(fileName), StandardCharsets.UTF_8));
                 while ((sCurrentLine = br.readLine()) != null) {
                     sb.append(sCurrentLine + "\n");
                 }
@@ -208,7 +209,7 @@ public class SelfExtractRun extends SelfExtract {
             // write property to disable 2PC commit
             String content = "-Dcom.ibm.tx.jta.disable2PC=true";
 
-            bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file.getAbsoluteFile()), "UTF-8"));
+            bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file.getAbsoluteFile()), StandardCharsets.UTF_8));
             bw.write(sb.toString());
             bw.write(content);
 

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractUtils.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.CodeSource;
 import java.security.PrivilegedAction;
@@ -119,7 +120,7 @@ public class SelfExtractUtils {
         List lines = new ArrayList();
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(in, "UTF-16"));
+            reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_16));
             for (String line; (line = reader.readLine()) != null;) {
                 wordWrap(line, lines);
             }

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/ShutdownHook.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/ShutdownHook.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -73,7 +74,7 @@ public class ShutdownHook implements Runnable {
             String pidFile = dir + File.separator + "wlp" + File.separator + "usr" + File.separator + "servers" + File.separator + ".pid" + File.separator
                              + serverName + ".pid";
             try {
-                BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(pidFile), "UTF-8"));
+                BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(pidFile), StandardCharsets.UTF_8));
                 try {
                     return br.readLine();
                 } finally {
@@ -337,7 +338,7 @@ public class ShutdownHook implements Runnable {
             }
         }
 
-        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file.getAbsoluteFile()), "UTF-8"));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file.getAbsoluteFile()), StandardCharsets.UTF_8));
 
         if (platformType == SelfExtractUtils.PlatformType_UNIX || platformType == SelfExtractUtils.PlatformType_OS400) {
             writeUnixCleanup(file, bw);

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/StreamReader.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/StreamReader.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -20,6 +20,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 class StreamReader extends Thread {
     InputStream is;
@@ -42,6 +43,7 @@ class StreamReader extends Thread {
         this.os = redirect;
     }
 
+    @Override
     public void run() {
         try {
             // stdin, process stream is output
@@ -62,7 +64,7 @@ class StreamReader extends Thread {
         if (os != null)
             pw = new PrintWriter(os);
 
-        InputStreamReader isr = new InputStreamReader(is, "UTF-8");
+        InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
         BufferedReader br = new BufferedReader(isr);
         String line = null;
         while ((line = br.readLine()) != null) {
@@ -77,7 +79,7 @@ class StreamReader extends Thread {
     }
 
     public void runOutputStream() throws IOException {
-        OutputStreamWriter osr = new OutputStreamWriter(os, "UTF-8");
+        OutputStreamWriter osr = new OutputStreamWriter(os, StandardCharsets.UTF_8);
         BufferedWriter br = new BufferedWriter(osr);
         br.write("Y");
     }


### PR DESCRIPTION
- Use StandardCharsets to pass in Charset instead of String name of the charset
- This PR does the work to do this change for all product code where possible.  Work was done in key locations previously in PRs #26601, #16633 and #15997. 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
