### PR TITLE
OpenTelemetry Logging can trigger the creation of open telemetry info

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
@@ -83,6 +83,7 @@ public class TelemetrySpiTest extends FATServletClient {
     public static void setup() throws Exception {
         // Exporter test
         PropertiesAsset exporterConfig = new PropertiesAsset()
+                        .addProperty("otel.sdk.disabled", "false")
                         .addProperty("otel.traces.exporter", "in-memory");
         WebArchive exporterTestWar = ShrinkWrap.create(WebArchive.class, EXPORTER_APP_NAME + ".war")
                         .addClass(ExporterTestServlet.class)
@@ -96,6 +97,7 @@ public class TelemetrySpiTest extends FATServletClient {
 
         // Sampler test
         PropertiesAsset samplerConfig = new PropertiesAsset()
+                        .addProperty("otel.sdk.disabled", "false")
                         .addProperty("otel.traces.sampler", TestSamplerProvider.NAME);
         WebArchive samplerTestWar = ShrinkWrap.create(WebArchive.class, SAMPLER_APP_NAME + ".war")
                         .addClass(SamplerTestServlet.class)
@@ -108,6 +110,7 @@ public class TelemetrySpiTest extends FATServletClient {
         // Resource test
         // TEST_KEY1 and TEST_KEY2 are expected by TestResourceProvider
         PropertiesAsset resourceConfig = new PropertiesAsset()
+                        .addProperty("otel.sdk.disabled", "false")
                         .addProperty("otel.traces.exporter", "in-memory")
                         .addProperty(TestResourceProvider.TEST_KEY1.getKey(), ResourceTestServlet.TEST_VALUE1);
         server.addEnvVar("OTEL_TEST_KEY2", ResourceTestServlet.TEST_VALUE2);
@@ -126,6 +129,7 @@ public class TelemetrySpiTest extends FATServletClient {
 
         // Propagator test
         PropertiesAsset propagatorConfig = new PropertiesAsset()
+                        .addProperty("otel.sdk.disabled", "false")
                         .addProperty("otel.traces.exporter", "in-memory")
                         .addProperty("otel.propagators", TestPropagatorProvider.NAME);
 
@@ -143,6 +147,7 @@ public class TelemetrySpiTest extends FATServletClient {
 
         // CustomizerTest
         PropertiesAsset customizerConfig = new PropertiesAsset()
+                        .addProperty("otel.sdk.disabled", "false")
                         .addProperty("otel.traces.exporter", "in-memory");
         WebArchive customizerTestWar = ShrinkWrap.create(WebArchive.class, CUSTOMIZER_APP_NAME + ".war")
                         .addClass(CustomizerTestServlet.class)
@@ -154,7 +159,7 @@ public class TelemetrySpiTest extends FATServletClient {
 
         ShrinkHelper.exportAppToServer(server, customizerTestWar, SERVER_ONLY);
 
-        server.addEnvVar("OTEL_SDK_DISABLED", "false");
+        //server.addEnvVar("OTEL_SDK_DISABLED", "false");
         server.addEnvVar("OTEL_BSP_SCHEDULE_DELAY", "100");
         server.startServer();
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/TelemetrySpiTest.java
@@ -159,7 +159,6 @@ public class TelemetrySpiTest extends FATServletClient {
 
         ShrinkHelper.exportAppToServer(server, customizerTestWar, SERVER_ONLY);
 
-        //server.addEnvVar("OTEL_SDK_DISABLED", "false");
         server.addEnvVar("OTEL_BSP_SCHEDULE_DELAY", "100");
         server.startServer();
     }

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/customizer/CustomizerTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/customizer/CustomizerTestServlet.java
@@ -46,10 +46,6 @@ public class CustomizerTestServlet extends FATServlet {
     private InMemorySpanExporter exporter;
 
     @Test
-    @SkipForRepeat({MicroProfileActions.MP70_EE11_ID, MicroProfileActions.MP70_EE10_ID, TelemetryActions.MP61_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID,
-                    TelemetryActions.MP50_MPTEL20_JAVA8_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP14_MPTEL20_ID,
-                    MicroProfileActions.MP71_EE11_ID, MicroProfileActions.MP71_EE10_ID,TelemetryActions.MP50_MPTEL21_ID,
-                    TelemetryActions.MP50_MPTEL21_JAVA8_ID, TelemetryActions.MP41_MPTEL21_ID, TelemetryActions.MP14_MPTEL21_ID  })
     public void testCustomizer() {
         Span span = tracer.spanBuilder("span").startSpan();
         span.end();

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/exporter/ExporterTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/exporter/ExporterTestServlet.java
@@ -44,10 +44,6 @@ public class ExporterTestServlet extends FATServlet {
     private Tracer tracer;
 
     @Test
-    @SkipForRepeat({MicroProfileActions.MP70_EE11_ID, MicroProfileActions.MP70_EE10_ID, TelemetryActions.MP61_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID,
-                    TelemetryActions.MP50_MPTEL20_JAVA8_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP14_MPTEL20_ID,
-                    MicroProfileActions.MP71_EE11_ID, MicroProfileActions.MP71_EE10_ID,TelemetryActions.MP50_MPTEL21_ID,
-                    TelemetryActions.MP50_MPTEL21_JAVA8_ID, TelemetryActions.MP41_MPTEL21_ID, TelemetryActions.MP14_MPTEL21_ID})
     public void testExporter() {
         AttributeKey<String> FOO_KEY = AttributeKey.stringKey("foo");
         Span span = tracer.spanBuilder("test span").setAttribute(FOO_KEY, "bar").startSpan();

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/PropagatorTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/propagator/PropagatorTestServlet.java
@@ -69,10 +69,6 @@ public class PropagatorTestServlet extends FATServlet {
     private TestSpans testSpans;
 
     @Test
-    @SkipForRepeat({MicroProfileActions.MP70_EE11_ID, MicroProfileActions.MP70_EE10_ID, TelemetryActions.MP61_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID,
-                    TelemetryActions.MP50_MPTEL20_JAVA8_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP14_MPTEL20_ID,
-                    MicroProfileActions.MP71_EE11_ID, MicroProfileActions.MP71_EE10_ID,TelemetryActions.MP50_MPTEL21_ID,
-                    TelemetryActions.MP50_MPTEL21_JAVA8_ID, TelemetryActions.MP41_MPTEL21_ID, TelemetryActions.MP14_MPTEL21_ID})
     public void testPropagator() {
         Span span = testSpans.withTestSpan(() -> {
             // Add a key to the baggage that we will look for later

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/resource/ResourceTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/resource/ResourceTestServlet.java
@@ -45,10 +45,6 @@ public class ResourceTestServlet extends FATServlet {
     private InMemorySpanExporter exporter;
 
     @Test
-    @SkipForRepeat({MicroProfileActions.MP70_EE11_ID, MicroProfileActions.MP70_EE10_ID, TelemetryActions.MP61_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID,
-                    TelemetryActions.MP50_MPTEL20_JAVA8_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP14_MPTEL20_ID,
-                    MicroProfileActions.MP71_EE11_ID, MicroProfileActions.MP71_EE10_ID,TelemetryActions.MP50_MPTEL21_ID,
-                    TelemetryActions.MP50_MPTEL21_JAVA8_ID, TelemetryActions.MP41_MPTEL21_ID, TelemetryActions.MP14_MPTEL21_ID})
     public void testResource() {
         Span span = tracer.spanBuilder("span").startSpan();
         span.end();

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/sampler/SamplerTestServlet.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/fat/src/io/openliberty/microprofile/telemetry/internal_fat/apps/spi/sampler/SamplerTestServlet.java
@@ -39,10 +39,6 @@ public class SamplerTestServlet extends FATServlet {
     private Tracer tracer;
 
     @Test
-    @SkipForRepeat({MicroProfileActions.MP70_EE11_ID, MicroProfileActions.MP70_EE10_ID, TelemetryActions.MP61_MPTEL20_ID, TelemetryActions.MP50_MPTEL20_ID,
-                    TelemetryActions.MP50_MPTEL20_JAVA8_ID, TelemetryActions.MP41_MPTEL20_ID, TelemetryActions.MP14_MPTEL20_ID,
-                    MicroProfileActions.MP71_EE11_ID, MicroProfileActions.MP71_EE10_ID,TelemetryActions.MP50_MPTEL21_ID,
-                    TelemetryActions.MP50_MPTEL21_JAVA8_ID, TelemetryActions.MP41_MPTEL21_ID, TelemetryActions.MP14_MPTEL21_ID})
     public void testSampler() {
         // Span 1 does not set SAMPLE_ME, so it should not be sampled
         Span span1 = tracer.spanBuilder("span1").startSpan();

--- a/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/internal/common/info/OpenTelemtryLifecycleManagerImpl.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/internal/common/info/OpenTelemtryLifecycleManagerImpl.java
@@ -295,6 +295,14 @@ public class OpenTelemtryLifecycleManagerImpl implements ApplicationStateListene
             }
 
             OpenTelemetryInfoReference atomicRef = (OpenTelemetryInfoReference) metaData.getMetaData(slotForOpenTelemetryInfoHolder);
+            
+            //This is true in app mode when this method is called during the startup routine of a WAB.
+            //Which in turn means that WABs will not emit trace during startup in app mode. However I beleive the previous behaviour would
+            //be to throw an NPE. TODO: Confirm this
+            if (atomicRef == null) {
+                return false;
+            }
+            
             LazyInitializer<OpenTelemetryInfoInternal> supplier = atomicRef.get();
             return supplier.isInitialized();
         }

--- a/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/internal/common/info/OpenTelemtryLifecycleManagerImpl.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.common/src/io/openliberty/microprofile/telemetry/internal/common/info/OpenTelemtryLifecycleManagerImpl.java
@@ -295,14 +295,14 @@ public class OpenTelemtryLifecycleManagerImpl implements ApplicationStateListene
             }
 
             OpenTelemetryInfoReference atomicRef = (OpenTelemetryInfoReference) metaData.getMetaData(slotForOpenTelemetryInfoHolder);
-            
+
             //This is true in app mode when this method is called during the startup routine of a WAB.
-            //Which in turn means that WABs will not emit trace during startup in app mode. However I beleive the previous behaviour would
-            //be to throw an NPE. TODO: Confirm this
+            //However WABs have a disabled open telemetry anyway. This just delays checking that until after the risk
+            //of recursion in the startup routine is gone.
             if (atomicRef == null) {
                 return false;
             }
-            
+
             LazyInitializer<OpenTelemetryInfoInternal> supplier = atomicRef.get();
             return supplier.isInitialized();
         }

--- a/dev/io.openliberty.microprofile.telemetry.logging.internal.common/src/io/openliberty/microprofile/telemetry20/logging/internal/OpenTelemetryLogHandler.java
+++ b/dev/io.openliberty.microprofile.telemetry.logging.internal.common/src/io/openliberty/microprofile/telemetry20/logging/internal/OpenTelemetryLogHandler.java
@@ -23,6 +23,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.propertytypes.SatisfyingConditionTarget;
 import org.osgi.service.condition.Condition;
 
@@ -41,17 +42,23 @@ import com.ibm.wsspi.collector.manager.SynchronousHandler;
 import io.openliberty.checkpoint.spi.CheckpointPhase;
 import io.openliberty.microprofile.telemetry.internal.common.AgentDetection;
 import io.openliberty.microprofile.telemetry.internal.common.constants.OpenTelemetryConstants;
+import io.openliberty.microprofile.telemetry.internal.common.info.OpenTelemetryLifecycleManager;
+import io.openliberty.microprofile.telemetry.internal.common.info.OpenTelemtryLifecycleManagerImpl;
 import io.openliberty.microprofile.telemetry.internal.interfaces.OpenTelemetryAccessor;
 import io.openliberty.microprofile.telemetry.spi.OpenTelemetryInfo;
 import io.opentelemetry.api.logs.LogRecordBuilder;
 
 @Component(name = OpenTelemetryLogHandler.COMPONENT_NAME, service = { Handler.class }, configurationPolicy = ConfigurationPolicy.OPTIONAL, property = { "service.vendor=IBM" })
 @SatisfyingConditionTarget("(" + Condition.CONDITION_ID + "=" + CheckpointPhase.CONDITION_PROCESS_RUNNING_ID + ")")
-public class OpenTelemetryLogHandler implements SynchronousHandler {
+public class OpenTelemetryLogHandler implements SynchronousHandler, OpenTelemtryLifecycleManagerImpl.OpenTelemetryInfoReadyListener {
 
     private static final TraceComponent tc = Tr.register(OpenTelemetryLogHandler.class, "TELEMETRY", "io.openliberty.microprofile.telemetry.internal.common.resources.MPTelemetry");
 
     public static final String COMPONENT_NAME = "io.openliberty.microprofile.telemetry20.logging.internal.OpenTelemetryLogHandler";
+
+    @Reference //needed to access the hidden part of the API
+    OpenTelemetryLifecycleManager openTelemetryLifecycleManager;
+    OpenTelemtryLifecycleManagerImpl openTelemtryLifecycleManagerImpl;
 
     protected static volatile boolean isInit = false;
 
@@ -79,6 +86,9 @@ public class OpenTelemetryLogHandler implements SynchronousHandler {
         this.sourcesList = validateSources(configuration);
 
         setAccessLogField(configuration);
+
+        //Cast here to save having to do it every log event
+        openTelemtryLifecycleManagerImpl = (OpenTelemtryLifecycleManagerImpl) openTelemetryLifecycleManager;
     }
 
     @Deactivate
@@ -162,6 +172,8 @@ public class OpenTelemetryLogHandler implements SynchronousHandler {
         MpTelemetryLogMappingUtils.mapLibertyEventToOpenTelemetry(builder, eventType, event);
     }
 
+    private final ThreadLocal<List<Object>> queuedMessages = ThreadLocal.withInitial(() -> new ArrayList<Object>());
+
     /** {@inheritDoc} */
     @Override
     public void synchronousWrite(Object event) {
@@ -170,10 +182,34 @@ public class OpenTelemetryLogHandler implements SynchronousHandler {
         if (OpenTelemetryAccessor.isRuntimeEnabled()) {
             // Runtime OpenTelemetry instance
             otelInstance = this.runtimeOtelInfo;
+        } else if (!openTelemtryLifecycleManagerImpl.isOpenTelemetryInitalized()) {
+
+            /*
+             * There is an issue where trace can trigger this method inside the routine to create an OpenTelemetryInfo, we need to ensure that doesn't lead to creating a second
+             * OpenTelemetryInfo so we check if the OpenTelemetryInfo is ready, if it is not we stick the event on a queue and process the lot when it is ready.
+             *
+             * As this is all happening on one thread, we don't need to worry about race conditions. Just ensure that we don't call getOpenTelemetryInfo() from this method before
+             * OpenTelemetryInfo is ready. And that we call notifyOpenTelemetryInfoReady once when it actually is ready.
+             */
+
+            queuedMessages.get().add(event);
         } else {
+
             // Application OpenTelemetry Instance
             otelInstance = OpenTelemetryAccessor.getOpenTelemetryInfo();
+            synchronousWriteInternal(event, otelInstance);
         }
+    }
+
+    @Override
+    public void notifyOpenTelemetryInfoReady(OpenTelemetryInfo otelInstance) {
+        for (Object event : queuedMessages.get()) {
+            synchronousWriteInternal(event, otelInstance);
+        }
+        queuedMessages.set(null);
+    }
+
+    private void synchronousWriteInternal(Object event, OpenTelemetryInfo otelInstance) {
 
         if (otelInstance != null && otelInstance.isEnabled()) {
             /*
@@ -364,4 +400,5 @@ public class OpenTelemetryLogHandler implements SynchronousHandler {
     public void setBufferManager(String arg0, BufferManager arg1) {
         //Not needed in a Synchronized Handler
     }
+
 }

--- a/dev/io.openliberty.microprofile.telemetry.logging.internal.common/src/io/openliberty/microprofile/telemetry20/logging/internal/OpenTelemetryLogHandler.java
+++ b/dev/io.openliberty.microprofile.telemetry.logging.internal.common/src/io/openliberty/microprofile/telemetry20/logging/internal/OpenTelemetryLogHandler.java
@@ -29,6 +29,7 @@ import org.osgi.service.condition.Condition;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.logging.collector.CollectorConstants;
 import com.ibm.ws.logging.data.AccessLogConfig;
 import com.ibm.ws.logging.data.FFDCData;
@@ -182,6 +183,7 @@ public class OpenTelemetryLogHandler implements SynchronousHandler, OpenTelemtry
         if (OpenTelemetryAccessor.isRuntimeEnabled()) {
             // Runtime OpenTelemetry instance
             otelInstance = this.runtimeOtelInfo;
+            synchronousWriteInternal(event, otelInstance);
         } else if (!openTelemtryLifecycleManagerImpl.isOpenTelemetryInitalized()) {
 
             /*
@@ -209,6 +211,8 @@ public class OpenTelemetryLogHandler implements SynchronousHandler, OpenTelemtry
         queuedMessages.set(null);
     }
 
+    //Methods called via OpenTelemetryLogHandler.synchronousWrite must be Trivial to prevent enormous amounts of trace about trace.
+    @Trivial
     private void synchronousWriteInternal(Object event, OpenTelemetryInfo otelInstance) {
 
         if (otelInstance != null && otelInstance.isEnabled()) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

#fixes 31508

This PR reenables some tests that should have been reenabled when mpTelemetry-2.0 was ready for them, and fixes a bug (31508) revealed by doing so.
