### PR TITLE
combination of java:global and qualifiers not allowed

### DIFF
--- a/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
@@ -74,6 +74,18 @@ CWWKC1207.lacks.qualifier.anno.explanation=The Qualifier annotation indicates \
 CWWKC1207.lacks.qualifier.anno.useraction=Add the @Qualifier and \
  @Retention(RUNTIME) annotations to the qualifier class.
 
+CWWKC1208.global.with.qualifiers=CWWKC1208E: The {0} application artifact \
+ specifies a {1} annotation or {2} deployment descriptor element that has the \
+ {3} name and {4} qualifiers list. The combination of qualifiers and the \
+ java:global name space is not permitted by Jakarta Concurrency. Switch to the \
+ java:app name space or remove the qualifiers from the configuration of the \
+ resource that has the {3} name.
+CWWKC1208.global.with.qualifiers.explanation=Jakarta Concurrency resource \
+ configuration cannot have both a java:global name space and qualifiers.
+CWWKC1208.global.with.qualifiers.useraction=Update the configuration of the \
+ application-defined Jakarta Concurrency resource to omit the qualifiers or \
+ use a different name space.
+
 CWWKC1217.no.virtual.threads=CWWKC1217I: The Concurrency specification requires \
  virtual=true to be ignored on the {0} application artifact's \
  {1} annotation or {2} deployment descriptor element with the {3} name \

--- a/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal/resources/io/openliberty/concurrent/internal/resources/CWWKCMessages.nlsprops
@@ -76,15 +76,15 @@ CWWKC1207.lacks.qualifier.anno.useraction=Add the @Qualifier and \
 
 CWWKC1208.global.with.qualifiers=CWWKC1208E: The {0} application artifact \
  specifies a {1} annotation or {2} deployment descriptor element that has the \
- {3} name and {4} qualifiers list. The combination of qualifiers and the \
- java:global name space is not permitted by Jakarta Concurrency. Switch to the \
- java:app name space or remove the qualifiers from the configuration of the \
- resource that has the {3} name.
-CWWKC1208.global.with.qualifiers.explanation=Jakarta Concurrency resource \
- configuration cannot have both a java:global name space and qualifiers.
+ {3} name and the {4} qualifiers list. You cannot configure a Jakarta Concurrency \
+ resource to have qualifiers and a java:global namespace at the same time. \
+ Remove the qualifiers from the configuration of the Jakarta Concurrency \
+ resource that has the {3} name or switch to the java:app namespace.
+CWWKC1208.global.with.qualifiers.explanation=The Jakarta Concurrency resource \
+ configuration cannot have qualifiers and a java:global namespace at the same time.
 CWWKC1208.global.with.qualifiers.useraction=Update the configuration of the \
  application-defined Jakarta Concurrency resource to omit the qualifiers or \
- use a different name space.
+ use a different namespace such as the java:app namespace.
 
 CWWKC1217.no.virtual.threads=CWWKC1217I: The Concurrency specification requires \
  virtual=true to be ignored on the {0} application artifact's \

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ConcurrencyResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ConcurrencyResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,21 +13,67 @@
 package io.openliberty.concurrent.internal.processor;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.resource.ResourceFactoryBuilder;
+import com.ibm.ws.runtime.metadata.ApplicationMetaData;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.runtime.metadata.MetaData;
+import com.ibm.ws.runtime.metadata.ModuleMetaData;
 
 /**
- * Super interface for all ResourceFcatoryBuilders that are provided by the
+ * Superclass for all ResourceFactoryBuilders that are provided by the
  * Concurrency component.
  */
-public interface ConcurrencyResourceFactoryBuilder extends ResourceFactoryBuilder {
+abstract class ConcurrencyResourceFactoryBuilder //
+                implements ResourceFactoryBuilder {
+    private static final TraceComponent tc = //
+                    Tr.register(ConcurrencyResourceFactoryBuilder.class);
+
+    /**
+     * Create an exception for the error condition where a java:global name is
+     * configured on an application-defined resource that also configures
+     * qualifiers.
+     *
+     * @param jndiName   JNDI name of the resource definition.
+     * @param qualifiers qualifier names.
+     * @param appName    application name.
+     * @param metadata   metadata of the application artifact.
+     * @return UnsupportedOperationException.
+     */
+    UnsupportedOperationException excJavaGlobalWithQualifiers(String jndiName,
+                                                              String[] qualifiers,
+                                                              String appName,
+                                                              MetaData metadata) {
+        String artifactName;
+        if (metadata instanceof ComponentMetaData)
+            artifactName = ((ComponentMetaData) metadata).getJ2EEName().toString();
+        else if (metadata instanceof ModuleMetaData)
+            artifactName = ((ModuleMetaData) metadata).getJ2EEName().toString();
+        else if (metadata instanceof ApplicationMetaData)
+            artifactName = ((ApplicationMetaData) metadata).getJ2EEName().toString();
+        else
+            artifactName = appName;
+
+        return new UnsupportedOperationException(Tr //
+                        .formatMessage(tc,
+                                       "CWWKC1208.global.with.qualifiers",
+                                       artifactName,
+                                       getDefinitionAnnotationClass().getSimpleName(),
+                                       getDDElementName(),
+                                       jndiName,
+                                       Arrays.toString(qualifiers)));
+    }
+
     /**
      * Returns the type of deployment descriptor element that this builder handles.
      * For example: managed-executor
      *
      * @return the type of deployment descriptor element that this builder handles.
      */
-    String getDDElementName();
+    abstract String getDDElementName();
 
     /**
      * Returns the type of resource definition annotation that this builder handles.
@@ -35,5 +81,5 @@ public interface ConcurrencyResourceFactoryBuilder extends ResourceFactoryBuilde
      *
      * @return the type of resource definition annotation that this builder handles.
      */
-    Class<? extends Annotation> getDefinitionAnnotationClass();
+    abstract Class<? extends Annotation> getDefinitionAnnotationClass();
 }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ContextServiceResourceFactoryBuilder.java
@@ -56,8 +56,8 @@ import jakarta.enterprise.concurrent.ContextServiceDefinition;
 /**
  * Creates, modifies, and removes ContextService resource factories that are defined via ContextServiceDefinition.
  */
-public class ContextServiceResourceFactoryBuilder implements //
-                ConcurrencyResourceFactoryBuilder, ResourceFactoryBuilder {
+public class ContextServiceResourceFactoryBuilder //
+                extends ConcurrencyResourceFactoryBuilder {
     private static final TraceComponent tc = Tr.register(ContextServiceResourceFactoryBuilder.class);
 
     private static final String CONTEXT_PID_ZOS_WLM = "com.ibm.ws.zos.wlm.context";
@@ -241,6 +241,11 @@ public class ContextServiceResourceFactoryBuilder implements //
         // Convert qualifier array to list attribute if present
         List<String> qualifierNames = null;
         if (qualifiers != null && qualifiers.length > 0) {
+            if (jndiName.startsWith("java:global"))
+                throw excJavaGlobalWithQualifiers(jndiName,
+                                                  qualifiers,
+                                                  declaringApplication,
+                                                  declaringMetadata);
             qualifierNames = Arrays.asList(qualifiers);
             contextSvcProps.put("qualifiers", qualifierNames);
         }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedExecutorResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2024 IBM Corporation and others.
+ * Copyright (c) 2021,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -52,8 +52,8 @@ import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
 /**
  * Creates, modifies, and removes ManagedExecutorService resource factories that are defined via ManagedExecutorDefinition.
  */
-public class ManagedExecutorResourceFactoryBuilder implements //
-                ConcurrencyResourceFactoryBuilder, ResourceFactoryBuilder {
+public class ManagedExecutorResourceFactoryBuilder //
+                extends ConcurrencyResourceFactoryBuilder {
     private static final TraceComponent tc = Tr.register(ManagedExecutorResourceFactoryBuilder.class);
 
     /**
@@ -165,6 +165,11 @@ public class ManagedExecutorResourceFactoryBuilder implements //
         // Convert qualifier array to list attribute if present
         List<String> qualifierNames = null;
         if (qualifiers != null && qualifiers.length > 0) {
+            if (jndiName.startsWith("java:global"))
+                throw excJavaGlobalWithQualifiers(jndiName,
+                                                  qualifiers,
+                                                  declaringApplication,
+                                                  declaringMetadata);
             qualifierNames = Arrays.asList(qualifiers);
             execSvcProps.put("qualifiers", qualifierNames);
         }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedScheduledExecutorResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2024 IBM Corporation and others.
+ * Copyright (c) 2021,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -53,7 +53,7 @@ import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
  * Creates, modifies, and removes ManagedScheduledExecutorService resource factories that are defined via ManagedScheduledExecutorDefinition.
  */
 public class ManagedScheduledExecutorResourceFactoryBuilder //
-                implements ConcurrencyResourceFactoryBuilder, ResourceFactoryBuilder {
+                extends ConcurrencyResourceFactoryBuilder {
     private static final TraceComponent tc = Tr.register(ManagedScheduledExecutorResourceFactoryBuilder.class);
 
     /**
@@ -165,6 +165,11 @@ public class ManagedScheduledExecutorResourceFactoryBuilder //
         // Convert qualifier array to list attribute if present
         List<String> qualifierNames = null;
         if (qualifiers != null && qualifiers.length > 0) {
+            if (jndiName.startsWith("java:global"))
+                throw excJavaGlobalWithQualifiers(jndiName,
+                                                  qualifiers,
+                                                  declaringApplication,
+                                                  declaringMetadata);
             qualifierNames = Arrays.asList(qualifiers);
             execSvcProps.put("qualifiers", qualifierNames);
         }

--- a/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
+++ b/dev/io.openliberty.concurrent.internal/src/io/openliberty/concurrent/internal/processor/ManagedThreadFactoryResourceFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2024 IBM Corporation and others.
+ * Copyright (c) 2021,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,8 +51,8 @@ import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
 /**
  * Creates, modifies, and removes ManagedThreadFactory resource factories that are defined via ManagedThreadFactoryDefinition.
  */
-public class ManagedThreadFactoryResourceFactoryBuilder implements //
-                ConcurrencyResourceFactoryBuilder, ResourceFactoryBuilder {
+public class ManagedThreadFactoryResourceFactoryBuilder //
+                extends ConcurrencyResourceFactoryBuilder {
     private static final TraceComponent tc = Tr.register(ManagedThreadFactoryResourceFactoryBuilder.class);
 
     /**
@@ -164,6 +164,11 @@ public class ManagedThreadFactoryResourceFactoryBuilder implements //
         // Convert qualifier array to list attribute if present
         List<String> qualifierNames = null;
         if (qualifiers != null && qualifiers.length > 0) {
+            if (jndiName.startsWith("java:global"))
+                throw excJavaGlobalWithQualifiers(jndiName,
+                                                  qualifiers,
+                                                  declaringApplication,
+                                                  declaringMetadata);
             qualifierNames = Arrays.asList(qualifiers);
             threadFactoryProps.put("qualifiers", qualifierNames);
         }


### PR DESCRIPTION
Resource definitions for Jakarta Concurrency resources cannot have the combination of java:global names and qualifiers. Javadoc for the resource definition annotations states this is not allowed and Liberty did not implement it either. We need to raise a meaningful error informing the use of this and how to correct their application.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".