### PR TITLE
Fixing App Name deadlock in Data

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
@@ -323,7 +323,8 @@ public class DataProvider implements //
 
     @Override
     public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {
-        String appName = appInfo.getName();
+        //Use deployment name but fall back to generated name
+        String appName = appInfo.getDeploymentName() == null ? appInfo.getName() : appInfo.getDeploymentName();
         Set<FutureEMBuilder> futures = futureEMBuilders.get(appName);
         Set<FutureEMBuilder> skip = futureEMBuildersInEJB.remove(appName);
         if (futures != null) {

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -62,7 +62,7 @@ public class DataTest extends FATServletClient {
 
     @Server("io.openliberty.data.internal.fat")
     @TestServlets({ @TestServlet(servlet = DataTestServlet.class, contextRoot = "DataTestApp"),
-                    @TestServlet(servlet = ProviderTestServlet.class, contextRoot = "ProviderTestApp") })
+                    @TestServlet(servlet = ProviderTestServlet.class, contextRoot = "DifferentAppName") })
     public static LibertyServer server;
 
     @BeforeClass
@@ -88,7 +88,10 @@ public class DataTest extends FATServletClient {
                         .addAsLibrary(providerJar);
         ShrinkHelper.exportAppToServer(server, providerWar);
 
-        server.startServer();
+        //Validate apps separately due to the different app name
+        server.startServerAndValidate(LibertyServer.DEFAULT_PRE_CLEAN, LibertyServer.DEFAULT_CLEANSTART, false);
+        server.validateAppLoaded("DataTestApp");
+        server.validateAppLoaded("DifferentAppName");
     }
 
     @AfterClass

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -61,8 +61,8 @@ public class DataTest extends FATServletClient {
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 
     @Server("io.openliberty.data.internal.fat")
-    @TestServlets({ @TestServlet(servlet = DataTestServlet.class, contextRoot = "DataTestApp"),
-                    @TestServlet(servlet = ProviderTestServlet.class, contextRoot = "DifferentAppName") })
+    @TestServlets({ @TestServlet(servlet = DataTestServlet.class, contextRoot = "DifferentAppName"),
+                    @TestServlet(servlet = ProviderTestServlet.class, contextRoot = "ProviderTestApp") })
     public static LibertyServer server;
 
     @BeforeClass
@@ -90,7 +90,7 @@ public class DataTest extends FATServletClient {
 
         //Validate apps separately due to the different app name
         server.startServerAndValidate(LibertyServer.DEFAULT_PRE_CLEAN, LibertyServer.DEFAULT_CLEANSTART, false);
-        server.validateAppLoaded("DataTestApp");
+        server.validateAppLoaded("ProviderTestApp");
         server.validateAppLoaded("DifferentAppName");
     }
 

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
@@ -29,9 +29,8 @@
     <classloader commonLibraryRef="DerbyLib"/>
   </application>
 
-  <application location="ProviderTestApp.war"/>
-  <!-- TODO Using a different name prevents futureEMBuilders from completing -->
-  <!-- <application name="DifferentAppName" location="ProviderTestApp.war"/> -->
+  <!-- Test using an application name set in server.xml -->
+  <application name="DifferentAppName" location="ProviderTestApp.war"/>
 
   <authData id="auth1" user="user1" password="pwd1"/>
   <authData id="auth2" user="user2" password="pwd2"/>

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
@@ -30,6 +30,8 @@
   </application>
 
   <application location="ProviderTestApp.war"/>
+  <!-- TODO Using a different name prevents futureEMBuilders from completing -->
+  <!-- <application name="DifferentAppName" location="ProviderTestApp.war"/> -->
 
   <authData id="auth1" user="user1" password="pwd1"/>
   <authData id="auth2" user="user2" password="pwd2"/>

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
@@ -25,12 +25,13 @@
 
   <include location="../fatTestPorts.xml"/>
 
-  <application location="DataTestApp.war">
+<!-- Test using an application name set in server.xml -->
+  <application name="DifferentAppName" location="DataTestApp.war">
     <classloader commonLibraryRef="DerbyLib"/>
   </application>
 
-  <!-- Test using an application name set in server.xml -->
-  <application name="DifferentAppName" location="ProviderTestApp.war"/>
+  
+  <application location="ProviderTestApp.war"/>
 
   <authData id="auth1" user="user1" password="pwd1"/>
   <authData id="auth2" user="user2" password="pwd2"/>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes a deadlock loading data repositories when an app name is set in server.xml.

Fixes #31138
