### PR TITLE
Update ASM to 9.8 (Java 25)

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -4489,27 +4489,27 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-analysis</artifactId>
-      <version>9.7.1</version>
+      <version>9.8</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
-      <version>9.7.1</version>
+      <version>9.8</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-tree</artifactId>
-      <version>9.7.1</version>
+      <version>9.8</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-util</artifactId>
-      <version>9.7.1</version>
+      <version>9.8</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>9.7.1</version>
+      <version>9.8</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -893,11 +893,11 @@ org.osgi:org.osgi.util.function:1.1.0
 org.osgi:org.osgi.util.promise:1.1.1
 org.osgi:osgi.core:7.0.0
 org.osgi:osgi.core:8.0.0
-org.ow2.asm:asm-analysis:9.7.1
-org.ow2.asm:asm-commons:9.7.1
-org.ow2.asm:asm-tree:9.7.1
-org.ow2.asm:asm-util:9.7.1
-org.ow2.asm:asm:9.7.1
+org.ow2.asm:asm-analysis:9.8
+org.ow2.asm:asm-commons:9.8
+org.ow2.asm:asm-tree:9.8
+org.ow2.asm:asm-util:9.8
+org.ow2.asm:asm:9.8
 org.postgresql:postgresql:42.7.2
 org.powermock:powermock-core:1.5
 org.quartz-scheduler:quartz:2.3.2

--- a/dev/com.ibm.ws.org.objectweb.asm/bnd.bnd
+++ b/dev/com.ibm.ws.org.objectweb.asm/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2024 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -10,16 +10,16 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.ow2.asm:asm;9.7.1}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.ow2.asm:asm-analysis;9.7.1}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.ow2.asm:asm-commons;9.7.1}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.ow2.asm:asm-tree;9.7.1}}!/META-INF/MANIFEST.MF,\
-          jar:${fileuri;${repo;org.ow2.asm:asm-util;9.7.1}}!/META-INF/MANIFEST.MF,\
+-include= jar:${fileuri;${repo;org.ow2.asm:asm;9.8}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.ow2.asm:asm-analysis;9.8}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.ow2.asm:asm-commons;9.8}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.ow2.asm:asm-tree;9.8}}!/META-INF/MANIFEST.MF,\
+          jar:${fileuri;${repo;org.ow2.asm:asm-util;9.8}}!/META-INF/MANIFEST.MF,\
           bnd.overrides
 
 instrument.disabled: true
 
-asmVersion=9.7.1
+asmVersion=9.8
 
 -buildpath: \
 	org.ow2.asm:asm;version=${asmVersion},\

--- a/dev/com.ibm.ws.org.objectweb.asm/bnd.overrides
+++ b/dev/com.ibm.ws.org.objectweb.asm/bnd.overrides
@@ -10,5 +10,5 @@ DynamicImport-Package: *
 # IMPORTANT: Remember to update io.openliberty.asm.ASMHelper.CURRENT_ASM to the value of the most current
 # org.objectweb.asm.Opcodes.ASM## constant when updating the ASM dependency.
 Export-Package: \
-  org.objectweb.asm.*;version="9.7.1",\
+  org.objectweb.asm.*;version="9.8",\
   io.openliberty.asm;version="1.0"

--- a/dev/com.ibm.ws.org.objectweb.asm/src/io/openliberty/asm/ASMHelper.java
+++ b/dev/com.ibm.ws.org.objectweb.asm/src/io/openliberty/asm/ASMHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ import org.objectweb.asm.Opcodes;
  */
 public class ASMHelper {
     private static final int CURRENT_ASM = Opcodes.ASM9; // Update this when an ASM update introduces a new constant
-    private static final int CURRENT_MAX_JAVA_LEVEL = Opcodes.V24; // Update this to show the maximum version of Java we can run with
+    private static final int CURRENT_MAX_JAVA_LEVEL = Opcodes.V25; // Update this to show the maximum version of Java we can run with
 
     /**
      * Returns the constant representing the current version of ASM.

--- a/dev/com.ibm.ws.ras.instrument_test/test/com/ibm/ws/ras/RasTransformTest.java
+++ b/dev/com.ibm.ws.ras.instrument_test/test/com/ibm/ws/ras/RasTransformTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -76,6 +76,7 @@ public class RasTransformTest extends LibertyRuntimeTransformer {
         majorCodeMap.put("22", 66);
         majorCodeMap.put("23", 67);
         majorCodeMap.put("24", 68);
+        majorCodeMap.put("25", 69);
 	}
 	
 	/**


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Update ASM to 9.8 to support Java 25.

Reference to previous update for Java 24 -> https://github.com/OpenLiberty/open-liberty/pull/29806