### PR TITLE
Allow attribute converter for ZonedDateTime

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -560,7 +560,8 @@ CWWKD1055.unsupported.entity.attr=CWWKD1055E: The {0} attribute of the {1} entit
  Jakarta Data provider also supports some Jakarta Persistence types, such as \
  embeddables. Alternatively, if you are using a Jakarta Persistence entity, \
  you can add the {5} annotation to the {0} attribute to provide an \
- AttributeConverter that converts an unsupported type to a supported type.
+ AttributeConverter implementation that converts an unsupported type to a \
+ supported type.
 CWWKD1055.unsupported.entity.attr.explanation=Jakarta Data does not support the \
  type used by the entity attribute.
 CWWKD1055.unsupported.entity.attr.useraction=Update the entity attribute to use \
@@ -1126,12 +1127,13 @@ CWWKD1110.incompat.with.collection.useraction=Update the repository method \
  to avoid using the keyword that is not compatible with the collection type.
 
 CWWKD1111.unsupported.convert=CWWKD1111E: The {0} AttributeConverter \
- implementation converts {1} values to the {2} type, which is not \
- supported by Jakarta Data. Jakarta Data supports Java enumeration types, \
- the {3} temporal types, and the following basic types: {4}. The built-in \
- Jakarta Data provider also supports some Jakarta Persistence types.
+ implementation converts {1} values to the {2} type, which is not supported \
+ by the Jakarta Data specification. The Jakarta Data specification supports \
+ Java enumeration types, the {3} temporal types, and the following basic \
+ types: {4}. The built-in Jakarta Data provider also supports some Jakarta \
+ Persistence types.
 CWWKD1111.unsupported.convert.explanation=The AttributeConverter implementation \
- cannot be used with Jakarta Data because it converts values to an unsupported \
- type.
+ cannot be used with the built-in Jakarta Data provider because it converts \
+ values to an unsupported type.
 CWWKD1111.unsupported.convert.useraction=Update the AttributeConverter \
  implementation to convert values to one of the supported types.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -558,7 +558,9 @@ CWWKD1055.unsupported.entity.attr=CWWKD1055E: The {0} attribute of the {1} entit
  has an unsupported type: {2}. Jakarta Data supports Java enumeration types, \
  the {3} temporal types, and the following basic types: {4}. The built-in \
  Jakarta Data provider also supports some Jakarta Persistence types, such as \
- embeddables.
+ embeddables. Alternatively, if you are using a Jakarta Persistence entity, \
+ you can add the {5} annotation to the {0} attribute to provide an \
+ AttributeConverter that converts an unsupported type to a supported type.
 CWWKD1055.unsupported.entity.attr.explanation=Jakarta Data does not support the \
  type used by the entity attribute.
 CWWKD1055.unsupported.entity.attr.useraction=Update the entity attribute to use \
@@ -1122,3 +1124,14 @@ CWWKD1110.incompat.with.collection.explanation=Some of the Query by Method Name 
  keywords are not compatible with entity attributes that have a collection type.
 CWWKD1110.incompat.with.collection.useraction=Update the repository method \
  to avoid using the keyword that is not compatible with the collection type.
+
+CWWKD1111.unsupported.convert=CWWKD1111E: The {0} AttributeConverter \
+ implementation converts {1} values to the {2} type, which is not \
+ supported by Jakarta Data. Jakarta Data supports Java enumeration types, \
+ the {3} temporal types, and the following basic types: {4}. The built-in \
+ Jakarta Data provider also supports some Jakarta Persistence types.
+CWWKD1111.unsupported.convert.explanation=The AttributeConverter implementation \
+ cannot be used with Jakarta Data because it converts values to an unsupported \
+ type.
+CWWKD1111.unsupported.convert.useraction=Update the AttributeConverter \
+ implementation to convert values to one of the supported types.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -66,6 +66,12 @@ public abstract class EntityManagerBuilder {
     private static final TraceComponent tc = Tr.register(EntityManagerBuilder.class);
 
     /**
+     * Entity attribute types that have an AttributeConverter.
+     * Only available when invoked by DBStoreEMBuilder. Otherwise null.
+     */
+    Set<Class<?>> convertibleTypes;
+
+    /**
      * The dataStore value of the Repository annotation,
      * or that value prefixed with java:comp/env,
      * or if unspecified, then java:comp/DefaultDataSource
@@ -117,14 +123,18 @@ public abstract class EntityManagerBuilder {
      * Invoked by subclass constructors to obtain the EntityInfo for each entity type.
      * After this method completes successfully, the entityInfoMap is populated.
      *
-     * @param entityTypes entity classes as known by the user, not generated.
+     * @param entityTypes      entity classes as known by the user, not generated.
+     * @param convertibleTypes types that have an AttributeConverter. Only available
+     *                             when invoked by DBStoreEMBuilder. Otherwise null.
      * @throws Exception if an error occurs.
      */
     // FFDC is not needed because exceptions are logged to Tr.error
     // and also re-thrown upon CompletableFuture<EntityInfo>.get()
     @FFDCIgnore(Throwable.class)
-    protected void collectEntityInfo(Set<Class<?>> entityTypes) throws Exception {
+    protected void collectEntityInfo(Set<Class<?>> entityTypes,
+                                     Set<Class<?>> convertibleTypes) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
+        this.convertibleTypes = convertibleTypes;
         EntityManager em = createEntityManager();
         try {
             Set<Class<?>> missingEntityTypes = new HashSet<>(entityTypes);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -21,7 +21,9 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Dictionary;
@@ -36,6 +38,7 @@ import java.util.TreeMap;
 import java.util.function.Function;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.util.UUID;
 
 import jakarta.data.Order;
 import jakarta.data.Sort;
@@ -45,11 +48,18 @@ import jakarta.data.repository.Insert;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
+import jakarta.persistence.AttributeConverter;
 
 /**
  * A location for helper methods that do not require any state.
  */
 public class Util {
+    /**
+     * Class name of the Jakarta Persistence AttributeConverter
+     */
+    public static final String ATTR_CONVERTER_CLASS_NAME = //
+                    AttributeConverter.class.getName();
+
     /**
      * End of line character(s).
      */
@@ -98,6 +108,33 @@ public class Util {
                     Set.of(Order.class, Sort.class, Sort[].class);
 
     /**
+     * Basic types that are supported by Jakarta Data for entity attributes.
+     */
+    public static final List<String> SUPPORTED_BASIC_TYPES = //
+                    List.of(BigDecimal.class.getSimpleName(),
+                            BigInteger.class.getSimpleName(),
+                            Boolean.class.getSimpleName(), "boolean",
+                            Byte.class.getSimpleName(), "byte",
+                            "byte[]",
+                            Character.class.getSimpleName(), "char",
+                            Double.class.getSimpleName(), "double",
+                            Float.class.getSimpleName(), "float",
+                            Integer.class.getSimpleName(), "int",
+                            Long.class.getSimpleName(), "long",
+                            Short.class.getSimpleName(), "short",
+                            String.class.getSimpleName(),
+                            UUID.class.getSimpleName());
+
+    /**
+     * Temporal types that are supported by Jakarta Data for entity attributes.
+     */
+    public static final List<String> SUPPORTED_TEMPORAL_TYPES = //
+                    List.of(Instant.class.getSimpleName(),
+                            LocalDate.class.getSimpleName(),
+                            LocalDateTime.class.getSimpleName(),
+                            LocalTime.class.getSimpleName());
+
+    /**
      * These types are never supported for entity attributes.
      *
      * ZonedDateTime is not one of the supported Temporal types of Jakarta Data
@@ -106,7 +143,7 @@ public class Util {
      * than was persisted. If proper support is added for it in the future,
      * then this restriction against using it can be made version dependent.
      */
-    static final Set<Class<?>> UNSUPPORTED_ATTR_TYPES = //
+    public static final Set<Class<?>> UNSUPPORTED_ATTR_TYPES = //
                     Set.of(Byte[].class, // deprecated in JPA 3.2
                            Character[].class, // deprecated in JPA 3.2
                            java.sql.Date.class, // deprecated in JPA 3.2

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
@@ -67,7 +67,7 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
               persistenceUnitRef);
         this.emf = emf;
 
-        collectEntityInfo(entityTypes);
+        collectEntityInfo(entityTypes, null);
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
 import java.sql.Connection;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
@@ -486,12 +487,35 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
             entityClassInfo.add(xml.toString());
         }
 
-        for (Class<?> type : converterTypes) {
+        Set<Class<?>> convertibleTypes = new HashSet<>();
+        for (Class<?> converterType : converterTypes) {
             StringBuilder xml = new StringBuilder(500) //
                             .append(" <converter class=\"") //
-                            .append(type.getName()).append("\"></converter>") //
+                            .append(converterType.getName()) //
+                            .append("\"></converter>") //
                             .append(EOLN);
             entityClassInfo.add(xml.toString());
+
+            for (Class<?> c = converterType; c != null; c = c.getSuperclass())
+                for (Type ifc : c.getGenericInterfaces())
+                    if (ifc instanceof ParameterizedType type &&
+                        ifc.getTypeName().startsWith(Util.ATTR_CONVERTER_CLASS_NAME)) {
+                        if (trace && tc.isDebugEnabled())
+                            Tr.debug(this, tc, "found converter: " + ifc.getTypeName());
+
+                        Type[] typeParams = type.getActualTypeArguments();
+                        if (Util.UNSUPPORTED_ATTR_TYPES.contains(typeParams[1]))
+                            throw exc(MappingException.class,
+                                      "CWWKD1111.unsupported.convert",
+                                      converterType.getName(),
+                                      typeParams[0].getTypeName(),
+                                      typeParams[1].getTypeName(),
+                                      Util.SUPPORTED_TEMPORAL_TYPES,
+                                      Util.SUPPORTED_BASIC_TYPES);
+
+                        if (typeParams[0] instanceof Class)
+                            convertibleTypes.add((Class<?>) typeParams[0]);
+                    }
         }
 
         Map<String, Object> properties = new HashMap<>();
@@ -509,7 +533,7 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
                                                                       properties,
                                                                       entityClassNames.toArray(new String[entityClassNames.size()]));
 
-        collectEntityInfo(entityTypes);
+        collectEntityInfo(entityTypes, convertibleTypes);
     }
 
     @Override

--- a/dev/io.openliberty.data.internal_fat_global/fat/src/test/jakarta/data/global/DataJavaGlobalTest.java
+++ b/dev/io.openliberty.data.internal_fat_global/fat/src/test/jakarta/data/global/DataJavaGlobalTest.java
@@ -79,6 +79,7 @@ public class DataJavaGlobalTest extends FATServletClient {
                         .jsonBody("""
                                         {
                                           "id": 1,
+                                          "expiresAt": "2025-10-01T13:30:00.133-05:00[America/Chicago]",
                                           "forDayOfWeek": "MONDAY",
                                           "message": "Do this first.",
                                           "monthDayCreated": "--04-25",
@@ -91,6 +92,7 @@ public class DataJavaGlobalTest extends FATServletClient {
                         .jsonBody("""
                                         {
                                           "id": 2,
+                                          "expiresAt": "2025-12-01T12:24:15.000-07:00[America/Los_Angeles]",
                                           "forDayOfWeek": "TUESDAY",
                                           "message": "Do this second.",
                                           "monthDayCreated": "--12-31",
@@ -103,6 +105,7 @@ public class DataJavaGlobalTest extends FATServletClient {
                         .jsonBody("""
                                         {
                                           "id": 3,
+                                          "expiresAt": "2026-12-31T15:45:59.999-06:00[America/Phoenix]",
                                           "forDayOfWeek": "WEDNESDAY",
                                           "message": "Do this third.",
                                           "monthDayCreated": "--04-25",
@@ -182,6 +185,8 @@ public class DataJavaGlobalTest extends FATServletClient {
         String found = "found: " + json;
 
         assertEquals(found, 1, json.getInt("id"));
+        assertEquals(found, "2025-10-01T13:30:00.133-05:00[America/Chicago]",
+                     json.getString("expiresAt"));
         assertEquals(found, "MONDAY", json.getString("forDayOfWeek"));
         assertEquals(found, "Do this first.", json.getString("message"));
         assertEquals(found, "--04-25", json.getString("monthDayCreated"));


### PR DESCRIPTION
Adds the ability to specify an AttributeConverter for ZonedDateTime and other types that Jakarta Data cannot support so that they can be converted into supported types. Includes an automated test.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

