### PR TITLE
Ensure correct features are repeated for com.ibm.ws.request.timing_fat 

### DIFF
--- a/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_1.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_1.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_2.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_2.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_3.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_3.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_4.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_4.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_5.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_5.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_6.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_6.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_7.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_7.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_8.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/contextInfoPattern/server_timing_8.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_NOContextInfo.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_NOContextInfo.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_TrueContextInfo.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_TrueContextInfo.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_TrueContextInfo.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_TrueContextInfo.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_original.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_original.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate0.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate0.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate1.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate1.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate10.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate10.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate10.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate10.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate2.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate2.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate2.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate2.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate3.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate3.xml
@@ -2,9 +2,9 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRateNeg2.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRateNeg2.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRateNeg2.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRateNeg2.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold0.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold0.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold0.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold0.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold1.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold1.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold1.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold1.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold10.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold10.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold10.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold10.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold3.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold3.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold3.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold3.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold4.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold4.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold4.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold4.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold7.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold7.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold7.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold7.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_NoGlobal.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_NoGlobal.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_NoGlobal.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_NoGlobal.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_NoSlowHungReqs.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_NoSlowHungReqs.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_NoSlowHungReqs.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_NoSlowHungReqs.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_ctxinfo_conflict.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_ctxinfo_conflict.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_ctxinfo_conflict.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_ctxinfo_conflict.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_ctxinfo_no_conflict.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_ctxinfo_no_conflict.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_ctxinfo_no_conflict.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_ctxinfo_no_conflict.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global_NoSlowReq.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global_NoSlowReq.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global_NoSlowReq.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global_NoSlowReq.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global_follows_local.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global_follows_local.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global_follows_local.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_global_follows_local.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_localOnly.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_localOnly.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_localOnly.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_localOnly.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_NoSlowReq.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_NoSlowReq.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_NoSlowReq.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_NoSlowReq.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_global_noConfig.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_global_noConfig.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_global_noConfig.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_global_noConfig.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_inherits.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_inherits.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_inherits.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_timing_local_inherits.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_withOutReqTiming.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_withOutReqTiming.xml
@@ -4,6 +4,7 @@
     <featureManager>
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_withOutReqTiming.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_withOutReqTiming.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>servlet-4.0</feature>
     </featureManager>

--- a/dev/com.ibm.ws.request.timing_fat/publish/servers/RequestTimingServer/server.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/servers/RequestTimingServer/server.xml
@@ -5,6 +5,7 @@
         <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
+		<feature>servlet-4.0</feature>
     </featureManager>
 
   

--- a/dev/com.ibm.ws.request.timing_fat/publish/servers/RequestTimingServer/server.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/servers/RequestTimingServer/server.xml
@@ -2,7 +2,6 @@
 
   <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.2</feature>
 		<feature>jdbc-4.0</feature>
 		<feature>requestTiming-1.0</feature>
 		<feature>servlet-4.0</feature>

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3557,7 +3557,6 @@ public class LibertyServer implements LogMonitorClient {
                                                      "opentracingFATServer3", //com.ibm.ws.opentracing.1.x_fat
                                                      "opentracingFATServer4", //com.ibm.ws.opentracing.1.x_fat
 
-                                                     "RequestTimingServer", //com.ibm.ws.request.timing_fat
                                                      "HungRequestTimingServer", //com.ibm.ws.request.timing.hung_fat
 
                                                      "com.ibm.ws.rest.handler.config.fat", //com.ibm.ws.rest.handler.config_fat
@@ -3577,8 +3576,6 @@ public class LibertyServer implements LogMonitorClient {
                                                      "com.ibm.ws.ui.fat", //com.ibm.ws.ui_rest_fat
 
                                                      "com.ibm.ws.jaxrs.fat.exceptionMappingWithOT", //com.ibm.ws.jaxrs.2.0_fat
-
-                                                     "RequestTimingServer", //com.ibm.ws.request.timing_fat
 
                                                      "MPServer41", //io.openliberty.microprofile41.internal_fat
                                                      "MPServer", //io.openliberty.microprofile.internal_fat


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #31453
- Added `servlet-4.0` feature in all the server.xml files in the com.ibm.ws.request.timing_fat to ensure the correct features are replaced when the FAT bucket is repeated for other JEE versions.
- Removed `RequestTimingServer` from the exempt list, so it can be tested to ensure the correct features are being tested during RepeatActions.
