### PR TITLE
disable agent test on zos

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent129Test.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent129Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package io.openliberty.microprofile.telemetry.internal.tests;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
 import static io.openliberty.microprofile.telemetry.internal.utils.TestUtils.findOneFrom;
 import static io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient.convertByteString;
 import static io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerSpanMatcher.hasKind;
@@ -50,6 +51,7 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
@@ -70,6 +72,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
  */
 @RunWith(FATRunner.class)
 @MaximumJavaLevel(javaLevel = 20)
+@SkipIfSysProp(OS_ZOS) //Agent129 crashes on ZOS because it tries to read /proc as UTF-8
 public class Agent129Test {
 
     private static final Class<Agent129Test> c = Agent129Test.class;
@@ -81,7 +84,7 @@ public class Agent129Test {
 
     private static KeyPairs keyPairs = new KeyPairs(server);
 
-    public static JaegerContainer jaegerContainer = new JaegerContainer(keyPairs.getCertificate(),keyPairs.getKey()).withLogConsumer(new SimpleLogConsumer(Agent129Test.class,
+    public static JaegerContainer jaegerContainer = new JaegerContainer(keyPairs.getCertificate(), keyPairs.getKey()).withLogConsumer(new SimpleLogConsumer(Agent129Test.class,
                                                                                                                                                             "jaeger"));
     public static RepeatTests repeat = TelemetryActions.telemetry11Repeats(SERVER_NAME);
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent250Test.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/Agent250Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package io.openliberty.microprofile.telemetry.internal.tests;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
 import static io.openliberty.microprofile.telemetry.internal.utils.TestUtils.findOneFrom;
 import static io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient.convertByteString;
 import static io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerSpanMatcher.hasKind;
@@ -44,13 +45,13 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
-import org.testcontainers.containers.Network;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
@@ -71,6 +72,7 @@ import io.opentelemetry.semconv.SemanticAttributes;
  */
 @RunWith(FATRunner.class)
 @MaximumJavaLevel(javaLevel = 20)
+@SkipIfSysProp(OS_ZOS) //Agent250 crashes on ZOS because it tries to read /proc as UTF-8
 public class Agent250Test {
 
     private static final Class<Agent250Test> c = Agent250Test.class;
@@ -171,7 +173,7 @@ public class Agent250Test {
         Span span = findOneFrom(spans, hasNoParent());
 
         if (TelemetryActions.mpTelemetry20EE7orEE8IsActive()) {
-                        assertThat(span, JaegerSpanMatcher.isSpan().withTraceId(traceId)
+            assertThat(span, JaegerSpanMatcher.isSpan().withTraceId(traceId)
                                               .withAttribute(SemanticAttributes.HTTP_ROUTE, "/agentTest")
                                               .withAttribute(SemanticAttributes.HTTP_REQUEST_METHOD, "GET"));
         } else {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigMultiAppTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigMultiAppTest.java
@@ -13,6 +13,7 @@
 package io.openliberty.microprofile.telemetry.internal.tests;
 
 import static io.openliberty.microprofile.telemetry.internal.utils.TestUtils.findOneFrom;
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
 import static io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerSpanMatcher.hasKind;
 import static io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerSpanMatcher.hasName;
 import static io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerSpanMatcher.hasNoParent;
@@ -43,6 +44,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
@@ -71,6 +73,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 @MaximumJavaLevel(javaLevel = 20)
+@SkipIfSysProp(OS_ZOS) //Agent119, 129, and 250 crashes on ZOS because it tries to read /proc as UTF-8
 public class AgentConfigMultiAppTest {
 
     public static final String SERVER_NAME = "TelemetryAgentMultiAppConfig";

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentConfigTest.java
@@ -13,6 +13,7 @@
 package io.openliberty.microprofile.telemetry.internal.tests;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
 import static io.openliberty.microprofile.telemetry.internal.utils.TestConstants.NULL_TRACE_ID;
 import static io.openliberty.microprofile.telemetry.internal.utils.TestUtils.findOneFrom;
 import static io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerSpanMatcher.hasKind;
@@ -47,6 +48,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
@@ -74,6 +76,7 @@ import io.openliberty.microprofile.telemetry.internal_fat.shared.TelemetryAction
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 @MaximumJavaLevel(javaLevel = 20)
+@SkipIfSysProp(OS_ZOS) //Agent119, 129, and 250 crashes on ZOS because it tries to read /proc as UTF-8
 public class AgentConfigTest {
 
     private static final String SERVER_NAME = "TelemetryAgentConfig";

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/AgentTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package io.openliberty.microprofile.telemetry.internal.tests;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
 import static io.openliberty.microprofile.telemetry.internal.utils.TestUtils.findOneFrom;
 import static io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerQueryClient.convertByteString;
 import static io.openliberty.microprofile.telemetry.internal.utils.jaeger.JaegerSpanMatcher.hasKind;
@@ -50,6 +51,7 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.MicroProfileActions;
@@ -71,6 +73,7 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
  */
 @RunWith(FATRunner.class)
 @MaximumJavaLevel(javaLevel = 20)
+@SkipIfSysProp(OS_ZOS) //Agent129 crashes on ZOS because it tries to read /proc as UTF-8
 public class AgentTest {
 
     private static final Class<AgentTest> c = AgentTest.class;


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Disables agent test on ZOS because the java agent version we use tries to read /proc in UTF-8

Fixes #31220