### PR TITLE
Revert "Fix for Data deadlock with EJB in .war"

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -296,7 +296,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         try {
             String resourceName = dataStore;
-            String metadataIdentifier = getMetadataIdentifier(inWebModule);
+            String metadataIdentifier = getMetadataIdentifier();
 
             // metadataIdentifier examples:
             // WEB#MyApp#MyWebModule.war
@@ -335,13 +335,8 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                         metadata = (ComponentMetaData) provider.metadataIdSvc //
                                         .getMetaData(metadataIdentifier);
                     } catch (IllegalStateException x) {
-                        try { //Check if this is an EJB in a Web Module
-                            metadata = (ComponentMetaData) provider.metadataIdSvc //
-                                            .getMetaData(getMetadataIdentifier(false));
-                        } catch (IllegalStateException y) {
-                            if (System.nanoTime() - start > TimeUnit.SECONDS.toNanos(30))
-                                throw x; //Throw exception for non-EJB check
-                        }
+                        if (System.nanoTime() - start > TimeUnit.SECONDS.toNanos(30))
+                            throw x;
                         // else retry because the deferred metadata is not available yet
                     }
                 } while (metadata == null);
@@ -677,14 +672,11 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
      * Obtains the metadata identifier for the module that defines the repository
      * interface.
      *
-     * @param isWebComponent true for a Web Module, false for an EJB Module
-     *
      * @return metadata identifier as the key, and application/module/component
      *         as the value. Module and component might be null or might not be
      *         present at all.
      */
-    private String getMetadataIdentifier(boolean isWebComponent) {
-
+    private String getMetadataIdentifier() {
         String mdIdentifier;
 
         if (jeeName.getModule() == null) {
@@ -693,7 +685,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                                                           null);
         } else {
             mdIdentifier = provider.metadataIdSvc //
-                            .getMetaDataIdentifier(isWebComponent ? "WEB" : "EJB",
+                            .getMetaDataIdentifier(inWebModule ? "WEB" : "EJB",
                                                    jeeName.getApplication(),
                                                    jeeName.getModule(),
                                                    null);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestEJB.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestEJB.java
@@ -15,7 +15,6 @@ package test.jakarta.data.web;
 import jakarta.annotation.PostConstruct;
 import jakarta.ejb.Singleton;
 import jakarta.ejb.Startup;
-import jakarta.inject.Inject;
 
 /**
  * A singleton startup EJB that is included inside the war file.
@@ -25,11 +24,11 @@ import jakarta.inject.Inject;
 public class DataTestEJB {
 
     //TODO renable after fixing deadlock in DataProvider
-    @Inject
-    Animals animals;
+//    @Inject
+//    Animals animals;
 
     @PostConstruct
     public void init() {
-        animals.findAll();
+//        animals.findAll();
     }
 }


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#31433 because it introduced an intermittent timing issue. Changes can be brought back later once that is resolved.