### PR TITLE
update tested.features for com.ibm.ws.jaxrs.2.1.client_fat

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/bnd.bnd
@@ -43,7 +43,9 @@ tested.features: \
   appsecurity-4.0, \
   expressionlanguage-4.0,\
   servlet-6.0,\
-  servlet-6.1
+  servlet-6.1,\
+  expressionlanguage-5.0,\
+  appsecurity-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2,\


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes this exception:
```
java.lang.Exception: Installed feature(s) [expressionlanguage-5.0, appsecurity-5.0] were not defined in the autoFVT/fat-metadata.json file! To correct this, add [expressionlanguage-5.0, appsecurity-5.0] to the 'tested.features' property in the bnd.bnd or build-test.xml file for this FAT so that an accurate test depdendency graph can be generated in the future.
	at componenttest.depchain.FeatureDependencyProcessor.validateTestedFeatures(FeatureDependencyProcessor.java:91)
	at componenttest.topology.impl.LibertyServer.validateServerStarted(LibertyServer.java:2966)
	at componenttest.topology.impl.LibertyServer.startServerWithArgs(LibertyServer.java:1977)
	at componenttest.topology.impl.LibertyServer.startServerAndValidate(LibertyServer.java:1519)
	at componenttest.topology.impl.LibertyServer.startServerAndValidate(LibertyServer.java:1501)
	at componenttest.topology.impl.LibertyServer.startServerAndValidate(LibertyServer.java:1488)
	at componenttest.topology.impl.LibertyServer.startServer(LibertyServer.java:1266)
	at com.ibm.ws.jaxrs21.client.fat.test.JAXRS21ClientLTPATest.setup(JAXRS21ClientLTPATest.java:53)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:575)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:27)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:30)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:397)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:201)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:24)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
	at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:149)
	at org.junit.rules.RunRules.evaluate(RunRules.java:18)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:39)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.run(JUnitTestRunner.java:520)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.launch(JUnitTestRunner.java:1060)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.main(JUnitTestRunner.java:911)
```