### PR TITLE
Skipped relevant test cases

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -81,6 +81,7 @@ public @interface SkipIfSysProp {
     // OS system properties
     public static final String OS_ZOS = "os.name=z/OS";
     public static final String OS_IBMI = "os.name=OS/400";
+    public static final String OS_ISERIES = "os.name=ISERIES";
 
     // Network system properties
     public static final String NETWORK_AWS = "global.network.location=AWS";

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSpnegoAuthenticationCacheTest.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/JCacheSpnegoAuthenticationCacheTest.java
@@ -168,7 +168,7 @@ public class JCacheSpnegoAuthenticationCacheTest extends BaseTestCase {
      * @throws Exception if the test fails for some unforeseen reason.
      */
     @Test
-    @SkipIfSysProp({SkipIfSysProp.OS_ZOS,SkipIfSysProp.OS_IBMI}) // Skip on z/OS due to configuration error
+    @SkipIfSysProp({SkipIfSysProp.OS_ZOS,SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES }) // Skip on z/OS due to configuration error
     @CheckForLeakedPasswords(USER1_PASSWORD)
     public void authCache_spnego() throws Exception {
         /*
@@ -237,7 +237,7 @@ public class JCacheSpnegoAuthenticationCacheTest extends BaseTestCase {
      * @throws Exception if the test fails for some unforeseen reason.
      */
     @Test
-    @SkipIfSysProp({SkipIfSysProp.OS_ZOS,SkipIfSysProp.OS_IBMI}) // Skip on z/OS due to configuration error
+    @SkipIfSysProp({SkipIfSysProp.OS_ZOS,SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES }) // Skip on z/OS due to configuration error
     @CheckForLeakedPasswords(USER1_PASSWORD)
     public void authCache_spnego_excludeGssCred() throws Exception {
         /*


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

we are seeing this failure:

```
A remote host refused an attempted connect operation.org.apache.directory.shared.kerberos.exceptions.KerberosException: A remote host refused an attempted connect operation.at org.apache.directory.kerberos.client.KdcConnection._getTgt(KdcConnection.java:381)at org.apache.directory.kerberos.client.KdcConnection.getTgt(KdcConnection.java:181)at org.apache.directory.kerberos.client.KdcConnection.getTgt(KdcConnection.java:145)at org.apache.directory.kerberos.client.Kinit.kinit(Kinit.java:72)at com.ibm.ws.security.wim.adapter.ldap.fat.krb5.ApacheDSandKDC.createTicketCacheFile(ApacheDSandKDC.java:304)at com.ibm.ws.security.wim.adapter.ldap.fat.krb5.ApacheDSandKDC.setupService(ApacheDSandKDC.java:275)at io.openliberty.jcache.internal.fat.testresource.KdcResource.before(KdcResource.java:111)at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:397)at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:201)at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:149)
--
```
Disabling the test cases that are failing for ISERIES
################################################################################################