### PR TITLE
feat: add websphere automation internal repository

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/containers/registry/InternalRegistry.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/registry/InternalRegistry.java
@@ -45,8 +45,9 @@ public class InternalRegistry extends Registry {
     static {
         REGISTRY_MIRRORS.put("NONE", "wasliberty-infrastructure-docker"); // images we cache (from sources like dockerhub)
 //        REGISTRY_MIRRORS.put("NONE", "wasliberty-internal-docker-remote"); //TODO replace with a more standard naming scheme
-        REGISTRY_MIRRORS.put("UNSUPPORTED", "wasliberty-intops-docker-local"); // TODO drop support for this local repository
-        REGISTRY_MIRRORS.put("localhost", "wasliberty-internal-docker-local"); // images we build
+        REGISTRY_MIRRORS.put("UNSUPPORTED_INTOPS", "wasliberty-intops-docker-local"); // TODO drop support for this local repository
+        REGISTRY_MIRRORS.put("UNSUPPORTED_AUTOMA", "websphere-automation"); // Images built from external projects (unsupported by liberty dev)
+        REGISTRY_MIRRORS.put("localhost", "wasliberty-internal-docker-local"); // Images we build from Dockerfiles
     }
 
     private static File CONFIG_DIR = DEFAULT_CONFIG_DIR;

--- a/dev/fattest.simplicity/src/componenttest/containers/substitution/LibertyMirrorSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/substitution/LibertyMirrorSubstitutor.java
@@ -49,8 +49,6 @@ public class LibertyMirrorSubstitutor extends ImageNameSubstitutor {
 
     private static final Class<?> c = LibertyMirrorSubstitutor.class;
 
-    private static final String MIRROR_PREFIX = "wasliberty-";
-
     @Override
     public DockerImageName apply(final DockerImageName original) {
         final String m = "apply";
@@ -58,13 +56,13 @@ public class LibertyMirrorSubstitutor extends ImageNameSubstitutor {
         final String repository;
         final String reason;
 
-        // Docker image was already defined in a mirror (only valid for WebSphere Liberty tests)
-        if (original.getRepository().startsWith(MIRROR_PREFIX)) {
-            return original; // Already in a mirror, return original
-        }
-
         Registry artifactory = ArtifactoryRegistry.instance();
         Registry internal = InternalRegistry.instance();
+
+        // Docker image was already defined in an internal mirror (only valid for WebSphere Liberty tests)
+        if (internal.supportsRepository(original)) {
+            return original; // Already in a mirror, return original
+        }
 
         if (artifactory.supportsRegistry(original)) {
             repository = artifactory.getMirrorRepository(original) + "/" + original.getRepository();

--- a/dev/fattest.simplicity/test/componenttest/containers/registry/ArtifactoryRegistryTest.java
+++ b/dev/fattest.simplicity/test/componenttest/containers/registry/ArtifactoryRegistryTest.java
@@ -188,11 +188,11 @@ public class ArtifactoryRegistryTest {
         testMap.put(DockerImageName.parse("wasliberty-icr-docker-remote/rhel:1.0"), Boolean.TRUE);
         testMap.put(DockerImageName.parse("wasliberty-mcr-docker-remote/debian:5.3.0"), Boolean.TRUE);
         testMap.put(DockerImageName.parse("wasliberty-aws-docker-remote/suse:4.5"), Boolean.TRUE);
-//        testMap.put(DockerImageName.parse("wasliberty-quay-docker-remote/fedora:8.7"), Boolean.TRUE);
+        testMap.put(DockerImageName.parse("wasliberty-quay-docker-remote/fedora:8.7"), Boolean.TRUE);
 
         // Unsupported repositories
         testMap.put(DockerImageName.parse("wasliberty-infrastructure-docker/arch:6.6"), Boolean.FALSE);
-        testMap.put(DockerImageName.parse("wasliberty-intops-docker-local/centos:5.4"), Boolean.FALSE);
+        testMap.put(DockerImageName.parse("websphere-automation/centos:5.4"), Boolean.FALSE);
         testMap.put(DockerImageName.parse("wasliberty-internal-docker-local/mint:4.12"), Boolean.FALSE);
 
         // Generated images

--- a/dev/fattest.simplicity/test/componenttest/containers/registry/InternalRegistryTest.java
+++ b/dev/fattest.simplicity/test/componenttest/containers/registry/InternalRegistryTest.java
@@ -161,7 +161,7 @@ public class InternalRegistryTest {
         Map<DockerImageName, Boolean> testMap = new HashMap<>();
         // Supported repositories
         testMap.put(DockerImageName.parse("wasliberty-infrastructure-docker/arch:6.6"), Boolean.TRUE);
-        testMap.put(DockerImageName.parse("wasliberty-intops-docker-local/centos:5.4"), Boolean.TRUE);
+        testMap.put(DockerImageName.parse("websphere-automation/centos:5.4"), Boolean.TRUE);
         testMap.put(DockerImageName.parse("wasliberty-internal-docker-local/mint:4.12"), Boolean.TRUE);
 
         // Unsupported repositories

--- a/dev/fattest.simplicity/test/componenttest/containers/substitution/LibertyMirrorSubstitutorTest.java
+++ b/dev/fattest.simplicity/test/componenttest/containers/substitution/LibertyMirrorSubstitutorTest.java
@@ -55,7 +55,7 @@ public class LibertyMirrorSubstitutorTest {
     public void testAlreadyMirrored() {
         LibertyMirrorSubstitutor substitutor = new LibertyMirrorSubstitutor();
 
-        DockerImageName expected = DockerImageName.parse("wasliberty-intops-docker-local/websphere/internal/image:1.0");
+        DockerImageName expected = DockerImageName.parse("websphere-automation/websphere/internal/image:1.0");
         DockerImageName actual = substitutor.apply(expected);
 
         assertEquals("Already mirrored images should have been the same after substitution.",


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Add entry for new for `websphere-automation` repository.
Update unit tests to reflect change.
Fix broken standard for repository prefix
