### PR TITLE
Restructure security-1.0 private feature to help with api / spi doc generation

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.adminSecurity-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.adminSecurity-2.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.adminSecurity-2.0
 singleton=true
 -features=io.openliberty.servlet.internal-5.0; ibm.tolerates:="6.0, 6.1", \
   com.ibm.websphere.appserver.distributedMap-1.0, \
-  com.ibm.websphere.appserver.security-1.0
+  com.ibm.websphere.appserver.security-2.0
 -bundles=com.ibm.websphere.security, \
  io.openliberty.webcontainer.security.internal; start-phase:=SERVICE_EARLY, \
  com.ibm.ws.webcontainer.security.admin, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.builtinAuthentication-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.builtinAuthentication-1.0.feature
@@ -6,7 +6,8 @@ singleton=true
 -features=io.openliberty.servlet.api-3.0; apiJar=false; ibm.tolerates:="3.1,4.0", \
   com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0", \
   com.ibm.websphere.appserver.ltpa-1.0, \
-  io.openliberty.jcache.internal-1.1
+  io.openliberty.jcache.internal-1.1, \
+  io.openliberty.jcache.internal1.1.ee-6.0; ibm.tolerates:="8.0"
 -bundles=\
   com.ibm.ws.security.authentication, \
   com.ibm.ws.security.credentials.wscred, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.builtinAuthentication-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.builtinAuthentication-2.0.feature
@@ -5,7 +5,8 @@ singleton=true
 -features=io.openliberty.servlet.api-5.0; apiJar=false; ibm.tolerates:="6.0, 6.1", \
   com.ibm.websphere.appserver.eeCompatible-9.0; ibm.tolerates:="10.0, 11.0", \
   com.ibm.websphere.appserver.ltpa-1.0, \
-  io.openliberty.jcache.internal-1.1
+  io.openliberty.jcache.internal-1.1, \
+  io.openliberty.jcache.internal1.1.ee-9.0
 -bundles=\
   com.ibm.ws.security.authentication, \
   com.ibm.ws.security.credentials.wscred, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.security-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.security-2.0.feature
@@ -1,15 +1,14 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.security-1.0
+symbolicName=com.ibm.websphere.appserver.security-2.0
 singleton=true
-WLP-DisableAllFeatures-OnConflict: false
 IBM-API-Package: com.ibm.wsspi.security.tai; type="ibm-api", \
  com.ibm.wsspi.security.token; type="ibm-api", \
  com.ibm.wsspi.security.auth.callback; type="ibm-api", \
  com.ibm.wsspi.security.common.auth.module; type="ibm-api", \
  com.ibm.websphere.security.auth.callback; type="ibm-api"
 -features= \
-  io.openliberty.servlet.api-3.0; apiJar=false; ibm.tolerates:="3.1,4.0", \
+  io.openliberty.servlet.api-5.0; apiJar=false; ibm.tolerates:="6.0,6.1", \
   io.openliberty.security.internal.common-1.0, \
-  io.openliberty.security.internal.ee-6.0
+  io.openliberty.security.internal.ee-9.0
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcache.internal-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcache.internal-1.1.feature
@@ -17,9 +17,7 @@ IBM-SPI-Package: \
   javax.cache.spi, \
   io.openliberty.jcache
 -features=\
-  com.ibm.websphere.appserver.eeCompatible-8.0; ibm.tolerates:="6.0,7.0,9.0,10.0,11.0", \
-  com.ibm.websphere.appserver.classloading-1.0, \
-  io.openliberty.jcache.internal1.1.ee-6.0; ibm.tolerates:="9.0"
+  com.ibm.websphere.appserver.classloading-1.0
 -bundles=\
   io.openliberty.jcache.internal, \
   com.ibm.ws.serialization

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcache.internal1.1.ee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jcache.internal1.1.ee-8.0.feature
@@ -1,13 +1,13 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.jcache.internal1.1.ee-6.0
+symbolicName=io.openliberty.jcache.internal1.1.ee-8.0
 WLP-DisableAllFeatures-OnConflict: false
 singleton=true
 #
 # CDI is optionally required by the JCache libraries.
 #
 -features=\
-  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0"
-#  com.ibm.websphere.appserver.javax.cdi-1.0; ibm.tolerates:="1.2"
+  com.ibm.websphere.appserver.eeCompatible-8.0
+#  com.ibm.websphere.appserver.javax.cdi-2.0
 -bundles=\
   com.ibm.websphere.javaee.jcache.1.1.core
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-10.0.feature
@@ -6,8 +6,7 @@ visibility = private
 
 -features=\
   io.openliberty.servlet.internal-6.0; ibm.tolerates:="6.1", \
-  com.ibm.websphere.appserver.adminSecurity-2.0, \
-  io.openliberty.securityAPI.jakarta-1.0
+  com.ibm.websphere.appserver.adminSecurity-2.0
 
 -bundles= com.ibm.ws.rest.handler.jakarta
 

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-6.0.feature
@@ -10,8 +10,7 @@ IBM-SPI-Package: com.ibm.wsspi.rest.handler; type="ibm-spi", \
 
 -features=\
   io.openliberty.servlet.internal-3.0; ibm.tolerates:="3.1,4.0", \
-  com.ibm.websphere.appserver.adminSecurity-1.0, \
-  io.openliberty.securityAPI.javaee-1.0
+  com.ibm.websphere.appserver.adminSecurity-1.0
 
 -bundles= com.ibm.ws.rest.handler
 

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.restHandler1.0.internal.ee-9.0.feature
@@ -9,8 +9,7 @@ IBM-SPI-Package: com.ibm.wsspi.rest.handler; type="ibm-spi", \
 
 -features=\
   io.openliberty.servlet.internal-5.0, \
-  com.ibm.websphere.appserver.adminSecurity-2.0, \
-  io.openliberty.securityAPI.jakarta-1.0
+  com.ibm.websphere.appserver.adminSecurity-2.0
 
 -bundles= com.ibm.ws.rest.handler.jakarta
 

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.security.internal.common-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.security.internal.common-1.0.feature
@@ -1,0 +1,16 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.security.internal.common-1.0
+WLP-DisableAllFeatures-OnConflict: false
+-features=com.ibm.websphere.appserver.basicRegistry-1.0, \
+  com.ibm.websphere.appserver.builtinAuthorization-1.0, \
+  com.ibm.websphere.appserver.ssl-1.0, \
+  com.ibm.websphere.appserver.ltpa-1.0
+-bundles=com.ibm.websphere.security.impl, \
+ com.ibm.ws.management.security, \
+ com.ibm.ws.security.quickstart
+-jars= \
+ com.ibm.websphere.appserver.api.security.spnego; location:=dev/api/ibm/
+-files= \
+ dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.security.spnego_1.1-javadoc.zip
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.security.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.security.internal.ee-6.0.feature
@@ -8,7 +8,6 @@ IBM-API-Package: javax.servlet.annotation;  type="spec", \
 visibility=private
 singleton=true
 -features= \
-  io.openliberty.servlet.api-3.0; apiJar=false; ibm.tolerates:="3.1,4.0", \
   com.ibm.websphere.appserver.builtinAuthentication-1.0, \
   io.openliberty.securityAPI.javaee-1.0
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.security.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.security.internal.ee-9.0.feature
@@ -3,7 +3,6 @@ symbolicName=io.openliberty.security.internal.ee-9.0
 visibility=private
 singleton=true
 -features= \
-  io.openliberty.servlet.api-5.0; apiJar=false; ibm.tolerates:="6.0, 6.1", \
   com.ibm.websphere.appserver.builtinAuthentication-2.0, \
   io.openliberty.securityAPI.jakarta-1.0
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundleSecurity.internal-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundleSecurity.internal-1.0.feature
@@ -5,7 +5,6 @@ visibility=private
 -features=io.openliberty.servlet.internal-3.0; ibm.tolerates:="3.1,4.0,5.0,6.0,6.1", \
   io.openliberty.webBundle.internal-1.0, \
   com.ibm.websphere.appserver.distributedMap-1.0, \
-  com.ibm.websphere.appserver.security-1.0, \
   com.ibm.websphere.appserver.authFilter-1.0, \
   io.openliberty.webBundleSecurity1.0.internal.ee-6.0; ibm.tolerates:="9.0, 10.0"
 -bundles=com.ibm.websphere.security, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundleSecurity1.0.internal.ee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundleSecurity1.0.internal.ee-10.0.feature
@@ -5,7 +5,8 @@ singleton=true
 visibility = private
 
 -features=\
-  io.openliberty.servlet.internal-6.0; ibm.tolerates:="6.1"
+  io.openliberty.servlet.internal-6.0; ibm.tolerates:="6.1", \
+  com.ibm.websphere.appserver.security-2.0
 
 -bundles= io.openliberty.webcontainer.security.internal; start-phase:=SERVICE_EARLY, \
           io.openliberty.security.authentication.internal.filter, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundleSecurity1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundleSecurity1.0.internal.ee-6.0.feature
@@ -7,7 +7,7 @@ visibility = private
 
 -features=\
   io.openliberty.servlet.internal-3.0; ibm.tolerates:="3.1, 4.0", \
-  io.openliberty.securityAPI.javaee-1.0
+  com.ibm.websphere.appserver.security-1.0
 
 -bundles= com.ibm.ws.webcontainer.security; start-phase:=SERVICE_EARLY, \
 		  com.ibm.ws.security.authentication.filter, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundleSecurity1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webBundleSecurity1.0.internal.ee-9.0.feature
@@ -6,7 +6,7 @@ visibility = private
 
 -features=\
   io.openliberty.servlet.internal-5.0, \
-  io.openliberty.securityAPI.jakarta-1.0
+  com.ibm.websphere.appserver.security-2.0
 
 -bundles= io.openliberty.webcontainer.security.internal; start-phase:=SERVICE_EARLY, \
           io.openliberty.security.authentication.internal.filter, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-2.0/com.ibm.websphere.appserver.appSecurity-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-2.0/com.ibm.websphere.appserver.appSecurity-2.0.feature
@@ -3,6 +3,10 @@ symbolicName=com.ibm.websphere.appserver.appSecurity-2.0
 WLP-DisableAllFeatures-OnConflict: false
 visibility=public
 IBM-API-Package: \
+  javax.servlet; type="spec", \
+  javax.servlet.annotation; type="spec", \
+  javax.servlet.descriptor; type="spec", \
+  javax.servlet.http; type="spec", \
   com.ibm.wsspi.security.tai; type="ibm-api", \
   com.ibm.wsspi.security.token; type="ibm-api", \
   com.ibm.wsspi.security.auth.callback; type="ibm-api", \
@@ -11,8 +15,7 @@ IBM-API-Package: \
 IBM-ShortName: appSecurity-2.0
 Subsystem-Name: Application Security 2.0
 -features=com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0", \
-  com.ibm.websphere.appserver.security-1.0, \
-  io.openliberty.securityAPI.javaee-1.0
+  com.ibm.websphere.appserver.security-1.0
 kind=ga
 edition=core
 WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
@@ -10,6 +10,10 @@ IBM-API-Package: javax.security.enterprise; type="spec", \
  javax.security.auth.message.callback; type="spec", \
  javax.security.auth.message.config; type="spec", \
  javax.security.auth.message.module; type="spec", \
+ javax.servlet; type="spec", \
+ javax.servlet.annotation; type="spec", \
+ javax.servlet.descriptor; type="spec", \
+ javax.servlet.http; type="spec", \
  com.ibm.wsspi.security.tai; type="ibm-api", \
  com.ibm.wsspi.security.token; type="ibm-api", \
  com.ibm.wsspi.security.auth.callback; type="ibm-api", \
@@ -23,8 +27,7 @@ Subsystem-Name: Application Security 3.0
   com.ibm.websphere.appserver.eeCompatible-8.0, \
   com.ibm.websphere.appserver.el-3.0, \
   com.ibm.websphere.appserver.cdi-2.0, \
-  com.ibm.websphere.appserver.security-1.0, \
-  io.openliberty.securityAPI.javaee-1.0
+  com.ibm.websphere.appserver.security-1.0
 -bundles=com.ibm.websphere.javaee.security.1.0; location:=dev/api/spec/; mavenCoordinates="javax.security.enterprise:javax.security.enterprise-api:1.0", \
  com.ibm.ws.security.javaeesec.1.0, \
  com.ibm.ws.security.javaeesec.cdi, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-4.0/io.openliberty.appSecurity-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-4.0/io.openliberty.appSecurity-4.0.feature
@@ -24,8 +24,7 @@ Subsystem-Name: Application Security 4.0 (Jakarta Security 2.0)
   com.ibm.websphere.appserver.servlet-5.0, \
   io.openliberty.servlet.internal-5.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
-  com.ibm.websphere.appserver.security-1.0, \
-  io.openliberty.securityAPI.jakarta-1.0, \
+  com.ibm.websphere.appserver.security-2.0, \
   io.openliberty.jakarta.security.enterprise-2.0, \
   io.openliberty.expressionLanguage-4.0, \
   io.openliberty.webAppSecurity-2.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-5.0/io.openliberty.appSecurity-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-5.0/io.openliberty.appSecurity-5.0.feature
@@ -25,8 +25,7 @@ Subsystem-Name: Application Security 5.0 (Jakarta Security 3.0)
   io.openliberty.jakarta.authentication-3.0, \
   com.ibm.websphere.appserver.servlet-6.0, \
   com.ibm.websphere.appserver.eeCompatible-10.0, \
-  com.ibm.websphere.appserver.security-1.0, \
-  io.openliberty.securityAPI.jakarta-1.0, \
+  com.ibm.websphere.appserver.security-2.0, \
   io.openliberty.jakarta.security.enterprise-3.0, \
   io.openliberty.expressionLanguage-5.0, \
   io.openliberty.jsonp-2.1, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-6.0/io.openliberty.appSecurity-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-6.0/io.openliberty.appSecurity-6.0.feature
@@ -25,8 +25,7 @@ Subsystem-Name: Application Security 6.0 (Jakarta Security 4.0)
   io.openliberty.jakarta.authentication-3.1, \
   com.ibm.websphere.appserver.servlet-6.1, \
   com.ibm.websphere.appserver.eeCompatible-11.0, \
-  com.ibm.websphere.appserver.security-1.0, \
-  io.openliberty.securityAPI.jakarta-1.0, \
+  com.ibm.websphere.appserver.security-2.0, \
   io.openliberty.jakarta.security.enterprise-4.0, \
   io.openliberty.expressionLanguage-6.0, \
   io.openliberty.jsonp-2.1, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/connectorsInboundSecurity-2.0/io.openliberty.connectorsInboundSecurity-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/connectorsInboundSecurity-2.0/io.openliberty.connectorsInboundSecurity-2.0.feature
@@ -13,8 +13,7 @@ Subsystem-Name: Jakarta Connectors 2.0 Inbound Security
 -features=io.openliberty.jakarta.authentication-2.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   io.openliberty.connectors-2.0, \
-  com.ibm.websphere.appserver.security-1.0, \
-  io.openliberty.securityAPI.jakarta-1.0, \
+  com.ibm.websphere.appserver.security-2.0, \
   com.ibm.websphere.appserver.transaction-2.0
 -bundles=\
    io.openliberty.connectors.security.internal.inbound

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jcaInboundSecurity-1.0/com.ibm.websphere.appserver.jcaInboundSecurity-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jcaInboundSecurity-1.0/com.ibm.websphere.appserver.jcaInboundSecurity-1.0.feature
@@ -3,6 +3,10 @@ symbolicName=com.ibm.websphere.appserver.jcaInboundSecurity-1.0
 WLP-DisableAllFeatures-OnConflict: false
 visibility=public
 IBM-API-Package: javax.security.auth.message.callback; type="spec", \
+  javax.servlet; type="spec", \
+  javax.servlet.annotation; type="spec", \
+  javax.servlet.descriptor; type="spec", \
+  javax.servlet.http; type="spec", \
   com.ibm.wsspi.security.tai; type="ibm-api", \
   com.ibm.wsspi.security.token; type="ibm-api", \
   com.ibm.wsspi.security.auth.callback; type="ibm-api", \
@@ -14,7 +18,6 @@ Subsystem-Name: Java Connector Architecture Security Inflow 1.0
   com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0", \
   io.openliberty.jcaInboundSecurity1.0.internal.ee-6.0; ibm.tolerates:=7.0, \
   com.ibm.websphere.appserver.security-1.0, \
-  io.openliberty.securityAPI.javaee-1.0, \
   com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:="1.2"
 -bundles=\
    com.ibm.ws.jca.inbound.security, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messagingSecurity-3.0/io.openliberty.messagingSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messagingSecurity-3.0/io.openliberty.messagingSecurity-3.0.feature
@@ -12,8 +12,7 @@ WLP-AlsoKnownAs: wasJmsSecurity-3.0
 Subsystem-Name: Messaging Server 3.0 Security
 -features=com.ibm.websphere.appserver.eeCompatible-9.0; ibm.tolerates:="10.0, 11.0", \
   io.openliberty.messagingServer-3.0, \
-  com.ibm.websphere.appserver.security-1.0, \
-  io.openliberty.securityAPI.jakarta-1.0
+  com.ibm.websphere.appserver.security-2.0
 -bundles=com.ibm.ws.messaging.utils, \
  com.ibm.ws.messaging.security, \
  com.ibm.ws.messaging.security.common

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/openapi-3.1/com.ibm.websphere.appserver.openapi-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/openapi-3.1/com.ibm.websphere.appserver.openapi-3.1.feature
@@ -6,6 +6,10 @@ singleton=true
 IBM-App-ForceRestart: install, uninstall
 IBM-ShortName: openapi-3.1
 IBM-API-Package: \
+  javax.servlet; type="spec", \
+  javax.servlet.annotation; type="spec", \
+  javax.servlet.descriptor; type="spec", \
+  javax.servlet.http; type="spec", \
   com.ibm.wsspi.security.tai; type="ibm-api", \
   com.ibm.wsspi.security.token; type="ibm-api", \
   com.ibm.wsspi.security.auth.callback; type="ibm-api", \
@@ -18,7 +22,6 @@ Subsystem-Name: OpenAPI 3.1
 -features=com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
   io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.adminSecurity-1.0, \
-  io.openliberty.securityAPI.javaee-1.0, \
   com.ibm.websphere.appserver.mpOpenAPI-1.0, \
   com.ibm.websphere.appserver.mpConfig-1.2; ibm.tolerates:="1.3,1.4", \
   com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1"

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/sessionCache-1.0/com.ibm.websphere.appserver.sessionCache-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/sessionCache-1.0/com.ibm.websphere.appserver.sessionCache-1.0.feature
@@ -20,7 +20,8 @@ IBM-API-Package: \
   com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:="1.1,2.0", \
   io.openliberty.servlet.api-4.0; apiJar=false; ibm.tolerates:="3.1,3.0,5.0,6.0,6.1", \
   io.openliberty.sessionCache1.0.internal.ee-6.0; ibm.tolerates:="9.0", \
-  io.openliberty.jcache.internal-1.1
+  io.openliberty.jcache.internal-1.1, \
+  io.openliberty.jcache.internal1.1.ee-8.0; ibm.tolerates:="6.0, 9.0"
 -bundles=\
   com.ibm.websphere.security
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsSecurity-1.0/com.ibm.websphere.appserver.wasJmsSecurity-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/wasJmsSecurity-1.0/com.ibm.websphere.appserver.wasJmsSecurity-1.0.feature
@@ -3,6 +3,10 @@ symbolicName=com.ibm.websphere.appserver.wasJmsSecurity-1.0
 WLP-DisableAllFeatures-OnConflict: false
 visibility=public
 IBM-API-Package: \
+  javax.servlet; type="spec", \
+  javax.servlet.annotation; type="spec", \
+  javax.servlet.descriptor; type="spec", \
+  javax.servlet.http; type="spec", \
   com.ibm.wsspi.security.tai; type="ibm-api", \
   com.ibm.wsspi.security.token; type="ibm-api", \
   com.ibm.wsspi.security.auth.callback; type="ibm-api", \
@@ -14,7 +18,6 @@ Subsystem-Name: Message Server Security 1.0
   com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0", \
   com.ibm.websphere.appserver.wasJmsServer-1.0, \
   com.ibm.websphere.appserver.security-1.0, \
-  io.openliberty.securityAPI.javaee-1.0, \
   com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:="1.2"
 -bundles=\
   com.ibm.ws.messaging.utils, \

--- a/dev/com.ibm.websphere.security_fat.1/publish/files/internalfeatures/webspheresecuritylibertyinternals-1.0.mf
+++ b/dev/com.ibm.websphere.security_fat.1/publish/files/internalfeatures/webspheresecuritylibertyinternals-1.0.mf
@@ -1,6 +1,7 @@
 Subsystem-ManifestVersion: 1
 Subsystem-SymbolicName: webspheresecuritylibertyinternals-1.0;visibility:=public
 Subsystem-Version: 1.0.0
-Subsystem-Content: com.ibm.websphere.appserver.security-1.0; type="osgi.subsystem.feature"
+Subsystem-Content: com.ibm.websphere.appserver.security-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature"
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2
+

--- a/dev/com.ibm.ws.security.token.ltpa_fat/publish/files/internalFeatureForFat/ltpafattestlibertyinternals-1.0.mf
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/publish/files/internalFeatureForFat/ltpafattestlibertyinternals-1.0.mf
@@ -2,8 +2,9 @@ Subsystem-ManifestVersion: 1
 Subsystem-SymbolicName: ltpafattestlibertyinternals-1.0;visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Content: com.ibm.websphere.appserver.ltpa-1.0; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.security-1.0; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.security-1.0; ibm.tolerates:="2.0"; type="osgi.subsystem.feature"
 Subsystem-Type: osgi.subsystem.feature
 IBM-API-Package: com.ibm.ws.security.token;  type="internal",
  org.osgi.framework;  type="internal"
 IBM-Feature-Version: 2
+


### PR DESCRIPTION
- Update to have a com.ibm.websphere.appserver.security-2.0 feature and put the common features from 1.0 into a common feature and then reference the security-1.0 or 2.0 features in the appropriate places whether doing EE 6, 7, 8 or EE 9+
- When generating feature javadoc references, both the Java EE and Jakarta EE 9 + versions of APIs are found and the wrong one can get used by the documentation generator since it will just pick one if more than one is available.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
