### PR TITLE
Translatable message when invalid keyword used for collection attribute

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1112,3 +1112,13 @@ CWWKD1109.jpa.anno.on.record.explanation=Jakarta Persistence annotations \
 CWWKD1109.jpa.anno.on.record.useraction=Switch to a Jakarta Persistence \
  entity class or remove the Jakarta Persistence annotation from the \
  Java record.
+
+CWWKD1110.incompat.with.collection=CWWKD1110E: The {0} method of the \
+ {1} repository interface has a name that includes the {2} keyword, which is \
+ incompatible with the {3} attribute of the {4} entity because the attribute \
+ has a collection type. The following Query by Method Name keywords can be \
+ used with entity attributes that have a collection type: {5}.
+CWWKD1110.incompat.with.collection.explanation=Some of the Query by Method Name \
+ keywords are not compatible with entity attributes that have a collection type.
+CWWKD1110.incompat.with.collection.useraction=Update the repository method \
+ to avoid using the keyword that is not compatible with the collection type.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -47,13 +47,47 @@ import jakarta.persistence.TypedQuery;
 public class CursoredPageImpl<T> implements CursoredPage<T> {
     private static final TraceComponent tc = Tr.register(CursoredPageImpl.class);
 
+    /**
+     * Values that are supplied when invoking the repository method that
+     * requests the cursored page.
+     */
     private final Object[] args;
+
+    /**
+     * Indicates the direction of pagination relative to a cursor.
+     * In the case of a first page requested with offset pagination,
+     * where there is no cursor, the direction is forward.
+     */
     private final boolean isForward;
+
+    /**
+     * The request for this page.
+     */
     private final PageRequest pageRequest;
+
+    /**
+     * Query information.
+     */
     private final QueryInfo queryInfo;
+
+    /**
+     * Results of the query for this page.
+     */
     private final List<T> results;
+
+    /**
+     * Total number of elements across all pages. This value is computed lazily,
+     * with -1 indicating it has not been computed yet.
+     */
     private long totalElements = -1;
 
+    /**
+     * Construct a new CursoredPage.
+     *
+     * @param queryInfo   query information.
+     * @param pageRequest the request for this page.
+     * @param args        values that are supplied to the repository method.
+     */
     @FFDCIgnore(Exception.class)
     @Trivial // avoid tracing customer data
     CursoredPageImpl(QueryInfo queryInfo, PageRequest pageRequest, Object[] args) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -39,12 +39,40 @@ import jakarta.persistence.TypedQuery;
 public class PageImpl<T> implements Page<T> {
     private static final TraceComponent tc = Tr.register(PageImpl.class);
 
+    /**
+     * Values that are supplied when invoking the repository method that
+     * requests the page.
+     */
     private final Object[] args;
+
+    /**
+     * The request for this page.
+     */
     private final PageRequest pageRequest;
+
+    /**
+     * Query information.
+     */
     private final QueryInfo queryInfo;
+
+    /**
+     * Results of the query for this page.
+     */
     private final List<T> results;
+
+    /**
+     * Total number of elements across all pages. This value is computed lazily,
+     * with -1 indicating it has not been computed yet.
+     */
     private long totalElements = -1;
 
+    /**
+     * Construct a new Page.
+     *
+     * @param queryInfo   query information.
+     * @param pageRequest the request for this page.
+     * @param args        values that are supplied to the repository method.
+     */
     @FFDCIgnore(Exception.class)
     @Trivial
     PageImpl(QueryInfo queryInfo, PageRequest pageRequest, Object[] args) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import static io.openliberty.data.internal.persistence.Condition.IgnoreCase;
+import static io.openliberty.data.internal.persistence.Condition.Not;
 import static io.openliberty.data.internal.persistence.Util.SORT_PARAM_TYPES;
 import static io.openliberty.data.internal.persistence.Util.lifeCycleReturnTypes;
 import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
@@ -2299,23 +2301,27 @@ public class QueryInfo {
     /**
      * Generates JPQL for a *By condition such as MyColumn[IgnoreCase][Not]Like
      */
-    private void generateCondition(String methodName, int start, int endBefore, StringBuilder q) {
+    private void generateCondition(String methodName,
+                                   int start,
+                                   int endBefore,
+                                   StringBuilder q) {
         int length = endBefore - start;
 
-        Condition condition = Condition.EQUALS;
+        Condition condition = Condition.Equal;
         switch (methodName.charAt(endBefore - 1)) {
             case 'n': // GreaterThan | LessThan | In | Between
                 if (length > 2) {
                     char ch = methodName.charAt(endBefore - 2);
                     if (ch == 'a') { // GreaterThan | LessThan
                         if (endsWith("GreaterTh", methodName, start, endBefore - 2))
-                            condition = Condition.GREATER_THAN;
+                            condition = Condition.GreaterThan;
                         else if (endsWith("LessTh", methodName, start, endBefore - 2))
-                            condition = Condition.LESS_THAN;
+                            condition = Condition.LessThan;
                     } else if (ch == 'I') { // In
-                        condition = Condition.IN;
-                    } else if (ch == 'e' && endsWith("Betwe", methodName, start, endBefore - 2)) {
-                        condition = Condition.BETWEEN;
+                        condition = Condition.In;
+                    } else if (ch == 'e' &&
+                               endsWith("Betwe", methodName, start, endBefore - 2)) {
+                        condition = Condition.Between;
                     }
                 }
                 break;
@@ -2324,11 +2330,13 @@ public class QueryInfo {
                     char ch = methodName.charAt(endBefore - 2);
                     if (ch == 'a') { // GreaterThanEqual | LessThanEqual
                         if (endsWith("GreaterThanEqu", methodName, start, endBefore - 2))
-                            condition = Condition.GREATER_THAN_EQUAL;
+                            condition = Condition.GreaterThanEqual;
                         else if (endsWith("LessThanEqu", methodName, start, endBefore - 2))
-                            condition = Condition.LESS_THAN_EQUAL;
-                    } else if (ch == 'l' & methodName.charAt(endBefore - 3) == 'u' && methodName.charAt(endBefore - 4) == 'N') {
-                        condition = Condition.NULL;
+                            condition = Condition.LessThanEqual;
+                    } else if (ch == 'l' &&
+                               methodName.charAt(endBefore - 3) == 'u' &&
+                               methodName.charAt(endBefore - 4) == 'N') {
+                        condition = Condition.Null;
                     }
                 }
                 break;
@@ -2336,13 +2344,15 @@ public class QueryInfo {
                 if (length > 4) {
                     char ch = methodName.charAt(endBefore - 4);
                     if (ch == 'L') {
-                        if (methodName.charAt(endBefore - 3) == 'i' && methodName.charAt(endBefore - 2) == 'k')
-                            condition = Condition.LIKE;
+                        if (methodName.charAt(endBefore - 3) == 'i' &&
+                            methodName.charAt(endBefore - 2) == 'k')
+                            condition = Condition.Like;
                     } else if (ch == 'T') {
-                        if (methodName.charAt(endBefore - 3) == 'r' && methodName.charAt(endBefore - 2) == 'u')
-                            condition = Condition.TRUE;
+                        if (methodName.charAt(endBefore - 3) == 'r' &&
+                            methodName.charAt(endBefore - 2) == 'u')
+                            condition = Condition.True;
                     } else if (endsWith("Fals", methodName, start, endBefore - 1)) {
-                        condition = Condition.FALSE;
+                        condition = Condition.False;
                     }
                 }
                 break;
@@ -2351,27 +2361,28 @@ public class QueryInfo {
                     char ch = methodName.charAt(endBefore - 8);
                     if (ch == 'E') {
                         if (endsWith("ndsWit", methodName, start, endBefore - 1))
-                            condition = Condition.ENDS_WITH;
-                    } else if (endBefore > 10 && ch == 'a' && endsWith("StartsWit", methodName, start, endBefore - 1)) {
-                        condition = Condition.STARTS_WITH;
+                            condition = Condition.EndsWith;
+                    } else if (endBefore > 10 && ch == 'a' &&
+                               endsWith("StartsWit", methodName, start, endBefore - 1)) {
+                        condition = Condition.StartsWith;
                     }
                 }
                 break;
             case 's': // Contains
                 if (endsWith("Contain", methodName, start, endBefore - 1))
-                    condition = Condition.CONTAINS;
+                    condition = Condition.Contains;
                 break;
             case 'y': // Empty
                 if (endsWith("Empt", methodName, start, endBefore - 1))
-                    condition = Condition.EMPTY;
+                    condition = Condition.Empty;
         }
 
         endBefore -= condition.length;
 
-        boolean negated = endsWith("Not", methodName, start, endBefore);
+        boolean negated = endsWith(Not.name(), methodName, start, endBefore);
         endBefore -= (negated ? 3 : 0);
 
-        boolean ignoreCase = endsWith("IgnoreCase", methodName, start, endBefore);
+        boolean ignoreCase = endsWith(IgnoreCase.name(), methodName, start, endBefore);
         endBefore -= (ignoreCase ? 10 : 0);
 
         String attribute = methodName.substring(start, endBefore);
@@ -2399,57 +2410,82 @@ public class QueryInfo {
         }
 
         boolean isCollection = entityInfo.collectionElementTypes.containsKey(name);
-        if (isCollection)
-            condition.verifyCollectionsSupported(name, ignoreCase);
+        if (isCollection && (ignoreCase || !condition.supportsCollections))
+            throw exc(MappingException.class,
+                      "CWWKD1110.incompat.with.collection",
+                      method.getName(),
+                      repositoryInterface.getName(),
+                      ignoreCase ? IgnoreCase.name() : condition.name(),
+                      name,
+                      entityInfo.getType().getName(),
+                      Condition.supportedForCollections());
 
         switch (condition) {
-            case STARTS_WITH:
-                q.append(attributeExpr).append(negated ? " NOT " : " ").append("LIKE CONCAT(");
+            case StartsWith:
+                q.append(attributeExpr) //
+                                .append(negated ? " NOT " : " ") //
+                                .append("LIKE CONCAT(");
                 generateParam(q, ignoreCase, ++jpqlParamCount).append(", '%')");
                 break;
-            case ENDS_WITH:
-                q.append(attributeExpr).append(negated ? " NOT " : " ").append("LIKE CONCAT('%', ");
+            case EndsWith:
+                q.append(attributeExpr) //
+                                .append(negated ? " NOT " : " ") //
+                                .append("LIKE CONCAT('%', ");
                 generateParam(q, ignoreCase, ++jpqlParamCount).append(")");
                 break;
-            case LIKE:
-                q.append(attributeExpr).append(negated ? " NOT " : " ").append("LIKE ");
+            case Like:
+                q.append(attributeExpr) //
+                                .append(negated ? " NOT " : " ") //
+                                .append("LIKE ");
                 generateParam(q, ignoreCase, ++jpqlParamCount);
                 break;
-            case BETWEEN:
-                q.append(attributeExpr).append(negated ? " NOT " : " ").append("BETWEEN ");
+            case Between:
+                q.append(attributeExpr) //
+                                .append(negated ? " NOT " : " ") //
+                                .append("BETWEEN ");
                 generateParam(q, ignoreCase, ++jpqlParamCount).append(" AND ");
                 generateParam(q, ignoreCase, ++jpqlParamCount);
                 break;
-            case CONTAINS:
+            case Contains:
                 if (isCollection) {
-                    q.append(" ?").append(++jpqlParamCount).append(negated ? " NOT " : " ").append("MEMBER OF ").append(attributeExpr);
+                    q.append(" ?").append(++jpqlParamCount) //
+                                    .append(negated ? " NOT " : " ") //
+                                    .append("MEMBER OF ").append(attributeExpr);
                 } else {
-                    q.append(attributeExpr).append(negated ? " NOT " : " ").append("LIKE CONCAT('%', ");
+                    q.append(attributeExpr) //
+                                    .append(negated ? " NOT " : " ") //
+                                    .append("LIKE CONCAT('%', ");
                     generateParam(q, ignoreCase, ++jpqlParamCount).append(", '%')");
                 }
                 break;
-            case NULL:
-            case NOT_NULL:
-            case TRUE:
-            case FALSE:
+            case Null:
+            case NotNull:
+            case True:
+            case False:
                 q.append(attributeExpr).append(condition.operator);
                 break;
-            case EMPTY:
-                q.append(attributeExpr).append(isCollection ? Condition.EMPTY.operator : Condition.NULL.operator);
+            case Empty:
+                q.append(attributeExpr).append(isCollection //
+                                ? Condition.Empty.operator //
+                                : Condition.Null.operator);
                 break;
-            case NOT_EMPTY:
-                q.append(attributeExpr).append(isCollection ? Condition.NOT_EMPTY.operator : Condition.NOT_NULL.operator);
+            case NotEmpty:
+                q.append(attributeExpr).append(isCollection //
+                                ? Condition.NotEmpty.operator //
+                                : Condition.NotNull.operator);
                 break;
-            case IN:
+            case In:
                 if (ignoreCase)
                     throw exc(UnsupportedOperationException.class,
                               "CWWKD1074.qbmn.incompat.keywords",
                               method.getName(),
                               repositoryInterface.getName(),
-                              "IgnoreCase",
-                              "In");
+                              IgnoreCase.name(),
+                              condition.name());
             default:
-                q.append(attributeExpr).append(negated ? " NOT " : "").append(condition.operator);
+                q.append(attributeExpr) //
+                                .append(negated ? " NOT " : "") //
+                                .append(condition.operator);
                 generateParam(q, ignoreCase, ++jpqlParamCount);
         }
     }
@@ -4901,7 +4937,7 @@ public class QueryInfo {
             boolean ignoreCase;
             boolean descending = iNext > 0 && iNext == desc;
             int endBefore = iNext < 0 ? methodName.length() : iNext;
-            if (ignoreCase = endsWith("IgnoreCase", methodName, i, endBefore))
+            if (ignoreCase = endsWith(IgnoreCase.name(), methodName, i, endBefore))
                 endBefore -= 10;
 
             String attribute = methodName.substring(i, endBefore);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -3835,6 +3835,52 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Test implementation of methods that a repository inherits from
+     * java.lang.Object, some of which go through the proxy handler.
+     */
+    @SuppressWarnings("unlikely-arg-type")
+    @Test
+    public void testObjectMethods() throws InterruptedException {
+        // .equals is true for same instance and false for other instance
+        assertEquals(true, people.equals(people));
+        assertEquals(false, people.equals(personnel));
+
+        // .getClass returns the repository interface
+        assertEquals(true, People.class.isAssignableFrom(people.getClass()));
+
+        // .hashCode returns same value each time invoked
+        int hash = people.hashCode();
+        assertEquals(hash, people.hashCode());
+
+        // .notify and .notifyAll
+        synchronized (people) {
+            people.notify();
+            people.notifyAll();
+        }
+
+        // .toString
+        String str = people.toString();
+        assertEquals(str,
+                     true,
+                     str.contains(People.class.getName()));
+
+        // .wait
+        synchronized (people) {
+            people.wait(20); // 20 ms
+            people.wait(10, 500000); // 10.5 ms
+            Thread.currentThread().interrupt();
+            try {
+                // wait until interrupted, which should be immediately per above
+                people.wait();
+            } catch (InterruptedException x) {
+                // expected
+            } finally {
+                Thread.interrupted();
+            }
+        }
+    }
+
+    /**
      * Verify a repository method that supplies id(this) as the sort criteria
      * hard coded within a JDQL query.
      */

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -118,7 +118,9 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1104E.*inWard", // @Param with empty string value
                                    "CWWKD1105E.*findByNameNotNullOrderByDescriptionAsc", // keyword in OrderBy
                                    "CWWKD1108E.*Invitation", // JPA entity lacks @Entity
-                                   "CWWKD1109E.*Investment" // Record entity has JPA anno
+                                   "CWWKD1109E.*Investment", // Record entity has JPA anno
+                                   "CWWKD1110E.*findByEmailAddressesGreaterThanEqual", // collection >=
+                                   "CWWKD1110E.*findByEmailAddressesIgnoreCaseContains" // collection IgnoreCase
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -146,11 +146,14 @@ public class DataErrPathsTestServlet extends FATServlet {
 
                 em.persist(new Voter(987665432, "Vivian", //
                                 LocalDate.of(1971, Month.OCTOBER, 1), //
-                                "701 Silver Creek Rd NE, Rochester, MN 55906"));
+                                "701 Silver Creek Rd NE, Rochester, MN 55906", //
+                                "vivian@openliberty.io", //
+                                "vivian.voter@openliberty.io"));
 
                 em.persist(new Voter(789001234, "Vincent", //
                                 LocalDate.of(1977, Month.SEPTEMBER, 26), //
-                                "770 W Silver Lake Dr NE, Rochester, MN 55906"));
+                                "770 W Silver Lake Dr NE, Rochester, MN 55906", //
+                                "vincent@openliberty.io"));
             } finally {
                 tx.commit();
             }
@@ -177,6 +180,44 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1019E:") ||
                 !x.getMessage().contains("livingAt"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised when the GreaterThanEqual keyword is applied to a
+     * collection of values.
+     */
+    @Test
+    public void testCollectionGreaterThanEqual() {
+        try {
+            List<Voter> found = voters.findByEmailAddressesGreaterThanEqual(1);
+            fail("Should not be able to compare a collection to a number." +
+                 " Found " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1110E:") ||
+                !x.getMessage().contains("GreaterThanEqual"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an error is raised when the IgnoreCase keyword is applied to a
+     * collection of values.
+     */
+    @Test
+    public void testCollectionIgnoreCase() {
+        List<Voter> found;
+        try {
+            String mixedCaseEmail = "Vivian@OpenLiberty.io";
+            found = voters.findByEmailAddressesIgnoreCaseContains(mixedCaseEmail);
+            fail("Should not be able to compare a collection ignoring case." +
+                 " Found " + found);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1110E:") ||
+                !x.getMessage().contains("IgnoreCase"))
                 throw x;
         }
     }
@@ -991,10 +1032,12 @@ public class DataErrPathsTestServlet extends FATServlet {
     public void testInsertMultipleEntitiesButOnlyReturnOne() {
         Voter v1 = new Voter(100200300, "Valerie", //
                         LocalDate.of(1947, Month.NOVEMBER, 7), //
-                        "88 23rd Ave SW, Rochester, MN 55902");
+                        "88 23rd Ave SW, Rochester, MN 55902", //
+                        "valerie@openliberty.io");
         Voter v2 = new Voter(400500600, "Vinny", //
                         LocalDate.of(1988, Month.NOVEMBER, 8), //
-                        "2016 45th St SE, Rochester, MN 55904");
+                        "2016 45th St SE, Rochester, MN 55904", //
+                        "vinny@openliberty.io");
         try {
             Voter inserted = voters.register(v1, v2);
             fail("Insert method with singular return type should not be able to " +
@@ -1161,11 +1204,13 @@ public class DataErrPathsTestServlet extends FATServlet {
         List<Voter> list = List //
                         .of(new Voter(999887777, "New Voter 1", //
                                         LocalDate.of(1999, Month.DECEMBER, 9), //
-                                        "213 13th Ave NW, Rochester, MN 55901"),
+                                        "213 13th Ave NW, Rochester, MN 55901", //
+                                        "voter1@openliberty.io"),
 
                             new Voter(777665555, "New Voter 2", //
                                             LocalDate.of(1987, Month.NOVEMBER, 7), //
-                                            "300 7th St SW, Rochester, MN 55902"));
+                                            "300 7th St SW, Rochester, MN 55902", //
+                                            "voter2@openliberty.io"));
 
         try {
             list = voters.addSome(list, Limit.of(1));

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voter.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voter.java
@@ -13,9 +13,13 @@
 package test.jakarta.data.errpaths.web;
 
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 
 /**
@@ -34,6 +38,9 @@ public class Voter {
 
     public String description;
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    public Set<String> emailAddresses = new HashSet<>();
+
     @Id
     @Column(nullable = false)
     public int ssn;
@@ -41,12 +48,18 @@ public class Voter {
     public Voter() {
     }
 
-    public Voter(int ssn, String name, LocalDate birthday, String address) {
+    public Voter(int ssn,
+                 String name,
+                 LocalDate birthday,
+                 String address,
+                 String... emailAddresses) {
         this.ssn = ssn;
         this.name = name;
         this.birthday = birthday;
         this.address = address;
         this.description = name + " born on " + birthday + " and living at " + address;
+        for (String email : emailAddresses)
+            this.emailAddresses.add(email);
     }
 
     @Override
@@ -56,6 +69,7 @@ public class Voter {
 
     @Override
     public String toString() {
-        return "Voter#" + ssn + " " + birthday + " " + name + " @" + address;
+        return "Voter#" + ssn + " " + birthday + " " + name +
+               " @" + address + " " + emailAddresses;
     }
 }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -232,6 +232,17 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                                                    PageRequest pageReq);
 
     /**
+     * This invalid method tries to apply the GreaterThanEqual keyword to a
+     * collection of values.
+     */
+    List<Voter> findByEmailAddressesGreaterThanEqual(int minEmailAddresses);
+
+    /**
+     * This invalid method tries to apply the IgnoreCase keyword to a collection.
+     */
+    List<Voter> findByEmailAddressesIgnoreCaseContains(String email);
+
+    /**
      * This invalid method omits the entity attribute name from findBy in the
      * method name.
      */


### PR DESCRIPTION
This PR contains a couple of different changes. I started out adding javadoc/comments to some of our classes that were missing them. While doing that, I noticed two minor issues and addressed them in this PR. One is that we have no tests for the Object methods of repositories, despite some of them being provided by an invocation handler. I added tests for them. Another is that I found a partially written english-only error message on an error path that we had forgotten to mark with a TODO comment.  I improved the message to include more information and added it to the nlsprops file to be handled the same as our other messages.  The Condition enumeration also gets some updates to have the names of enumeration constants exactly match Query by Method Name keywords so we can have less hard coded Strings and hard coded length values in the code.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
