### PR TITLE
Test case needs to specify scale for to prevent it from defaulting to 0

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATest.java
@@ -42,10 +42,12 @@ public class DataJPATest extends FATServletClient {
     static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
                                    "CWWKD1026E.*allSorted",
+                                   "CWWKD1046E.*publicDebtAsBigInteger",
                                    "CWWKD1046E.*publicDebtAsByte",
                                    "CWWKD1046E.*publicDebtAsDouble",
                                    "CWWKD1046E.*publicDebtAsFloat",
                                    "CWWKD1046E.*publicDebtAsInt",
+                                   "CWWKD1046E.*publicDebtAsLong",
                                    "CWWKD1046E.*publicDebtAsShort",
                                    "CWWKD1046E.*numFullTimeWorkersAsByte",
                                    "CWWKD1046E.*numFullTimeWorkersAsDouble",

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -512,15 +512,11 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(27480960216618.32,
                      demographics.publicDebtAsBigDecimal(when)
                                      .doubleValue(),
-                     1.0);
+                     0.01);
 
         try {
             Optional<BigInteger> i = demographics.publicDebtAsBigInteger(when);
-            // TODO is BigDecimal.toBigIntegerExact() broken?
-            // or are the fractional digits not being included?
-            //fail("Should not convert BigDecimal 27480960216618.32 to BigInteger " + i);
-            assertEquals(27480960216618L,
-                         i.orElseThrow().longValue());
+            fail("Should not convert BigDecimal 27480960216618.32 to BigInteger " + i);
         } catch (MappingException x) {
             if (x.getCause() instanceof ArithmeticException)
                 ; // expected - out of range
@@ -561,11 +557,7 @@ public class DataJPATestServlet extends FATServlet {
 
         try {
             Long l = demographics.publicDebtAsLong(when);
-            // TODO is BigDecimal.longValueExact() broken?
-            // or are the fractional digits not being included?
-            //fail("Should not convert BigDecimal 27480960216618.32 to Long " + l);
-            assertEquals(Long.valueOf(27480960216618L),
-                         l);
+            fail("Should not convert BigDecimal 27480960216618.32 to Long " + l);
         } catch (MappingException x) {
             // expected - out of range
         }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DemographicInfo.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DemographicInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -35,10 +35,10 @@ public class DemographicInfo {
     @Id
     public BigInteger id;
 
-    @Column
+    @Column(precision = 20, scale = 2)
     public BigDecimal publicDebt;
 
-    @Column
+    @Column(precision = 20, scale = 2)
     public BigDecimal intragovernmentalDebt;
 
     @Column


### PR DESCRIPTION
The scale of BigDecimal entity attributes is defaulting to 0 in a test, causing fractional digits to be lost.  The PR corrects the entity definition and enables the correct assertions in the test.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".