### PR TITLE
Fix spelling of Optional in EL 6.0 FAT

### DIFF
--- a/dev/io.openliberty.org.apache.jasper.expressionLanguage.6.0_fat/test-applications/EL60OptionalELResolverTest.war/src/io/openliberty/el60/fat/optionalelresolver/servlets/EL60OptionalELResolverTestServlet.java
+++ b/dev/io.openliberty.org.apache.jasper.expressionLanguage.6.0_fat/test-applications/EL60OptionalELResolverTest.war/src/io/openliberty/el60/fat/optionalelresolver/servlets/EL60OptionalELResolverTestServlet.java
@@ -57,7 +57,7 @@ public class EL60OptionalELResolverTestServlet extends FATServlet {
         Optional<Object> actualResult = elp.eval("testBean.testString");
         log("actualResult: " + actualResult);
 
-        // Without the OpionalELResolver a Java Optional is returned.
+        // Without the OptionalELResolver a Java Optional is returned.
         assertTrue("The actual result was: " + actualResult + " but was expected to be: " + expectedResult, actualResult.get().equals(expectedResult));
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
