### PR TITLE
Add test for deadlock in Data with Startup EJB in war file

### DIFF
--- a/dev/io.openliberty.data.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat/bnd.bnd
@@ -24,7 +24,7 @@ javac.target: 17
 fat.minimum.java.level: 17
 fat.project: true
 
-tested.features: databaseRotation, checkpoint
+tested.features: databaseRotation, checkpoint, connectors-2.1
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true
@@ -36,18 +36,20 @@ tested.features: databaseRotation, checkpoint
 -sub: *.bnd
 
 -buildpath: \
-  com.ibm.websphere.appserver.spi.logging,\
-  com.ibm.websphere.org.osgi.core,\
-  com.ibm.websphere.org.osgi.service.component,\
-  com.ibm.wsspi.org.osgi.service.component.annotations,\
-  com.ibm.ws.componenttest.2.0;version=latest,\
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  io.openliberty.jakarta.annotation.2.1,\
-  io.openliberty.jakarta.cdi.4.0,\
-  io.openliberty.jakarta.concurrency.3.0,\
-  io.openliberty.jakarta.data.1.0,\
-  io.openliberty.jakarta.interceptor.2.1,\
-  io.openliberty.jakarta.persistence.3.1,\
-  io.openliberty.jakarta.servlet.6.0;version=latest,\
-  io.openliberty.jakarta.transaction.2.0;version=latest,\
-  io.openliberty.org.testcontainers;version=latest
+	com.ibm.websphere.appserver.spi.logging,\
+	com.ibm.websphere.org.osgi.core,\
+	com.ibm.websphere.org.osgi.service.component,\
+	com.ibm.wsspi.org.osgi.service.component.annotations,\
+	com.ibm.ws.componenttest.2.0;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	io.openliberty.jakarta.annotation.2.1,\
+	io.openliberty.jakarta.cdi.4.0,\
+	io.openliberty.jakarta.concurrency.3.0,\
+	io.openliberty.jakarta.data.1.0,\
+	io.openliberty.jakarta.enterpriseBeans.4.0,\
+	io.openliberty.jakarta.interceptor.2.1,\
+	io.openliberty.jakarta.persistence.3.1,\
+	io.openliberty.jakarta.servlet.6.0;version=latest,\
+	io.openliberty.jakarta.transaction.2.0;version=latest,\
+	io.openliberty.org.testcontainers;version=latest
+	

--- a/dev/io.openliberty.data.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat/bnd.bnd
@@ -24,7 +24,7 @@ javac.target: 17
 fat.minimum.java.level: 17
 fat.project: true
 
-tested.features: databaseRotation, checkpoint, connectors-2.1
+tested.features: databaseRotation, checkpoint
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022,2024 IBM Corporation and others.
+    Copyright (c) 2022,2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
@@ -20,7 +20,7 @@
     <feature>jndi-1.0</feature>
     <!-- persistence-3.2 must NOT be added so that we cover Jakarta Data with JDBC only -->
     <feature>servlet-6.1</feature>
-    <feature>enterpriseBeans-4.0</feature>
+    <feature>enterpriseBeansLite-4.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
@@ -20,6 +20,7 @@
     <feature>jndi-1.0</feature>
     <!-- persistence-3.2 must NOT be added so that we cover Jakarta Data with JDBC only -->
     <feature>servlet-6.1</feature>
+    <feature>enterpriseBeans-4.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestEJB.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestEJB.java
@@ -1,6 +1,15 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package test.jakarta.data.web;
 
 import jakarta.annotation.PostConstruct;

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestEJB.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestEJB.java
@@ -1,0 +1,25 @@
+/**
+ *
+ */
+package test.jakarta.data.web;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Startup;
+
+/**
+ * A singleton startup EJB that is included inside the war file.
+ */
+@Startup
+@Singleton
+public class DataTestEJB {
+
+    //TODO renable after fixing deadlock in DataProvider
+//    @Inject
+//    Animals animals;
+
+    @PostConstruct
+    public void init() {
+//        animals.findAll();
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".



Adds a disabled Singleton Startup EJB that is packaged inside the war file. This recreates a deadlock scenario because the futureEMBuilder is never completed. This section in DataProvider handles completing the futureEMBuilders needed during module start, but it excludes those in the WebModule and not inside a jar file:

```
if (!futureEMBuilder.inWebModule &&
    moduleNameWithDot != null &&
    moduleNameWithDot.length() == moduleName.length() + 4 &&
    moduleNameWithDot.startsWith(moduleName) &&
    moduleNameWithDot.endsWith(".jar")) {
```