### PR TITLE
Fix PKIX KeyManagerFactory for user defined client and server aliases

### DIFF
--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509KeyManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2024 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@ import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -32,6 +34,7 @@ import com.ibm.websphere.ssl.Constants;
 import com.ibm.websphere.ssl.JSSEHelper;
 import com.ibm.websphere.ssl.SSLConfig;
 import com.ibm.ws.ffdc.FFDCFilter;
+import com.ibm.ws.ssl.JSSEProviderFactory;
 import com.ibm.ws.ssl.config.KeyStoreManager;
 import com.ibm.ws.ssl.config.SSLConfigManager;
 import com.ibm.ws.ssl.config.WSKeyStore;
@@ -260,13 +263,20 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
                 Tr.exit(tc, "chooseClientAlias: null");
             return null;
         } else if (clientAlias != null && !clientAlias.equals("")) {
+            String algorithm = KeyManagerFactory.getDefaultAlgorithm();
+            boolean isPKIX = algorithm.equalsIgnoreCase("PKIX") ? true : false;
             String[] list = km.getClientAliases(keyType, issuers);
-
             if (list != null) {
                 boolean found = false;
                 for (int i = 0; i < list.length && !found; i++) {
-                    if (clientAlias.equalsIgnoreCase(list[i]))
+                    if (isPKIX && resolvePKIXAlias(clientAlias, list[i])) {
+                        clientAlias = list[i];
                         found = true;
+
+                    } else {
+                        if (clientAlias.equalsIgnoreCase(list[i]))
+                            found = true;
+                    }
                 }
 
                 if (found) {
@@ -284,10 +294,15 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
                 }
             }
 
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
+            if (isPKIX) {
+                Tr.exit(tc, "chooseClientAlias alias not found returning alias");
+                return clientAlias;
+            }else{
+                if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
                 Tr.exit(tc, "chooseClientAlias (default)", new Object[] { clientAlias });
-            // error case, alias not found in the list.
-            return clientAlias;
+                // error case, alias not found in the list.
+                return clientAlias;
+            }
         } else {
             String[] keyArray = new String[] { keyType };
             String alias = km.chooseClientAlias(keyArray, issuers, null);
@@ -377,7 +392,8 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
     public String chooseServerAlias(String keyType, Principal[] issuers) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.entry(tc, "chooseServerAlias", new Object[] { keyType, issuers });
-
+        String algorithm = KeyManagerFactory.getDefaultAlgorithm();
+        boolean isPKIX = algorithm.equalsIgnoreCase("PKIX") ? true : false;
         Map<String, Object> connectionInfo = JSSEHelper.getInstance().getInboundConnectionInfo();
         String certMappingFile = certMappingKeyManager.getProperty(CertMappingKeyManager.PROTOCOL_HTTPS_CERT_MAPPING_FILE);
         String mappedAlias = null;
@@ -396,9 +412,13 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
                 if (list != null) {
                     boolean found = false;
                     for (int i = 0; i < list.length && !found; i++) {
-                        if (serverAlias.equalsIgnoreCase(list[i]))
+                        if (isPKIX && resolvePKIXAlias(serverAlias, list[i])) {
+                            serverAlias = list[i];
                             found = true;
-
+                        } else {
+                            if (serverAlias.equalsIgnoreCase(list[i]))
+                                found = true;
+                        }
                     }
 
                     if (found) {
@@ -414,8 +434,8 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
                         }
                         return serverAlias.toLowerCase();
                     }
-                }
 
+                }
                 if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
                     Tr.exit(tc, "chooseServerAlias (default)", new Object[] { serverAlias });
                 return serverAlias;
@@ -440,6 +460,25 @@ public final class WSX509KeyManager extends X509ExtendedKeyManager implements X5
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.exit(tc, "chooseServerAlias", new Object[] { mappedAlias });
         return mappedAlias;
+    }
+
+    /**
+     * This is needed because when using PKIX as the KeyManagerFactory, the alias gets converted from default to 1.0.default. 
+     * So we need to have a way to handle the prefix. 
+     */
+    private boolean resolvePKIXAlias(String alias, String keyManagerAlias) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(tc, "resolvePKIXAlias", "KeyManager Factory algorithm is PKIX");
+        if (keyManagerAlias.toLowerCase().contains(alias.toLowerCase())) {
+            Pattern r = Pattern.compile("\\d+\\.\\d+\\." + alias + "$", Pattern.CASE_INSENSITIVE);
+            Matcher m = r.matcher(keyManagerAlias);
+            if (m.find()) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(tc, "resolvePKIXAlias", "Should use alias:" + keyManagerAlias);
+                    return true;
+            }
+        }
+        return false;
     }
 
     /*


### PR DESCRIPTION
`PKIX` KeyManagerFactory handles the certificate aliases differently from the `SunX509` KeyManagerFactory. Whereas SunX509 keeps the name of the alias intact (`default`), PKIX adds a prefix to the alias name at runtime (`1.0.default`)

When `clientKeyAlias` or `serverKeyAlias` is specified in the `ssl` configuration with `PKIX` KeyManagerFactory, this introduces an unexpected SSL connection error.  

```sh
[20/05/2025, 1:30:15:007 GMT] 00000052 id=00000000 SystemErr                                                    R javax.net.ssl|ERROR|42|Default Executor-thread-10|2025-05-20 1:30:15:007 GMT|TransportContext.java:358|Fatal (HANDSHAKE_FAILURE): No available authentication scheme (
"throwable" : {
  javax.net.ssl.SSLHandshakeException: No available authentication scheme
  	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:131)
  	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:117)
  	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:353)
  	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:309)
  	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:300)
```

To test this, update the `java.security` and set `ssl.KeyManagerFactory.algorithm=PKIX` instead of `SunX509`.

Then in the ssl config add the following:
```xml
    <ssl id="defaultSSLConfig" clientAuthentication="false" securityLevel="HIGH" serverKeyAlias="default"/>
``` 


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

