### PR TITLE
test: avoid creating a connection during Metamodel creation

### DIFF
--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/PersistenceServiceUnit.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/PersistenceServiceUnit.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,13 +15,14 @@ package com.ibm.wsspi.persistence;
 import java.io.Writer;
 
 import javax.persistence.EntityManager;
+import javax.persistence.metamodel.Metamodel;
 
 /**
  * Interface used to :
  * <ul>
  * <li>create EntityManagers based off PersistenceServiceUnitConfig.</li>
  * <li>drive schema / table operations.</li>
- * 
+ *
  * </P> <b>Note:</b> When a user has finished using the unit, .close() must be invoked. Once a
  * PersistenceServiceUnit has been closed, all of its EntityManagers are considered to be closed.
  */
@@ -30,10 +31,12 @@ public interface PersistenceServiceUnit {
       * Returns a non-thread safe EntityManager. It is expected that the provided EntityManager is
       * short lived. An EntityManager should be created on a per request basis. When work is
       * complete, the EntityManager needs to be closed.
-      * 
+      *
       * @return An EntityManager for this unit.
       */
      public EntityManager createEntityManager();
+
+     public Metamodel createMetamodel();
 
      /**
       * DataSource precedence : privileged, nonJta, jta
@@ -65,7 +68,7 @@ public interface PersistenceServiceUnit {
       * <p>
       * Only valid to be invoked via a client script. Cannot be invoked multiple times. TODO --
       * 154030
-      * 
+      *
       * @param out
       *             a Writer where DDL will be written to.
       */
@@ -76,7 +79,7 @@ public interface PersistenceServiceUnit {
       * consumer of this service is shutting down.
       */
      public void close();
-     
+
      /**
       * Returns the termination token of SQL statements based on the Database platform.
       */

--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/PersistenceServiceUnitImpl.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/PersistenceServiceUnitImpl.java
@@ -89,7 +89,9 @@ public final class PersistenceServiceUnitImpl implements PersistenceServiceUnit 
         // Remaps String -> NVARCHAR (or equivalent)
         _serviceProperties.put(TARGET_DATABASE_PROPERTIES, "UseNationalCharacterVaryingTypeForString=true");
 
-        _emf = _provider.createContainerEntityManagerFactory(_pui, _serviceProperties);
+//        _emf = _provider.createContainerEntityManagerFactory(_pui, _serviceProperties);
+        _emf = _provider.createContainerEMF(_pui, _serviceProperties, false);
+
         dbManager.processUnicodeSettings(_emf, conf);
 
         _schemaMgr = new SchemaManager(_serviceProperties, _pui, _provider, dbManager);

--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/PersistenceServiceUnitImpl.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/PersistenceServiceUnitImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
+import javax.persistence.metamodel.Metamodel;
 import javax.sql.DataSource;
 import javax.transaction.TransactionManager;
 
@@ -104,6 +105,11 @@ public final class PersistenceServiceUnitImpl implements PersistenceServiceUnit 
     public EntityManager createEntityManager() {
         // TODO(151457) -- could keep track of these -- wrapper - yes! pool
         return _emf.createEntityManager();
+    }
+
+    @Override
+    public Metamodel createMetamodel() {
+        return _emf.getMetamodel();
     }
 
     @Override

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerUtil.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerUtil.java
@@ -77,7 +77,6 @@ public final class DatabaseContainerUtil {
     private final ServerConfiguration serverClone;
     private final JdbcDatabaseContainer<?> databaseCont;
     private final DatabaseContainerType databaseType;
-    private final boolean isModifiable;
 
     //Optional fields
     private boolean useGeneric = true;
@@ -89,6 +88,7 @@ public final class DatabaseContainerUtil {
     //Optional updates
     private Map<String, Fileset> libraries = Collections.emptyMap();
     private Set<JavaPermission> permissions = Collections.emptySet();
+    private boolean isModifiable;
 
     ///// Constructor /////
     private DatabaseContainerUtil(LibertyServer serv, JdbcDatabaseContainer<?> cont) throws Exception {
@@ -145,9 +145,7 @@ public final class DatabaseContainerUtil {
      */
     public static DatabaseContainerUtil build(LibertyServer server, JdbcDatabaseContainer<?> cont) {
         try {
-            DatabaseContainerUtil instance = new DatabaseContainerUtil(server, cont);
-            Log.info(c, "build", instance.toString());
-            return instance;
+            return new DatabaseContainerUtil(server, cont);
         } catch (Exception e) {
             throw new RuntimeException("Failure while building database container util", e);
         }
@@ -184,6 +182,8 @@ public final class DatabaseContainerUtil {
         this.permissions = serverClone.getJavaPermissions().stream()
                         .filter(p -> p.getCodeBase().contains(toReplacementString(DRIVER_KEY)))
                         .collect(Collectors.toSet());
+        
+        this.isModifiable |= !this.libraries.isEmpty() ||  !this.permissions.isEmpty();
 
         return this;
     }
@@ -251,6 +251,8 @@ public final class DatabaseContainerUtil {
     public void modify() throws Exception {
         
         final String m = "modify";
+        
+        Log.info(c, m, this.toString());
         
         //Skip modify if there is nothing to modify
         if (!isModifiable) {
@@ -497,8 +499,11 @@ public final class DatabaseContainerUtil {
     public String toString() {
         return "DatabaseContainerUtil"
                         + System.lineSeparator() + "[server=" + server.getServerName() + ", databaseType=" + databaseType + ", isModifiable=" + isModifiable 
-                        + System.lineSeparator() + "datasources=" + datasources.stream().map(ds -> getElementId(ds)).collect(Collectors.toList())
-                        + System.lineSeparator() + "authDatas=" + authDatas.stream().map(ad -> getElementId(ad)).collect(Collectors.toList()) + "]";
+                        + System.lineSeparator() + "\tdatasources=" + datasources.stream().map(ds -> getElementId(ds)).collect(Collectors.toList())
+                        + System.lineSeparator() + "\tauthDatas=" + authDatas.stream().map(ad -> getElementId(ad)).collect(Collectors.toList()) 
+                        + System.lineSeparator() + "\tlibraries=" + libraries.keySet()
+                        + System.lineSeparator() + "\tpermissions=" + permissions.stream().map(ps -> getElementId(ps)).collect(Collectors.toList())
+                        + System.lineSeparator() + "]";
     }
     
     

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -669,7 +669,7 @@ public class LibertyServer implements LogMonitorClient {
          */
         private boolean criuRestoreDisableRecovery = true;
 
-        private Properties checkpointEnv = null;
+        private Properties checkpointEnv = new Properties();
 
         /**
          * Set of regular expressions to match against lines to ignore in the post checkpoint log files. Error / Warning messages found

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
@@ -328,11 +328,17 @@ public class DataProvider implements //
         Set<FutureEMBuilder> skip = futureEMBuildersInEJB.remove(appName);
         if (futures != null) {
             for (FutureEMBuilder futureEMBuilder : futures) {
-                if (skip == null || !skip.contains(futureEMBuilder))
-                    // This delays createEMBuilder until restore.
-                    // While this works by avoiding all connections to the data source, it does make restore much slower.
-                    // TODO figure out how to do more work on restore without having to make a connection to the data source
-                    CheckpointPhase.onRestore(() -> futureEMBuilder.completeAsync(futureEMBuilder::createEMBuilder, executor));
+                if (skip == null || !skip.contains(futureEMBuilder)) {
+                    if (CheckpointPhase.getPhase().restored()) { // No checkpoint or during restore
+                        futureEMBuilder.completeAsync(futureEMBuilder::createEMBuilder, executor);
+                    } else { // Before checkpoint
+                        try {
+                            futureEMBuilder.complete(futureEMBuilder.createEMBuilder());
+                        } catch (Throwable x) {
+                            futureEMBuilder.completeExceptionally(x);
+                        }
+                    }
+                }
 
                 // Application is ready for DDL generation; register with DDLGen MBean.
                 // Only those using the Persistence Service will participate, but all will

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
@@ -330,11 +330,14 @@ public class DataProvider implements //
             for (FutureEMBuilder futureEMBuilder : futures) {
                 if (skip == null || !skip.contains(futureEMBuilder)) {
                     if (CheckpointPhase.getPhase().restored()) { // No checkpoint or during restore
+                        System.out.println("KJA1017 on restore calling completeAysnc on: " + futureEMBuilder.toString());
                         futureEMBuilder.completeAsync(futureEMBuilder::createEMBuilder, executor);
                     } else { // Before checkpoint
                         try {
+                            System.out.println("KJA1017 on checkpoint calling complete on: " + futureEMBuilder.toString());
                             futureEMBuilder.complete(futureEMBuilder.createEMBuilder());
                         } catch (Throwable x) {
+                            System.out.println("KJA1017 on checkpoint calling completeExceptionally on: " + futureEMBuilder.toString());
                             futureEMBuilder.completeExceptionally(x);
                         }
                     }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -125,52 +125,116 @@ public abstract class EntityManagerBuilder {
     @FFDCIgnore(Throwable.class)
     protected void collectEntityInfo(Set<Class<?>> entityTypes) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
-        EntityManager em = createEntityManager();
-        try {
-            Set<Class<?>> missingEntityTypes = new HashSet<>(entityTypes);
-            Metamodel model = em.getMetamodel();
-            for (EntityType<?> entityType : model.getEntities()) {
-                Map<String, String> attributeNames = new HashMap<>();
-                Map<String, List<Member>> attributeAccessors = new HashMap<>();
-                SortedSet<String> attributeNamesForUpdate = new TreeSet<>();
-                SortedMap<String, Class<?>> attributeTypes = new TreeMap<>();
-                SortedMap<String, Member> idClassAttributeAccessors = null;
-                Map<String, Class<?>> collectionElementTypes = new HashMap<>();
-                Map<Class<?>, List<String>> relationAttributeNames = new HashMap<>();
-                Queue<Attribute<?, ?>> relationships = new LinkedList<>();
-                Queue<String> relationPrefixes = new LinkedList<>();
-                Queue<List<Member>> relationAccessors = new LinkedList<>();
-                Class<?> recordClass = getRecordClass(entityType.getJavaType());
-                Class<?> idType = null;
-                String versionAttrName = null;
+        Set<Class<?>> missingEntityTypes = new HashSet<>(entityTypes);
+        Metamodel model = createMetamodel();
+        for (EntityType<?> entityType : model.getEntities()) {
+            Map<String, String> attributeNames = new HashMap<>();
+            Map<String, List<Member>> attributeAccessors = new HashMap<>();
+            SortedSet<String> attributeNamesForUpdate = new TreeSet<>();
+            SortedMap<String, Class<?>> attributeTypes = new TreeMap<>();
+            SortedMap<String, Member> idClassAttributeAccessors = null;
+            Map<String, Class<?>> collectionElementTypes = new HashMap<>();
+            Map<Class<?>, List<String>> relationAttributeNames = new HashMap<>();
+            Queue<Attribute<?, ?>> relationships = new LinkedList<>();
+            Queue<String> relationPrefixes = new LinkedList<>();
+            Queue<List<Member>> relationAccessors = new LinkedList<>();
+            Class<?> recordClass = getRecordClass(entityType.getJavaType());
+            Class<?> idType = null;
+            String versionAttrName = null;
 
-                Class<?> jpaEntityClass = entityType.getJavaType();
-                Class<?> userEntityClass = recordClass == null ? jpaEntityClass : recordClass;
-                missingEntityTypes.remove(userEntityClass);
+            Class<?> jpaEntityClass = entityType.getJavaType();
+            Class<?> userEntityClass = recordClass == null ? jpaEntityClass : recordClass;
+            missingEntityTypes.remove(userEntityClass);
 
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "collecting info for " +
-                                       userEntityClass.getName());
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(this, tc, "collecting info for " +
+                                   userEntityClass.getName());
 
-                try {
-                    for (Attribute<?, ?> attr : entityType.getAttributes()) {
-                        String attributeName = attr.getName();
-                        PersistentAttributeType attributeType = attr.getPersistentAttributeType();
+            try {
+                for (Attribute<?, ?> attr : entityType.getAttributes()) {
+                    String attributeName = attr.getName();
+                    PersistentAttributeType attributeType = attr.getPersistentAttributeType();
+                    switch (attributeType) {
+                        case BASIC:
+                        case ELEMENT_COLLECTION:
+                            if (attributeNamesForUpdate != null)
+                                attributeNamesForUpdate.add(attributeName);
+                            break;
+                        case ONE_TO_ONE:
+                        case MANY_TO_ONE:
+                            attributeNamesForUpdate = null; // must use merge instead
+                            // continue
+                        case EMBEDDED:
+                            relationAttributeNames.put(attr.getJavaType(), new ArrayList<>());
+                            relationships.add(attr);
+                            relationPrefixes.add(attributeName);
+                            relationAccessors.add(Collections.singletonList(attr.getJavaMember()));
+                            break;
+                        case ONE_TO_MANY:
+                        case MANY_TO_MANY:
+                            attributeNamesForUpdate = null; // must use merge instead
+                            break;
+                        default:
+                            throw new RuntimeException(); // unreachable unless more types are added
+                    }
+
+                    Member accessor = recordClass == null ? attr.getJavaMember() : recordClass.getMethod(attributeName);
+
+                    attributeNames.put(attributeName.toLowerCase(), attributeName);
+                    attributeAccessors.put(attributeName, Collections.singletonList(accessor));
+                    attributeTypes.put(attributeName, attr.getJavaType());
+                    if (attr.isCollection()) {
+                        if (attr instanceof PluralAttribute)
+                            collectionElementTypes.put(attributeName, ((PluralAttribute<?, ?, ?>) attr).getElementType().getJavaType());
+                    } else {
+                        SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute ? (SingularAttribute<?, ?>) attr : null;
+                        if (singleAttr != null && singleAttr.isId()) {
+                            attributeNames.put(ID, attributeName);
+                            idType = singleAttr.getJavaType();
+                        } else if (singleAttr != null && singleAttr.isVersion()) {
+                            versionAttrName = attributeName;
+                        } else if (Collection.class.isAssignableFrom(attr.getJavaType())) {
+                            // collection attribute that is not annotated with ElementCollection
+                            collectionElementTypes.put(attributeName, Object.class);
+                        }
+                    }
+                }
+
+                // Guard against recursive processing of OneToOne (and similar) relationships
+                // by tracking whether we have already processed each entity class involved.
+                Set<Class<?>> entityTypeClasses = new HashSet<>();
+                entityTypeClasses.add(entityType.getJavaType());
+
+                for (Attribute<?, ?> attr; (attr = relationships.poll()) != null;) {
+                    String prefix = relationPrefixes.poll();
+                    List<Member> accessors = relationAccessors.poll();
+                    ManagedType<?> relation = model.managedType(attr.getJavaType());
+                    if (relation instanceof EntityType && !entityTypeClasses.add(attr.getJavaType()))
+                        break;
+                    List<String> relAttributeList = relationAttributeNames.get(attr.getJavaType());
+                    for (Attribute<?, ?> relAttr : relation.getAttributes()) {
+                        String relationAttributeName = relAttr.getName();
+                        String fullAttributeName = prefix + '.' + relationAttributeName;
+                        List<Member> relAccessors = new LinkedList<>(accessors);
+                        relAccessors.add(relAttr.getJavaMember());
+                        relAttributeList.add(fullAttributeName);
+
+                        PersistentAttributeType attributeType = relAttr.getPersistentAttributeType();
                         switch (attributeType) {
                             case BASIC:
                             case ELEMENT_COLLECTION:
                                 if (attributeNamesForUpdate != null)
-                                    attributeNamesForUpdate.add(attributeName);
+                                    attributeNamesForUpdate.add(fullAttributeName);
                                 break;
                             case ONE_TO_ONE:
                             case MANY_TO_ONE:
                                 attributeNamesForUpdate = null; // must use merge instead
                                 // continue
                             case EMBEDDED:
-                                relationAttributeNames.put(attr.getJavaType(), new ArrayList<>());
-                                relationships.add(attr);
-                                relationPrefixes.add(attributeName);
-                                relationAccessors.add(Collections.singletonList(attr.getJavaMember()));
+                                relationAttributeNames.put(relAttr.getJavaType(), new ArrayList<>());
+                                relationships.add(relAttr);
+                                relationPrefixes.add(fullAttributeName);
+                                relationAccessors.add(relAccessors);
                                 break;
                             case ONE_TO_MANY:
                             case MANY_TO_MANY:
@@ -180,192 +244,122 @@ public abstract class EntityManagerBuilder {
                                 throw new RuntimeException(); // unreachable unless more types are added
                         }
 
-                        Member accessor = recordClass == null ? attr.getJavaMember() : recordClass.getMethod(attributeName);
+                        // Allow a qualified name such as @OrderBy("address.street.name")
+                        // No chance of conflicts because attributes defined on the entity cannot have a period
+                        String fullAttributeNameLower = fullAttributeName.toLowerCase();
+                        attributeNames.put(fullAttributeNameLower, fullAttributeName);
 
-                        attributeNames.put(attributeName.toLowerCase(), attributeName);
-                        attributeAccessors.put(attributeName, Collections.singletonList(accessor));
-                        attributeTypes.put(attributeName, attr.getJavaType());
-                        if (attr.isCollection()) {
-                            if (attr instanceof PluralAttribute)
-                                collectionElementTypes.put(attributeName, ((PluralAttribute<?, ?, ?>) attr).getElementType().getJavaType());
-                        } else {
-                            SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute ? (SingularAttribute<?, ?>) attr : null;
-                            if (singleAttr != null && singleAttr.isId()) {
-                                attributeNames.put(ID, attributeName);
+                        // Allow a qualified name such as findByAddress_Street_Name if it doesn't overlap
+                        // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
+                        String relationAttributeName_ = fullAttributeNameLower.replace('.', '_');
+                        String conflictingAttribute = attributeNames.putIfAbsent(relationAttributeName_, fullAttributeName);
+
+                        if (conflictingAttribute != null)
+                            throw exc(MappingException.class,
+                                      "CWWKD1075.entity.attr.conflict",
+                                      userEntityClass.getName(),
+                                      fullAttributeName,
+                                      conflictingAttribute);
+
+                        // Allow a qualified name such as findByAddressStreetName if it doesn't overlap
+                        // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
+                        String relationAttributeNameUndelimited = fullAttributeNameLower.replace(".", "");
+                        conflictingAttribute = attributeNames.putIfAbsent(relationAttributeNameUndelimited, fullAttributeName);
+
+                        // TODO need to handle the situation where a field name on the base entity conflicts with the column name
+                        // of an embeddable.  See issue: https://github.com/OpenLiberty/open-liberty/issues/29643
+
+                        // Precedence for this valid scenario is defined under
+                        // 2.9.2. Scenario 2: Customer Repository with
+                        // Resolution that requires a Delimiter
+                        if (conflictingAttribute != null && trace && tc.isDebugEnabled())
+                            Tr.debug(tc, "overlapping undelimited name " +
+                                         relationAttributeNameUndelimited +
+                                         " will resolve to basic attribute " +
+                                         conflictingAttribute + " instead of " +
+                                         fullAttributeName);
+
+                        attributeAccessors.put(fullAttributeName, relAccessors);
+
+                        attributeTypes.put(fullAttributeName, relAttr.getJavaType());
+                        if (relAttr.isCollection()) {
+                            if (relAttr instanceof PluralAttribute)
+                                collectionElementTypes.put(fullAttributeName, ((PluralAttribute<?, ?, ?>) relAttr).getElementType().getJavaType());
+                        } else if (relAttr instanceof SingularAttribute) {
+                            SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
+                            if (singleAttr.isId() && attributeNames.putIfAbsent(ID, fullAttributeName) == null) {
                                 idType = singleAttr.getJavaType();
-                            } else if (singleAttr != null && singleAttr.isVersion()) {
-                                versionAttrName = attributeName;
-                            } else if (Collection.class.isAssignableFrom(attr.getJavaType())) {
-                                // collection attribute that is not annotated with ElementCollection
-                                collectionElementTypes.put(attributeName, Object.class);
+                            } else if (singleAttr.isVersion()) {
+                                versionAttrName = relationAttributeName_; // to be suitable for query-by-method
                             }
                         }
                     }
-
-                    // Guard against recursive processing of OneToOne (and similar) relationships
-                    // by tracking whether we have already processed each entity class involved.
-                    Set<Class<?>> entityTypeClasses = new HashSet<>();
-                    entityTypeClasses.add(entityType.getJavaType());
-
-                    for (Attribute<?, ?> attr; (attr = relationships.poll()) != null;) {
-                        String prefix = relationPrefixes.poll();
-                        List<Member> accessors = relationAccessors.poll();
-                        ManagedType<?> relation = model.managedType(attr.getJavaType());
-                        if (relation instanceof EntityType && !entityTypeClasses.add(attr.getJavaType()))
-                            break;
-                        List<String> relAttributeList = relationAttributeNames.get(attr.getJavaType());
-                        for (Attribute<?, ?> relAttr : relation.getAttributes()) {
-                            String relationAttributeName = relAttr.getName();
-                            String fullAttributeName = prefix + '.' + relationAttributeName;
-                            List<Member> relAccessors = new LinkedList<>(accessors);
-                            relAccessors.add(relAttr.getJavaMember());
-                            relAttributeList.add(fullAttributeName);
-
-                            PersistentAttributeType attributeType = relAttr.getPersistentAttributeType();
-                            switch (attributeType) {
-                                case BASIC:
-                                case ELEMENT_COLLECTION:
-                                    if (attributeNamesForUpdate != null)
-                                        attributeNamesForUpdate.add(fullAttributeName);
-                                    break;
-                                case ONE_TO_ONE:
-                                case MANY_TO_ONE:
-                                    attributeNamesForUpdate = null; // must use merge instead
-                                    // continue
-                                case EMBEDDED:
-                                    relationAttributeNames.put(relAttr.getJavaType(), new ArrayList<>());
-                                    relationships.add(relAttr);
-                                    relationPrefixes.add(fullAttributeName);
-                                    relationAccessors.add(relAccessors);
-                                    break;
-                                case ONE_TO_MANY:
-                                case MANY_TO_MANY:
-                                    attributeNamesForUpdate = null; // must use merge instead
-                                    break;
-                                default:
-                                    throw new RuntimeException(); // unreachable unless more types are added
-                            }
-
-                            // Allow a qualified name such as @OrderBy("address.street.name")
-                            // No chance of conflicts because attributes defined on the entity cannot have a period
-                            String fullAttributeNameLower = fullAttributeName.toLowerCase();
-                            attributeNames.put(fullAttributeNameLower, fullAttributeName);
-
-                            // Allow a qualified name such as findByAddress_Street_Name if it doesn't overlap
-                            // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
-                            String relationAttributeName_ = fullAttributeNameLower.replace('.', '_');
-                            String conflictingAttribute = attributeNames.putIfAbsent(relationAttributeName_, fullAttributeName);
-
-                            if (conflictingAttribute != null)
-                                throw exc(MappingException.class,
-                                          "CWWKD1075.entity.attr.conflict",
-                                          userEntityClass.getName(),
-                                          fullAttributeName,
-                                          conflictingAttribute);
-
-                            // Allow a qualified name such as findByAddressStreetName if it doesn't overlap
-                            // Check for conflicts with attributes defined on the entity to avoid ambiguous queries and sorts
-                            String relationAttributeNameUndelimited = fullAttributeNameLower.replace(".", "");
-                            conflictingAttribute = attributeNames.putIfAbsent(relationAttributeNameUndelimited, fullAttributeName);
-
-                            // TODO need to handle the situation where a field name on the base entity conflicts with the column name
-                            // of an embeddable.  See issue: https://github.com/OpenLiberty/open-liberty/issues/29643
-
-                            // Precedence for this valid scenario is defined under
-                            // 2.9.2. Scenario 2: Customer Repository with
-                            // Resolution that requires a Delimiter
-                            if (conflictingAttribute != null && trace && tc.isDebugEnabled())
-                                Tr.debug(tc, "overlapping undelimited name " +
-                                             relationAttributeNameUndelimited +
-                                             " will resolve to basic attribute " +
-                                             conflictingAttribute + " instead of " +
-                                             fullAttributeName);
-
-                            attributeAccessors.put(fullAttributeName, relAccessors);
-
-                            attributeTypes.put(fullAttributeName, relAttr.getJavaType());
-                            if (relAttr.isCollection()) {
-                                if (relAttr instanceof PluralAttribute)
-                                    collectionElementTypes.put(fullAttributeName, ((PluralAttribute<?, ?, ?>) relAttr).getElementType().getJavaType());
-                            } else if (relAttr instanceof SingularAttribute) {
-                                SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
-                                if (singleAttr.isId() && attributeNames.putIfAbsent(ID, fullAttributeName) == null) {
-                                    idType = singleAttr.getJavaType();
-                                } else if (singleAttr.isVersion()) {
-                                    versionAttrName = relationAttributeName_; // to be suitable for query-by-method
-                                }
-                            }
-                        }
-                    }
-
-                    String idAttrName = attributeNames.get(ID);
-
-                    if (attributeNamesForUpdate != null) {
-                        attributeNamesForUpdate.remove(ID);
-                        if (idAttrName != null)
-                            attributeNamesForUpdate.remove(idAttrName);
-                        if (versionAttrName != null)
-                            attributeNamesForUpdate.remove(versionAttrName);
-                    }
-
-                    if (!entityType.hasSingleIdAttribute()) {
-                        // Per JavaDoc, the above means there is an IdClass.
-                        // An EclipseLink extension that allows an Id on an embeddable of an entity
-                        // is an exception to this, which we indicate with idClassType null.
-                        Type<?> idClassType = getIdType(entityType);
-                        if (idClassType != null) {
-                            @SuppressWarnings("unchecked")
-                            Set<SingularAttribute<?, ?>> idClassAttributes = (Set<SingularAttribute<?, ?>>) (Set<?>) entityType.getIdClassAttributes();
-                            if (idClassAttributes != null) {
-                                attributeNames.remove(ID);
-                                idType = idClassType.getJavaType();
-                                idClassAttributeAccessors = getIdClassAccessors(idType, idClassAttributes);
-                            }
-                        }
-                    }
-
-                    EntityInfo entityInfo = new EntityInfo( //
-                                    entityType.getName(), //
-                                    jpaEntityClass, //
-                                    recordClass, //
-                                    attributeAccessors, //
-                                    attributeNames, //
-                                    attributeNamesForUpdate, //
-                                    attributeTypes, //
-                                    collectionElementTypes, //
-                                    relationAttributeNames, //
-                                    idType, //
-                                    idClassAttributeAccessors, //
-                                    versionAttrName, //
-                                    this);
-
-                    entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture).complete(entityInfo);
-                } catch (Throwable x) { // Ignored FFDC
-                    if (!(x instanceof DataException))
-                        x = exc(CompletionException.class,
-                                "CWWKD1081.entity.general.err",
-                                userEntityClass.getName(),
-                                getClassNames(repositoryInterfaces),
-                                dataStore,
-                                x.getMessage()).initCause(x);
-                    entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture) //
-                                    .completeExceptionally(x);
                 }
-            }
 
-            if (!missingEntityTypes.isEmpty()) {
-                DataException x = exc(DataException.class,
-                                      "CWWKD1082.entity.classes.missing",
-                                      dataStore,
-                                      getClassNames(missingEntityTypes),
-                                      getClassNames(repositoryInterfaces));
-                for (Class<?> ec : missingEntityTypes)
-                    entityInfoMap.computeIfAbsent(ec, EntityInfo::newFuture) //
-                                    .completeExceptionally(x);
+                String idAttrName = attributeNames.get(ID);
+
+                if (attributeNamesForUpdate != null) {
+                    attributeNamesForUpdate.remove(ID);
+                    if (idAttrName != null)
+                        attributeNamesForUpdate.remove(idAttrName);
+                    if (versionAttrName != null)
+                        attributeNamesForUpdate.remove(versionAttrName);
+                }
+
+                if (!entityType.hasSingleIdAttribute()) {
+                    // Per JavaDoc, the above means there is an IdClass.
+                    // An EclipseLink extension that allows an Id on an embeddable of an entity
+                    // is an exception to this, which we indicate with idClassType null.
+                    Type<?> idClassType = getIdType(entityType);
+                    if (idClassType != null) {
+                        @SuppressWarnings("unchecked")
+                        Set<SingularAttribute<?, ?>> idClassAttributes = (Set<SingularAttribute<?, ?>>) (Set<?>) entityType.getIdClassAttributes();
+                        if (idClassAttributes != null) {
+                            attributeNames.remove(ID);
+                            idType = idClassType.getJavaType();
+                            idClassAttributeAccessors = getIdClassAccessors(idType, idClassAttributes);
+                        }
+                    }
+                }
+
+                EntityInfo entityInfo = new EntityInfo( //
+                                entityType.getName(), //
+                                jpaEntityClass, //
+                                recordClass, //
+                                attributeAccessors, //
+                                attributeNames, //
+                                attributeNamesForUpdate, //
+                                attributeTypes, //
+                                collectionElementTypes, //
+                                relationAttributeNames, //
+                                idType, //
+                                idClassAttributeAccessors, //
+                                versionAttrName, //
+                                this);
+
+                entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture).complete(entityInfo);
+            } catch (Throwable x) { // Ignored FFDC
+                if (!(x instanceof DataException))
+                    x = exc(CompletionException.class,
+                            "CWWKD1081.entity.general.err",
+                            userEntityClass.getName(),
+                            getClassNames(repositoryInterfaces),
+                            dataStore,
+                            x.getMessage()).initCause(x);
+                entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture) //
+                                .completeExceptionally(x);
             }
-        } finally {
-            if (em != null)
-                em.close();
+        }
+
+        if (!missingEntityTypes.isEmpty()) {
+            DataException x = exc(DataException.class,
+                                  "CWWKD1082.entity.classes.missing",
+                                  dataStore,
+                                  getClassNames(missingEntityTypes),
+                                  getClassNames(repositoryInterfaces));
+            for (Class<?> ec : missingEntityTypes)
+                entityInfoMap.computeIfAbsent(ec, EntityInfo::newFuture) //
+                                .completeExceptionally(x);
         }
     }
 
@@ -375,6 +369,8 @@ public abstract class EntityManagerBuilder {
      * @return a new EntityManager instance.
      */
     public abstract EntityManager createEntityManager();
+
+    public abstract Metamodel createMetamodel();
 
     /**
      * Returns an alphabetized comma-delimited list of the class names as text

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
@@ -31,6 +31,7 @@ import io.openliberty.data.internal.persistence.EntityManagerBuilder;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceException;
+import jakarta.persistence.metamodel.Metamodel;
 
 /**
  * This builder is used when a persistence unit reference JNDI name is configured as the repository dataStore.
@@ -78,6 +79,16 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "createEntityManager: " + em);
         return em;
+    }
+
+    @Override
+    @Trivial
+    public Metamodel createMetamodel() {
+        Metamodel mm = emf.getMetamodel();
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "createMetamodel: " + mm);
+        return mm;
     }
 
     @FFDCIgnore(PersistenceException.class)

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -82,6 +82,7 @@ import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Table;
+import jakarta.persistence.metamodel.Metamodel;
 
 /**
  * This builder is used when a data source JNDI name, id, resource reference,
@@ -516,6 +517,16 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "createEntityManager: " + em);
         return em;
+    }
+
+    @Override
+    @Trivial
+    public Metamodel createMetamodel() {
+        Metamodel mm = persistenceServiceUnit.createMetamodel();
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "createMetamodel: " + mm);
+        return mm;
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
@@ -72,6 +72,7 @@ public class DataTestCheckpoint extends FATServletClient {
         ShrinkHelper.exportAppToServer(server, providerWar);
 
         server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
+        server.startServer();
 
         // This test has expected errors during server start, but we need to ignore them in order to take a checkpoint
         server.addCheckpointRegexIgnoreMessages(DataTest.EXPECTED_ERROR_MESSAGES);

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
@@ -72,7 +72,9 @@ public class DataTestCheckpoint extends FATServletClient {
         ShrinkHelper.exportAppToServer(server, providerWar);
 
         server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
-        server.startServer();
+
+        // This test has expected errors during server start, but we need to ignore them in order to take a checkpoint
+        server.addCheckpointRegexIgnoreMessages(DataTest.EXPECTED_ERROR_MESSAGES);
 
         server.checkpointRestore();
     }

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package test.jakarta.data;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.spi.Extension;
 
@@ -36,7 +33,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.database.container.DatabaseContainerFactory;
-import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -75,15 +71,8 @@ public class DataTestCheckpoint extends FATServletClient {
                         .addAsLibrary(providerJar);
         ShrinkHelper.exportAppToServer(server, providerWar);
 
-        Map<String, String> envVars = new HashMap<>();
-        envVars.put("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
-
         server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
         server.startServer();
-
-        //Server started, application started, checkpoint taken, server is now stopped.
-        //Configure environment variable used by servlet
-        server.addEnvVarsForCheckpoint(envVars);
 
         server.checkpointRestore();
     }

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTestCheckpoint.java
@@ -72,10 +72,11 @@ public class DataTestCheckpoint extends FATServletClient {
         ShrinkHelper.exportAppToServer(server, providerWar);
 
         server.setCheckpoint(CheckpointPhase.AFTER_APP_START, false, null);
-        server.startServer();
 
         // This test has expected errors during server start, but we need to ignore them in order to take a checkpoint
         server.addCheckpointRegexIgnoreMessages(DataTest.EXPECTED_ERROR_MESSAGES);
+
+        server.startServer();
 
         server.checkpointRestore();
     }

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.checkpoint.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.checkpoint.fat/server.xml
@@ -43,7 +43,8 @@
   <!-- For all other repositories: -->
   <dataSource id="DefaultDataSource" fat.modify="true">
     <jdbcDriver libraryRef="JDBCLibrary"/>
-    <properties.derby.embedded createDatabase="create" databaseName="memory:testdb" user="dbuser1" password="dbpwd1"/>
+    <!-- createDatabase="create" -->
+    <properties.derby.embedded databaseName="memory:testdb" user="dbuser1" password="dbpwd1"/>
   </dataSource>
 
   <library id="JDBCLibrary">


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Related #29909

This pull request attempts to test different Liberty side changes we could make to avoid creating a connection to the database during EclipseLink Metamodel creation. 
The following changes were attempted: 
- Switch from getting the metamodel from the EntityManager and instead use the EntityManagerFactory
- Initialize the EntityManagerFactory with the `connectionRequired` boolean set to false

By using the debugger and running this test on a machine that supports checkpoint I was able to determine
that the creation of the metamodel in EclipseLink is tightly coupled to the creation of the EntityManagerFactory session and also the Entity Descriptors.  In short, EclipseLink creates the entire mapping layer during the Runtime Metamodel creation.  The mapping layer requires a connection to be made to the database to determine which database is being used. 