### PR TITLE
Access repository from startup event

### DIFF
--- a/dev/io.openliberty.data.internal_fat_global/fat/src/test/jakarta/data/global/DataJavaGlobalTest.java
+++ b/dev/io.openliberty.data.internal_fat_global/fat/src/test/jakarta/data/global/DataJavaGlobalTest.java
@@ -278,4 +278,29 @@ public class DataJavaGlobalTest extends FATServletClient {
                 throw x;
         }
     }
+
+    /**
+     * Verify that a REST Application method that observes the CDI Startup event
+     * has access to a Jakarta Data repository and can use it to populate data.
+     */
+    @Test
+    public void testStartupEventInRestApplication() throws Exception {
+        String path = "/DataGlobalRestApp/data/referral/email/" +
+                      "startup@openliberty.io";
+        JsonObject json = new HttpRequest(server, path).run(JsonObject.class);
+
+        String found = "found: " + json;
+
+        assertEquals(found,
+                     "startup@openliberty.io",
+                     json.getString("email"));
+
+        assertEquals(found,
+                     "Startup Event",
+                     json.getString("name"));
+
+        assertEquals(found,
+                     5075556789L,
+                     json.getJsonNumber("phone").longValue());
+    }
 }

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/DataGlobalRestApp.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/DataGlobalRestApp.java
@@ -12,9 +12,23 @@
  *******************************************************************************/
 package test.jakarta.data.global.rest;
 
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Startup;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("/data")
-public class DataGlobalRestApp extends Application {   
+public class DataGlobalRestApp extends Application {
+    @Inject
+    Referrals referrals;
+
+    /**
+     * Set up some data before tests run.
+     */
+    public void startup(@Observes Startup event) {
+        referrals.save(Referral.of("startup@openliberty.io",
+                                   "Startup Event",
+                                   5075556789L));
+    }
 }

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/DataGlobalWebAppServlet.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/DataGlobalWebAppServlet.java
@@ -14,6 +14,9 @@ package test.jakarta.data.global.webapp;
 
 import static org.junit.Assert.assertEquals;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Startup;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
 
@@ -21,6 +24,7 @@ import org.junit.Test;
 
 import componenttest.app.FATServlet;
 
+@ApplicationScoped
 @SuppressWarnings("serial")
 @WebServlet("/webapp/*")
 public class DataGlobalWebAppServlet extends FATServlet {
@@ -29,6 +33,13 @@ public class DataGlobalWebAppServlet extends FATServlet {
 
     @Inject
     Dictionary dictionary;
+
+    /**
+     * Set up some data before tests run.
+     */
+    public void setup(@Observes Startup event) {
+        dictionary.addWord(Word.of("initialized"));
+    }
 
     /**
      * Use a repository that requires a java:global DataSource that is defined in
@@ -60,5 +71,15 @@ public class DataGlobalWebAppServlet extends FATServlet {
         assertEquals(false, alphabet.hasLetter('2'));
 
         assertEquals(1, alphabet.deleteLetter('D'));
+    }
+
+    /**
+     * Verify that a method that observes the CDI Startup event has access to a
+     * Jakarta Data repository and can use it to populate data.
+     */
+    @Test
+    public void testStartupEvent() {
+
+        assertEquals(true, dictionary.isWord("initialized"));
     }
 }


### PR DESCRIPTION
It should be possible to access Jakarta Data repositories from methods that observe the CDI Startup event, which will be useful to perform setup/initialization.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
