### PR TITLE
CDI test for a duplicate lib in two wars

### DIFF
--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/duplicate/lib/DuplicateLibraryBean.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/duplicate/lib/DuplicateLibraryBean.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.duplicate.lib;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+@ApplicationScoped
+@Named("DuplicateLibraryBean")
+public class DuplicateLibraryBean {
+
+    public String test() {
+        return "OK";
+    }
+}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/duplicate/war1/DuplicateWar1Servlet.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/duplicate/war1/DuplicateWar1Servlet.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.duplicate.war1;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.cdi.visibility.tests.duplicate.lib.DuplicateLibraryBean;
+
+import componenttest.app.FATServlet;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+@SuppressWarnings("serial")
+@WebServlet("/war1")
+public class DuplicateWar1Servlet extends FATServlet {
+
+    @Inject
+    private DuplicateLibraryBean bean;
+
+    @Test
+    @Mode(TestMode.FULL)
+    public void testBeanWar1() {
+        assertEquals("OK", bean.test());
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/duplicate/war2/DuplicateWar2Servlet.java
+++ b/dev/com.ibm.ws.cdi.visibility_fat/fat/src/com/ibm/ws/cdi/visibility/tests/duplicate/war2/DuplicateWar2Servlet.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.visibility.tests.duplicate.war2;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.cdi.visibility.tests.duplicate.lib.DuplicateLibraryBean;
+
+import componenttest.app.FATServlet;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+@SuppressWarnings("serial")
+@WebServlet("/war2")
+public class DuplicateWar2Servlet extends FATServlet {
+
+    @Inject
+    private DuplicateLibraryBean bean;
+
+    @Test
+    @Mode(TestMode.FULL)
+    public void testBeanWar2() {
+        assertEquals("OK", bean.test());
+    }
+
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Asserts current behaviour when two wars contain the same library.

Does not reproduce the issue from #31525