### PR TITLE
Added TCP portOpenRetries to MpHealth31 SlowAppHealthCheckTests to resolve port binding issues

### DIFF
--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckFastTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckFastTest.java
@@ -28,6 +28,7 @@ import javax.json.JsonObject;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -104,6 +105,13 @@ public class SlowAppStartupHealthCheckFastTest {
 
         boolean flag = server1.removeDropinsApplications(APP_NAME + ".war");
         log("cleanUp", " - Removed the app? [" + flag + "]");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Once the tests and repeated tests are completed, ensure the server
+        // is fully stopped, in order to avoid conflicts with succeeding tests.
+        server1.stopServer(EXPECTED_FAILURES);
     }
 
     /*

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckTest.java
@@ -28,6 +28,7 @@ import javax.json.JsonObject;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -90,6 +91,13 @@ public class SlowAppStartupHealthCheckTest {
 
         if ((server1 != null) && (server1.isStarted()))
             server1.stopServer(EXPECTED_FAILURES);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Once the tests and repeated tests are completed, ensure the server
+        // is fully stopped, in order to avoid conflicts with succeeding tests.
+        server1.stopServer(EXPECTED_FAILURES);
     }
 
     /*

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheck/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheck/server.xml
@@ -15,5 +15,9 @@
     <logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
     <application location="DelayedHealthCheckApp.war"/>
     <webContainer deferServletLoad="false"/> 
+    
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+        <tcpOptions portOpenRetries="60" />                   
+    </httpEndpoint>
 	
 </server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheckFast/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheckFast/server.xml
@@ -15,5 +15,9 @@
     <logging traceSpecification="*=info:HEALTH=all:logservice=all=enabled:io.openliberty.org.eclipse.microprofile.health.3.1.*=all=enabled"/>
 
     <webContainer deferServletLoad="false"/> 
+    
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+        <tcpOptions portOpenRetries="60" />                   
+    </httpEndpoint>
 	
 </server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
 fixes #31254 
- The MpHealth31 SlowAppHealthCheck Tests were failing, due to unable to bind to a port. Added "portOpenRetries=60" to all the server.xml in the FAT, so it tries to bind a port, at least 60 times before failing.
- The port conflicts maybe a result of infrastructure issues/slowness, where the previous tests may not have released the port in time, for the other tests to use. This method will allow some time for the ports to be released, before they can get used again.