### PR TITLE
entity with multiple of same embedded type

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Segment.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Segment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ public class Segment {
 
     @Embedded
     @Column(nullable = false)
-    @AttributeOverrides( // TODO remove once #29459 is fixed (if it is valid)
+    @AttributeOverrides( // required by EclipseLink to have 2 of same embedded type
     { @AttributeOverride(name = "x", column = @Column(name = "POINTAX")),
       @AttributeOverride(name = "y", column = @Column(name = "POINTAY"))
     })
@@ -38,7 +38,7 @@ public class Segment {
 
     @Embedded
     @Column(nullable = false)
-    @AttributeOverrides( // TODO remove once #29459 is fixed (if it is valid)
+    @AttributeOverrides( // required by EclipseLink to have 2 of same embedded type
     { @AttributeOverride(name = "x", column = @Column(name = "POINTBX")),
       @AttributeOverride(name = "y", column = @Column(name = "POINTBY"))
     })


### PR DESCRIPTION
Received confirmation from the JPA team that EclipseLink does not intend to support multiple of the same embedded type under and entity without overrides, despite the unusual error that we see out of EclipseLink running invalid SQL against the database rather than raising an appropriate message for unsupported. The JPA team will look into improving that on the EclipseLink side. This PR will make the workaround of using attribute overrides official in the test because that is considered by EclipseLink to be the required way to do it, not a workaround.

Adding fixes #29459 to make github close that issue upon closing this PR.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
