### PR TITLE
Switch test code to use a ConcurrentHashMap for thread safety

### DIFF
--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-bundles/ddmodel_fat_bundle/src/com/ibm/ws/javaee/ddmodel/fat/ContainerHelperComponent.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-bundles/ddmodel_fat_bundle/src/com/ibm/ws/javaee/ddmodel/fat/ContainerHelperComponent.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012,2020 IBM Corporation and others.
+ * Copyright (c) 2012,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,7 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.javaee.ddmodel.fat;
 
-import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -47,7 +48,7 @@ public class ContainerHelperComponent
 
     //
 
-    private final HashMap<String, Container> modules = new HashMap<String, Container>();
+    private final Map<String, Container> modules = new ConcurrentHashMap<>();
 
     @Override
     public Container getModuleContainer(String moduleName) {


### PR DESCRIPTION
- Trace showed that two threads were calling the metadata listeners concurrently which can lead to a lose of data in a HashMap.  Switching to ConcurrentHashMap will avoid this problem.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
