### PR TITLE
Create uploadfat task

### DIFF
--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -686,6 +686,25 @@ buildfat {
   dependsOn zipProjectFVT
 }
 
+task uploadfat {
+  dependsOn buildfat
+  doLast {
+    // Ensure that async upload doesn't occur when adding a file to upload.
+    while(new File("${rootDir}/upload.lock").exists()) {
+      Thread.sleep(100)
+    }
+    new FileWriter("${rootDir}/upload.lock", true).withWriter { }
+
+    def sourceFile = zipProjectFVT.archiveFile.get().asFile.absolutePath
+    def targetFile = uploadRemotePath + zipProjectFVT.archiveFile.get().asFile
+    def uploadLogFile = new FileWriter("${rootDir}/upload.log", true)
+    uploadLogFile.append(sourceFile + "," + targetFile + "\n")
+    uploadLogFile.close()
+
+    new File("${rootDir}/upload.lock").delete()
+  }
+}
+
 task buildandrun {
   dependsOn buildfat
   dependsOn runfat


### PR DESCRIPTION
- The `uploadfat` task writes file paths into a file named `upload.log` to be uploaded asynchronously in batches by the Jenkins job driving Gradle.