### PR TITLE
Redirect dump files from arquillian to a location where the fat framework will upload them

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -165,7 +165,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -173,7 +173,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -154,7 +154,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -158,7 +158,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -176,7 +176,7 @@
                         </property>
                     </systemProperties>
 
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -159,7 +159,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
@@ -159,7 +159,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -156,7 +156,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -149,7 +149,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -147,7 +147,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
@@ -158,7 +158,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
@@ -210,7 +210,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-verbose:class</argLine> -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>

--- a/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -159,7 +159,7 @@
                             <value>src/test/resources/logging.properties</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -159,7 +159,7 @@
                             <value>src/test/resources/logging.properties</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -190,7 +190,7 @@
                             <value>src/test/resources/logging.properties</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -182,7 +182,7 @@
                             <value>src/test/resources/logging.properties</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/tck/pom.xml
@@ -141,7 +141,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                         <configuration>
-                            <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                            <argLine>${fat.framework.args}</argLine>
                             <systemPropertyVariables>
                                 <wlp>${wlp}</wlp>
                                 <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -142,7 +142,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                         <configuration>
-                            <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                            <argLine>${fat.framework.args}</argLine>
                             <systemProperties>
                                 <property>
                                     <name>java.util.logging.config.file</name>

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -142,7 +142,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                         <configuration>
-                            <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                            <argLine>${fat.framework.args}</argLine>
                             <systemProperties>
                                 <property>
                                     <name>java.util.logging.config.file</name>

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -142,7 +142,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                         <configuration>
-                            <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                            <argLine>${fat.framework.args}</argLine>
                             <systemProperties>
                                 <property>
                                     <name>java.util.logging.config.file</name>

--- a/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -159,7 +159,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                         <configuration>
-                            <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                            <argLine>${fat.framework.args}</argLine>
                             <systemProperties>
                                 <property>
                                     <name>java.util.logging.config.file</name>

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
@@ -132,7 +132,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -193,7 +193,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -193,7 +193,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -53,7 +53,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <dependenciesToScan>
                         <dependency>org.eclipse.microprofile.openapi:microprofile-openapi-tck</dependency>
                     </dependenciesToScan>

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
@@ -54,7 +54,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <dependenciesToScan>
                         <dependency>org.eclipse.microprofile.openapi:microprofile-openapi-tck</dependency>
                     </dependenciesToScan>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -199,7 +199,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -205,7 +205,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -217,7 +217,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
@@ -199,7 +199,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/publish/tckRunner/tck/pom.xml
@@ -136,7 +136,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS becuase arquillian calls string.getBtytes() -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/publish/tckRunner/tck/pom.xml
@@ -193,7 +193,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine><!-- Needed for ZOS becuase arquillian calls string.getBtytes() -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
@@ -308,7 +308,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
@@ -306,7 +306,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -355,7 +355,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
@@ -356,7 +356,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
@@ -279,7 +279,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-verbose:class</argLine> -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -468,6 +468,17 @@ public class TCKRunner {
         stringArrayList.add("-DcomponentRootDir=" + getComponentRootDir());
         stringArrayList.add("-Dsun.rmi.transport.tcp.responseTimeout=" + DEFAULT_MBEAN_TIMEOUT);
 
+        //Set the argline.
+        StringBuilder sb = new StringBuilder();
+        sb.append("-Dfat.framework.args\"");
+        sb.append("-Dproject.build.sourceEncoding=UTF-8"); //Becuase arquillian calls string.getBtytes() it can fail on ZOS if it defaults to a ZOS charset.
+        sb.append(" -Dcom.ibm.tools.attach.enable=yes"); //Needed becuase because arquillian uses com.sun.tools.attach to find VMs.
+        if (this.server.isIBMJVM()) {
+            sb.append(" -Xdump:directory=${project.basedir}/../../../results/"); //This means that if MVN creates dumpfiles they will go into a directory that gets uploaded into the build break report
+        }
+        sb.append("\"");
+        stringArrayList.add(sb.toString());
+
         stringArrayList.addAll(getJarCliProperties());
 
         // The cmd below is a base for running the TCK as a whole for this project.

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -180,7 +180,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -170,7 +170,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.0</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <dependenciesToScan>
                         <dependency>${jakarta.concurrent.tck.groupid}:jakarta.enterprise.concurrent-tck</dependency>
                     </dependenciesToScan>

--- a/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonb.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -173,7 +173,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.5.2</version>
 				<configuration>
-					<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBytes(). -->
+					<argLine>${fat.framework.args}</argLine>
 					<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
 					<trimStackTrace>false</trimStackTrace>
 					<failIfNoTests>true</failIfNoTests>

--- a/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.jsonp.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -80,7 +80,7 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>3.5.2</version>
 						<configuration>
-							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). -->
+							<argLine>${fat.framework.args}</argLine>
 							<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
 							<trimStackTrace>false</trimStackTrace>
 							<failIfNoTests>true</failIfNoTests>
@@ -126,7 +126,7 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>3.5.2</version>
 						<configuration>
-							<argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBytes(). -->
+							<argLine>${fat.framework.args}</argLine>
 							<forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
 							<trimStackTrace>false</trimStackTrace>
 							<failIfNoTests>true</failIfNoTests>

--- a/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -423,7 +423,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <argLine>-Xmx2048m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>

--- a/dev/io.openliberty.jakarta.rest.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.rest.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -396,7 +396,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <argLine>-Xmx2048m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -236,7 +236,7 @@
 				<version>2.17</version> <!-- Any changes to the surefire version
 				must be tested against ZOS -->
 				<configuration>
-					<argLine>-Dfile.encoding=${project.build.sourceEncoding}
+					<argLine>${fat.framework.args}</argLine>
 						-Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed
 					for ZOS. sourceEncoding is needed becuase arquillian calls
 					string.getBtytes(). Attach is needed becuase because

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -172,7 +172,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.config.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -173,7 +173,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.config.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -181,7 +181,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -155,7 +155,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -165,7 +165,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -165,7 +165,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -203,7 +203,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-verbose:class</argLine> -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -193,7 +193,7 @@
                             <value>src/test/resources/logging.properties</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -193,7 +193,7 @@
                             <value>src/test/resources/logging.properties</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.health.4.0.internal.javax_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.4.0.internal.javax_fat_tck/publish/tckRunner/tck/pom.xml
@@ -198,7 +198,7 @@
                             <value>src/test/resources/logging.properties</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -193,7 +193,7 @@
                             <value>src/test/resources/logging.properties</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -192,7 +192,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -263,7 +263,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -265,7 +265,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -140,7 +140,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine><!-- Needed for ZOS. sourceEncoding is needed because arquillian calls String.getBtytes(). Attach is needed because because Arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -159,7 +159,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                         <configuration>
-                            <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                            <argLine>${fat.framework.args}</argLine>
                             <systemProperties>
                                 <property>
                                     <name>java.util.logging.config.file</name>

--- a/dev/io.openliberty.microprofile.metrics.internal.4.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -165,7 +165,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                         <configuration>
-                            <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                            <argLine>${fat.framework.args}</argLine>
                             <systemProperties>
                                 <property>
                                     <name>java.util.logging.config.file</name>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -165,7 +165,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                         <configuration>
-                            <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                            <argLine>${fat.framework.args}</argLine>
                             <systemProperties>
                                 <property>
                                     <name>java.util.logging.config.file</name>

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -165,7 +165,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                         <configuration>
-                            <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                            <argLine>${fat.framework.args}</argLine>
                             <systemProperties>
                                 <property>
                                     <name>java.util.logging.config.file</name>

--- a/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -58,7 +58,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemProperties>
                       <property>
                         <name>java.util.logging.config.file</name>

--- a/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -66,7 +66,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemProperties>
                       <property>
                         <name>java.util.logging.config.file</name>

--- a/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -66,7 +66,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemProperties>
                       <property>
                         <name>java.util.logging.config.file</name>

--- a/dev/io.openliberty.microprofile.openapi.4.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.4.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -59,7 +59,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemProperties>
                       <property>
                         <name>java.util.logging.config.file</name>

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -211,7 +211,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}
+                    <argLine>${fat.framework.args}</argLine>
                         -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). 
                         Attach is needed becuase because arquillian uses com.sun.tools.attach to 
                         find VMs -->

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -273,7 +273,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}
+                    <argLine>${fat.framework.args}</argLine>
                         -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). 
                         Attach is needed becuase because arquillian uses com.sun.tools.attach to 
                         find VMs -->

--- a/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -224,7 +224,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine><!-- Needed for ZOS becuase arquillian calls string.getBtytes() -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -194,7 +194,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine><!-- Needed for ZOS becuase arquillian calls string.getBtytes() -->
+                    <argLine>${fat.framework.args}</argLine>
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -386,7 +386,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -380,7 +380,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -392,7 +392,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
                 <configuration>
-                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -224,7 +224,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -224,7 +224,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -234,7 +234,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/io.openliberty.microprofile.telemetry.2.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -234,7 +234,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>${fat.framework.args}</argLine>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/> <!-- Default forkNode has encoding issues on ZOS -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>


### PR DESCRIPTION
We had a bug with a segfault from the maven part of the TCK, which never uploaded the dump file. This will fix such things from happening again.

It also moves all the argline contents to a variable passed in from the fat framework. So if I ever need to update that for a build break again I wont have to do it in 70 places. 

fixes #31412