### PR TITLE
EJB method that observes startup uses repository

### DIFF
--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreEJBApp/src/test/jakarta/data/datastore/ejbapp/DataEJBAppBeanInterface.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreEJBApp/src/test/jakarta/data/datastore/ejbapp/DataEJBAppBeanInterface.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.datastore.ejbapp;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Startup;
+
+/**
+ * Interface that allows DataEJBAppBean to have an Observes Startup method
+ * without getting the error:
+ * WELD-000088: Observer method must be static or local business method
+ */
+public interface DataEJBAppBeanInterface {
+
+    /**
+     * Add some data on startup.
+     */
+    void startup(@Observes Startup event);
+}

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/ejb/DataStoreTestEJB.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/ejb/DataStoreTestEJB.java
@@ -22,6 +22,8 @@ import jakarta.annotation.Resource;
 import jakarta.annotation.sql.DataSourceDefinition;
 import jakarta.ejb.EJBException;
 import jakarta.ejb.Stateless;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Startup;
 import jakarta.inject.Inject;
 
 import javax.sql.DataSource;
@@ -51,6 +53,15 @@ public class DataStoreTestEJB {
 
     @Inject
     DSDRepoEJB dsdRepoEJB;
+
+    /**
+     * Populate the database before running the test.
+     */
+    public void setup(@Observes Startup event) {
+        System.out.println("DataStoreTestEJB observed Startup");
+
+        dsdRepo.store(EJBModuleDSDEntity.of(1, "startup has been observed"));
+    }
 
     /**
      * Use a repository, defined in an EJB, that specifies the JNDI name of a
@@ -134,4 +145,14 @@ public class DataStoreTestEJB {
         }
     }
 
+    /**
+     * Verify that code in an EJB module can access a Jakarta Data repository from
+     * a CDI Startup event.
+     */
+    public void testStartupEventObserverInEJBModuleUsesRepository() {
+
+        EJBModuleDSDEntity found = dsdRepo.acquire(1).orElseThrow();
+        assertEquals(1, found.id);
+        assertEquals("startup has been observed", found.value);
+    }
 }

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreTestServlet.java
@@ -418,6 +418,24 @@ public class DataStoreTestServlet extends FATServlet {
     }
 
     /**
+     * Verify that code in an EJB application can access a Jakarta Data repository
+     * from a CDI Startup event.
+     */
+    @Test
+    public void testStartupEventObserverInEJBApplicationUsesRepository() {
+        ejbApp.accept("testStartupEventObserverInEJBApplicationUsesRepository");
+    }
+
+    /**
+     * Verify that code in an EJB module can access a Jakarta Data repository from
+     * a CDI Startup event.
+     */
+    @Test
+    public void testStartupEventObserverInEJBModuleUsesRepository() {
+        testEJB.testStartupEventObserverInEJBModuleUsesRepository();
+    }
+
+    /**
      * Verify that ServletContextListener can inject a Jakarta Data repository
      * and use it to initialize data.
      */


### PR DESCRIPTION
EJB methods that observe the CDI Startup event using a Jakarta Data repository.
Covers an EJB module within an application and an EJB application that has no other modules.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
