### PR TITLE
repository using java:global resource reference from same and different application

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -5399,13 +5399,16 @@ public class QueryInfo {
      */
     private void setType(Class<? extends Annotation> annoClass, Type operationType) {
         type = operationType;
-        if (entityParamType == null)
+        if (entityParamType == null) {
+            int paramCount = method.getParameterCount();
             throw exc(UnsupportedOperationException.class,
                       "CWWKD1009.lifecycle.param.err",
                       method.getName(),
                       repositoryInterface.getName(),
-                      method.getParameterCount(),
+                      paramCount == 1 ? method.getGenericParameterTypes()[0] //
+                                      : paramCount,
                       annoClass.getSimpleName());
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -753,11 +753,15 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
                 x.getMessage().startsWith("CWWKD"))
                 throw (RuntimeException) x;
 
+            String datastore = dsFactory instanceof ResRefDelegator //
+                            ? ((ResRefDelegator) dsFactory).jndiName //
+                            : databaseStoreId;
+
             throw (DataException) exc(DataException.class,
                                       "CWWKD1064.datastore.error",
                                       repoMethod.getName(),
                                       repoInterface.getName(),
-                                      databaseStoreId,
+                                      datastore,
                                       x.getMessage()).initCause(x);
         }
     }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/ResRefDelegator.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/ResRefDelegator.java
@@ -24,7 +24,7 @@ import com.ibm.wsspi.resource.ResourceInfo;
  * specified as the dataStore for a Repository.
  */
 class ResRefDelegator implements ResourceFactory {
-    private final String jndiName;
+    final String jndiName;
     private final ComponentMetaData metadata;
 
     /**

--- a/dev/io.openliberty.data.internal_fat_global/publish/servers/io.openliberty.data.internal.fat.global/server.xml
+++ b/dev/io.openliberty.data.internal_fat_global/publish/servers/io.openliberty.data.internal.fat.global/server.xml
@@ -31,6 +31,7 @@
   </application>
 
   <application location="DataGlobalWebApp.war">
+    <classloader commonLibraryRef="DerbyLib"/>
   </application>
 
   <library id="DerbyLib">

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/DataGlobalRefRestResource.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/DataGlobalRefRestResource.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.global.rest;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@ApplicationScoped
+@Path("/referral")
+public class DataGlobalRefRestResource {
+    @Inject
+    Referrals referrals;
+
+    @GET
+    @Path("/email/{email}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Referral getReferral(@PathParam("email") String email) {
+
+        return referrals.findById(email)
+                        .orElseThrow(() -> new NotFoundException("email: " + email));
+    }
+
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/save")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public Referral saveReferral(Referral referral) {
+
+        return referrals.save(referral);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/DataGlobalRefRestResource.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/DataGlobalRefRestResource.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package test.jakarta.data.global.rest;
 
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.TreeMap;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
@@ -21,13 +27,36 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
+
+import javax.sql.DataSource;
 
 @ApplicationScoped
 @Path("/referral")
 public class DataGlobalRefRestResource {
     @Inject
     Referrals referrals;
+
+    @GET
+    @Path("/datasource")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, String> getDataSourceInfo() {
+
+        Map<String, String> info = new TreeMap<String, String>();
+
+        DataSource ds = referrals.getDataSource();
+        try (Connection con = ds.getConnection()) {
+            DatabaseMetaData mdata = con.getMetaData();
+            info.put("DatabaseProductName", mdata.getDatabaseProductName());
+            info.put("DriverName", mdata.getDriverName());
+            info.put("UserName", mdata.getUserName());
+        } catch (SQLException x) {
+            throw new WebApplicationException(x);
+        }
+
+        return info;
+    }
 
     @GET
     @Path("/email/{email}")

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Referral.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Referral.java
@@ -18,25 +18,29 @@ import jakarta.persistence.Id;
 
 /**
  * A simple entity for a repository that relies on a DataSource with a
- * java:global JNDI name that is defined in this application.
+ * java:global/env resource reference that is defined in another application.
  */
 @Entity
-public class Reminder {
+public class Referral {
     @Id
-    public long id;
+    public String email;
 
     @Column(nullable = false)
-    public String message;
+    public String name;
 
-    public static Reminder of(long id, String message) {
-        Reminder r = new Reminder();
-        r.id = id;
-        r.message = message;
+    @Column
+    public Long phone;
+
+    public static Referral of(String email, String name, Long phone) {
+        Referral r = new Referral();
+        r.email = email;
+        r.name = name;
+        r.phone = phone;
         return r;
     }
 
     @Override
     public String toString() {
-        return "Reminder#" + id + ":" + message;
+        return "Referral:" + email + " " + name + " #" + phone;
     }
 }

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Referrals.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Referrals.java
@@ -12,31 +12,13 @@
  *******************************************************************************/
 package test.jakarta.data.global.rest;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Repository;
 
 /**
- * A simple entity for a repository that relies on a DataSource with a
- * java:global JNDI name that is defined in this application.
+ * A repository that relies on a DataSource with a java:global/env
+ * resource reference that is defined in another application.
  */
-@Entity
-public class Reminder {
-    @Id
-    public long id;
-
-    @Column(nullable = false)
-    public String message;
-
-    public static Reminder of(long id, String message) {
-        Reminder r = new Reminder();
-        r.id = id;
-        r.message = message;
-        return r;
-    }
-
-    @Override
-    public String toString() {
-        return "Reminder#" + id + ":" + message;
-    }
+@Repository(dataStore = "java:global/env/jdbc/WebAppDataSourceRef")
+public interface Referrals extends BasicRepository<Referral, String> {
 }

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Referrals.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Referrals.java
@@ -15,10 +15,14 @@ package test.jakarta.data.global.rest;
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Repository;
 
+import javax.sql.DataSource;
+
 /**
  * A repository that relies on a DataSource with a java:global/env
  * resource reference that is defined in another application.
  */
 @Repository(dataStore = "java:global/env/jdbc/WebAppDataSourceRef")
 public interface Referrals extends BasicRepository<Referral, String> {
+
+    DataSource getDataSource();
 }

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Reminders.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Reminders.java
@@ -16,6 +16,10 @@ import jakarta.annotation.sql.DataSourceDefinition;
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Repository;
 
+/**
+ * A repository that relies on a DataSource with a java:global JNDI name
+ * that is defined in this application.
+ */
 @DataSourceDefinition(name = "java:global/jdbc/RestResourceDataSource",
                       className = "org.apache.derby.jdbc.EmbeddedXADataSource",
                       databaseName = "memory:testdb",

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/Alphabet.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/Alphabet.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.global.webapp;
+
+import static jakarta.data.repository.By.ID;
+
+import jakarta.annotation.Resource;
+import jakarta.annotation.sql.DataSourceDefinition;
+import jakarta.data.repository.By;
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+
+/**
+ * A Jakarta Data repository that requires a DataSource with a java:global/env
+ * resource reference that that is defined by this application.
+ */
+@DataSourceDefinition(name = "java:global/jdbc/WebAppDataSource",
+                      className = "org.apache.derby.jdbc.EmbeddedXADataSource",
+                      databaseName = "memory:testdb",
+                      user = "dbuser2",
+                      password = "dbpwd2",
+                      properties = "createDatabase=create")
+@Resource(name = "java:global/env/jdbc/WebAppDataSourceRef",
+          lookup = "java:global/jdbc/WebAppDataSource")
+@Repository(dataStore = "java:global/env/jdbc/WebAppDataSourceRef")
+public interface Alphabet extends DataRepository<Letter, Character> {
+
+    @Insert
+    void addLetter(Letter letter);
+
+    @Delete
+    int deleteLetter(@By(ID) char ch);
+
+    boolean existsById(char ch);
+
+    default boolean hasLetter(char ch) {
+        return existsById(ch);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/DataGlobalWebAppServlet.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/DataGlobalWebAppServlet.java
@@ -25,6 +25,9 @@ import componenttest.app.FATServlet;
 @WebServlet("/webapp/*")
 public class DataGlobalWebAppServlet extends FATServlet {
     @Inject
+    Alphabet alphabet;
+
+    @Inject
     Dictionary dictionary;
 
     /**
@@ -41,5 +44,21 @@ public class DataGlobalWebAppServlet extends FATServlet {
         assertEquals(false, dictionary.isWord("llo"));
 
         assertEquals(1, dictionary.deleteWord("hello"));
+    }
+
+    /**
+     * Use a repository that requires a java:global/env DataSource resource
+     * reference that is defined in this same application.
+     */
+    @Test
+    public void testRepositoryUsesResourceReferenceFromSameApp() {
+
+        alphabet.addLetter(Letter.of('D'));
+
+        assertEquals(true, alphabet.hasLetter('D'));
+
+        assertEquals(false, alphabet.hasLetter('2'));
+
+        assertEquals(1, alphabet.deleteLetter('D'));
     }
 }

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/Letter.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/Letter.java
@@ -10,33 +10,29 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package test.jakarta.data.global.rest;
+package test.jakarta.data.global.webapp;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
 /**
- * A simple entity for a repository that relies on a DataSource with a
- * java:global JNDI name that is defined in this application.
+ * A simple entity to use with a Jakarta Data repository that requires a DataSource
+ * with a java:global/env resource reference that that is defined by this
+ * application.
  */
 @Entity
-public class Reminder {
+public class Letter {
     @Id
-    public long id;
+    public char id;
 
-    @Column(nullable = false)
-    public String message;
-
-    public static Reminder of(long id, String message) {
-        Reminder r = new Reminder();
-        r.id = id;
-        r.message = message;
-        return r;
+    public static Letter of(char letter) {
+        Letter w = new Letter();
+        w.id = letter;
+        return w;
     }
 
     @Override
     public String toString() {
-        return "Reminder#" + id + ":" + message;
+        return "Letter:" + id;
     }
 }


### PR DESCRIPTION
Jakarta Data repositories should be able to use java:global/env DataSource resource references in the same or a different application as the data store.  If an a different application and the application is stopped, ensure a meaningful error is raised.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
