### PR TITLE
Do instrumentation within javaCompile

### DIFF
--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -157,11 +157,8 @@ compileJava {
 
   options.warnings = false
   options.fork = true
-}
-
-if (!bnd.project.isNoBundles() && !parseBoolean(bnd.get('instrument.disabled', 'false'))) {
-  task instrument {
-    dependsOn compileJava
+  
+  if (!bnd.project.isNoBundles() && !parseBoolean(bnd.get('instrument.disabled', 'false'))) {
     inputs.files { rasInstrumentationInputFiles() }
     outputs.dir compileJava.destinationDir
     def instrument = fileTree(dir: compileJava.destinationDir, include: bnd.get('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd.get('instrument.classesExcludes').split("\\s*,\\s*"))
@@ -174,8 +171,6 @@ if (!bnd.project.isNoBundles() && !parseBoolean(bnd.get('instrument.disabled', '
       }
     }
   }
-  compileTestJava.dependsOn(instrument)
-  jar.dependsOn(instrument)
 }
 
 tasks.withType(Test) configureEach {


### PR DESCRIPTION
If two tasks update the same files, it breaks gradle's up-to-date check for those tasks, meaning that it will always re-run them when doing a build.

Merge `instrument` and `compileJava` so that there's only one task responsible for writing the class files.

The current code was changed in #20783 (ebf1fa79) to fix an instrumentation problem, so we need to make sure this change doesn't regress that.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

