### PR TITLE
Data feature added after already using app

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/io.openliberty.data-1.0.feature
@@ -2,6 +2,7 @@
 symbolicName=io.openliberty.data-1.0
 visibility=public
 singleton=true
+IBM-App-ForceRestart: install, uninstall
 IBM-ShortName: data-1.0
 IBM-API-Package: \
   jakarta.data; type="spec",\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.1/io.openliberty.data-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.1/io.openliberty.data-1.1.feature
@@ -2,6 +2,7 @@
 symbolicName=io.openliberty.data-1.1
 visibility=public
 singleton=true
+IBM-App-ForceRestart: install, uninstall
 IBM-ShortName: data-1.1
 # This feature temporarily serves as a place to keep around some function that
 # did not make it into the Jakarta Data 1.0 specification, but could be added in

--- a/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/DataConfigTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_config/test-applications/DataConfigTestApp/src/test/jakarta/data/config/web/DataConfigTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,6 @@ import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLSyntaxErrorException;
 
 import jakarta.annotation.Resource;
-import jakarta.data.exceptions.DataException;
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
@@ -84,6 +83,13 @@ public class DataConfigTestServlet extends FATServlet {
     }
 
     /**
+     * A servlet operation that doesn't do anything. It can be used when the
+     * Jakarta Data feature is not enabled.
+     */
+    public void testDoNotUseJakartaData(HttpServletRequest request, PrintWriter response) {
+    }
+
+    /**
      * Adds new data to tables. The data must not already exist.
      */
     public void testEntitiesCanBeAdded(HttpServletRequest request, PrintWriter response) {
@@ -101,7 +107,10 @@ public class DataConfigTestServlet extends FATServlet {
         try {
             Employee found = employees.findById(111222).orElseGet(() -> null);
             assertEquals("Employee table should not be found.", null, found);
-        } catch (DataException x) {
+        } catch (RuntimeException x) {
+            // Allow other methods of the servlet to be used without Jakarta Data enabled
+            if (!x.getClass().getName().startsWith("jakarta.data.exceptions."))
+                throw x;
             boolean expectedException = false;
             for (Throwable cause = x.getCause(); cause != null && !expectedException; cause = cause.getCause())
                 expectedException = cause instanceof SQLSyntaxErrorException;
@@ -112,7 +121,10 @@ public class DataConfigTestServlet extends FATServlet {
         try {
             Student found = students.findById(1234).orElseGet(() -> null);
             assertEquals("Student table should not be found", null, found);
-        } catch (DataException x) {
+        } catch (RuntimeException x) {
+            // Allow other methods of the servlet to be used without Jakarta Data enabled
+            if (!x.getClass().getName().startsWith("jakarta.data.exceptions."))
+                throw x;
             boolean expectedException = false;
             for (Throwable cause = x.getCause(); cause != null && !expectedException; cause = cause.getCause())
                 expectedException = cause instanceof SQLSyntaxErrorException;
@@ -145,7 +157,10 @@ public class DataConfigTestServlet extends FATServlet {
         employees.save(new Employee(222333, null, "TestMappedSuperclass", 25));
         try {
             employees.save(new Employee(333444, "TestMappedSuperclass", null, 35));
-        } catch (DataException x) {
+        } catch (RuntimeException x) {
+            // Allow other methods of the servlet to be used without Jakarta Data enabled
+            if (!x.getClass().getName().startsWith("jakarta.data.exceptions."))
+                throw x;
             boolean expectedException = false;
             for (Throwable cause = x.getCause(); cause != null && !expectedException; cause = cause.getCause())
                 expectedException = cause instanceof SQLIntegrityConstraintViolationException;


### PR DESCRIPTION
It should be possible to add the data-1.0 feature to a running server after you have already used an application and discovered that it needs Jakarta Data. The addition of the data-1.0 feature needs to force the application to restart in order to process and inject the Jakarta Data repositories.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
