### PR TITLE
Remove Auto-generated catch block comment in NettyConnectionReadCompletedCallback.java

### DIFF
--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/NettyConnectionReadCompletedCallback.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/NettyConnectionReadCompletedCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -440,8 +440,7 @@ public class NettyConnectionReadCompletedCallback extends BaseConnectionReadCall
 									((NettyNetworkConnection)vc).setHearbeatInterval(0);
 									readCtx.read(1, this, false, IOReadRequestContext.NO_TIMEOUT);      // F184828
 								} catch (NettyException e) {
-									// TODO Auto-generated catch block
-									e.printStackTrace();
+									throw new RuntimeException(e);
 								}
 							}
 						}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

for #30891
for #31415