### PR TITLE
repository used from Observes Startup method of EJB in WAR

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
@@ -903,7 +903,9 @@ public class DataProvider implements //
                     moduleNameWithDot != null &&
                     moduleNameWithDot.length() == moduleName.length() + 4 &&
                     moduleNameWithDot.startsWith(moduleName) &&
-                    moduleNameWithDot.endsWith(".jar")) {
+                    moduleNameWithDot.regionMatches(true, //
+                                                    moduleNameWithDot.length() - 4, //
+                                                    ".jar", 0, 4)) {
 
                     if (trace && tc.isDebugEnabled())
                         Tr.debug(this, tc, "matched with " + futureEMBuilder.jeeName);

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web2/DataEJBInWebModule.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web2/DataEJBInWebModule.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.datastore.web2;
+
+import jakarta.ejb.Singleton;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Startup;
+import jakarta.inject.Inject;
+
+import test.jakarta.data.datastore.lib.ServerDSEntity;
+
+/**
+ * An EJB in the web module that uses a Jakarta Data repository from a method
+ * that observes startup of the application.
+ */
+@Singleton
+public class DataEJBInWebModule {
+    @Inject
+    WebModule2DSResRefRepo repo;
+
+    public void onStartup(@Observes Startup event) {
+        System.out.println("Observed Startup of DataEJBInWebModule");
+
+        repo.write(ServerDSEntity.of("DataEJBInWebModule.onStartup", 123));
+    }
+
+}

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web2/DataStoreSecondServlet.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web2/DataStoreSecondServlet.java
@@ -80,6 +80,21 @@ public class DataStoreSecondServlet extends FATServlet {
     }
 
     /**
+     * Verifies that an EJB in the web module can have a method that observes the
+     * CDI Startup event, during which the method access a Jakarta Data repository.
+     */
+    @Test
+    public void testEJBInWARObservesStartupAndUsesRepository() {
+
+        // Entity that is written by the method that Observes Startup must be
+        // present in the database
+        ServerDSEntity e = serverDSResRefRepo.read("DataEJBInWebModule.onStartup")
+                        .orElseThrow();
+        assertEquals("DataEJBInWebModule.onStartup", e.id);
+        assertEquals(123, e.value);
+    }
+
+    /**
      * Use a repository that specifies a resource reference to a data source,
      * where the resource reference has a container managed authentication alias
      * that is defined in server.xml, ResRefAuth2, with user resrefuser2.


### PR DESCRIPTION
A Jakarta Data repository can be used from a method of an EJB in a Web module where the method observes the CDI Startup event.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
