### PR TITLE
test of repository using datasource from different app

### DIFF
--- a/dev/io.openliberty.data.internal_fat_global/fat/src/test/jakarta/data/global/DataJavaGlobalTest.java
+++ b/dev/io.openliberty.data.internal_fat_global/fat/src/test/jakarta/data/global/DataJavaGlobalTest.java
@@ -28,10 +28,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpRequest;
+import test.jakarta.data.global.webapp.DataGlobalWebAppServlet;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
@@ -46,6 +48,7 @@ public class DataJavaGlobalTest extends FATServletClient {
                     };
 
     @Server("io.openliberty.data.internal.fat.global")
+    @TestServlet(servlet = DataGlobalWebAppServlet.class, contextRoot = "DataGlobalWebApp")
     public static LibertyServer server;
 
     @BeforeClass
@@ -55,6 +58,11 @@ public class DataJavaGlobalTest extends FATServletClient {
                         .create(WebArchive.class, "DataGlobalRestApp.war")
                         .addPackage("test.jakarta.data.global.rest");
         ShrinkHelper.exportAppToServer(server, DataGlobalRestApp);
+
+        WebArchive DataGlobalWebApp = ShrinkWrap
+                        .create(WebArchive.class, "DataGlobalWebApp.war")
+                        .addPackage("test.jakarta.data.global.webapp");
+        ShrinkHelper.exportAppToServer(server, DataGlobalWebApp);
 
         server.startServer();
 

--- a/dev/io.openliberty.data.internal_fat_global/publish/servers/io.openliberty.data.internal.fat.global/server.xml
+++ b/dev/io.openliberty.data.internal_fat_global/publish/servers/io.openliberty.data.internal.fat.global/server.xml
@@ -30,6 +30,9 @@
     <classloader commonLibraryRef="DerbyLib"/>
   </application>
 
+  <application location="DataGlobalWebApp.war">
+  </application>
+
   <library id="DerbyLib">
     <file name="${shared.resource.dir}/derby/derby.jar"/>
   </library>

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/DataGlobalWebAppServlet.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/DataGlobalWebAppServlet.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.global.webapp;
+
+import static org.junit.Assert.assertEquals;
+
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/webapp/*")
+public class DataGlobalWebAppServlet extends FATServlet {
+    @Inject
+    Dictionary dictionary;
+
+    /**
+     * Use a repository that requires a java:global DataSource that is defined in
+     * a different application.
+     */
+    @Test
+    public void testRepositoryUsesDataSourceFromDifferentApp() {
+
+        dictionary.addWord(Word.of("hello"));
+
+        assertEquals(true, dictionary.isWord("Hello"));
+
+        assertEquals(false, dictionary.isWord("llo"));
+
+        assertEquals(1, dictionary.deleteWord("hello"));
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/Dictionary.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/Dictionary.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.global.webapp;
+
+import static jakarta.data.repository.By.ID;
+
+import jakarta.data.repository.By;
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+
+/**
+ * A Jakarta Data repository that requires a DataSource that is defined by a
+ * different application.
+ */
+@Repository(dataStore = "java:global/jdbc/RestResourceDataSource")
+public interface Dictionary extends DataRepository<Word, String> {
+
+    @Insert
+    void addWord(Word word);
+
+    @Delete
+    int deleteWord(@By(ID) String letters);
+
+    boolean existsByIdIgnoreCase(String id);
+
+    default boolean isWord(String letters) {
+        return existsByIdIgnoreCase(letters);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/Word.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/Word.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.global.webapp;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * A simple entity to use with a Jakarta Data repository that requires a DataSource
+ * that is defined in a different application.
+ */
+@Entity
+public class Word {
+    @Id
+    public String id;
+
+    public static Word of(String letters) {
+        Word w = new Word();
+        w.id = letters;
+        return w;
+    }
+
+    @Override
+    public String toString() {
+        return "Word:" + id;
+    }
+}


### PR DESCRIPTION
Jakarta Data repositories can configure to use a DataSource in java:global that is defined in one application and used in a repository in other applications. As long as the defining application remains up, the Jakarta Data repositories from applications that are running remain usable. This PR adds tests for these scenarios.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
