### PR TITLE
Update kernel feature logic for wmq versionless features.

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverBaseline.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverBaseline.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -186,6 +186,8 @@ public class FeatureResolverBaseline {
     private static final String VERSIONLESS_PREFIX = "io.openliberty.versionless.";
     /** Prefix of public microprofile versionless features. */
     private static final String VERSIONLESS_MP_PREFIX = "io.openliberty.versionless.mp";
+    /** Common prefix of public WebSphere Liberty versionless features. */
+    private static final String VERSIONLESS_PREFIX2 = "com.ibm.websphere.appserver.versionless.";
 
     private static final boolean INCLUDE_EE = true;
     private static final boolean INCLUDE_MP = true;
@@ -198,7 +200,7 @@ public class FeatureResolverBaseline {
         List<String> versionlessFeatures = new ArrayList<>();
         for ( ProvisioningFeatureDefinition featureDef : repository.getFeatures() ) {
             String featureName = featureDef.getSymbolicName();
-            if ( !featureName.startsWith(VERSIONLESS_PREFIX) ) {
+            if ( !featureName.startsWith(VERSIONLESS_PREFIX) && !featureName.startsWith(VERSIONLESS_PREFIX2) ) {
 //                System.out.println("Skip: Missing prefix [ " + featureName + " ]");
                 continue;
             }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/util/RepoXML.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/util/RepoXML.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -91,9 +91,10 @@ public class RepoXML extends BaseXML {
     };
 
     public static final String VERSIONLESS_PREFIX = "io.openliberty.versionless.";
+    public static final String VERSIONLESS_PREFIX2 = "com.ibm.websphere.appserver.versionless.";
 
     public static boolean isVersionless(ProvisioningFeatureDefinition def) {
-        return def.getSymbolicName().startsWith(VERSIONLESS_PREFIX);
+        return def.getSymbolicName().startsWith(VERSIONLESS_PREFIX) || def.getSymbolicName().startsWith(VERSIONLESS_PREFIX2);
     }
 
     public static boolean isPublic(ProvisioningFeatureDefinition def) {

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessJavaEEToMicroProfileTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessJavaEEToMicroProfileTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,15 +14,15 @@ package com.ibm.ws.feature.tests;
 
 import java.util.Collection;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.After;
+
+import com.ibm.ws.feature.tests.util.PlatformConstants;
 
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
-
-import com.ibm.ws.feature.tests.util.PlatformConstants;
 
 // @formatter:off
 
@@ -32,6 +32,7 @@ public class VersionlessJavaEEToMicroProfileTest extends VersionlessTest {
     public static final String SERVER_NAME_EE8 = "ee8toMP";
     public static final String SERVER_NAME_EE9 = "ee9toMP";
     public static final String SERVER_NAME_EE10 = "ee10toMP";
+    public static final String SERVER_NAME_EE11 = "ee11toMP";
 
     public static final String[] ALLOWED_ERRORS = { "CWWKF0001E", "CWWKF0048E" };
 
@@ -94,7 +95,22 @@ public class VersionlessJavaEEToMicroProfileTest extends VersionlessTest {
                      new String[] { "mpMetrics-5.0", "mpHealth-4.0" },
                      TestCase.NO_FAILURES,
                      ALLOWED_ERRORS,
-                     TestCase.JAVA_11)
+                     TestCase.JAVA_11),
+
+        new TestCase("ee11toHealthAndMetricsMax",
+                     SERVER_NAME_EE11,
+                     PlatformConstants.MICROPROFILE_DESCENDING,
+                     new String[] { "mpMetrics-5.1", "mpHealth-4.0" },
+                     TestCase.NO_FAILURES,
+                     ALLOWED_ERRORS,
+                     TestCase.JAVA_17),
+        new TestCase("ee11toHealthAndMetricsMin",
+                     SERVER_NAME_EE11,
+                     PlatformConstants.MICROPROFILE_ASCENDING,
+                     new String[] { "mpMetrics-5.1", "mpHealth-4.0" },
+                     TestCase.NO_FAILURES,
+                     ALLOWED_ERRORS,
+                     TestCase.JAVA_17)
     };
 
     @Parameterized.Parameters

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessServletToMicroProfileTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessServletToMicroProfileTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,9 @@ public class VersionlessServletToMicroProfileTest extends VersionlessTest {
 
     public static final String SERVER_NAME_SERVLET6_HEALTH = "Servlet6toHealth";
     public static final String SERVER_NAME_SERVLET6_METRICS = "Servlet6toMetrics";
+
+    public static final String SERVER_NAME_SERVLET61_HEALTH = "Servlet6_1toHealth";
+    public static final String SERVER_NAME_SERVLET61_METRICS = "Servlet6_1toMetrics";
 
     public static final String SERVER_JAKARTAEE8 = "jakartaee8";
 
@@ -94,6 +97,21 @@ public class VersionlessServletToMicroProfileTest extends VersionlessTest {
                      PlatformConstants.MICROPROFILE_ASCENDING,
                      new String[] { "mpMetrics-5.0" }, TestCase.NO_FAILURES, ALLOWED_ERRORS,
                      TestCase.JAVA_11),
+
+        new TestCase("servlet61HealthMax", SERVER_NAME_SERVLET61_HEALTH,
+                     PlatformConstants.MICROPROFILE_DESCENDING,
+                     new String[] { "mpHealth-4.0" }, TestCase.NO_FAILURES, ALLOWED_ERRORS),
+        new TestCase("servlet6HealthMin", SERVER_NAME_SERVLET61_HEALTH,
+                     PlatformConstants.MICROPROFILE_ASCENDING,
+                     new String[] { "mpHealth-4.0" }, TestCase.NO_FAILURES, ALLOWED_ERRORS),
+        new TestCase("servlet6MetricsMax", SERVER_NAME_SERVLET61_METRICS,
+                     PlatformConstants.MICROPROFILE_DESCENDING,
+                     new String[] { "mpMetrics-5.1" }, TestCase.NO_FAILURES, ALLOWED_ERRORS,
+                     TestCase.JAVA_17),
+        new TestCase("servlet6MetricsMin", SERVER_NAME_SERVLET61_METRICS,
+                     PlatformConstants.MICROPROFILE_ASCENDING,
+                     new String[] { "mpMetrics-5.1" }, TestCase.NO_FAILURES, ALLOWED_ERRORS,
+                     TestCase.JAVA_17),
 
         //JAKARTA8 TEST
         new TestCase("jakartaee8", SERVER_JAKARTAEE8, "",

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ public class VersionlessTest {
 
         public static final int UNSPECIFIED_JAVA_LEVEL = -1;
         public static final int JAVA_11 = 11;
+        public static final int JAVA_17 = 17;
         public final int minJavaLevel;
 
         public TestCase(String description, String serverName,

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/util/PlatformConstants.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/util/PlatformConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,16 +14,16 @@ package com.ibm.ws.feature.tests.util;
 
 public interface PlatformConstants {
 
-    String MICROPROFILE_DESCENDING = "MicroProfile-6.1, MicroProfile-6.0, MicroProfile-5.0, MicroProfile-4.1, " +
+    String MICROPROFILE_DESCENDING = "MicroProfile-7.0, MicroProfile-6.1, MicroProfile-6.0, MicroProfile-5.0, MicroProfile-4.1, " +
                                      "MicroProfile-4.0, MicroProfile-3.3, MicroProfile-3.2, MicroProfile-3.0, MicroProfile-2.2, MicroProfile-2.1, " +
                                      "MicroProfile-2.0, MicroProfile-1.4, MicroProfile-1.3, MicroProfile-1.2, MicroProfile-1.0";
 
     String MICROPROFILE_ASCENDING = "MicroProfile-1.0, MicroProfile-1.2, MicroProfile-1.3, MicroProfile-1.4, " +
                                     "MicroProfile-2.0, MicroProfile-2.1, MicroProfile-2.2, MicroProfile-3.0, MicroProfile-3.2, MicroProfile-3.3, " +
-                                    "MicroProfile-4.0, MicroProfile-4.1, MicroProfile-5.0, MicroProfile-6.0, MicroProfile-6.1";
+                                    "MicroProfile-4.0, MicroProfile-4.1, MicroProfile-5.0, MicroProfile-6.0, MicroProfile-6.1, MicroProfile-7.0";
 
-    String JAKARTA_DESCENDING = "jakartaee-11.0, jakartaee-10.0, jakartaee-9.1, javaee-8.0, javaee-7.0, javaee-6.0";
+    String JAKARTA_DESCENDING = "jakartaee-11.0, jakartaee-10.0, jakartaee-9.1, jakartaee-8.0, javaee-8.0, javaee-7.0, javaee-6.0";
 
-    String JAKARTA_ASCENDING = "javaee-6.0, javaee-7.0, javaee-8.0, jakartaee-9.1, jakartaee-10.0, jakartaee-11.0";
+    String JAKARTA_ASCENDING = "javaee-6.0, javaee-7.0, javaee-8.0, jakartaee-8.0, jakartaee-9.1, jakartaee-10.0, jakartaee-11.0";
 
 }

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/util/RepositoryUtil.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/util/RepositoryUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -476,6 +476,7 @@ public class RepositoryUtil {
      *
      * @param featureName Name of a versionless feature. This is NOT simply a versioned feature name
      *            minus the version. The "package" name should be "io.openliberty.versionless."
+     *            or "com.ibm.websphere.appserver.versionless."
      *            <br>Example: io.openliberty.versionless.appClientSupport
      * @return feature definition of the versionless feature associated with the input featureName
      */
@@ -524,7 +525,9 @@ public class RepositoryUtil {
      * @param featureName the symbolic feature name
      */
     public static String asVersionlessFeatureName(String featureName) {
-        return "io.openliberty.versionless." + asShortName(featureName);
+        String shortName = asShortName(featureName);
+        // wmqJmsClient and wmqMessagingClient versionless features are WebSphere Liberty versionless features and have a different prefix
+        return (shortName.startsWith("wmq") ? "com.ibm.websphere.appserver.versionless." : "io.openliberty.versionless.") + shortName;
     }
 
     /**
@@ -538,7 +541,10 @@ public class RepositoryUtil {
      * @param featureName the symbolic feature name
      */
     public static String asInternalVersionlessFeatureName(String featureName) {
-        return "io.openliberty.internal.versionless." + asShortNameWithVersion(featureName);
+        String shortNameWithVersion = asShortNameWithVersion(featureName);
+        // wmqJmsClient and wmqMessagingClient versionless features are WebSphere Liberty versionless features and have a different prefix
+        return (shortNameWithVersion.startsWith("wmq") ? "com.ibm.ws.internal.versionless." : "io.openliberty.internal.versionless.")
+               + shortNameWithVersion;
     }
 
     /**
@@ -719,7 +725,7 @@ public class RepositoryUtil {
     }
 
     public static boolean isVersionless(String featureName) {
-        return (featureName.startsWith("io.openliberty.versionless"));
+        return (featureName.startsWith("io.openliberty.versionless") || featureName.startsWith("com.ibm.websphere.appserver.versionless"));
     }
 
     private static List<String> versionlessFeatures;

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/Servlet6_1toHealth/bootstrap.properties
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/Servlet6_1toHealth/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/Servlet6_1toHealth/server.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/Servlet6_1toHealth/server.xml
@@ -1,0 +1,19 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server>
+
+    <featureManager>
+        <feature>servlet-6.1</feature>
+        <feature>mpHealth</feature>
+    </featureManager>
+    
+    <include location="../fatTestCommon.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/Servlet6_1toMetrics/bootstrap.properties
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/Servlet6_1toMetrics/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/Servlet6_1toMetrics/server.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/Servlet6_1toMetrics/server.xml
@@ -1,0 +1,19 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server>
+
+    <featureManager>
+        <feature>servlet-6.1</feature>
+        <feature>mpMetrics</feature>
+    </featureManager>
+    
+    <include location="../fatTestCommon.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee11toMP/bootstrap.properties
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee11toMP/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee11toMP/server.xml
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/publish/servers/ee11toMP/server.xml
@@ -1,0 +1,29 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server>
+
+    <featureManager>
+        <feature>jakartaee-11.0</feature>
+        <feature>mpMetrics</feature>
+        <feature>mpHealth</feature>
+    </featureManager>
+    
+    <!-- jakartaee-11.0 includs ssl, which requires a keystore -->
+    <keyStore id="defaultKeyStore" password="yourPassword"/>
+
+    <!-- jakartaee-11.0 enables remote EJBs, which require an ORB,
+         which requires a user registry.  The QSS element
+         creates a simple one element user registry. -->
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <orb id="defaultOrb" orbSSLInitTimeout="60"/>
+
+    <include location="../fatTestCommon.xml"/>
+
+</server>


### PR DESCRIPTION
- Update versionless processing to recognize com.ibm.websphere.appserver.versionless and com.ibm.ws.internal.versionless feature name prefixes in addition to io.openliberty.verisonless and io.openlibert.internal.versionless to handle the new WebSphere Liberty versionless feature that is planned
- Update tests to include MP 7.0 and Jakarta EE 11 scenarios

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
