### PR TITLE
fix fips 140-3 enabled check not allowing 140-2 on semeru

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -341,7 +341,7 @@ public class CryptoUtils {
         if (fips140_3Checked)
             return fips140_3Enabled;
         else {
-            boolean enabled = "140-3".equals(FIPSLevel) || "true".equals(getPropertyLowerCase("global.fips_140-3", "false")) || isSemeruFips();
+            boolean enabled = "140-3".equals(FIPSLevel);
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "isFips140_3Enabled: " + enabled);
             }


### PR DESCRIPTION
Fixes #31347

this check is blocking 140-2 from being enabled on semeru because they both rely on the `semeru.fips` property being set to `true`, but the current code is always assuming the fips level is 140-3 when that property is set to `true` even though the fips level may not match. thus, we should just be relying on the `com.ibm.fips.mode` property to get the fips levels which is set automatically by the jdk. `global.fips_140-3` check also no longer needed since it was there previously to enable fips in the fat tests, but that is no longer needed since the fat framework now sets the correct fips jvm.options for us.