### PR TITLE
Run MP Reactive Messaging Kafka tests with Kafka client 4.0.0

### DIFF
--- a/dev/com.ibm.websphere.org.eclipse.microprofile/build.gradle
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile/build.gradle
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 configurations {
   config11 {
@@ -43,6 +40,10 @@ configurations {
     canBeConsumed = true
     canBeResolved = false
   }
+  reactivemessaging10 {
+    canBeConsumed = true
+    canBeResolved = false
+  }
 }
 
 artifacts {
@@ -54,4 +55,5 @@ artifacts {
   ft11(file('build/libs/com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.1.jar'))
   openapi10(file('build/libs/com.ibm.websphere.org.eclipse.microprofile.openapi.1.0.jar'))
   reactivestreams10(file('build/libs/com.ibm.websphere.org.eclipse.microprofile.reactive.streams.operators.1.0.jar'))
+  reactivemessaging10(file('build/libs/com.ibm.websphere.org.eclipse.microprofile.reactive.messaging.1.0.jar'))
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/build.gradle
@@ -1,40 +1,10 @@
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
-
-configurations {
-    kafkaClient {
-      transitive = false
-    }
-    requiredLibs.extendsFrom kafkaClient {
-      transitive = false
-    }
-}
+apply from: '../io.openliberty.microprofile.reactive.messaging.internal_fat.common/include-kafka-client.gradle'
 
 dependencies {
-    kafkaClient 'org.apache.kafka:kafka-clients:3.5.1'
-    kafkaClient 'org.lz4:lz4-java:1.8.0'
-    kafkaClient 'com.github.luben:zstd-jni:1.5.5-1'
-    kafkaClient 'org.xerial.snappy:snappy-java:1.1.10.1'
-    kafkaClient project(':com.ibm.ws.org.slf4j.api')
-    kafkaClient project(':com.ibm.ws.org.slf4j.jdk14')
-    requiredLibs 'org.testng:testng:7.5.1'
-    requiredLibs 'org.reactivestreams:reactive-streams-tck:1.0.3'
-    requiredLibs project(':com.ibm.websphere.org.reactivestreams.reactive-streams.1.0')
-    requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka')
-    requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka.adapter')
-    requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl')
-    requiredLibs project(':com.ibm.ws.io.smallrye.reactive.streams-operators')
-    requiredLibs project(':com.ibm.ws.crypto.passwordutil');
-    requiredLibs project(':com.ibm.ws.kernel.service');
-    requiredLibs project(path: ':com.ibm.websphere.org.eclipse.microprofile', configuration: 'reactivestreams10');
     requiredLibs project(path: ':io.openliberty.microprofile.reactive.messaging.internal_fat.common', configuration: 'original');
+    requiredLibs project(':com.ibm.ws.crypto.passwordutil');
 }
 
-task addKafkaClientLibs (type: Copy) {
-    into new File(autoFvtDir, 'lib/LibertyFATTestFiles/libs')
-    from configurations.kafkaClient
-    shouldRunAfter autoFVT
-}
-
-zipAutoFVT.dependsOn addKafkaClientLibs
 addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/publish/servers/CheckpointSimpleRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/publish/servers/CheckpointSimpleRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
+        <feature>mpConfig-1.3</feature>
         <feature>servlet-4.0</feature>
         <feature>jsonb-1.0</feature>
         <feature>concurrent-1.0</feature>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/publish/servers/ContextRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/publish/servers/ContextRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
+        <feature>mpConfig-1.3</feature>
         <feature>servlet-4.0</feature>
         <feature>jndi-1.0</feature>
     </featureManager>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/publish/servers/CustomContextRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/publish/servers/CustomContextRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
+        <feature>mpConfig-1.3</feature>
         <feature>servlet-4.0</feature>
         <feature>jndi-1.0</feature>
         <feature>concurrent-1.0</feature>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/publish/servers/SimpleRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/publish/servers/SimpleRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -20,5 +20,6 @@
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
         <feature>servlet-4.0</feature>
+        <feature>mpConfig-1.3</feature>
     </featureManager>
 </server>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/build.gradle
@@ -1,40 +1,30 @@
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
-
-configurations {
-    kafkaClient {
-      transitive = false
-    }
-    requiredLibs.extendsFrom kafkaClient {
-      transitive = false
-    }
-}
+apply from: '../io.openliberty.microprofile.reactive.messaging.internal_fat.common/include-kafka-client.gradle'
 
 dependencies {
-    kafkaClient 'org.apache.kafka:kafka-clients:3.5.1'
-    kafkaClient 'org.lz4:lz4-java:1.8.0'
-    kafkaClient 'com.github.luben:zstd-jni:1.5.5-1'
-    kafkaClient 'org.xerial.snappy:snappy-java:1.1.10.1'
-    kafkaClient project(':com.ibm.ws.org.slf4j.api')
-    kafkaClient project(':com.ibm.ws.org.slf4j.jdk14')
+    // Our implementation of reactive streams publishers and consumers
+    // Needed here to run the RS TCK
+    requiredLibs (project(':com.ibm.ws.microprofile.reactive.messaging.kafka')) {
+      transitive = false
+    }
+    requiredLibs (project(':com.ibm.ws.microprofile.reactive.messaging.kafka.adapter')) {
+      transitive = false
+    }
+    requiredLibs (project(':com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl')) {
+      transitive = false
+    }
+    requiredLibs (project(':io.openliberty.microprofile.reactive.messaging.internal')) {
+      transitive = false
+    }
+
     requiredLibs 'org.testng:testng:7.5.1'
     requiredLibs 'org.reactivestreams:reactive-streams-tck:1.0.3'
     requiredLibs project(':com.ibm.websphere.org.reactivestreams.reactive-streams.1.0')
-    requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka')
-    requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka.adapter')
-    requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl')
     requiredLibs project(':com.ibm.ws.io.smallrye.reactive.streams-operators')
-    requiredLibs project(':com.ibm.ws.crypto.passwordutil');
-    requiredLibs project(':com.ibm.ws.kernel.service');
     requiredLibs project(path: ':com.ibm.websphere.org.eclipse.microprofile', configuration: 'reactivestreams10');
+    requiredLibs project(path: ':com.ibm.websphere.org.eclipse.microprofile', configuration: 'reactivemessaging10');
     requiredLibs project(path: ':io.openliberty.microprofile.reactive.messaging.internal_fat.common', configuration: 'original');
 }
 
-task addKafkaClientLibs (type: Copy) {
-    into new File(autoFvtDir, 'lib/LibertyFATTestFiles/libs')
-    from configurations.kafkaClient
-    shouldRunAfter autoFVT
-}
-
-zipAutoFVT.dependsOn addKafkaClientLibs
 addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaPublisherVerification.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaPublisherVerification.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.tck;
 
@@ -21,11 +18,12 @@ import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.junit.BeforeClass;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
@@ -64,6 +62,7 @@ public class KafkaPublisherVerification extends PublisherVerification<Message<St
         asyncProvider = new MockAsyncProvider();
     }
 
+    @AfterClass
     public static void cleanupClass() {
         if (asyncProvider != null) {
             asyncProvider.close();

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ConcurrentRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ConcurrentRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
+        <feature>mpConfig-1.3</feature>
         <feature>servlet-4.0</feature>
         <feature>concurrent-1.0</feature>
     </featureManager>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ContextRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/ContextRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
+        <feature>mpConfig-1.3</feature>
         <feature>servlet-4.0</feature>
         <feature>jndi-1.0</feature>
     </featureManager>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/CustomContextRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/CustomContextRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
+        <feature>mpConfig-1.3</feature>
         <feature>servlet-4.0</feature>
         <feature>jndi-1.0</feature>
         <feature>concurrent-1.0</feature>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/JsonbRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/JsonbRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023 IBM Corporation and others.
+    Copyright (c) 2023, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
+        <feature>mpConfig-1.3</feature>
         <feature>servlet-4.0</feature>
         <feature>jsonb-1.0</feature>
         <feature>concurrent-1.0</feature>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/SharedLibRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/SharedLibRxMessagingServer/server.xml
@@ -39,4 +39,16 @@
     <javaPermission codebase="${kafkaCodebase}" className="java.net.SocketPermission" name="*" actions="connect"/>
     <javaPermission codebase="${kafkaCodebase}" className="java.lang.RuntimePermission" name="getClassLoader" actions="*"/>
     <javaPermission codebase="${kafkaCodebase}" className="java.io.FilePermission" name="*" actions="read"/>
+    
+    <!-- same permissions for when we're using Kafka client 4 -->
+    <variable name="kafkaCodebase4" value="${server.config.dir}/kafkaLib/kafka-clients-4.0.0.jar"/>
+    <javaPermission codebase="${kafkaCodebase4}" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
+    <javaPermission codebase="${kafkaCodebase4}" className="javax.management.MBeanPermission" name="*" actions="*"/>
+    <javaPermission codebase="${kafkaCodebase4}" className="javax.management.MBeanTrustPermission" name="register"/>
+    <javaPermission codebase="${kafkaCodebase4}" className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission codebase="${kafkaCodebase4}" className="java.net.SocketPermission" name="*" actions="connect"/>
+    <javaPermission codebase="${kafkaCodebase4}" className="java.lang.RuntimePermission" name="getClassLoader" actions="*"/>
+    <javaPermission codebase="${kafkaCodebase4}" className="java.io.FilePermission" name="*" actions="read"/>
+    <javaPermission codebase="${kafkaCodebase4}" className="java.lang.RuntimePermission" name="accessDeclaredMembers" actions="*"/>
+
 </server>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/SharedLibRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/SharedLibRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019, 2022 IBM Corporation and others.
+    Copyright (c) 2019, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
+        <feature>mpConfig-1.3</feature>
         <feature>servlet-4.0</feature>
     </featureManager>
     

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/SimpleRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/SimpleRxMessagingServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@
         <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
+        <feature>mpConfig-1.3</feature>
         <feature>servlet-4.0</feature>
     </featureManager>
 </server>

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/include-kafka-client.gradle
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/include-kafka-client.gradle
@@ -1,0 +1,60 @@
+// Includable gradle to package the Kafka client into the locations within the autoFVT.zip expected
+// by KafkaUtils.kafkaClientLibs.
+// 
+// Places the Kafka 3.x client (compatible with Java 8) on the classpath and the Kafka 4.x client
+// within LibertyFATTestFiles.
+//
+// Usage:
+// apply from: '../io.openliberty.microprofile.reactive.messaging.internal_fat.common/include-kafka-client.gradle'
+
+
+// New dependency configurations
+configurations {
+    kafkaClientCommon {
+      transitive = false
+    }
+    kafkaClient3 {
+      transitive = false
+    }
+    kafkaClient {
+      transitive = false
+    }
+}
+
+// Dependency specifications
+dependencies {
+    kafkaClientCommon 'org.lz4:lz4-java:1.8.0'
+    kafkaClientCommon 'com.github.luben:zstd-jni:1.5.6-6'
+    kafkaClientCommon 'org.xerial.snappy:snappy-java:1.1.10.5'
+    kafkaClientCommon project(':com.ibm.ws.org.slf4j.api')
+    kafkaClientCommon project(':com.ibm.ws.org.slf4j.jdk14')
+    
+    // Runs on Java 8
+    kafkaClient3 'org.apache.kafka:kafka-clients:3.5.1'
+
+    // Requires Java 11
+    kafkaClient 'org.apache.kafka:kafka-clients:4.0.0'
+}
+
+// Tasks which copy the dependencies to the AutoFVT directory
+task addKafkaClientCommonLibs (type: Copy) {
+    into new File(autoFvtDir, 'publish/kafka-client-common')
+    from configurations.kafkaClientCommon
+    shouldRunAfter autoFVT
+}
+
+task addKafkaClient3Libs (type: Copy) {
+    into new File(autoFvtDir, 'publish/kafka-client-3')
+    from configurations.kafkaClient3
+    shouldRunAfter autoFVT
+}
+
+task addKafkaClientLibs (type: Copy) {
+    into new File(autoFvtDir, 'lib/LibertyFATTestFiles/kafka-client')
+    from configurations.kafkaClient
+    shouldRunAfter autoFVT
+}
+
+zipAutoFVT.dependsOn addKafkaClientCommonLibs
+zipAutoFVT.dependsOn addKafkaClient3Libs
+zipAutoFVT.dependsOn addKafkaClientLibs

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/common/KafkaUtils.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/common/KafkaUtils.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common;
 
@@ -19,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +34,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.containers.ExtendedK
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClientProvider;
 
+import componenttest.app.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -50,8 +49,20 @@ public class KafkaUtils {
     private final static String KAFKA_REGEX = "E Error.*kafka";
 
     public static File[] kafkaClientLibs() {
-        File libsDir = new File("lib/LibertyFATTestFiles/libs");
-        return libsDir.listFiles();
+        ArrayList<File> result = new ArrayList<>();
+
+        File commonDir = new File("publish/kafka-client-common");
+        result.addAll(Arrays.asList(commonDir.listFiles()));
+
+        if (JavaInfo.majorVersion() <= 8) {
+            File clientDir = new File("publish/kafka-client-3");
+            result.addAll(Arrays.asList(clientDir.listFiles()));
+        } else {
+            File clientDir = new File("lib/LibertyFATTestFiles/kafka-client");
+            result.addAll(Arrays.asList(clientDir.listFiles()));
+        }
+
+        return result.toArray(new File[0]);
     }
 
     public static URL kafkaPermissions() {

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/common/permissions.xml
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat.common/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/common/permissions.xml
@@ -91,5 +91,10 @@
         <name>modifyPrivateCredentials</name>
      </permission>
      
+     <!-- Kafka client 4 reflectively checks for SecurityManager support -->
+     <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>accessDeclaredMembers</name>
+     </permission>
      
 </permissions>

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/build.gradle
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/build.gradle
@@ -1,25 +1,8 @@
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
-
-configurations {
-    kafkaClient
-    requiredLibs.extendsFrom kafkaClient
-}
+apply from: '../io.openliberty.microprofile.reactive.messaging.internal_fat.common/include-kafka-client.gradle'
 
 dependencies {
-    kafkaClient 'org.apache.kafka:kafka-clients:3.5.1'
-    kafkaClient 'org.lz4:lz4-java:1.8.0'
-    kafkaClient 'com.github.luben:zstd-jni:1.5.5-1'
-    kafkaClient 'org.xerial.snappy:snappy-java:1.1.10.1'
-    kafkaClient project(':com.ibm.ws.org.slf4j.api')
-    kafkaClient project(':com.ibm.ws.org.slf4j.jdk14')
     requiredLibs project(path: ':io.openliberty.microprofile.reactive.messaging.internal_fat.common', configuration: 'transformed')
 }
 
-task addKafkaClientLibs (type: Copy) {
-    into new File(autoFvtDir, 'lib/LibertyFATTestFiles/libs')
-    from configurations.kafkaClient
-    shouldRunAfter autoFVT
-}
-
-zipAutoFVT.dependsOn addKafkaClientLibs
 addRequiredLibraries.dependsOn copyTestContainers


### PR DESCRIPTION
v4 of the client requires Java 11, so package a v3 client as well and use that if running on an earlier Java version.

Additional changes:
- Make the logic that packages the Kafka client into the autoFVT zip common
- Remove many unneeded dependencies from `com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat` which had been copied from another project
- Don't include transitive dependencies of the Kafka connector implementation in `com.ibm.ws.microprofile.reactive.messaging_fat`

Fixes #31227

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

