### PR TITLE
Move default tcpOptions tests to their own class/server

### DIFF
--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/FATSuite.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/FATSuite.java
@@ -26,7 +26,8 @@ import io.openliberty.transport.http_fat.accesslists.AccessListsTests;
                 MaxOpenConnectionsTest.class,
                 PortOpenRetriesTests.class,
                 SoLingerTests.class,
-                SoReuseAddrTests.class
+                SoReuseAddrTests.class,
+                TcpOptionsDefaultTests.class
 })
 
 public class FATSuite {

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxOpenConnectionsTest.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxOpenConnectionsTest.java
@@ -60,9 +60,7 @@ public class MaxOpenConnectionsTest {
     }
 
     /**
-     * The test will first check the default value of maxOpenConnections by searching the trace file.
-     *
-     * Next the server will set maxOpenConnections to 2 and validate the value by searching the trace file.
+     * The test will set maxOpenConnections to 2 and validate the value by searching the trace file.
      *
      * Three connections are then created. Since the number of connections is 1 greater than maxOpenConnections
      * the following exception should be found in the logs:
@@ -75,9 +73,6 @@ public class MaxOpenConnectionsTest {
     @Test
     public void testMaxOpenConnections() throws Exception {
         URL url = HttpUtils.createURL(server, "/");
-
-        // Validate that maxOpenConnections default is 128000.
-        assertNotNull("The default value of maxOpenConnections was not 128000!", server.waitForStringInTrace("maxOpenConnections: 128000"));
 
         // Set maxOpenConnections to 2.
         server.saveServerConfiguration();

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/PortOpenRetriesTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/PortOpenRetriesTests.java
@@ -33,6 +33,7 @@ import componenttest.topology.impl.LibertyServer;
  * Test to ensure that the tcpOptions portOpenRetries works.
  */
 @RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
 public class PortOpenRetriesTests {
 
     private static final String CLASS_NAME = PortOpenRetriesTests.class.getName();
@@ -97,17 +98,6 @@ public class PortOpenRetriesTests {
     }
 
     /**
-     * The test will check the default value of portOpenRetries by searching the trace file.
-     *
-     * The default value is 0.
-     */
-    @Test
-    public void testPortOpenRetries_default() throws Exception {
-        // Validate that portOpenRetries default is 0.
-        assertNotNull("The default value of portOpenRetries was not: 0!", server1.waitForStringInTrace("portOpenRetries: 0"));
-    }
-
-    /**
      * The test will set portOpenRetries to a value of 60 and validate in the trace file that
      * the correct value is being used.
      *
@@ -117,7 +107,6 @@ public class PortOpenRetriesTests {
      * @throws Exception
      */
     @Test
-    @Mode(TestMode.FULL)
     public void testPortOpenRetries_nonDefault() throws Exception {
         ServerConfiguration configuration = server1.getServerConfiguration();
         LOG.info("Server configuration that the test started with: " + configuration);
@@ -143,7 +132,6 @@ public class PortOpenRetriesTests {
      * @throws Exception
      */
     @Test
-    @Mode(TestMode.FULL)
     public void testPortOpenRetries_invalid() throws Exception {
         ServerConfiguration configuration = server1.getServerConfiguration();
         LOG.info("Server configuration that the test started with: " + configuration);
@@ -179,7 +167,6 @@ public class PortOpenRetriesTests {
      * @throws Exception
      */
     @Test
-    @Mode(TestMode.FULL)
     public void testPortOpenRetries() throws Exception {
         // Start server2 and use the class name so we can find logs easily.
         server2.startServer(PortOpenRetriesTests.class.getSimpleName() + ".log");
@@ -195,7 +182,7 @@ public class PortOpenRetriesTests {
         assertNotNull("Attempt 5 to bind did not fail and should have!", server2.waitForStringInTrace("attempt 5 of 6 failed to open the port"));
 
         // Validate that CWWKO0221E was logged.
-        assertNotNull("The PortOpenRetries2 server was able to bind successfully should not have been able to!!", server2.waitForStringInLog("CWWKO0221E"));
+        assertNotNull("The PortOpenRetries2 server was able to bind successfully but should not have been able to!", server2.waitForStringInLog("CWWKO0221E"));
 
         if (server2 != null && server2.isStarted()) {
             server2.stopServer("CWWKO0221E");

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/SoLingerTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/SoLingerTests.java
@@ -33,6 +33,7 @@ import componenttest.topology.impl.LibertyServer;
  * Test to ensure that the tcpOptions soLinger works.
  */
 @RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
 public class SoLingerTests {
 
     private static final String CLASS_NAME = SoLingerTests.class.getName();
@@ -88,17 +89,6 @@ public class SoLingerTests {
     }
 
     /**
-     * The test will check the default value of soLinger by searching the trace file.
-     *
-     * The default value of soLinger is -1.
-     */
-    @Test
-    public void testSoLinger_default() throws Exception {
-        // Validate that soLinger default is -1.
-        assertNotNull("The default value of soLinger was not -1!", server.waitForStringInTrace("soLinger: -1"));
-    }
-
-    /**
      * The test will set soLinger to a value of 20 and validate in the trace file that
      * the correct value is being used.
      *
@@ -108,7 +98,6 @@ public class SoLingerTests {
      * @throws Exception
      */
     @Test
-    @Mode(TestMode.FULL)
     public void testSoLinger_nonDefault() throws Exception {
         ServerConfiguration configuration = server.getServerConfiguration();
         LOG.info("Server configuration that the test started with: " + configuration);
@@ -135,7 +124,6 @@ public class SoLingerTests {
      * @throws Exception
      */
     @Test
-    @Mode(TestMode.FULL)
     public void testSoLinger_tooLow() throws Exception {
         ServerConfiguration configuration = server.getServerConfiguration();
         LOG.info("Server configuration that the test started with: " + configuration);
@@ -165,7 +153,6 @@ public class SoLingerTests {
      * @throws Exception
      */
     @Test
-    @Mode(TestMode.FULL)
     public void testSoLinger_tooHigh() throws Exception {
         ServerConfiguration configuration = server.getServerConfiguration();
         LOG.info("Server configuration that the test started with: " + configuration);

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/SoReuseAddrTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/SoReuseAddrTests.java
@@ -13,9 +13,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.logging.Logger;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +31,7 @@ import componenttest.topology.impl.LibertyServer;
  * Test to ensure that the tcpOptions soReuseAddr works.
  */
 @RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
 public class SoReuseAddrTests {
 
     private static final String CLASS_NAME = SoReuseAddrTests.class.getName();
@@ -56,45 +55,6 @@ public class SoReuseAddrTests {
     }
 
     /**
-     * Save the server configuration before each test, this should be the default server
-     * configuration.
-     *
-     * @throws Exception
-     */
-    @Before
-    public void beforeTest() throws Exception {
-        server.saveServerConfiguration();
-
-        ServerConfiguration configuration = server.getServerConfiguration();
-        LOG.info("Server configuration that was saved: " + configuration);
-    }
-
-    /**
-     * Restore the server configuration to the default state after each test.
-     *
-     * @throws Exception
-     */
-    @After
-    public void afterTest() throws Exception {
-        // Restore the server to the default state.
-        server.setMarkToEndOfLog();
-        server.setTraceMarkToEndOfDefaultTrace();
-        server.restoreServerConfiguration();
-        server.waitForConfigUpdateInLogUsingMark(null);
-    }
-
-    /**
-     * The test will check the default value of soReuseAddr by searching the trace file.
-     *
-     * The default value of soReuseAddr is true.
-     */
-    @Test
-    public void testSoReuseAddr_default() throws Exception {
-        // Validate that soReuseAddr default is true.
-        assertNotNull("The default value of soReuseAddr was not true!", server.waitForStringInTrace("soReuseAddr: true"));
-    }
-
-    /**
      * The test will set soReuseAddr to a value of false and validate in the trace file that
      * the correct value is being used.
      *
@@ -104,7 +64,6 @@ public class SoReuseAddrTests {
      * @throws Exception
      */
     @Test
-    @Mode(TestMode.FULL)
     public void testSoReuseAddr_nonDefault() throws Exception {
         ServerConfiguration configuration = server.getServerConfiguration();
         LOG.info("Server configuration that the test started with: " + configuration);

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/TcpOptionsDefaultTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/TcpOptionsDefaultTests.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.transport.http_fat;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Test to verify default values of tcpOptions.
+ */
+@RunWith(FATRunner.class)
+public class TcpOptionsDefaultTests {
+
+    private static final String CLASS_NAME = TcpOptionsDefaultTests.class.getName();
+    static final Logger LOG = Logger.getLogger(CLASS_NAME);
+
+    @Server("TcpOptionsDefaults")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Start the server and use the class name so we can find logs easily.
+        server.startServer(TcpOptionsDefaultTests.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * The test will check the default value of maxOpenConnections by searching the trace file.
+     *
+     * The default value is 128000.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testMaxOpenConnections_default() throws Exception {
+        // Validate that maxOpenConnections default is 128000.
+        assertNotNull("The default value of maxOpenConnections was not 128000!", server.waitForStringInTrace("maxOpenConnections: 128000"));
+    }
+
+    /**
+     * The test will check the default value of portOpenRetries by searching the trace file.
+     *
+     * The default value is 0.
+     */
+    @Test
+    public void testPortOpenRetries_default() throws Exception {
+        // Validate that portOpenRetries default is 0.
+        assertNotNull("The default value of portOpenRetries was not: 0!", server.waitForStringInTrace("portOpenRetries: 0"));
+    }
+
+    /**
+     * The test will check the default value of soLinger by searching the trace file.
+     *
+     * The default value of soLinger is -1.
+     */
+    @Test
+    public void testSoLinger_default() throws Exception {
+        // Validate that soLinger default is -1.
+        assertNotNull("The default value of soLinger was not -1!", server.waitForStringInTrace("soLinger: -1"));
+    }
+
+    /**
+     * The test will check the default value of soReuseAddr by searching the trace file.
+     *
+     * The default value of soReuseAddr is true.
+     */
+    @Test
+    public void testSoReuseAddr_default() throws Exception {
+        // Validate that soReuseAddr default is true.
+        assertNotNull("The default value of soReuseAddr was not true!", server.waitForStringInTrace("soReuseAddr: true"));
+    }
+}

--- a/dev/io.openliberty.transport.http_fat/publish/servers/TcpOptionsDefaults/bootstrap.properties
+++ b/dev/io.openliberty.transport.http_fat/publish/servers/TcpOptionsDefaults/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:TCPChannel=all
+com.ibm.ws.logging.max.file.size=100
+com.ibm.ws.logging.max.files=10
+com.ibm.ws.logging.trace.format=BASIC

--- a/dev/io.openliberty.transport.http_fat/publish/servers/TcpOptionsDefaults/server.xml
+++ b/dev/io.openliberty.transport.http_fat/publish/servers/TcpOptionsDefaults/server.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server description="Test tcpOptions default configuration.">
+
+    <include location="../fatTestCommon.xml"/>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="${bvt.prop.HTTP_default}"
+                  httpsPort="${bvt.prop.HTTP_default.secure}">
+    </httpEndpoint>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+    </featureManager>
+
+</server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #31387