### PR TITLE
Junits for coverage for AsciiCharacter

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataCoverageTests.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataCoverageTests.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2024,2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.web;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.jpa.data.tests.models.AsciiCharacter;
+import jakarta.annotation.Resource;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.UserTransaction;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/JakartaDataCoverageTests")
+public class JakartaDataCoverageTests extends FATServlet {
+
+    @PersistenceContext(unitName = "RecreatePersistenceUnit")
+    private EntityManager em;
+
+    @Resource
+    private UserTransaction tx;
+
+    @Test
+    public void alwaysPasses() {
+        assertTrue("This test always passes", true);
+    }
+
+    @Test // Verifies that a JPQL query using an alias returns the correct hexadecimal value for a persisted AsciiCharacter
+    public void testAsciiCharacterQueryReturnsHexadecimalWithAlias() {
+        int id = (int) (System.currentTimeMillis() % Integer.MAX_VALUE);
+        AsciiCharacter character = new AsciiCharacter();
+        character.setId(id);
+        character.setThisCharacter('P');
+        character.setHexadecimal("50");
+        character.setNumericValue(80);
+        character.setControl(false);
+
+        try {
+            tx.begin();
+            em.createQuery("DELETE FROM AsciiCharacter a WHERE a.thisCharacter = :char")
+                            .setParameter("char", character.getThisCharacter())
+                            .executeUpdate();
+            em.persist(character);
+            tx.commit();
+        } catch (Exception e) {
+            try {
+                tx.rollback();
+            } catch (SystemException se) {
+                throw new RuntimeException("Rollback failed during testOLGH28913QueryHexadecimalWithAlias", se);
+            }
+            throw new RuntimeException("Transaction failed during testOLGH28913QueryHexadecimalWithAlias", e);
+        }
+
+        TypedQuery<String> query = em.createQuery(
+                                                  "SELECT a.hexadecimal FROM AsciiCharacter a WHERE a.thisCharacter = :char", String.class);
+        query.setParameter("char", character.getThisCharacter());
+
+        List<String> results = query.getResultList();
+
+        assertNotNull("Query result should not be null", results);
+        assertFalse("Query result should not be empty", results.isEmpty());
+        assertTrue("Expected hexadecimal value not found in results", results.contains(character.getHexadecimal()));
+    }
+
+    @Test
+    public void testAsciiCharacterInvalidFieldAccessWithoutAlias() {
+        try {
+            em.createQuery("SELECT nonExistentField FROM AsciiCharacter", String.class)
+                            .getResultList();
+            fail("Expected exception due to invalid field was not thrown");
+        } catch (RuntimeException e) { // Includes PersistenceException
+            String msg = e.getMessage();
+            assertNotNull("Exception message should not be null", msg);
+            assertTrue("Exception message should reference 'nonExistentField'", msg.contains("nonExistentField"));
+        }
+    }
+
+    @Test
+    public void testAsciiCharacterMultipleResultsQuery() {
+        try {
+            tx.begin();
+            em.persist(AsciiCharacter.of(65)); // 'A'
+            em.persist(AsciiCharacter.of(66)); // 'B'
+            tx.commit();
+        } catch (NotSupportedException | SystemException | RollbackException | HeuristicMixedException | HeuristicRollbackException e) {
+            throw new RuntimeException("Transaction failed during testOLGH28913MultipleResultsQuery", e);
+        }
+
+        List<String> results = em.createQuery(
+                                              "SELECT a.hexadecimal FROM AsciiCharacter a WHERE a.hexadecimal IS NOT NULL", String.class)
+                        .getResultList();
+
+        assertTrue("Expected hex value 41 not found", results.contains("41")); // 65 in hex
+        assertTrue("Expected hex value 42 not found", results.contains("42")); // 66 in hex
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataCoverageTests.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataCoverageTests.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.fail;
 import java.util.List;
 
 import org.junit.Test;
+import org.junit.BeforeEach;
 
 import componenttest.app.FATServlet;
 import io.openliberty.jpa.data.tests.models.AsciiCharacter;
@@ -32,6 +33,13 @@ import jakarta.transaction.RollbackException;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.UserTransaction;
 
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.ibm.websphere.csi.J2EEName;
+import com.ibm.ws.jpa.JPAPuId;
+import com.ibm.ws.jpa.management.JPAEMFactory;
+
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/JakartaDataCoverageTests")
 public class JakartaDataCoverageTests extends FATServlet {
@@ -41,6 +49,25 @@ public class JakartaDataCoverageTests extends FATServlet {
 
     @Resource
     private UserTransaction tx;
+    
+    private JPAEMFactory mockDelegateFactory;
+    private JPAEMFactoryV32 factoryUnderTest;
+    private JPAPuId mockPuId;
+    private J2EEName mockJ2eeName;
+
+    @BeforeEach
+    void setUp() {
+        mockPuId = mock(JPAPuId.class);
+        mockJ2eeName = mock(J2EEName.class);
+        mockDelegateFactory = mock(JPAEMFactory.class);
+
+        // Use a subclass to inject the mock delegate
+        factoryUnderTest = new JPAEMFactoryV32(mockPuId, mockJ2eeName, null) {
+            {
+                this.ivFactory = mockDelegateFactory;
+            }
+        };
+    }
 
     @Test
     public void alwaysPasses() {
@@ -115,4 +142,26 @@ public class JakartaDataCoverageTests extends FATServlet {
         assertTrue("Expected hex value 41 not found", results.contains("41")); // 65 in hex
         assertTrue("Expected hex value 42 not found", results.contains("42")); // 66 in hex
     }
+    
+    @Test
+    void testRunInTransactionDelegatesToIvFactory() {
+        Consumer<EntityManager> work = em -> { /* do nothing */ };
+
+        factoryUnderTest.runInTransaction(work);
+
+        verify(mockDelegateFactory, times(1)).runInTransaction(work);
+    }
+
+    @Test
+    void testCallInTransactionDelegatesToIvFactory() {
+        Function<EntityManager, String> work = em -> "result";
+
+        when(mockDelegateFactory.callInTransaction(any())).thenReturn("result");
+
+        String result = factoryUnderTest.callInTransaction(work);
+
+        verify(mockDelegateFactory, times(1)).callInTransaction(work);
+        assert result.equals("result");
+    }
+    
 }

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataCoverageTests.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataCoverageTests.java
@@ -84,7 +84,7 @@ public class JakartaDataCoverageTests extends FATServlet {
         assertTrue("Expected hexadecimal value not found in results", results.contains(character.getHexadecimal()));
     }
 
-    @Test
+    @Test //Verifies that querying a non-existent field in AsciiCharacter throws a runtime exception
     public void testAsciiCharacterInvalidFieldAccessWithoutAlias() {
         try {
             em.createQuery("SELECT nonExistentField FROM AsciiCharacter", String.class)
@@ -97,7 +97,7 @@ public class JakartaDataCoverageTests extends FATServlet {
         }
     }
 
-    @Test
+    @Test // Verifies that multiple persisted AsciiCharacter entries return correct hexadecimal values via JPQL query
     public void testAsciiCharacterMultipleResultsQuery() {
         try {
             tx.begin();


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Junits for AsciiCharacter for code coverage