### PR TITLE
fix: increase connectionWaitTimeout for UCP tests

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
@@ -91,13 +91,13 @@
     <dataSource id="ds-replay" jndiName="jdbc/ds-replay" type="javax.sql.DataSource">
         <jdbcDriver libraryRef="UCPDBLib"/>
         <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"
-                               connectionFactoryClassName="oracle.jdbc.replay.OracleDataSourceImpl" />
+                               connectionFactoryClassName="oracle.jdbc.replay.OracleDataSourceImpl" connectionWaitTimeout="30" />
     </dataSource>
     
     <dataSource id="ds-replay-xa" jndiName="jdbc/ds-replay-xa" type="javax.sql.XADataSource">
         <jdbcDriver libraryRef="UCPDBLib"/>
         <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}"
-                               connectionFactoryClassName="oracle.jdbc.replay.OracleXADataSourceImpl" />
+                               connectionFactoryClassName="oracle.jdbc.replay.OracleXADataSourceImpl" connectionWaitTimeout="30" />
     </dataSource>
     
     <!-- 
@@ -105,12 +105,12 @@
     -->
     <dataSource id="ds-autocommit-ltc" jndiName="jdbc/ds-autocommit-ltc" type="javax.sql.DataSource">
         <jdbcDriver libraryRef="UCPDBLib"/>
-        <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
+        <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" connectionWaitTimeout="30" />
     </dataSource>
     
     <dataSource id="ds-autocommit-global" jndiName="jdbc/ds-autocommit-global" type="javax.sql.DataSource">
         <jdbcDriver libraryRef="UCPDBLib"/>
-        <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" />
+        <properties.oracle.ucp URL="${env.ORACLE_URL}" user="${env.ORACLE_USER}" password="${env.ORACLE_PASSWORD}" connectionWaitTimeout="30" />
     </dataSource>
     
     <javaPermission codebase="${shared.resource.dir}/ucp/ojdbc8.jar" className="java.security.AllPermission"/>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Recent tests added to the Oracle UCP test suite did not have an increased ConnectionWaitTimeout (CWT) configured.
This can lead to a test failure with an exception stack that could be misinterpreted: 

```txt
junit.framework.AssertionFailedError: 2025-05-06-17:41:55:392 ERROR: Caught exception attempting to call test method testReplayDataSource on servlet ucp.web.OracleUCPTestServlet
java.sql.SQLException: UCP-29: Failed to get a connection DSRA0010E: SQL State = null, Error Code = 29
at oracle.ucp.util.UCPErrorHandler.newSQLException(UCPErrorHandler.java:399)
at oracle.ucp.util.UCPErrorHandler.throwSQLException(UCPErrorHandler.java:163)
at oracle.ucp.jdbc.PoolDataSourceImpl.getConnection(PoolDataSourceImpl.java:2016)
at oracle.ucp.jdbc.PoolDataSourceImpl.getConnection(PoolDataSourceImpl.java:1939)
at oracle.ucp.jdbc.PoolDataSourceImpl.getConnection(PoolDataSourceImpl.java:1873)
at oracle.ucp.jdbc.PoolDataSourceImpl.getConnection(PoolDataSourceImpl.java:1854)
at com.ibm.ws.rsadapter.impl.DatabaseHelper.getConnectionFromDatasource(DatabaseHelper.java:1467)
...
Caused by: oracle.ucp.UniversalConnectionPoolException: UCP-45064: All connections in the Universal Connection Pool are in use - [ 0, 0, 0, 0, 0, 0, 1, 2147483647, 0, 0 ]
at oracle.ucp.util.UCPErrorHandler.newUniversalConnectionPoolException(UCPErrorHandler.java:316)
at oracle.ucp.util.UCPErrorHandler.throwUniversalConnectionPoolException(UCPErrorHandler.java:62)
at oracle.ucp.common.UniversalConnectionPoolImpl.borrowConnectionWithoutCountingRequests(UniversalConnectionPoolImpl.java:514)
at oracle.ucp.common.UniversalConnectionPoolImpl.borrowConnectionAndValidateHelper(UniversalConnectionPoolImpl.java:262)
at oracle.ucp.common.UniversalConnectionPoolImpl.borrowConnectionAndValidate(UniversalConnectionPoolImpl.java:188)
at oracle.ucp.common.UniversalConnectionPoolImpl.borrowConnection(UniversalConnectionPoolImpl.java:157)
at oracle.ucp.jdbc.JDBCConnectionPool.borrowConnection(JDBCConnectionPool.java:207)
at oracle.ucp.jdbc.oracle.OracleJDBCConnectionPool.borrowConnection(OracleJDBCConnectionPool.java:609)
at oracle.ucp.jdbc.oracle.OracleConnectionConnectionPool.borrowConnection(OracleConnectionConnectionPool.java:128)
```

If we look at the connection pool stats and annotate the stats with their corresponding names we see: 

```
[ borrowed: 0, total: 0, created: 0, closed: 0, abandoned: 0, labeled: 0, pending: 1, capacity: 2147483647, peak: 0, peak borrowed: 0 ]
```

So it isn't that the connection pool hit it's max, instead a connection was failed to be returned from the pool upon request. 

The error is misleading because really what happened was the pool hit the ConnectionWaitTImeout (CWT).
But in Oracle 23+ the behavior changed where connection requests are handled by a separate pool maintenance thread with retires instead of by the thread that called getConnection().

As a result, the pool maintenance thread was using the OutboundConnectionTimeout, while the original thread kept calling the pool maintenance thread until the ConnectionWaitTimeout elapsed.  However, instead of throwing an error signaling a ConnectionWaitTimeout the original thread just threw a generic "no connection available" exception.

See accompanying javadoc: https://docs.oracle.com/en/database/oracle/oracle-database/23/jjuar/oracle/ucp/jdbc/PoolDataSource.html#SYSTEM_PROPERTY_CREATE_CONNECTION_IN_BORROW_THREAD

I have increased the ConnectionWaitTimeout in hops that that giving the UCP more retries will help resolve the falky network issues.  If not we could look at increasing the `OutboundConnectionTimeout` or reverting to the old behavior using `CreateConnectionInBorrowThread​` config.