### PR TITLE
Fix test defect related to testMultipleModuleWarsAllRunAsWithDB

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/multipleModule.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/multipleModule.ear/resources/META-INF/permissions.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
         http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
     version="7">
+
+   <permission>
+      <class-name>javax.security.auth.AuthPermission</class-name>
+      <name>wssecurity.getCallerSubject</name>
+   </permission>
     
    <permission>
       <class-name>javax.security.auth.AuthPermission</class-name>


### PR DESCRIPTION
Currently the above test fails when running on java2security. This is because the app is missing the `wssecurity.getCallerSubject` permission.

```sh
[3/16/25, 9:02:11:630 PDT] 0000002f SystemErr R java.security.AccessControlException: Access denied ("javax.security.auth.AuthPermission" "wssecurity.getCallerSubject") [3/16/25, 9:02:11:632 PDT] 0000002f SystemErr R at java.base/java.security.AccessController.throwACE(AccessController.java:177) [3/16/25, 9:02:11:744 PDT] 0000002f SystemErr R at java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:239) [3/16/25, 9:02:11:746 PDT] 0000002f SystemErr R at java.base/java.security.AccessController.checkPermission(AccessController.java:386) [3/16/25, 9:02:11:747 PDT] 0000002f SystemErr R at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:416) [3/16/25, 9:02:11:748 PDT] 0000002f SystemErr R at com.ibm.websphere.security.auth.WSSubject.getCallerSubject(WSSubject.java:337) [3/16/25, 9:02:11:749 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet$1.run(FlexibleBaseNoJavaEESecServlet.java:732) [3/16/25, 9:02:11:750 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet$1.run(FlexibleBaseNoJavaEESecServlet.java:728) [3/16/25, 9:02:11:751 PDT] 0000002f SystemErr R at java.base/java.security.AccessController.doPrivileged(AccessController.java:748) [3/16/25, 9:02:11:752 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet.fetchSubject(FlexibleBaseNoJavaEESecServlet.java:728) [3/16/25, 9:02:11:753 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet.access$000(FlexibleBaseNoJavaEESecServlet.java:62) [3/16/25, 9:02:11:755 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet$BaseServletParms.getSubject(FlexibleBaseNoJavaEESecServlet.java:208) [3/16/25, 9:02:11:755 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet$WriteSubjectStep.invoke(FlexibleBaseNoJavaEESecServlet.java:332) [3/16/25, 9:02:11:756 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet.performCustomTasks(FlexibleBaseNoJavaEESecServlet.java:718) [3/16/25, 9:02:11:758 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet.performTask(FlexibleBaseNoJavaEESecServlet.java:149) [3/16/25, 9:02:11:758 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet.handleRequest(FlexibleBaseNoJavaEESecServlet.java:127) [3/16/25, 9:02:11:759 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet.doGet(FlexibleBaseNoJavaEESecServlet.java:94) [3/16/25, 9:02:11:760 PDT] 0000002f SystemErr R at javax.servlet.http.HttpServlet.service(HttpServlet.java:686) [3/16/25, 9:02:11:761 PDT] 0000002f SystemErr R at web.jar.base.FlexibleBaseNoJavaEESecServlet.service(FlexibleBaseNoJavaEESecServlet.java:89) [3/16/25, 9:02:11:762 PDT] 0000002f SystemErr R at javax.servlet.http.HttpServlet.service(HttpServlet.java:791) [3/16/25, 9:02:11:763 PDT] 0000002f SystemErr R at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1266) [3/16/25, 9:02:11:764 PDT] 0000002f SystemErr R at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:754) [3/16/25, 9:02:11:765 PDT] 0000002f SystemErr R at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:451) [3/16/25, 9:02:11:765 PDT] 0000002f SystemErr R at com.ibm.ws.webcontainer.filter.WebAppFilterChain.invokeTarget(WebAppFilterChain.java:197)
```
This MR adds that permission.
[Internal Link to failure](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=304069)

- [X ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

# Delete this section and fill in the remaining info from the template

ATTENTION, READ THIS: Updated July 2024 

Read and understand this completely, then delete the static part of the template. 

If a reviewer or merger sees this template, they should fail the review or merge.

If this code change is fixing a user-visible bug in previously released code, it MUST
have an associated issue **mentioned in the PR text or description**.  
 
   - That Issue also MUST be labelled “release bug”

     This directs automation to scrape this fix for inclusion in the next release's
     list of bugs fixed.

   - The linkage between PR and Issue should use the `Fixes #...` syntax rather than a manual
     link via the Development widget.

Otherwise, a link to an issue or specific issue labels are optional.

For full details, please see this wiki page: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions
################################################################################################
