### PR TITLE
Add open port retries for MP Health 31 FAT

### DIFF
--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/bnd.bnd
@@ -48,25 +48,26 @@ tested.features: \
   
 
 -buildpath: \
-	com.ibm.ws.org.apache.commons.compress;version=latest, \
-	com.ibm.ws.org.apache.commons.io;version=latest, \
-	org.apache.johnzon:johnzon-core;version=1.1.0, \
-	com.ibm.websphere.javaee.jsonp.1.1;version=latest, \
-	com.ibm.websphere.javaee.cdi.2.0;version=latest, \
-	io.openliberty.org.eclipse.microprofile.health.3.1;version=latest, \
-    com.ibm.websphere.javaee.servlet.3.0;version=latest,\
-    com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
+	com.ibm.ws.org.apache.commons.compress;version=latest,\
+	com.ibm.ws.org.apache.commons.io;version=latest,\
+	org.apache.johnzon:johnzon-core;version='1.1.0',\
+	com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
+	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
+	io.openliberty.org.eclipse.microprofile.health.3.1;version=latest,\
+	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.jsonb.1.0;version=latest,\
-	org.apache.kafka:kafka-clients;version=3.5.1,\
+	org.apache.kafka:kafka-clients;version='3.5.1',\
 	com.ibm.ws.org.slf4j.jdk14;version=latest,\
 	io.openliberty.org.testcontainers;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
-	org.testng:testng;version=7.5.1,\
+	org.testng:testng;version='7.5.1',\
 	com.ibm.ws.io.smallrye.reactive.streams-operators;version=latest,\
 	com.ibm.ws.microprofile.reactive.messaging.kafka;version=latest,\
 	com.ibm.ws.microprofile.reactive.messaging.kafka.adapter;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.reactive.messaging.1.0;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.reactive.streams.operators.1.0;version=latest,\
+	io.openliberty.microprofile.health.internal_fat.common,\
 	io.openliberty.microprofile.health.internal_fat.common
 	

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckFastTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckFastTest.java
@@ -79,7 +79,7 @@ public class SlowAppStartupHealthCheckFastTest {
         log("setupClass", testName + "Starting the server.");
 
         if (!server.isStarted())
-            server.startServer(false, false);
+            server.startServer(true, false);
 
         // Read to run a smarter planet
         server.waitForStringInLogUsingMark("CWWKF0011I");

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckFastTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/SlowAppStartupHealthCheckFastTest.java
@@ -206,7 +206,9 @@ public class SlowAppStartupHealthCheckFastTest {
 
                             log("testStartupEndpointOnServerStart", message + " At this point the test will be re-run. Number of current attempts ---> " + num_of_attempts);
                             startServerThread.join();
-                            cleanUp();
+                            log("testStartupEndpointOnServerStart", " - Stopping the server, to re-run the test...");
+                            if ((server1 != null) && (server1.isStarted()))
+                                server1.stopServer(EXPECTED_FAILURES);
                             break; // We repeat the test case
                         }
                     } else {

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheckFast/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/SlowAppStartupHealthCheckFast/server.xml
@@ -17,7 +17,7 @@
     <webContainer deferServletLoad="false"/> 
     
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
-        <tcpOptions portOpenRetries="60" />                   
+        <tcpOptions portOpenRetries="180" />                   
     </httpEndpoint>
 	
 </server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Related to #31254
- Added more port retries to avoid open port binding issues, during server startup
- Start the server cleanly, each test run.