### PR TITLE
remove experimental keywords

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2380,9 +2380,6 @@ public class QueryInfo {
                 if (ignoreCase = endsWith("IgnoreCas", methodName, start, endBefore - 1)) {
                     function = "LOWER(";
                     endBefore -= 10;
-                } else if (endsWith("WithMinut", methodName, start, endBefore - 1)) {
-                    function = "EXTRACT (MINUTE FROM ";
-                    endBefore -= 10;
                 } else if (endsWith("AbsoluteValu", methodName, start, endBefore - 1)) {
                     function = "ABS(";
                     endBefore -= 13;
@@ -2392,9 +2389,6 @@ public class QueryInfo {
                 if (rounded = endsWith("Rounde", methodName, start, endBefore - 1)) {
                     function = "ROUND(";
                     endBefore -= 7;
-                } else if (endsWith("WithSecon", methodName, start, endBefore - 1)) {
-                    function = "EXTRACT (SECOND FROM ";
-                    endBefore -= 10;
                 }
                 break;
             case 'n':
@@ -2409,18 +2403,6 @@ public class QueryInfo {
                     endBefore -= 9;
                 }
                 break;
-            case 'r':
-                if (endsWith("WithYea", methodName, start, endBefore - 1)) {
-                    function = "EXTRACT (YEAR FROM ";
-                    endBefore -= 8;
-                } else if (endsWith("WithHou", methodName, start, endBefore - 1)) {
-                    function = "EXTRACT (HOUR FROM ";
-                    endBefore -= 8;
-                } else if (endsWith("WithQuarte", methodName, start, endBefore - 1)) {
-                    function = "EXTRACT (QUARTER FROM ";
-                    endBefore -= 11;
-                }
-                break;
             case 't':
                 if (endsWith("CharCoun", methodName, start, endBefore - 1)) {
                     function = "LENGTH(";
@@ -2428,24 +2410,6 @@ public class QueryInfo {
                 } else if (endsWith("ElementCoun", methodName, start, endBefore - 1)) {
                     function = "SIZE(";
                     endBefore -= 12;
-                }
-                break;
-            case 'y':
-                if (endsWith("WithDa", methodName, start, endBefore - 1)) {
-                    function = "EXTRACT (DAY FROM ";
-                    endBefore -= 7;
-                }
-                break;
-            case 'h':
-                if (endsWith("WithMont", methodName, start, endBefore - 1)) {
-                    function = "EXTRACT (MONTH FROM ";
-                    endBefore -= 9;
-                }
-                break;
-            case 'k':
-                if (endsWith("WithWee", methodName, start, endBefore - 1)) {
-                    function = "EXTRACT (WEEK FROM ";
-                    endBefore -= 8;
                 }
                 break;
         }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2371,29 +2371,8 @@ public class QueryInfo {
         boolean negated = endsWith("Not", methodName, start, endBefore);
         endBefore -= (negated ? 3 : 0);
 
-        String function = null;
-        boolean ignoreCase = false;
-
-        switch (methodName.charAt(endBefore - 1)) {
-            case 'e':
-                if (ignoreCase = endsWith("IgnoreCas", methodName, start, endBefore - 1)) {
-                    function = "LOWER(";
-                    endBefore -= 10;
-                }
-                break;
-            case 't':
-                if (endsWith("CharCoun", methodName, start, endBefore - 1)) {
-                    function = "LENGTH(";
-                    endBefore -= 9;
-                } else if (endsWith("ElementCoun", methodName, start, endBefore - 1)) {
-                    function = "SIZE(";
-                    endBefore -= 12;
-                }
-                break;
-        }
-
-        boolean trimmed = endsWith("Trimmed", methodName, start, endBefore);
-        endBefore -= (trimmed ? 7 : 0);
+        boolean ignoreCase = endsWith("IgnoreCase", methodName, start, endBefore);
+        endBefore -= (ignoreCase ? 10 : 0);
 
         String attribute = methodName.substring(start, endBefore);
 
@@ -2403,16 +2382,12 @@ public class QueryInfo {
         String name = getAttributeName(attribute, true);
 
         StringBuilder attributeExpr = new StringBuilder();
-        if (function != null)
-            attributeExpr.append(function); // such as LOWER(  or  ROUND(
-        if (trimmed)
-            attributeExpr.append("TRIM(");
+        if (ignoreCase)
+            attributeExpr.append("LOWER(");
 
         appendAttributeName(name, attributeExpr);
 
-        if (trimmed)
-            attributeExpr.append(')');
-        if (function != null)
+        if (ignoreCase)
             attributeExpr.append(')');
 
         if (negated) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -2373,34 +2373,12 @@ public class QueryInfo {
 
         String function = null;
         boolean ignoreCase = false;
-        boolean rounded = false;
 
         switch (methodName.charAt(endBefore - 1)) {
             case 'e':
                 if (ignoreCase = endsWith("IgnoreCas", methodName, start, endBefore - 1)) {
                     function = "LOWER(";
                     endBefore -= 10;
-                } else if (endsWith("AbsoluteValu", methodName, start, endBefore - 1)) {
-                    function = "ABS(";
-                    endBefore -= 13;
-                }
-                break;
-            case 'd':
-                if (rounded = endsWith("Rounde", methodName, start, endBefore - 1)) {
-                    function = "ROUND(";
-                    endBefore -= 7;
-                }
-                break;
-            case 'n':
-                if (endsWith("RoundedDow", methodName, start, endBefore - 1)) {
-                    function = "FLOOR(";
-                    endBefore -= 11;
-                }
-                break;
-            case 'p':
-                if (endsWith("RoundedU", methodName, start, endBefore - 1)) {
-                    function = "CEILING(";
-                    endBefore -= 9;
                 }
                 break;
             case 't':
@@ -2435,10 +2413,7 @@ public class QueryInfo {
         if (trimmed)
             attributeExpr.append(')');
         if (function != null)
-            if (rounded)
-                attributeExpr.append(", 0)"); // round to zero digits beyond the decimal
-            else
-                attributeExpr.append(')');
+            attributeExpr.append(')');
 
         if (negated) {
             Condition negatedCondition = condition.negate();

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4920,7 +4920,7 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Use repository methods with Rounded, RoundedUp, and RoundedDown keywords.
+     * Use repository methods with ROUND, CEILING, and FLOOR functions in a Query.
      */
     @Test
     public void testRounding() {

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -485,17 +485,6 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Test the CharCount keyword to query based on string length.
-     */
-    @Test
-    public void testCharCountKeyword() {
-        assertIterableEquals(List.of("eleven", "nineteen", "seven", "thirteen", "three"),
-                             primes.findByNameCharCountBetween(5, 8)
-                                             .map(p -> p.name)
-                                             .collect(Collectors.toList()));
-    }
-
-    /**
      * Asynchronous repository method that returns a CompletableFuture of Page.
      */
     @Test
@@ -2448,6 +2437,10 @@ public class DataTestServlet extends FATServlet {
         // Equals
         assertEquals("twenty-nine", primes.findByNameIgnoreCase("Twenty-Nine").name);
 
+        Prime prime = primes.findByNameIgnoreCase(" Four Thousand Twenty-One ");
+        assertEquals(4021L, prime.numberId);
+        assertEquals(" Four thousand twenty-one ", prime.name);
+
         // Not
         assertIterableEquals(List.of("two", "five", "seven"),
                              primes.findByNameIgnoreCaseNotAndNumberIdLessThanOrderByNumberIdAsc("Three", 10)
@@ -3468,6 +3461,21 @@ public class DataTestServlet extends FATServlet {
     public void testLeftFunction() {
         assertEquals(List.of("seven", "seventeen"),
                      primes.matchLeftSideOfName("seven"));
+    }
+
+    /**
+     * Test the LENGTH JDQL function to query based on string length.
+     */
+    @Test
+    public void testLengthFunction() {
+        assertIterableEquals(List.of("eleven",
+                                     "nineteen",
+                                     "seven",
+                                     "thirteen",
+                                     "three"),
+                             primes.findByLengthOfNameBetween(5, 8)
+                                             .map(p -> p.name)
+                                             .collect(Collectors.toList()));
     }
 
     /**
@@ -6037,19 +6045,16 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Test the Trimmed keyword by querying against data that has leading and trailing blank space.
+     * Test the TRIM function by querying against data that has leading and trailing
+     * blank space.
      */
     @Test
-    public void testTrimmedKeyword() {
-        List<Prime> found = primes.findByNameTrimmedCharCountAndNumberIdBetween(24, 4000L, 4025L);
+    public void testTrimFunction() {
+        List<Prime> found = primes.withTrimmedNameLengthAndNumBetween(24, 4000L, 4025L);
         assertNotNull(found);
         assertEquals("Found: " + found, 1, found.size());
         assertEquals(4021L, found.get(0).numberId);
         assertEquals(" Four thousand twenty-one ", found.get(0).name);
-
-        Prime prime = primes.findByNameTrimmedIgnoreCase("FOUR THOUSAND TWENTY-ONE").orElseThrow();
-        assertEquals(4021L, prime.numberId);
-        assertEquals(" Four thousand twenty-one ", prime.name);
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package test.jakarta.data.web;
+
+import static jakarta.data.repository.By.ID;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -80,13 +82,16 @@ public interface Packages extends BasicRepository<Package, Integer> {
                                                                   Order<Package> order,
                                                                   PageRequest pagination);
 
-    @OrderBy(value = "id")
+    @Query("SELECT id WHERE FLOOR(height) = :height")
+    @OrderBy(ID)
     List<Integer> findIdByHeightRoundedDown(int height);
 
-    @OrderBy(value = "id")
+    @Query("SELECT id WHERE CEILING(length) = :length")
+    @OrderBy(ID)
     List<Integer> findIdByLengthRoundedUp(int length);
 
-    @OrderBy(value = "id")
+    @Query("SELECT id WHERE ROUND(width, 0) = :width")
+    @OrderBy(ID)
     List<Integer> findIdByWidthRounded(int width);
 
     @Delete

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -140,8 +140,9 @@ public interface Primes {
     @OrderBy(value = "romanNumeral", descending = true)
     List<Prime> findByHexIgnoreCaseGreaterThanAndRomanNumeralIgnoreCaseLessThanEqualAndNumberIdLessThan(String hexAbove, String maxNumeral, long numBelow);
 
+    @Query("WHERE LENGTH(name) BETWEEN ?1 AND ?2")
     @OrderBy("name")
-    Stream<Prime> findByNameCharCountBetween(int minLength, int maxLength);
+    Stream<Prime> findByLengthOfNameBetween(int minLength, int maxLength);
 
     Prime findByNameIgnoreCase(String name);
 
@@ -160,10 +161,6 @@ public interface Primes {
     @OrderBy(ID)
     Iterator<Prime> findByNameStartsWithAndNumberIdLessThanOrNameContainsAndNumberIdLessThan(String prefix, long max1, String contains, long max2,
                                                                                              PageRequest pagination);
-
-    List<Prime> findByNameTrimmedCharCountAndNumberIdBetween(int length, long min, long max);
-
-    Optional<Prime> findByNameTrimmedIgnoreCase(String name);
 
     Prime findByNumberIdBetween(long min, long max);
 
@@ -482,4 +479,6 @@ public interface Primes {
                                                  @Param("max") long maximum,
                                                  PageRequest pageRequest);
 
+    @Query("WHERE (LENGTH(TRIM(name))=?1 AND numberId BETWEEN ?2 AND ?3)")
+    List<Prime> withTrimmedNameLengthAndNumBetween(int length, long min, long max);
 }

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -265,8 +265,9 @@ public class DataExperimentalServlet extends FATServlet {
     }
 
     /**
-     * Test the ElementCount keyword by querying against a collection attribute with different sizes.
-     * Also covers WithMinute and WithSecond.
+     * Test the ElementCount function by querying for a collection attribute of
+     * different sizes. Also covers EXTRACT MINUTE and EXTRACT SECOND in a JPQL
+     * query.
      */
     @Test
     public void testElementCountAndExtract() throws Exception {
@@ -312,26 +313,26 @@ public class DataExperimentalServlet extends FATServlet {
 
         reservations.saveAll(List.of(r1, r2, r3, r4));
 
-        // ElementCount keyword
+        // ElementCount Function
 
         assertEquals(List.of("host1@openliberty.io", "host4@openliberty.io"),
-                     reservations.findByInviteesElementCount(2)
+                     reservations.withInviteeCount(2)
                                      .map(r -> r.host)
                                      .collect(Collectors.toList()));
 
         assertEquals(Collections.EMPTY_LIST,
-                     reservations.findByInviteesElementCount(0)
+                     reservations.withInviteeCount(0)
                                      .map(r -> r.host)
                                      .collect(Collectors.toList()));
-
-        // ElementCount Function
 
         assertEquals(List.of("host3@openliberty.io"),
                      reservations.withInviteeCount(3)
                                      .map(r -> r.host)
                                      .collect(Collectors.toList()));
 
-        // WithHour, WithMinute. We cannot compare the hour without knowing which time zone the database stores it in.
+        // EXTRACT HOUR, EXTRACT MINUTE.
+        // We cannot compare the hour without knowing which time zone the database
+        // stores it in. The range of 0 to 23 includes all hours.
 
         assertEquals(List.of(113001L, 213002L),
                      reservations.startingWithin(0, 23, 15));
@@ -339,7 +340,7 @@ public class DataExperimentalServlet extends FATServlet {
         assertEquals(List.of(313003L),
                      reservations.startsWithinHoursWithMinute(0, 23, 35));
 
-        // WithSecond
+        // EXTRACT SECOND
 
         assertEquals(List.of(313003L),
                      reservations.findMeetingIdStoppingAtSecond(30));

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -334,7 +334,7 @@ public class DataExperimentalServlet extends FATServlet {
         // WithHour, WithMinute. We cannot compare the hour without knowing which time zone the database stores it in.
 
         assertEquals(List.of(113001L, 213002L),
-                     reservations.findMeetingIdByStartWithHourBetweenAndStartWithMinute(0, 23, 15));
+                     reservations.startingWithin(0, 23, 15));
 
         assertEquals(List.of(313003L),
                      reservations.startsWithinHoursWithMinute(0, 23, 35));
@@ -342,7 +342,7 @@ public class DataExperimentalServlet extends FATServlet {
         // WithSecond
 
         assertEquals(List.of(313003L),
-                     reservations.findMeetingIdByStopWithSecond(30));
+                     reservations.findMeetingIdStoppingAtSecond(30));
 
         assertEquals(List.of(113001L, 213002L, 413004L),
                      reservations.endsAtSecond(0));

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
@@ -100,9 +100,6 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
 
     Iterable<Reservation> findByHost(String host);
 
-    @OrderBy(ID)
-    Stream<Reservation> findByInviteesElementCount(int size);
-
     Collection<Reservation> findByLocationContainsOrderByMeetingID(String locationSubstring);
 
     Stream<Reservation> findByMeetingIdIn(Iterable<Long> ids);

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.experimental.web;
 
+import static io.openliberty.data.repository.Is.Op.Equal;
 import static io.openliberty.data.repository.Is.Op.GreaterThanEqual;
 import static io.openliberty.data.repository.Is.Op.In;
 import static io.openliberty.data.repository.Is.Op.LessThanEqual;
@@ -159,10 +160,9 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
 
     HashSet<Reservation> findByLocationAndInviteesNotContains(String location, String noninvitee);
 
-    @OrderBy("host")
-    List<Long> findMeetingIdByStartWithHourBetweenAndStartWithMinute(int minHour, int maxHour, int minute);
-
-    List<Long> findMeetingIdByStopWithSecond(int second);
+    @Find
+    @Select("meetingId")
+    List<Long> findMeetingIdStoppingAtSecond(@By("stop") @Extract(SECOND) int second);
 
     // Use a record as the return type
     @Find
@@ -187,6 +187,13 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
     List<String> locationsThatStartWith(@By("location") @Is(Prefixed) String beginningOfLocationName);
 
     int removeByHostNotIn(Collection<String> hosts);
+
+    @Find
+    @Select("meetingId")
+    @OrderBy("host")
+    List<Long> startingWithin(@By("start") @Extract(HOUR) @Is(GreaterThanEqual) int minHour,
+                              @By("start") @Extract(HOUR) @Is(LessThanEqual) int maxHour,
+                              @By("start") @Extract(MINUTE) @Is(Equal) int minute);
 
     @Find
     @Select("meetingID")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
@@ -71,8 +71,6 @@ public interface Businesses extends BasicRepository<Business, Integer> {
     // embeddable 3 levels deep where @Column resolves name conflict
     Business[] findByLocation_Address_Street_NameIgnoreCaseEndsWithOrderByLocation_Address_Street_DirectionIgnoreCaseAscNameAsc(String streetName);
 
-    List<Business> findByLocationLongitudeAbsoluteValueBetween(float min, float max);
-
     // embeddable as result type
     @OrderBy("location.address.street")
     @OrderBy("location.address.houseNum")
@@ -107,6 +105,9 @@ public interface Businesses extends BasicRepository<Business, Integer> {
                         String streetName,
                         String streetDir,
                         String businessName);
+
+    @Query("WHERE ABS(location.longitude) BETWEEN ?1 AND ?2")
+    List<Business> longitudeAbsoluteValueBetween(float min, float max);
 
     @Find
     @OrderBy("name") // Business.name, not Business.Location.Address.Street.name

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCards.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,15 +51,19 @@ public interface CreditCards extends DataRepository<CreditCard, CardId> {
     @OrderBy("number")
     List<CreditCard> expiringInWeek(int weekNumber);
 
+    @Query("WHERE EXTRACT (QUARTER FROM expiresOn) <> :quarterToExclude")
     @OrderBy("number")
     Stream<CreditCard> findByExpiresOnWithQuarterNot(int quarterToExclude);
 
+    @Query("WHERE EXTRACT (WEEK FROM expiresOn) = :weekNumber")
     @OrderBy("number")
     List<CreditCard> findByExpiresOnWithWeek(int weekNumber);
 
+    @Query("WHERE EXTRACT (MONTH FROM expiresOn) IN :months")
     @OrderBy("number")
     Stream<CreditCard> findByIssuedOnWithMonthIn(Iterable<Integer> months);
 
+    @Query("WHERE EXTRACT (DAY FROM expiresOn) BETWEEN :minDayOfMonth AND :maxDayOfMonth")
     @OrderBy("number")
     Stream<CreditCard> findByIssuedOnWithDayBetween(int minDayOfMonth, int maxDayOfMonth);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1998,15 +1998,16 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Verify WithYear, WithQuarter, WithMonth, and WithDay Functions to compare different parts of a date.
+     * Verify EXTRACT YEAR/QUARTER/MONTH/DAY functions to compare different parts
+     * of a date.
      */
     @Test
-    public void testExtractFromDateFunctions() {
-        // WithYear
+    public void testExtractFromDateFunctions1() {
+        // EXTRACT YEAR
         assertEquals(List.of(4000921041110001L, 4000921042220002L),
                      creditCards.expiringInOrBefore(2024));
 
-        // WithQuarter
+        // EXTRACT QUARTER
         assertEquals(List.of(1000921011110001L, 1000921011120002L, 1000921011130003L,
                              2000921021110001L, 2000921022220002L,
                              3000921031110001L, 3000921032220002L, 3000921033330003L),
@@ -2014,68 +2015,80 @@ public class DataJPATestServlet extends FATServlet {
                                      .map(cc -> cc.number)
                                      .collect(Collectors.toList()));
 
-        // WithMonth
-        assertEquals(List.of(1000921011110001L, 1000921011120002L, 1000921011130003L, 4000921041110001L, 4000921042220002L),
-                     creditCards.issuedInMonth(List.of(Month.APRIL.getValue(), Month.AUGUST.getValue(), Month.JANUARY.getValue()))
+        // EXTRACT MONTH
+        assertEquals(List.of(1000921011110001L, 1000921011120002L, 1000921011130003L,
+                             4000921041110001L, 4000921042220002L),
+                     creditCards.issuedInMonth(List.of(Month.APRIL.getValue(),
+                                                       Month.AUGUST.getValue(),
+                                                       Month.JANUARY.getValue()))
                                      .map(cc -> cc.number)
                                      .collect(Collectors.toList()));
 
-        // WithDay
-        assertEquals(List.of(1000921011110001L, 2000921021110001L, 3000921031110001L, 4000921041110001L, 5000921051110001L, 6000921061110001L),
+        // EXTRACT DAY
+        assertEquals(List.of(1000921011110001L,
+                             2000921021110001L,
+                             3000921031110001L,
+                             4000921041110001L,
+                             5000921051110001L,
+                             6000921061110001L),
                      creditCards.issuedBetween(5, 15)
                                      .map(cc -> cc.number)
                                      .collect(Collectors.toList()));
     }
 
     /**
-     * Verify WithYear, WithQuarter, WithMonth, and WithDay in query-by-method-name to compare different parts of a date.
+     * Additional test coverage to verify EXTRACT YEAR/QUARTER/MONTH/DAY functions
+     * compare parts of a date.
      */
     @Test
-    public void testExtractFromDateKeywords() {
-        // WithYear
-        assertEquals(List.of(1000921011110001L, 1000921011120002L, 1000921011130003L, 4000921041110001L, 4000921042220002L, 5000921051110001L, 5000921052220002L),
+    public void testExtractFromDateFunction2() {
+        // EXTRACT YEAR
+        assertEquals(List.of(1000921011110001L, 1000921011120002L, 1000921011130003L,
+                             4000921041110001L, 4000921042220002L,
+                             5000921051110001L, 5000921052220002L),
                      creditCards.findNumberByExpiresOnWithYearLessThanEqual(2025));
 
-        // WithQuarter
-        assertEquals(List.of(4000921041110001L, 4000921042220002L, 5000921051110001L, 5000921052220002L, 6000921061110001L, 6000921062220002L),
+        // EXTRACT QUARTER
+        assertEquals(List.of(4000921041110001L, 4000921042220002L,
+                             5000921051110001L, 5000921052220002L,
+                             6000921061110001L, 6000921062220002L),
                      creditCards.findByExpiresOnWithQuarterNot(1)
                                      .map(cc -> cc.number)
                                      .collect(Collectors.toList()));
 
-        // WithMonth
-        assertEquals(List.of(2000921021110001L, 2000921022220002L, 5000921051110001L, 5000921052220002L),
-                     creditCards.findByIssuedOnWithMonthIn(List.of(Month.FEBRUARY.getValue(), Month.MAY.getValue(), Month.SEPTEMBER.getValue()))
+        // EXTRACT MONTH
+        assertEquals(List.of(2000921021110001L, 2000921022220002L,
+                             5000921051110001L, 5000921052220002L),
+                     creditCards.findByIssuedOnWithMonthIn(List.of(Month.FEBRUARY.getValue(),
+                                                                   Month.MAY.getValue(),
+                                                                   Month.SEPTEMBER.getValue()))
                                      .map(cc -> cc.number)
                                      .collect(Collectors.toList()));
 
-        // WithDay
-        assertEquals(List.of(1000921011120002L, 2000921022220002L, 3000921032220002L, 4000921042220002L, 5000921052220002L, 6000921062220002L),
+        // EXTRACT DAY
+        assertEquals(List.of(1000921011120002L, 2000921022220002L,
+                             3000921032220002L,
+                             4000921042220002L,
+                             5000921052220002L,
+                             6000921062220002L),
                      creditCards.findByIssuedOnWithDayBetween(20, 29)
                                      .map(cc -> cc.number)
                                      .collect(Collectors.toList()));
     }
 
     /**
-     * Verify WithWeek Function to compare the week-of-year part of a date.
+     * Verify the EXTRACT WEEK function to compare the week-of-year part of a date.
      */
     @OnlyIfSysProp(DB_Not_Default) // Derby doesn't support a WEEK function in SQL
     @Test
     public void testExtractWeekFromDateFunction() {
-        // WithWeek
+        // EXTRACT WEEK
         List<CreditCard> results = creditCards.expiringInWeek(15);
 
         assertEquals(1, results.size());
         assertEquals(4000921041110001L, results.get(0).number);
-    }
 
-    /**
-     * Verify WithWeek in query-by-method-name to compare the week-of-year part of a date.
-     */
-    @OnlyIfSysProp(DB_Not_Default) // Derby doesn't support a WEEK function in SQL
-    @Test
-    public void testExtractWeekFromDateKeyword() {
-        // WithWeek
-        List<CreditCard> results = creditCards.findByExpiresOnWithWeek(17);
+        results = creditCards.findByExpiresOnWithWeek(17);
 
         assertEquals(1, results.size());
         assertEquals(4000921042220002L, results.get(0).number);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -289,11 +289,13 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Test the AbsoluteValue keyword by querying on values that could be positive or negative.
+     * Test that the ABS JDQL function can be used in a Query with the BETWEEN
+     * operation, and that it queries on values that could be positive or negative.
      */
     @Test
-    public void testAbsoluteValueKeyword() {
-        List<Business> found = businesses.findByLocationLongitudeAbsoluteValueBetween(92.503f, 92.504f);
+    public void testAbsoluteValueFunctionBetween() {
+        List<Business> found = businesses.longitudeAbsoluteValueBetween(92.503f,
+                                                                        92.504f);
         assertNotNull(found);
         assertEquals("Found " + found.toString(), 1, found.size());
         assertEquals("IBM", found.get(0).name);


### PR DESCRIPTION
Remove various Query by Method Name keywords that were experimented with but did not end up in Jakarta Data.
In some cases, repository methods in the tests that were using the now removed keywords have been switched to use JDQL or JPQL with `@Query` or to use other annotations. Otherwise, where there is too much duplication, the corresponding test code was just removed.  Some tests and test repository methods were renamed to better reflect what is now being tested.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
