### PR TITLE
feat: add support for websphere automation testing

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/containers/registry/InternalRegistry.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/registry/InternalRegistry.java
@@ -45,8 +45,7 @@ public class InternalRegistry extends Registry {
     static {
         REGISTRY_MIRRORS.put("NONE", "wasliberty-infrastructure-docker"); // images we cache (from sources like dockerhub)
 //        REGISTRY_MIRRORS.put("NONE", "wasliberty-internal-docker-remote"); //TODO replace with a more standard naming scheme
-        REGISTRY_MIRRORS.put("UNSUPPORTED_INTOPS", "wasliberty-intops-docker-local"); // TODO drop support for this local repository
-        REGISTRY_MIRRORS.put("UNSUPPORTED_AUTOMA", "websphere-automation"); // Images built from external projects (unsupported by liberty dev)
+        REGISTRY_MIRRORS.put("UNSUPPORTED", "websphere-automation"); // Images built from external projects (unsupported by liberty dev)
         REGISTRY_MIRRORS.put("localhost", "wasliberty-internal-docker-local"); // Images we build from Dockerfiles
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Follow up to https://github.com/OpenLiberty/open-liberty/pull/31237
Remove deprecated `wasliberty-intops-docker-local` repository
