### PR TITLE
fix: default managed thread factory context classloader

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -13,25 +13,26 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-src: \
-	fat/src,\
-	test-applications/concurrentCDI2App/src,\
-	test-applications/concurrentCDI3App/src,\
-	test-applications/concurrentCDI4App/src,\
-	test-applications/concurrentCDIWeb/src
+src:\
+    fat/src,\
+    test-applications/concurrentCDI2App/src,\
+    test-applications/concurrentCDI3App/src,\
+    test-applications/concurrentCDI4App/src,\
+    test-applications/concurrentCDIWeb/src
 
 fat.project: true
 
--buildpath: \
-	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
-	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
-	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
-	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
-	io.openliberty.jakarta.annotation.2.1;version=latest,\
-	io.openliberty.jakarta.cdi.4.1;version=latest,\
-	io.openliberty.jakarta.concurrency.3.1;version=latest,\
-	io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\
-	io.openliberty.jakarta.interceptor.2.1;version=latest,\
-	io.openliberty.jakarta.servlet.6.1;version=latest,\
-	io.openliberty.jakarta.transaction.2.0;version=latest
+-buildpath:\
+    com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+    com.ibm.websphere.javaee.cdi.1.2;version=latest,\
+    com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
+    com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+    com.ibm.websphere.javaee.transaction.1.2;version=latest,\
+    io.openliberty.jakarta.annotation.2.1;version=latest,\
+    io.openliberty.jakarta.cdi.4.1;version=latest,\
+    io.openliberty.jakarta.concurrency.3.1;version=latest,\
+    io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\
+    io.openliberty.jakarta.interceptor.2.1;version=latest,\
+    io.openliberty.jakarta.servlet.6.1;version=latest,\
+    io.openliberty.jakarta.transaction.2.0;version=latest
+

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -170,6 +170,26 @@ public class ConcurrentCDITest extends FATServletClient {
     }
 
     @Test
+    public void testInjectManagedThreadFactoryDefaultInstanceClassloader() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedThreadFactoryDefaultInstanceClassloaderFromBean() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedThreadFactoryDefaultInstanceClassloaderFromEJB() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testInjectManagedThreadFactoryDefaultInstanceClassloaderFromLookup() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
     public void testInjectManagedThreadFactoryQualifiedFromAnno() throws Exception {
         runTest(server, APP_NAME, testName);
     }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -170,6 +170,11 @@ public class ConcurrentCDITest extends FATServletClient {
     }
 
     @Test
+    public void testInjectManagedThreadFactoryQualifiedClassloader() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
     public void testInjectManagedThreadFactoryDefaultInstanceClassloader() throws Exception {
         runTest(server, APP_NAME, testName);
     }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/Invoker.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/Invoker.java
@@ -13,9 +13,11 @@
 package concurrent.cdi.ejb;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 
 public interface Invoker {
 
     public <T> T runInEJB(Callable<T> testCode) throws Exception;
 
+    public void testDefaultManagedThreadFactoryClassloader(CompletableFuture<String> future);
 }

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/InvokerEJB.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/InvokerEJB.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package concurrent.cdi.ejb;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.concurrent.Callable;
@@ -43,16 +44,31 @@ public class InvokerEJB implements Invoker {
 
         // Requires the application's classloader (to access application scoped classes)
         Runnable task = () -> {
-            System.out.println("KJA1017 Thread classloader is: " + Thread.currentThread().getContextClassLoader());
-            System.out.println("KJA1017 Invoker classloader is: " + Invoker.class.getClassLoader());
+            try {
+                assertNotNull("Expected context classloader to be non-null",
+                              Thread.currentThread().getContextClassLoader());
+                assertEquals("Expected context classloader and Invoker classloader to be the same",
+                             Invoker.class.getClassLoader(),
+                             Thread.currentThread().getContextClassLoader());
+            } catch (AssertionError e) {
+                future.completeExceptionally(e);
+            }
+
             try {
                 Class.forName("java.lang.Integer"); //Exists as part of JVM
                 Class.forName("concurrent.cdi.ejb.Invoker"); //Exists inside EJB Module
-                Class.forName("concurrent.cdi.ext.ConcurrentCDIExtension"); // Exists outside EJB Module
-                future.complete("SUCCESS");
             } catch (ClassNotFoundException e) {
                 future.completeExceptionally(e);
             }
+
+            try {
+                Class.forName("concurrent.cdi.ext.ConcurrentCDIExtension"); // Exists outside EJB Module
+                future.completeExceptionally(new AssertionError("Should not have been able to load a class outside the EJB Module"));
+            } catch (ClassNotFoundException e) {
+                // expected
+            }
+
+            future.complete("SUCCESS");
         };
 
         Thread thread = defaultManagedThreadFactory.newThread(task);

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/InvokerEJB.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/ejb/InvokerEJB.java
@@ -43,6 +43,8 @@ public class InvokerEJB implements Invoker {
 
         // Requires the application's classloader (to access application scoped classes)
         Runnable task = () -> {
+            System.out.println("KJA1017 Thread classloader is: " + Thread.currentThread().getContextClassLoader());
+            System.out.println("KJA1017 Invoker classloader is: " + Invoker.class.getClassLoader());
             try {
                 Class.forName("java.lang.Integer"); //Exists as part of JVM
                 Class.forName("concurrent.cdi.ejb.Invoker"); //Exists inside EJB Module

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/AppBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/AppBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,34 +10,25 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package concurrent.cdi.ejb;
+package concurrent.cdi.web;
 
 import static org.junit.Assert.assertNotNull;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 
-import jakarta.ejb.Local;
-import jakarta.ejb.Stateless;
-import jakarta.ejb.TransactionManagement;
-import jakarta.ejb.TransactionManagementType;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-@Local(Invoker.class)
-@Stateless
-@TransactionManagement(TransactionManagementType.CONTAINER)
-public class InvokerEJB implements Invoker {
-
-    @Override
-    public <T> T runInEJB(Callable<T> testCode) throws Exception {
-        return testCode.call();
-    }
+/**
+ * An application scoped bean that inject
+ */
+@ApplicationScoped
+public class AppBean {
 
     @Inject
-    ManagedThreadFactory defaultManagedThreadFactory;
+    private ManagedThreadFactory defaultManagedThreadFactory;
 
-    @Override
     public void testDefaultManagedThreadFactoryClassloader(CompletableFuture<String> future) {
         assertNotNull(defaultManagedThreadFactory);
 
@@ -45,8 +36,8 @@ public class InvokerEJB implements Invoker {
         Runnable task = () -> {
             try {
                 Class.forName("java.lang.Integer"); //Exists as part of JVM
-                Class.forName("concurrent.cdi.ejb.Invoker"); //Exists inside EJB Module
-                Class.forName("concurrent.cdi.ext.ConcurrentCDIExtension"); // Exists outside EJB Module
+                Class.forName("concurrent.cdi.web.MyAsync"); //Exists inside Web Module
+                Class.forName("concurrent.cdi.ext.ConcurrentCDIExtension"); // Exists outside Web Module
                 future.complete("SUCCESS");
             } catch (ClassNotFoundException e) {
                 future.completeExceptionally(e);

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/AppBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/AppBean.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.concurrent.CompletableFuture;
@@ -34,8 +35,16 @@ public class AppBean {
 
         // Requires the application's classloader (to access application scoped classes)
         Runnable task = () -> {
-            System.out.println("KJA1017 Thread classloader is: " + Thread.currentThread().getContextClassLoader());
-            System.out.println("KJA1017 MyAsync classloader is: " + MyAsync.class.getClassLoader());
+            try {
+                assertNotNull("Expected context classloader to be non-null",
+                              Thread.currentThread().getContextClassLoader());
+
+                assertEquals("Expected context classloader and MyAsync classloader to be the same",
+                             MyAsync.class.getClassLoader(),
+                             Thread.currentThread().getContextClassLoader());
+            } catch (AssertionError e) {
+                future.completeExceptionally(e);
+            }
 
             try {
                 Class.forName("java.lang.Integer"); //Exists as part of JVM

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/AppBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/AppBean.java
@@ -34,6 +34,9 @@ public class AppBean {
 
         // Requires the application's classloader (to access application scoped classes)
         Runnable task = () -> {
+            System.out.println("KJA1017 Thread classloader is: " + Thread.currentThread().getContextClassLoader());
+            System.out.println("KJA1017 MyAsync classloader is: " + MyAsync.class.getClassLoader());
+
             try {
                 Class.forName("java.lang.Integer"); //Exists as part of JVM
                 Class.forName("concurrent.cdi.web.MyAsync"); //Exists inside Web Module

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -709,6 +709,41 @@ public class ConcurrentCDIServlet extends HttpServlet {
         assertEquals("value1", result);
     }
 
+    public void testInjectManagedThreadFactoryQualifiedClassloader() throws Exception {
+        assertNotNull(threadFactoryWithAppContext);
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        final ClassLoader expected = MyAsync.class.getClassLoader();
+
+        Runnable task = () -> {
+            try {
+                assertNotNull("Expected thread context classloader to be non-null",
+                              Thread.currentThread().getContextClassLoader());
+
+                assertEquals("Expected thread context classloader and MyAsync classloader to be the same",
+                             expected,
+                             Thread.currentThread().getContextClassLoader());
+            } catch (AssertionError e) {
+                future.completeExceptionally(e);
+            }
+
+            try {
+                Class.forName("java.lang.Integer"); //Exists as part of JVM
+                Class.forName("concurrent.cdi.web.MyAsync"); //Exists inside Web Module
+                Class.forName("concurrent.cdi.ext.ConcurrentCDIExtension"); // Exists outside Web Module
+                future.complete("SUCCESS");
+            } catch (ClassNotFoundException e) {
+                future.completeExceptionally(e);
+            }
+        };
+
+        Thread thread = threadFactoryWithAppContext.newThread(task);
+        thread.start();
+
+        String result = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals("SUCCESS", result);
+    }
+
     /**
      * Inject an instance of the default ManagedThreadFactory resource and use it.
      * Ensure that the default ManagedThreadFactory is configured with the application's classloader.
@@ -721,8 +756,16 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
         // Requires the application's classloader (to access application scoped classes)
         Runnable task = () -> {
-            System.out.println("KJA1017 Thread classloader is: " + Thread.currentThread().getContextClassLoader());
-            System.out.println("KJA1017 MyAsync classloader is: " + MyAsync.class.getClassLoader());
+            try {
+                assertNotNull("Expected context classloader to be non-null",
+                              Thread.currentThread().getContextClassLoader());
+
+                assertEquals("Expected context classloader and MyAsync classloader to be the same",
+                             MyAsync.class.getClassLoader(),
+                             Thread.currentThread().getContextClassLoader());
+            } catch (AssertionError e) {
+                future.completeExceptionally(e);
+            }
 
             try {
                 Class.forName("java.lang.Integer"); //Exists as part of JVM
@@ -775,8 +818,16 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
         // Requires the application's classloader (to access application scoped classes)
         Runnable task = () -> {
-            System.out.println("KJA1017 Thread classloader is: " + Thread.currentThread().getContextClassLoader());
-            System.out.println("KJA1017 MyAsync classloader is: " + MyAsync.class.getClassLoader());
+            try {
+                assertNotNull("Expected context classloader to be non-null",
+                              Thread.currentThread().getContextClassLoader());
+
+                assertEquals("Expected context classloader and MyAsync classloader to be the same",
+                             MyAsync.class.getClassLoader(),
+                             Thread.currentThread().getContextClassLoader());
+            } catch (AssertionError e) {
+                future.completeExceptionally(e);
+            }
 
             try {
                 Class.forName("java.lang.Integer"); //Exists as part of JVM

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -18,6 +18,7 @@ import static jakarta.enterprise.concurrent.ContextServiceDefinition.TRANSACTION
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -235,6 +236,9 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
     @Inject
     TestBean testBean;
+
+    @Inject
+    AppBean appBean;
 
     @Resource
     UserTransaction tx;
@@ -680,6 +684,7 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
     /**
      * Inject an instance of the default ManagedThreadFactory resource and use it.
+     * Ensure that the default ManagedThreadFactory is configured with the application's context.
      */
     public void testInjectManagedThreadFactoryDefaultInstance() throws Exception {
         assertNotNull(defaultManagedThreadFactory);
@@ -702,6 +707,86 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
         Object result = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
         assertEquals("value1", result);
+    }
+
+    /**
+     * Inject an instance of the default ManagedThreadFactory resource and use it.
+     * Ensure that the default ManagedThreadFactory is configured with the application's classloader.
+     * As opposed to the module/container?
+     */
+    public void testInjectManagedThreadFactoryDefaultInstanceClassloader() throws Exception {
+        assertNotNull(defaultManagedThreadFactory);
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        // Requires the application's classloader (to access application scoped classes)
+        Runnable task = () -> {
+            try {
+                Class.forName("java.lang.Integer"); //Exists as part of JVM
+                Class.forName("concurrent.cdi.web.MyAsync"); //Exists inside Web Module
+                Class.forName("concurrent.cdi.ext.ConcurrentCDIExtension"); // Exists outside Web Module
+                future.complete("SUCCESS");
+            } catch (ClassNotFoundException e) {
+                future.completeExceptionally(e);
+            }
+        };
+
+        Thread thread = defaultManagedThreadFactory.newThread(task);
+        thread.start();
+
+        String result = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals("SUCCESS", result);
+    }
+
+    public void testInjectManagedThreadFactoryDefaultInstanceClassloaderFromBean() throws Exception {
+        assertNotNull(appBean);
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        appBean.testDefaultManagedThreadFactoryClassloader(future);
+
+        String result = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals("SUCCESS", result);
+    }
+
+    public void testInjectManagedThreadFactoryDefaultInstanceClassloaderFromEJB() throws Exception {
+        assertNotNull(ejb);
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        ejb.testDefaultManagedThreadFactoryClassloader(future);
+
+        String result = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals("SUCCESS", result);
+    }
+
+    public void testInjectManagedThreadFactoryDefaultInstanceClassloaderFromLookup() throws Exception {
+        Instance<ManagedThreadFactory> defaultManagedThreadFactoryInstance = CDI.current().select(ManagedThreadFactory.class, new Annotation[] { Default.Literal.INSTANCE });
+
+        assertTrue("ManagedTheadFactoryBean should have been avaialble with default qualifier",
+                   defaultManagedThreadFactoryInstance.isResolvable());
+
+        ManagedThreadFactory defaultManagedThreadFactoryLookup = defaultManagedThreadFactoryInstance.get();
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        // Requires the application's classloader (to access application scoped classes)
+        Runnable task = () -> {
+            try {
+                Class.forName("java.lang.Integer"); //Exists as part of JVM
+                Class.forName("concurrent.cdi.web.MyAsync"); //Exists inside Web Module
+                Class.forName("concurrent.cdi.ext.ConcurrentCDIExtension"); // Exists outside Web Module
+                future.complete("SUCCESS");
+            } catch (ClassNotFoundException e) {
+                future.completeExceptionally(e);
+            }
+        };
+
+        Thread thread = defaultManagedThreadFactoryLookup.newThread(task);
+        thread.start();
+
+        String result = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertEquals("SUCCESS", result);
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIWeb/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -721,6 +721,9 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
         // Requires the application's classloader (to access application scoped classes)
         Runnable task = () -> {
+            System.out.println("KJA1017 Thread classloader is: " + Thread.currentThread().getContextClassLoader());
+            System.out.println("KJA1017 MyAsync classloader is: " + MyAsync.class.getClassLoader());
+
             try {
                 Class.forName("java.lang.Integer"); //Exists as part of JVM
                 Class.forName("concurrent.cdi.web.MyAsync"); //Exists inside Web Module
@@ -772,6 +775,9 @@ public class ConcurrentCDIServlet extends HttpServlet {
 
         // Requires the application's classloader (to access application scoped classes)
         Runnable task = () -> {
+            System.out.println("KJA1017 Thread classloader is: " + Thread.currentThread().getContextClassLoader());
+            System.out.println("KJA1017 MyAsync classloader is: " + MyAsync.class.getClassLoader());
+
             try {
                 Class.forName("java.lang.Integer"); //Exists as part of JVM
                 Class.forName("concurrent.cdi.web.MyAsync"); //Exists inside Web Module

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -15,8 +15,10 @@ package io.openliberty.concurrent.internal.cdi;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Member;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.osgi.framework.BundleContext;
@@ -33,8 +35,11 @@ import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.runtime.metadata.MetaData;
 import com.ibm.ws.runtime.metadata.ModuleMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
+import com.ibm.wsspi.resource.ResourceFactory;
+import com.ibm.wsspi.resource.ResourceInfo;
 
 import io.openliberty.concurrent.internal.cdi.interceptor.AsyncInterceptor;
+import io.openliberty.concurrent.internal.cdi.metadata.MTFDeferredMetaDataFactory;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
 import jakarta.enterprise.concurrent.Asynchronous;
@@ -46,16 +51,16 @@ import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.enterprise.concurrent.ManagedThreadFactoryDefinition;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Default;
-import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
-import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
 import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 
 /**
  * CDI Extension for Jakarta Concurrency 3.1+ in Jakarta EE 11+, which corresponds to CDI 4.1+
@@ -71,13 +76,6 @@ public class ConcurrencyExtension implements Extension {
      * OSGi service for the Concurrency extension;
      */
     private ConcurrencyExtensionMetadata extSvc;
-
-    /**
-     * Indicates if we were able to create a default ManagedThreadFactory bean.
-     * If so, an instance of the bean is obtained during afterDeploymentValidation
-     * to force context capture to occur.
-     */
-    private boolean producedDefaultMTF;
 
     /**
      * Register interceptors before bean discovery.
@@ -124,10 +122,63 @@ public class ConcurrencyExtension implements Extension {
         if (!cdi.select(ManagedScheduledExecutorService.class, DEFAULT_QUALIFIER_ARRAY).isResolvable())
             event.addBean(new ManagedScheduledExecutorBean(extSvc.defaultManagedScheduledExecutorFactory, DEFAULT_QUALIFIER_SET));
 
-        if (!cdi.select(ManagedThreadFactory.class, DEFAULT_QUALIFIER_ARRAY).isResolvable()) {
-            event.addBean(new ManagedThreadFactoryBean(cmd, extSvc, DEFAULT_QUALIFIER_SET));
-            producedDefaultMTF = true;
-        }
+        // Default managed thread factory is dependent scoped.
+        // beans are created based on injection point to determine Classloader at creation
+        //
+        final ResourceFactory MTFfactory = extSvc.defaultManagedThreadFactoryFactory;
+        event.addBean() //
+                        .types(ManagedThreadFactory.class) //
+                        .beanClass(ManagedThreadFactory.class) //
+                        .scope(Dependent.class) //
+                        .qualifiers(DEFAULT_QUALIFIER_ARRAY) //
+                        .id("ManagedThreadFactory:Default:" + MTFfactory) //unique identifier for PassivationCapable
+                        .alternative(false) //
+                        .createWith(cc -> {
+                            final String m = "lambda$createWith$BeanConfigurator";
+
+                            // Get declaring classloader - based on injection point
+                            InjectionPoint ip = CDI.current().select(InjectionPoint.class).get();
+                            Member member = ip.getMember();
+                            ClassLoader declaringClassLoader = null;
+                            if (Objects.nonNull(member)) { // When injection point is on a field or method
+                                declaringClassLoader = member.getDeclaringClass().getClassLoader();
+                            } else { // Programmatic lookup
+                                // TODO how can we determine classloader during programmatic lookup?
+                                // There seems to be a disconnect between the Concurrency and CDI specs in this space.
+                                // Concurrency says the default MTF
+                            }
+
+                            // Get declaring metadata
+                            ApplicationMetaData amd = cmd.getModuleMetaData().getApplicationMetaData();
+                            MTFDeferredMetaDataFactory metadataFactory = (MTFDeferredMetaDataFactory) extSvc.mtfMetadataFactory;
+                            MetaData declaringMetadata = metadataFactory.createComponentMetadata(amd, declaringClassLoader);
+
+                            final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+                            if (trace && tc.isEntryEnabled())
+                                Tr.entry(this, tc, m, cc, MTFfactory);
+
+                            ManagedThreadFactory instance;
+                            try {
+                                ResourceInfo info = new MTFBeanResourceInfoImpl(declaringClassLoader, declaringMetadata);
+                                instance = (ManagedThreadFactory) MTFfactory.createResource(info);
+                            } catch (RuntimeException x) {
+                                if (trace && tc.isEntryEnabled())
+                                    Tr.exit(this, tc, m, x);
+                                throw x;
+                            } catch (Exception x) {
+                                if (trace && tc.isEntryEnabled())
+                                    Tr.exit(this, tc, m, x);
+                                throw new RuntimeException(x);
+                            }
+
+                            if (trace && tc.isEntryEnabled())
+                                Tr.exit(this, tc, m, instance);
+
+                            return instance;
+                        });
+        // No destoryWith method necessary
+        // in-flight threads from this factory are expected to outlive the ManagedThreadFactory itself.
 
         // Look for beans from the module and the application.
         // TODO EJBs and component level?
@@ -223,26 +274,6 @@ public class ConcurrencyExtension implements Extension {
                          toArtifactName(factory.getDeclaringMetadata()),
                          toStackTrace(x));
             }
-        }
-    }
-
-    /**
-     * Force context to be initialized for the default ManagedThreadFactory instance
-     * if we were able to produce one.
-     *
-     * @param event
-     * @param beanManager
-     */
-    public void afterDeploymentValidation(@Observes AfterDeploymentValidation event,
-                                          BeanManager beanManager) {
-        if (producedDefaultMTF) {
-            CDI<Object> cdi = CDI.current();
-            Instance<ManagedThreadFactory> instance = //
-                            cdi.select(ManagedThreadFactory.class, new Annotation[0]);
-            ManagedThreadFactory mtf = instance.get();
-
-            // Force instantiation of the bean in order to cause context to be captured
-            mtf.toString();
         }
     }
 

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -31,11 +31,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.cdi.extension.CDIExtensionMetadataInternal;
-import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
-import com.ibm.ws.container.service.app.deploy.EARApplicationInfo;
 import com.ibm.ws.container.service.metadata.extended.DeferredMetaDataFactory;
-import com.ibm.ws.container.service.state.ApplicationStateListener;
-import com.ibm.ws.container.service.state.StateChangeException;
 import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.wsspi.resource.ResourceFactory;
 
@@ -49,8 +45,8 @@ import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.enterprise.inject.spi.Extension;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
-           service = { ApplicationStateListener.class, CDIExtensionMetadata.class, QualifiedResourceFactories.class })
-public class ConcurrencyExtensionMetadata implements ApplicationStateListener, CDIExtensionMetadata, CDIExtensionMetadataInternal, QualifiedResourceFactories {
+           service = { CDIExtensionMetadata.class, QualifiedResourceFactories.class })
+public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIExtensionMetadataInternal, QualifiedResourceFactories {
     private static final TraceComponent tc = Tr.register(ConcurrencyExtensionMetadata.class);
 
     private static final Set<Class<?>> beanClasses = Set.of(ContextService.class,
@@ -89,8 +85,6 @@ public class ConcurrencyExtensionMetadata implements ApplicationStateListener, C
                policy = ReferencePolicy.DYNAMIC,
                policyOption = ReferencePolicyOption.GREEDY)
     protected volatile ResourceFactory defaultManagedThreadFactoryFactory;
-
-    protected volatile ClassLoader applicationClassLoader;
 
     /**
      * Jakarta EE version.
@@ -215,28 +209,5 @@ public class ConcurrencyExtensionMetadata implements ApplicationStateListener, C
     }
 
     protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
-    }
-
-    @Override
-    public void applicationStarting(ApplicationInfo appInfo) throws StateChangeException {
-        System.out.println("KJA1017 applicationStarting: " + appInfo.toString());
-        if (appInfo instanceof EARApplicationInfo) {
-            System.out.println("KJA1017 is EARApplicationInfo");
-            applicationClassLoader = ((EARApplicationInfo) appInfo).getApplicationClassLoader();
-            System.out.println("KJA1017 applicationClassLoader is: " + applicationClassLoader.toString());
-        }
-    }
-
-    @Override
-    public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {
-    }
-
-    @Override
-    public void applicationStopping(ApplicationInfo appInfo) {
-    }
-
-    @Override
-    public void applicationStopped(ApplicationInfo appInfo) {
-        applicationClassLoader = null; //TODO is this necessary?
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -31,7 +31,11 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.cdi.extension.CDIExtensionMetadataInternal;
+import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
+import com.ibm.ws.container.service.app.deploy.EARApplicationInfo;
 import com.ibm.ws.container.service.metadata.extended.DeferredMetaDataFactory;
+import com.ibm.ws.container.service.state.ApplicationStateListener;
+import com.ibm.ws.container.service.state.StateChangeException;
 import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.wsspi.resource.ResourceFactory;
 
@@ -45,8 +49,8 @@ import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.enterprise.inject.spi.Extension;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
-           service = { CDIExtensionMetadata.class, QualifiedResourceFactories.class })
-public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIExtensionMetadataInternal, QualifiedResourceFactories {
+           service = { ApplicationStateListener.class, CDIExtensionMetadata.class, QualifiedResourceFactories.class })
+public class ConcurrencyExtensionMetadata implements ApplicationStateListener, CDIExtensionMetadata, CDIExtensionMetadataInternal, QualifiedResourceFactories {
     private static final TraceComponent tc = Tr.register(ConcurrencyExtensionMetadata.class);
 
     private static final Set<Class<?>> beanClasses = Set.of(ContextService.class,
@@ -85,6 +89,8 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
                policy = ReferencePolicy.DYNAMIC,
                policyOption = ReferencePolicyOption.GREEDY)
     protected volatile ResourceFactory defaultManagedThreadFactoryFactory;
+
+    protected volatile ClassLoader applicationClassLoader;
 
     /**
      * Jakarta EE version.
@@ -209,5 +215,28 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
     }
 
     protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
+    }
+
+    @Override
+    public void applicationStarting(ApplicationInfo appInfo) throws StateChangeException {
+        System.out.println("KJA1017 applicationStarting: " + appInfo.toString());
+        if (appInfo instanceof EARApplicationInfo) {
+            System.out.println("KJA1017 is EARApplicationInfo");
+            applicationClassLoader = ((EARApplicationInfo) appInfo).getApplicationClassLoader();
+            System.out.println("KJA1017 applicationClassLoader is: " + applicationClassLoader.toString());
+        }
+    }
+
+    @Override
+    public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {
+    }
+
+    @Override
+    public void applicationStopping(ApplicationInfo appInfo) {
+    }
+
+    @Override
+    public void applicationStopped(ApplicationInfo appInfo) {
+        applicationClassLoader = null; //TODO is this necessary?
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,17 +17,10 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Set;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceReference;
-
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.classloading.ClassLoaderIdentifierService;
-import com.ibm.ws.container.service.metadata.extended.IdentifiableComponentMetaData;
 import com.ibm.ws.runtime.metadata.ApplicationMetaData;
-import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.runtime.metadata.MetaData;
 import com.ibm.wsspi.resource.ResourceFactory;
 import com.ibm.wsspi.resource.ResourceInfo;
@@ -53,8 +46,7 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
     private final Set<Type> beanTypes = Set.of(ManagedThreadFactory.class);
 
     /**
-     * Class loader of the application artifact that defines the managed thread factory definition.
-     * Or, if a bean for a default instance then the class loader for the application.
+     * Classloader of the application artifact that defines the managed thread factory definition.
      */
     private final ClassLoader declaringClassLoader;
 
@@ -72,37 +64,6 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
      * Qualifiers for the injection points for this bean.
      */
     private final Set<Annotation> qualifiers;
-
-    /**
-     * Construct a new bean for this resource, which is for default ManagedThreadFactory instances
-     * at the application level.
-     *
-     * @param cmd        component metadata from the thread upon which the CDI extension runs.
-     * @param extSvc     OSGi service for the Concurrency extension.
-     * @param qualifiers qualifiers for the bean.
-     */
-    ManagedThreadFactoryBean(ComponentMetaData cmd, ConcurrencyExtensionMetadata extSvc, Set<Annotation> qualifiers) {
-        this.factory = extSvc.defaultManagedThreadFactoryFactory;
-        this.qualifiers = qualifiers;
-
-        // TODO find out how to get the class loader for the application.
-        // It is not correct to use whichever application component's classloader happens to be on the thread.
-        if (cmd instanceof IdentifiableComponentMetaData) {
-            String identifier = ((IdentifiableComponentMetaData) cmd).getPersistentIdentifier();
-
-            BundleContext bc = FrameworkUtil.getBundle(ClassLoaderIdentifierService.class).getBundleContext();
-            ServiceReference<ClassLoaderIdentifierService> ref = bc.getServiceReference(ClassLoaderIdentifierService.class);
-            ClassLoaderIdentifierService classloaderIdSvc = bc.getService(ref);
-            this.declaringClassLoader = classloaderIdSvc.getClassLoader(identifier);
-        } else {
-            throw new IllegalArgumentException(cmd.toString()); // internal error
-        }
-
-        // The Concurrency extension could be running under any module/component of the application.
-        ApplicationMetaData amd = cmd.getModuleMetaData().getApplicationMetaData();
-        MTFDeferredMetaDataFactory metadataFactory = (MTFDeferredMetaDataFactory) extSvc.mtfMetadataFactory;
-        this.declaringMetadata = metadataFactory.createComponentMetadata(amd, declaringClassLoader);
-    }
 
     /**
      * Construct a new bean for this resource.

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
@@ -17,15 +17,9 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Set;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceReference;
-
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.classloading.ClassLoaderIdentifierService;
-import com.ibm.ws.container.service.metadata.extended.IdentifiableComponentMetaData;
 import com.ibm.ws.runtime.metadata.ApplicationMetaData;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.runtime.metadata.MetaData;
@@ -84,19 +78,7 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
     ManagedThreadFactoryBean(ComponentMetaData cmd, ConcurrencyExtensionMetadata extSvc, Set<Annotation> qualifiers) {
         this.factory = extSvc.defaultManagedThreadFactoryFactory;
         this.qualifiers = qualifiers;
-
-        // TODO find out how to get the class loader for the application.
-        // It is not correct to use whichever application component's classloader happens to be on the thread.
-        if (cmd instanceof IdentifiableComponentMetaData) {
-            String identifier = ((IdentifiableComponentMetaData) cmd).getPersistentIdentifier();
-
-            BundleContext bc = FrameworkUtil.getBundle(ClassLoaderIdentifierService.class).getBundleContext();
-            ServiceReference<ClassLoaderIdentifierService> ref = bc.getServiceReference(ClassLoaderIdentifierService.class);
-            ClassLoaderIdentifierService classloaderIdSvc = bc.getService(ref);
-            this.declaringClassLoader = classloaderIdSvc.getClassLoader(identifier);
-        } else {
-            throw new IllegalArgumentException(cmd.toString()); // internal error
-        }
+        this.declaringClassLoader = null;
 
         // The Concurrency extension could be running under any module/component of the application.
         ApplicationMetaData amd = cmd.getModuleMetaData().getApplicationMetaData();

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
@@ -78,7 +78,7 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
     ManagedThreadFactoryBean(ComponentMetaData cmd, ConcurrencyExtensionMetadata extSvc, Set<Annotation> qualifiers) {
         this.factory = extSvc.defaultManagedThreadFactoryFactory;
         this.qualifiers = qualifiers;
-        this.declaringClassLoader = null;
+        this.declaringClassLoader = extSvc.applicationClassLoader; //Could be null - in which case defer the classloader decision until later
 
         // The Concurrency extension could be running under any module/component of the application.
         ApplicationMetaData amd = cmd.getModuleMetaData().getApplicationMetaData();
@@ -96,6 +96,8 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
         this.factory = factory;
         this.qualifiers = factory.getQualifiers();
         this.declaringClassLoader = factory.getDeclaringClassLoader();
+
+        System.out.println("KJA1017 declaring classloader: " + declaringClassLoader);
 
         MetaData mdata = factory.getDeclaringMetadata();
         if (mdata instanceof ApplicationMetaData amd) {

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ManagedThreadFactoryBean.java
@@ -17,9 +17,15 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Set;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.classloading.ClassLoaderIdentifierService;
+import com.ibm.ws.container.service.metadata.extended.IdentifiableComponentMetaData;
 import com.ibm.ws.runtime.metadata.ApplicationMetaData;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.runtime.metadata.MetaData;
@@ -78,7 +84,19 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
     ManagedThreadFactoryBean(ComponentMetaData cmd, ConcurrencyExtensionMetadata extSvc, Set<Annotation> qualifiers) {
         this.factory = extSvc.defaultManagedThreadFactoryFactory;
         this.qualifiers = qualifiers;
-        this.declaringClassLoader = extSvc.applicationClassLoader; //Could be null - in which case defer the classloader decision until later
+
+        // TODO find out how to get the class loader for the application.
+        // It is not correct to use whichever application component's classloader happens to be on the thread.
+        if (cmd instanceof IdentifiableComponentMetaData) {
+            String identifier = ((IdentifiableComponentMetaData) cmd).getPersistentIdentifier();
+
+            BundleContext bc = FrameworkUtil.getBundle(ClassLoaderIdentifierService.class).getBundleContext();
+            ServiceReference<ClassLoaderIdentifierService> ref = bc.getServiceReference(ClassLoaderIdentifierService.class);
+            ClassLoaderIdentifierService classloaderIdSvc = bc.getService(ref);
+            this.declaringClassLoader = classloaderIdSvc.getClassLoader(identifier);
+        } else {
+            throw new IllegalArgumentException(cmd.toString()); // internal error
+        }
 
         // The Concurrency extension could be running under any module/component of the application.
         ApplicationMetaData amd = cmd.getModuleMetaData().getApplicationMetaData();
@@ -96,8 +114,6 @@ public class ManagedThreadFactoryBean implements Bean<ManagedThreadFactory>, Pas
         this.factory = factory;
         this.qualifiers = factory.getQualifiers();
         this.declaringClassLoader = factory.getDeclaringClassLoader();
-
-        System.out.println("KJA1017 declaring classloader: " + declaringClassLoader);
 
         MetaData mdata = factory.getDeclaringMetadata();
         if (mdata instanceof ApplicationMetaData amd) {


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fix the default ManagedThreadFactory context classloader available at injection.
Related #29867 