### PR TITLE
library path config for JDBC

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -585,7 +585,8 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
                                  : DataSource.class.isAssignableFrom(cl) ? DataSource.class.getName()
                                  : Driver.class.getName();
                         } else {
-                            searchedLibraryFiles.addAll(JDBCDriverService.getClasspath(library, false));
+                            searchedLibraryFiles.addAll(
+                                JDBCDriverService.getAbsolutePaths(library));
                             if (dsTypeSearchOrder == null) {
                                 type = Driver.class.getName();
                                 for (Iterator<Driver> it = ServiceLoader.load(Driver.class, loader).iterator(); it.hasNext(); ) {
@@ -634,12 +635,14 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
                     } catch (ClassNotFoundException x) {
                         if (trace && tc.isDebugEnabled())
                             Tr.debug(tc, className + " not found in", libraryPid);
-                        searchedLibraryFiles.addAll(JDBCDriverService.getClasspath(library, false));
+                        searchedLibraryFiles.addAll(
+                            JDBCDriverService.getAbsolutePaths(library));
                     } catch (Exception x) {
                         FFDCFilter.processException(x, DataSourceResourceFactoryBuilder.class.getName(), "444", new Object[] { libraryRef });
                         if (trace && tc.isDebugEnabled())
                             Tr.debug(tc, libraryRef.toString(), x);
-                        searchedLibraryFiles.addAll(JDBCDriverService.getClasspath(library, false));
+                        searchedLibraryFiles.addAll(
+                            JDBCDriverService.getAbsolutePaths(library));
                         // Continue to try other libraryRefs
                     }
                 }

--- a/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/JDBCDriverManagerTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -27,6 +27,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jdbc.fat.driver.derby.FATDriver;
@@ -58,12 +59,26 @@ public class JDBCDriverManagerTest extends FATServletClient {
                         .merge(derbyJar)
                         .addAsServiceProvider(java.sql.Driver.class, FATDriver.class);
 
+        JavaArchive folderDriver = ShrinkWrap.create(JavaArchive.class, "FolderDriver.jar")
+                        .addPackage("jdbc.fat.folder.driver")
+                        .addPackage("jdbc.fat.folder.driver.pool");
+
         JavaArchive proxyDriver = ShrinkWrap.create(JavaArchive.class, "ProxyDriver.jar")
                         .addPackage("jdbc.fat.proxy.driver")
                         .addAsServiceProvider(java.sql.Driver.class, ProxyDrivr.class);
 
         ShrinkHelper.exportToServer(server, "derby", fatDriver);
         ShrinkHelper.exportToServer(server, "proxydriver", proxyDriver);
+
+        ShrinkHelper.exportArtifact(folderDriver, "publish/libs", true, false, true);
+        String destinationLibFolder = server.getInstallRoot() +
+                                      "/usr/servers/com.ibm.ws.jdbc.fat.driver/libs";
+        LibertyFileManager.copyFileIntoLiberty(server.getMachine(),
+                                               destinationLibFolder,
+                                               "folderjdbc",
+                                               "publish/libs/FolderDriver.jar",
+                                               true,
+                                               server.getServerRoot());
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_driver/publish/servers/com.ibm.ws.jdbc.fat.driver/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2018, 2023 IBM Corporation and others.
+    Copyright (c) 2018, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -25,6 +25,14 @@
  
     <library id="FATDriverLib">
         <file name="${server.config.dir}/derby/FATDriver.jar"/>
+    </library>
+
+    <library id="FolderJDBCLib">
+        <folder dir="libs/folderjdbc"/>
+    </library>
+
+    <library id="PathJDBCLib">
+        <path name="${server.config.dir}/libs/folderjdbc"/>
     </library>
 
     <library id="ProxyDriverLib">
@@ -61,6 +69,18 @@
     <dataSource id="fatDriverInvalidURLLoginTimeout" jndiName="jdbc/fatDriverInvalidURLLoginTimeout">
       <jdbcDriver libraryRef="FATDriverLib"/>
       <properties url="jdbc:fatdriver:memory:jdbcdriver1;create=true;LoginTimeout=10"/>
+    </dataSource>
+
+    <dataSource id="folderds" jndiName="jdbc/folderds">
+      <jdbcDriver libraryRef="FolderJDBCLib"
+                  javax.sql.DataSource="jdbc.fat.folder.driver.FolderDataSource"/>
+      <properties catalog="folderdb" schema="folderschema1"/>
+    </dataSource>
+
+    <dataSource id="folderpoolds" jndiName="jdbc/folderpoolds">
+      <jdbcDriver libraryRef="PathJDBCLib"
+                  javax.sql.ConnectionPoolDataSource="jdbc.fat.folder.driver.pool.FolderPoolDataSource"/>
+      <properties catalog="folderdb" schema="folderschema2"/>
     </dataSource>
 
     <dataSource id="proxydriver" jndiName="jdbc/proxydriver">

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/folder/driver/FolderDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/folder/driver/FolderDataSource.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.folder.driver;
+
+import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
+
+/**
+ * A DataSource for a fake JDBC driver that is packaged in a folder
+ * rather than a jar file.
+ */
+public class FolderDataSource implements DataSource {
+    private final Properties props = new Properties();
+
+    public String getCatalog() {
+        return props.getProperty("Catalog");
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return getConnection(null, null);
+    }
+
+    @Override
+    public Connection getConnection(String user, String password) {
+        Properties info = (Properties) props.clone();
+        info.setProperty("DatabaseProductName", "FolderDB");
+        info.setProperty("DatabaseProductVersion", "1.0.0.0");
+        info.setProperty("DriverName", "FolderJDBC");
+        info.setProperty("DriverVersion", "1.0");
+        info.setProperty("DatabaseMajorVersion", "1");
+        info.setProperty("DatabaseMinorVersion", "0");
+        info.setProperty("JDBCMajorVersion", "4");
+        info.setProperty("JDBCMinorVersion", "1");
+        if (user != null)
+            info.setProperty("UserName", user);
+
+        return (Connection) Proxy //
+                        .newProxyInstance(getClass().getClassLoader(),
+                                          new Class<?>[] { Connection.class },
+                                          new FolderJDBCHandler(Connection.class, info));
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return Integer.parseInt(props.getProperty("LoginTimeout", "0"));
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    public String getSchema() {
+        return props.getProperty("Schema");
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> ifc) throws SQLException {
+        return ifc.isInstance(this);
+    }
+
+    public void setCatalog(String value) {
+        props.put("Catalog", value);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) {
+        props.put("LoginTimeout", Integer.toString(seconds));
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) {
+    }
+
+    public void setSchema(String value) {
+        props.put("Schema", value);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> ifc) throws SQLException {
+        if (ifc.isInstance(this))
+            return ifc.cast(this);
+        else
+            throw new SQLException(this + " doesn't wrap " + ifc);
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/folder/driver/FolderJDBCHandler.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/folder/driver/FolderJDBCHandler.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.folder.driver;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Properties;
+
+/**
+ * A proxy for JDBC API that delegates getter operations to key/value properties
+ * and delegates methods that obtain additional JDBC API to another proxy instance.
+ */
+public class FolderJDBCHandler implements InvocationHandler {
+    private final Properties props;
+    private final Class<?> type;
+
+    public FolderJDBCHandler(Class<?> type, Properties props) {
+        this.type = type;
+        this.props = props;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        String methodName = method.getName();
+        Class<?> returnType = method.getReturnType();
+
+        if ("hashCode".equals(methodName))
+            return System.identityHashCode(proxy);
+
+        if ("toString".equals(methodName))
+            return "jdbc.fat.folder.driver." + type.getSimpleName() +
+                   '@' + Integer.toHexString(System.identityHashCode(proxy));
+
+        String s = methodName.startsWith("get") //
+                        ? props.getProperty(methodName.substring(3)) //
+                        : null;
+
+        if (boolean.class.equals(returnType))
+            return s == null ? true : Boolean.parseBoolean(s);
+        if (long.class.equals(returnType))
+            return s == null ? 0 : Long.parseLong(s);
+        if (int.class.equals(returnType))
+            return s == null ? 0 : Integer.parseInt(s);
+        if (short.class.equals(returnType))
+            return s == null ? 0 : Short.parseShort(s);
+        if (String.class.equals(returnType))
+            return s == null ? null : s;
+
+        if (returnType.isInterface())
+            return Proxy.newProxyInstance(FolderJDBCHandler.class.getClassLoader(),
+                                          new Class[] { returnType },
+                                          new FolderJDBCHandler(returnType, props));
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/folder/driver/pool/FolderPoolDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/fatdriver/src/jdbc/fat/folder/driver/pool/FolderPoolDataSource.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.folder.driver.pool;
+
+import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.PooledConnection;
+
+import jdbc.fat.folder.driver.FolderJDBCHandler;
+
+/**
+ * A ConnectionPoolDataSource for a fake JDBC driver that is packaged in a folder
+ * rather than a jar file.
+ */
+public class FolderPoolDataSource implements ConnectionPoolDataSource {
+    private final Properties props = new Properties();
+
+    public String getCatalog() {
+        return props.getProperty("Catalog");
+    }
+
+    @Override
+    public PooledConnection getPooledConnection() throws SQLException {
+        return getPooledConnection(null, null);
+    }
+
+    @Override
+    public PooledConnection getPooledConnection(String user, String password) {
+        Properties info = (Properties) props.clone();
+        info.setProperty("DatabaseProductName", "FolderDB");
+        info.setProperty("DatabaseProductVersion", "1.0.0.0");
+        info.setProperty("DriverName", "FolderJDBC");
+        info.setProperty("DriverVersion", "1.0");
+        info.setProperty("DatabaseMajorVersion", "1");
+        info.setProperty("DatabaseMinorVersion", "0");
+        info.setProperty("JDBCMajorVersion", "4");
+        info.setProperty("JDBCMinorVersion", "1");
+        if (user != null)
+            info.setProperty("UserName", user);
+
+        return (PooledConnection) Proxy //
+                        .newProxyInstance(getClass().getClassLoader(),
+                                          new Class<?>[] { PooledConnection.class },
+                                          new FolderJDBCHandler(PooledConnection.class, info));
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return Integer.parseInt(props.getProperty("LoginTimeout", "0"));
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    public String getSchema() {
+        return props.getProperty("Schema");
+    }
+
+    public void setCatalog(String value) {
+        props.put("Catalog", value);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) {
+        props.put("LoginTimeout", Integer.toString(seconds));
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) {
+    }
+
+    public void setSchema(String value) {
+        props.put("Schema", value);
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/test-applications/jdbcapp/src/jdbc/fat/driver/web/JDBCDriverManagerServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -262,6 +262,38 @@ public class JDBCDriverManagerServlet extends FATServlet {
             con.createStatement().executeUpdate("insert into address values ('Quarry Hill Nature Center', 701, 'Silver Creek Road NE', 'Rochester', 'MN', 55906)");
         } finally {
             con.close();
+        }
+    }
+
+    /**
+     * Verify that the content of a JDBC driver JAR file can be expanded into a
+     * folder and the shared library can point at the folder name, and the library
+     * can be used to configure a jdbcDriver/dataSource.
+     */
+    @Test
+    public void testDriverArtifactExpandedIntoFolder() throws Exception {
+        // Using folder dir={folder}
+        DataSource ds = InitialContext.doLookup("jdbc/folderds");
+        try (Connection con = ds.getConnection("dbuser1", "dbpwd1")) {
+            DatabaseMetaData mdata = con.getMetaData();
+            assertEquals("FolderJDBC", mdata.getDriverName());
+            assertEquals("dbuser1", mdata.getUserName());
+
+            // Properties configured in server.xml:
+            assertEquals("folderdb", con.getCatalog());
+            assertEquals("folderschema1", con.getSchema());
+        }
+
+        // Using path name={folder}
+        ds = InitialContext.doLookup("jdbc/folderpoolds");
+        try (Connection con = ds.getConnection("dbuser1", "dbpwd1")) {
+            DatabaseMetaData mdata = con.getMetaData();
+            assertEquals("FolderJDBC", mdata.getDriverName());
+            assertEquals("dbuser1", mdata.getUserName());
+
+            // Properties configured in server.xml:
+            assertEquals("folderdb", con.getCatalog());
+            assertEquals("folderschema2", con.getSchema());
         }
     }
 

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/publish/servers/postgresql-test-server/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/publish/servers/postgresql-test-server/server.xml
@@ -1,3 +1,15 @@
+<!--
+    Copyright (c) 2019, 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+-->
 <server>
 
     <featureManager>
@@ -22,7 +34,7 @@
     </library>
     
     <library id="PostgresLibJar">
-        <file name="${shared.resource.dir}/postgres/postgresql.jar"/>
+        <path name="${shared.resource.dir}/postgres/postgresql.jar"/>
     </library>
     
     <!-- datasource type auto-detection should locate the java.sql.Driver in the driver.jar -->


### PR DESCRIPTION
Fixes #30813
Adds tests for `folder dir=` and `path name={folder}`.
Improves error reporting by including the Library.getFolders() in the list of locations searched for the data source class.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
