### PR TITLE
Wait for TCP Channel started message in SoReuseAddr test

### DIFF
--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/SoReuseAddrTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/SoReuseAddrTests.java
@@ -76,6 +76,11 @@ public class SoReuseAddrTests {
         server.updateServerConfiguration(configuration);
         server.waitForConfigUpdateInLogUsingMark(null);
 
+        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv6) port 8010.
+        // We should wait for the TCP Channel to start before checking the trace. If we don't it is possible we try to start shutting down
+        // the server before we even have finished starting up causing quiesce issues.
+        server.waitForStringInLogUsingMark("CWWKO0219I");
+
         // Validate that soReuseAddr is set to false.
         assertNotNull("The configured value of soReuseAddr was not false!", server.waitForStringInTraceUsingMark("soReuseAddr: false"));
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #31544