### PR TITLE
Remove TODO and security exempt line from EE 11 test buckets that don't need it

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017,2024 IBM Corporation and others.
+# Copyright (c) 2017,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info=enabled:concurrent=all:context=all:concurrencyPolicy=all
-# Java 2 security is not required for Jakarta EE 11 features:
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.checkpoint.fat/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.checkpoint.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2023 IBM Corporation and others.
+# Copyright (c) 2022,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all
-# TODO can remove the following once this test bucket requires Java 21 where Java 2 security is disabled
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2023 IBM Corporation and others.
+# Copyright (c) 2022,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all
-# TODO can remove the following once this test bucket requires Java 21 where Java 2 security is disabled
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_datastore/publish/servers/io.openliberty.data.internal.fat.datastore/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_datastore/publish/servers/io.openliberty.data.internal.fat.datastore/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2023 IBM Corporation and others.
+# Copyright (c) 2023,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all
-# TODO can remove the following once this test bucket requires Java 21 where Java 2 security is disabled
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,4 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_errorpaths/publish/servers/io.openliberty.data.internal.fat.errpaths/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/publish/servers/io.openliberty.data.internal.fat.errpaths/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all
-# TODO can remove the following once this test bucket requires Java 21 where Java 2 security is disabled
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.checkpoint.fat.jpa/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.checkpoint.fat.jpa/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2023 IBM Corporation and others.
+# Copyright (c) 2022,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all:checkpoint=all
-# TODO can remove the following once this test bucket requires Java 21 where Java 2 security is disabled
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.fat.jpa/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.fat.jpa/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2023 IBM Corporation and others.
+# Copyright (c) 2022,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all
-# TODO can remove the following once this test bucket requires Java 21 where Java 2 security is disabled
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate.integrate/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate.integrate/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all:org.hibernate=all
-# TODO can remove the following once this test bucket requires Java 21 where Java 2 security is disabled
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all:org.hibernate=all
-# TODO can remove the following once this test bucket requires Java 21 where Java 2 security is disabled
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql.container/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql.container/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,4 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2023 IBM Corporation and others.
+# Copyright (c) 2022,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,4 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all
-websphere.java.security.exempt=true

--- a/dev/io.openliberty.data.internal_fat_validation/publish/servers/io.openliberty.data.internal.fat.validation/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_validation/publish/servers/io.openliberty.data.internal.fat.validation/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2023 IBM Corporation and others.
+# Copyright (c) 2023,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,5 +12,3 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all
-# TODO can remove the following once this test bucket requires Java 21 where Java 2 security is disabled
-websphere.java.security.exempt=true


### PR DESCRIPTION
Java 2 Security is not required for EE 11 features

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
