### PR TITLE
add fips enabled unit and fat tests, and also improve existing fips fat tests

### DIFF
--- a/dev/com.ibm.ws.kernel.service/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.service/bnd.bnd
@@ -84,6 +84,9 @@ instrument.classesExcludes: com/ibm/ws/kernel/service/utils/resources/*.class, \
   org.jmock:jmock-legacy;version=2.5.0, \
   cglib:cglib;version=3.3.0, \
   com.ibm.ws.org.objectweb.asm;version=latest, \
-  org.mockito:mockito-all;version=1.9.5, \
   com.ibm.ws.kernel.boot;version=latest, \
-  com.ibm.ws.logging;version=latest
+  com.ibm.ws.logging;version=latest, \
+  org.mockito:mockito-core;version=4.11.0, \
+  org.mockito:mockito-inline;version=4.11.0, \
+  net.bytebuddy:byte-buddy;version=1.16.1, \
+  net.bytebuddy:byte-buddy-agent;version=1.16.1

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -28,7 +28,6 @@ import com.ibm.ws.kernel.service.util.JavaInfo;
 public class CryptoUtils {
     private static final TraceComponent tc = Tr.register(CryptoUtils.class);
 
-    static String FIPSLevel = getFipsLevel();
     public final static String MESSAGE_DIGEST_ALGORITHM_SHA256 = "SHA-256";
     public final static String MESSAGE_DIGEST_ALGORITHM_SHA384 = "SHA-384";
     public final static String MESSAGE_DIGEST_ALGORITHM_SHA512 = "SHA-512";
@@ -341,13 +340,14 @@ public class CryptoUtils {
         if (fips140_3Checked)
             return fips140_3Enabled;
         else {
-            boolean enabled = "140-3".equals(FIPSLevel);
+            fips140_3Enabled = false;
+            boolean enabled = "140-3".equals(getFipsLevel());
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "isFips140_3Enabled: " + enabled);
             }
 
             if (enabled) { // Check for FIPS 140-3 available
-                if (isIBMJCEPlusFIPSAvailable() || isOpenJCEPlusFIPSAvailable() || isFIPSProviderAvailable()) {
+                if (isIBMJCEPlusFIPSAvailable() || isOpenJCEPlusFIPSAvailable() || isIBMJCEPlusFIPSProviderAvailable() || isOpenJCEPlusFIPSProviderAvailable()) {
                     fips140_3Enabled = true;
                     Tr.info(tc, "FIPS_140_3ENABLED", (ibmJCEPlusFIPSAvailable ? IBMJCE_PLUS_FIPS_NAME : OPENJCE_PLUS_FIPS_NAME));
                 } else {
@@ -360,21 +360,36 @@ public class CryptoUtils {
     }
 
     /**
-     * Check the provider names exist instead of the provider class for securityUtility command.
+     * Check the provider name exist instead of the provider class for securityUtility command.
      *
      */
-    private static boolean isFIPSProviderAvailable() {
-        return (Security.getProvider(IBMJCE_PLUS_FIPS_NAME) != null || Security.getProvider(OPENJCE_PLUS_FIPS_NAME) != null);
+    static boolean isIBMJCEPlusFIPSProviderAvailable() {
+        return (Security.getProvider(IBMJCE_PLUS_FIPS_NAME) != null);
+    }
+
+    /**
+     * Check the provider name exist instead of the provider class for securityUtility command.
+     *
+     */
+    static boolean isOpenJCEPlusFIPSProviderAvailable() {
+        return (Security.getProvider(OPENJCE_PLUS_FIPS_NAME) != null);
     }
 
     public static boolean isFips140_2Enabled() {
         //JDK set the fip mode default to 140-2
-        boolean result = !isFips140_3Enabled() && "true".equals(getPropertyLowerCase(USE_FIPS_PROVIDER, "false")) &&
-                         IBMJCE_PLUS_FIPS_NAME.equalsIgnoreCase(getPropertyLowerCase(USE_FIPS_PROVIDER_NAME, "NO_PROVIDER_NAME"));
+        boolean result = !isFips140_3Enabled() && "true".equals(getUseFipsProvider()) && IBMJCE_PLUS_FIPS_NAME.equalsIgnoreCase(getFipsProviderName());
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "isFips140_2Enabled: " + result);
         }
         return result;
+    }
+
+    static String getUseFipsProvider() {
+        return getPropertyLowerCase(USE_FIPS_PROVIDER, "false");
+    }
+
+    static String getFipsProviderName() {
+        return getPropertyLowerCase(USE_FIPS_PROVIDER_NAME, "NO_PROVIDER_NAME");
     }
 
     public static boolean isFIPSEnabled() {

--- a/dev/com.ibm.ws.kernel.service/test/com/ibm/ws/common/crypto/CryptoUtilsTest.java
+++ b/dev/com.ibm.ws.kernel.service/test/com/ibm/ws/common/crypto/CryptoUtilsTest.java
@@ -1,0 +1,596 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.common.crypto;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ *
+ */
+public class CryptoUtilsTest {
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_3_ibmJcePlusFipsAvailable() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-3");
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSAvailable).thenReturn(true);
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertTrue("Expected FIPS 140-3 to be enabled, but was disabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_3_openJcePlusFipsAvailable() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-3");
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSAvailable).thenReturn(true);
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertTrue("Expected FIPS 140-3 to be enabled, but was disabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_3_ibmJcePlusFipsProviderAvailable() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-3");
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable).thenReturn(true);
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertTrue("Expected FIPS 140-3 to be enabled, but was disabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_3_openJcePlusFipsProviderAvailable() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-3");
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable).thenReturn(true);
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertTrue("Expected FIPS 140-3 to be enabled, but was disabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_3_noProvidersAvailable_useFipsProvider_true_fipsProviderName_ibmJcePlusFips() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-3");
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("IBMJCEPlusFIPS");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            // Edge case where fipsLevel is 140-3, but isFips140_2Enabled returns true.
+            // This happens because the fipsLevel is 140-3, but IBMJCEPlusFIPS nor OpenJCEPlusFIPS are available so the FIPS 140-3 check fails.
+            // However, the usefipsprovider and usefipsProviderName are set correctly so the FIPS 140-2 check passes.
+            // This is probably okay to leave as-is as the server admin will likely try to resolve the missing provider
+            // issue to use the intended FIPS 140-3 and then the FIPS 140-3 check will pass and the FIPS 140-2 check will fail.
+            assertTrue("Expected FIPS 140-2 to be enabled, but was disabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_3_noProvidersAvailable_useFipsProvider_true_fipsProviderName_openJcePlusFips() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-3");
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("OpenJCEPlusFIPS");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_3_noProvidersAvailable_useFipsProvider_true_fipsProviderName_noProviderName() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-3");
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("NO_PROVIDER_NAME");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_3_noProvidersAvailable_useFipsProvider_false() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-3");
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("false");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_3_noProvidersAvailable_useFipsProvider_invalid() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-3");
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable).thenReturn(false);
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("abc");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isIBMJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::isOpenJCEPlusFIPSProviderAvailable, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_2_useFipsProvider_true_fipsProviderName_ibmJcePlusFips() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-2");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("IBMJCEPlusFIPS");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertTrue("Expected FIPS 140-2 to be enabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_2_useFipsProvider_true_fipsProviderName_openJcePlusFips() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-2");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("OpenJCEPlusFIPS");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_2_useFipsProvider_true_fipsProviderName_noProviderName() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-2");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("NO_PROVIDER_NAME");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_2_useFipsProvider_false() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-2");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("false");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_140_2_useFipsProvider_invalid() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("140-2");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("abc");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_disabled_useFipsProvider_true_fipsProviderName_ibmJcePlusFips() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("disabled");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("IBMJCEPlusFIPS");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            // Edge case where fipsLevel is disabled, but isFips140_2Enabled returns true.
+            // This may occur when using older IBM JDK's where com.ibm.fips.mode
+            // may not exist yet, so getFipsLevel would return disabled, so
+            // this getFips140_2Enabled result here is valid. Also, usefipsprovider
+            // and usefipsProviderName are IBM JDK properties, so we don't need to worry
+            // about the Semeru JDK case.
+            assertTrue("Expected FIPS 140-2 to be enabled, but was disabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_disabled_useFipsProvider_true_fipsProviderName_openJcePlusFips() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("disabled");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("OpenJCEPlusFIPS");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_disabled_useFipsProvider_true_fipsProviderName_noProviderName() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("disabled");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("NO_PROVIDER_NAME");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_disabled_useFipsProvider_false() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("disabled");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("false");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_disabled_useFipsProvider_invalid() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("disabled");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("abc");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_invalid_useFipsProvider_true_fipsProviderName_ibmJcePlusFips() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("abc");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("IBMJCEPlusFIPS");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            // Edge case where fipsLevel is abc, but isFips140_2Enabled returns true.
+            // I don't think this will ever actually occur because the IBM JDK won't let you set
+            // com.ibm.fips.mode to abc. The Semeru JDK does let you set it to abc,
+            // but usefipsprovider and usefipsProviderName are IBM JDK properties, so this combination
+            // wouldn't occur in practice.
+            assertTrue("Expected FIPS 140-2 to be enabled, but was disabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_invalid_useFipsProvider_true_fipsProviderName_openJcePlusFips() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("abc");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("OpenJCEPlusFIPS");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_invalid_useFipsProvider_true_fipsProviderName_noProviderName() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("abc");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("true");
+            mock.when(CryptoUtils::getFipsProviderName).thenReturn("NO_PROVIDER_NAME");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::getFipsProviderName, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_invalid_useFipsProvider_false() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("abc");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("false");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void testFipsEnabled_fipsLevel_invalid_useFipsProvider_invalid() {
+        try (MockedStatic<CryptoUtils> mock = Mockito.mockStatic(CryptoUtils.class)) {
+            mock.when(CryptoUtils::getFipsLevel).thenReturn("abc");
+            mock.when(CryptoUtils::getUseFipsProvider).thenReturn("abc");
+            mock.when(CryptoUtils::isFips140_3Enabled).thenCallRealMethod();
+            mock.when(CryptoUtils::isFips140_2Enabled).thenCallRealMethod();
+
+            CryptoUtils.fips140_3Checked = false;
+            assertFalse("Expected FIPS 140-3 to be disabled, but was enabled.", CryptoUtils.isFips140_3Enabled());
+            assertFalse("Expected FIPS 140-2 to be disabled, but was enabled.", CryptoUtils.isFips140_2Enabled());
+
+            mock.verify(CryptoUtils::getFipsLevel, Mockito.times(1));
+            mock.verify(CryptoUtils::getUseFipsProvider, Mockito.times(1));
+            mock.verify(CryptoUtils::isFips140_3Enabled, Mockito.times(2));
+            mock.verify(CryptoUtils::isFips140_2Enabled, Mockito.times(1));
+            mock.verifyNoMoreInteractions();
+        }
+    }
+
+}

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -7824,8 +7824,8 @@ public class LibertyServer implements LogMonitorClient {
                 Log.info(c, methodName, "global build properties FIPS_140_3 is set for server " + getServerName() +
                                         " and IBM java 17 is available to run with FIPS 140-3 enabled.");
             } else {
-                Log.info(c, methodName, "The global build properties FIPS_140_3 is set for server " + getServerName() +
-                                        ",  but no IBM java 8 or java 17 on liberty server to run with FIPS 140-3 enabled.");
+                throw new RuntimeException("The global build properties FIPS_140_3 is set for server " + getServerName() +
+                                           ",  but no IBM java 8 or java 17 on liberty server to run with FIPS 140-3 enabled.");
             }
         }
         return GLOBAL_FIPS_140_3 && (isIBMJVM8 || isIBMJVM17);
@@ -7849,8 +7849,8 @@ public class LibertyServer implements LogMonitorClient {
                 Log.info(c, methodName, "global build properties FIPS_140_2 is set for server " + getServerName() +
                                         " and IBM java 8 is available to run with FIPS 140-2 enabled.");
             } else {
-                Log.info(c, methodName, "The global build properties FIPS_140_2 is set for server " + getServerName() +
-                                        ",  but no IBM java 8 on liberty server to run with FIPS 140-2 enabled.");
+                throw new RuntimeException("The global build properties FIPS_140_2 is set for server " + getServerName() +
+                                           ",  but no IBM java 8 on liberty server to run with FIPS 140-2 enabled.");
             }
         }
         return GLOBAL_FIPS_140_2 && (isIBMJVM8);

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -8106,7 +8106,6 @@ public class LibertyServer implements LogMonitorClient {
                                                  + " with IBM Java 17, adding required JVM arguments to run with FIPS 140-3 enabled");
                 opts.put("-Dsemeru.fips", "true");
                 opts.put("-Dsemeru.customprofile", "OpenJCEPlusFIPS.FIPS140-3-withPKCS12");
-                opts.put("-Dcom.ibm.fips.mode", "140-3");
             } else if (info.majorVersion() == 8) {
                 Log.info(c, "getFipsJvmOptions", "FIPS 140-3 global build properties is set for server "
                                                  + getServerName()
@@ -8114,7 +8113,6 @@ public class LibertyServer implements LogMonitorClient {
                 opts.put("-Xenablefips140-3", null);
                 opts.put("-Dcom.ibm.jsse2.usefipsprovider", "true");
                 opts.put("-Dcom.ibm.jsse2.usefipsProviderName", "IBMJCEPlusFIPS");
-                opts.put("-Dcom.ibm.fips.mode", "140-3");
 
             }
             if (includeGlobalArgs) {
@@ -8127,7 +8125,6 @@ public class LibertyServer implements LogMonitorClient {
                                                  + " with IBM Java 8, adding required JVM arguments to run with FIPS 140-2 enabled");
                 opts.put("-Dcom.ibm.jsse2.usefipsprovider", "true");
                 opts.put("-Dcom.ibm.jsse2.usefipsProviderName", "IBMJCEPlusFIPS");
-                opts.put("-Dcom.ibm.fips.mode", "140-2");
             }
             if (includeGlobalArgs) {
                 opts.put("-Dglobal.fips_140-2", "true");

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -7813,22 +7813,22 @@ public class LibertyServer implements LogMonitorClient {
     public boolean isFIPS140_3EnabledAndSupported(JavaInfo serverJavaInfo, boolean logOutput) throws IOException {
         String methodName = "isFIPS140_3EnabledAndSupported";
         boolean isIBMJVM8 = (serverJavaInfo.majorVersion() == 8) && (serverJavaInfo.VENDOR == Vendor.IBM);
-        boolean isIBMJVM17 = (serverJavaInfo.majorVersion() == 17) && (serverJavaInfo.VENDOR == Vendor.IBM);
+        boolean isIBMJVMGreaterOrEqualTo11 = (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.IBM);
         if (logOutput && GLOBAL_FIPS_140_3) {
             Log.info(c, methodName, "Liberty server is running JDK version: " + serverJavaInfo.majorVersion()
                                     + " and vendor: " + serverJavaInfo.VENDOR);
             if (isIBMJVM8) {
                 Log.info(c, methodName, "global build properties FIPS_140_3 is set for server " + getServerName() +
                                         " and IBM java 8 is available to run with FIPS 140-3 enabled.");
-            } else if (isIBMJVM17) {
+            } else if (isIBMJVMGreaterOrEqualTo11) {
                 Log.info(c, methodName, "global build properties FIPS_140_3 is set for server " + getServerName() +
-                                        " and IBM java 17 is available to run with FIPS 140-3 enabled.");
+                                        " and IBM java " + serverJavaInfo.majorVersion() + " is available to run with FIPS 140-3 enabled.");
             } else {
                 throw new RuntimeException("The global build properties FIPS_140_3 is set for server " + getServerName() +
-                                           ",  but no IBM java 8 or java 17 on liberty server to run with FIPS 140-3 enabled.");
+                                           ",  but no IBM java on liberty server to run with FIPS 140-3 enabled.");
             }
         }
-        return GLOBAL_FIPS_140_3 && (isIBMJVM8 || isIBMJVM17);
+        return GLOBAL_FIPS_140_3 && (isIBMJVM8 || isIBMJVMGreaterOrEqualTo11);
     }
 
     public boolean isFIPS140_3EnabledAndSupported() throws IOException {
@@ -8100,7 +8100,7 @@ public class LibertyServer implements LogMonitorClient {
     private Map<String, String> getFipsJvmOptions(JavaInfo info, boolean includeGlobalArgs) throws Exception, IOException {
         Map<String, String> opts = new HashMap<>();
         if (isFIPS140_3EnabledAndSupported(info, false)) {
-            if (info.majorVersion() == 17) {
+            if (info.majorVersion() >= 11) {
                 Log.info(c, "getFipsJvmOptions",
                          "FIPS 140-3 global build properties is set for server " + getServerName()
                                                  + " with IBM Java 17, adding required JVM arguments to run with FIPS 140-3 enabled");


### PR DESCRIPTION
- added units tests for CryptoUtils to make sure the fips enabled methods are returning the correct values. also did some refactoring in CryptoUtils to make these unit tests a bit easier to write, but shouldn't cause any functional changes.
- added tests in the LTPAKeyRotationTests server startup to validate the fips 140-3 and 140-2 enabled/disabled messages.
- rely on jdk to set the `com.ibm.fips.mode` in the fat tests, since server admins shouldn't be setting this property and should rely on the jdk to set it.
- set semeru fips properties for java versions >= 11 instead of just when java version == 17 in fips fats
- throw a runtime exception when an unsupported jdk is used in the fat tests and the global fips flag is set to make sure it doesn't just silently run in non-fips mode when the global fips flag was set.