### PR TITLE
We should not run testSpnegoUsingRawKerberosTokenSuccessful on z/OS

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
@@ -150,7 +150,8 @@ public class BasicAuthTest extends ContainerKDCCommonTest {
      * @throws Exception
      */
 
-    @Test
+     @Test
+     @SkipIfSysProp(SkipIfSysProp.OS_ZOS) // Skip on z/OS due to configuration error
     public void testSpnegoUsingRawKerberosTokenSuccessful() throws Exception {
         setDefaultSpnegoServerConfig();
         String targetSpn = "HTTP/" + TARGET_SERVER;


### PR DESCRIPTION
We should not run testSpnegoUsingRawKerberosTokenSuccessful on z/OS systems.

This fixes defect 302182


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
