### PR TITLE
Current soln to ISE encountered when Health check is invoked inbetwee…

### DIFF
--- a/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthCheck40ServiceImpl.java
+++ b/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthCheck40ServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -748,8 +749,12 @@ public class HealthCheck40ServiceImpl implements HealthCheck40Service {
                             Tr.debug(tc, "In performHealthCheck(): appName = " + appName + ", moduleName = " + moduleName);
                         }
                         try {
-
-                            hcResponses = hcExecutor.runHealthChecks(appName, moduleName, healthCheckProcedure);
+                            /*
+                             * Prevent calls to any apps that are "stopping".
+                             */
+                            if (!stoppingApplication.contains(appName)) {
+                                hcResponses = hcExecutor.runHealthChecks(appName, moduleName, healthCheckProcedure);
+                            }
 
                         } catch (HealthCheckBeanCallException e) {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -782,6 +787,26 @@ public class HealthCheck40ServiceImpl implements HealthCheck40Service {
         if (hcExecutor != null) {
             hcExecutor.removeModuleReferences(appName, moduleName);
         }
+    }
+
+    /*
+     * Temp solution to app shutting down and a performFileHealthCheck running at the same time.
+     * This leads to scenario where the application is completely shut down while the Health Check
+     * process is underway. Specifically when a Contextual Proxy is created right before app stops,
+     * followed by the app stopping and then the invocation of the contextual proxy. This causes an
+     * ISE due to the app metadata no longer existing during the proxy invocation.
+     *
+     * The set and the `stopping` and `started` method calls below allow us to create a block for
+     * any health checks conducted on a `stopping` App. The set is cleared when the app is redeployed.
+     */
+    Set<String> stoppingApplication = ConcurrentHashMap.newKeySet();
+
+    public void stoppingApplication(String appName) {
+        stoppingApplication.add(appName);
+    }
+
+    public void startedApplication(String appName) {
+        stoppingApplication.remove(appName);
     }
 
     /**


### PR DESCRIPTION
…n Application Stopping and Application Stopped, leading to an HC in flux whilest application has already stopped


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
Fixes #31068

#build
