### PR TITLE
Fix the way we generate random bytes for LTPA

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -395,15 +395,9 @@ public class CryptoUtils {
     public static byte[] generateRandomBytes(int length) {
         byte[] seed = null;
         SecureRandom rand = new SecureRandom();
+        seed = new byte[length];
+        rand.nextBytes(seed);
 
-        // TODO: Investigate hardware Crypto
-        //String hardwareCryptoProvider = "IBMJCECCA";
-        //Provider provider = rand.getProvider();
-        //if (hardwareCryptoProvider.equals(provider.getName())) {
-        //    seed = new byte[length];
-        //    rand.nextBytes(seed);
-        //} else {
-        seed = rand.generateSeed(length);
         return seed;
     }
 }


### PR DESCRIPTION
In this change, we are looking to update the way we generate random bytes for LTPA keys and audit files. Using `generateSeed()` does not work for Hardware Crypto z/OS Systems and introduces the following error.

```java
java.lang.UnsupportedOperationException com.ibm.ws.security.token.ltpa.internal.LTPAKeyCreateTask 
```


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
