### PR TITLE
Partial incoming body buffer size netty

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/HttpPipelineInitializer.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/HttpPipelineInitializer.java
@@ -41,6 +41,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.ChannelHandler.Sharable;
@@ -116,7 +117,7 @@ public class HttpPipelineInitializer extends ChannelInitializerWrapper {
         channel.attr(NettyHttpConstants.IS_OUTBOUND_KEY).set(false);
         channel.attr(NettyHttpConstants.ENDPOINT_PID).set(chain.getEndpointPID());
 
-        RecvByteBufAllocator channelAllocator = channel.config().getRecvByteBufAllocator();
+        FixedRecvByteBufAllocator channelAllocator = new FixedRecvByteBufAllocator(httpConfig.getIncomingBodyBufferSize());
         LoggingRecvByteBufAllocator loggingAllocator = new LoggingRecvByteBufAllocator(channelAllocator);
         channel.config().setRecvByteBufAllocator(loggingAllocator);
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/http2/LibertyUpgradeCodec.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/http2/LibertyUpgradeCodec.java
@@ -172,7 +172,8 @@ public class LibertyUpgradeCodec implements UpgradeCodecFactory {
 
     HttpToHttp2ConnectionHandler buildHttp2ConnectionHandler(HttpChannelConfig httpConfig, Channel channel) {
         DefaultHttp2Connection connection = new DefaultHttp2Connection(true);
-        int maxContentlength = (int) httpConfig.getMessageSizeLimit();
+        // Netty accepts integer for max length so we would need to adapt for this
+        int maxContentlength = httpConfig.getMessageSizeLimit() >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) httpConfig.getMessageSizeLimit();
         InboundHttp2ToHttpAdapterBuilder builder = new InboundHttp2ToHttpAdapterBuilder(connection).propagateSettings(false).validateHttpHeaders(false);
         if (maxContentlength > 0)
             builder.maxContentLength(maxContentlength);


### PR DESCRIPTION
Added implementation for `incomingBodyBufferSize` for setting read body buffer size. This implementation would also apply for headers and every other read done by the channel. Also added a fix for `MessageSizeLimit` on H2 Netty moving from Long to Integer and handling overflow