### PR TITLE
Fix SPNEGO FAT Connection failures

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/KerberosContainer.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/KerberosContainer.java
@@ -54,9 +54,9 @@ public class KerberosContainer extends GenericContainer<KerberosContainer> {
         withNetwork(network);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected void configure() {
+        withExposedPorts(99, 464, 749);
         withNetworkAliases(KRB5_KDC);
         withCreateContainerCmdModifier(cmd -> {
             cmd.withHostName(KRB5_KDC);
@@ -71,27 +71,16 @@ public class KerberosContainer extends GenericContainer<KerberosContainer> {
                         .withStartupTimeout(Duration.ofSeconds(FATRunner.FAT_TEST_LOCALRUN ? 15 : 300)));
         withCreateContainerCmdModifier(cmd -> {
             //Add previously exposed ports and UDP port
-
-            List<ExposedPort> exposedPorts = new ArrayList<ExposedPort>();
+            List<ExposedPort> exposedPorts = new ArrayList<>();
             for (ExposedPort p : cmd.getExposedPorts()) {
-                Log.info(c, "configure", "ExposedPort=" + p.getPort());
                 exposedPorts.add(p);
             }
             exposedPorts.add(ExposedPort.udp(99));
             cmd.withExposedPorts(exposedPorts);
 
-            // Add previous port bindings and UDP port binding
+            //Add previous port bindings and UDP port binding
             Ports ports = cmd.getPortBindings();
-            int containerPort = 99;
-            int hostPort = 88;
-
-            String kdcPortMapping = String.format("%d:%d/%s", hostPort, containerPort, InternetProtocol.UDP);
-            Log.info(c, "configure", "adding KDC port mapping: " + kdcPortMapping);
-
-            Log.info(c, "configure", "PortBinding.parse(kdcPortMapping): " + PortBinding.parse(kdcPortMapping));
-            ports.add(PortBinding.parse(kdcPortMapping));
-
-            Log.info(c, "configure", "ports: " + ports);
+            ports.bind(ExposedPort.udp(99), Ports.Binding.empty());
             cmd.withPortBindings(ports);
             cmd.withHostName(KRB5_KDC);
         });


### PR DESCRIPTION
When running SPNEGO buckets, we should fall back to other available ports. 

- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
