### PR TITLE
MP OpenAPI translate cache warning messages

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/cache/CacheEntry.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/cache/CacheEntry.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.microprofile.openapi20.internal.cache;
 
@@ -42,6 +39,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 import io.openliberty.microprofile.openapi20.internal.utils.LoggingUtils;
+import io.openliberty.microprofile.openapi20.internal.utils.MessageConstants;
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.runtime.OpenApiProcessor;
 import io.smallrye.openapi.runtime.OpenApiStaticFile;
@@ -130,7 +128,7 @@ public class CacheEntry {
                 return null;
             }
         } catch (IOException e) {
-            Tr.warning(tc, "Unexpected error attempting to read cache for the {0} application. The error is {1}", applicationName, e.toString());
+            Tr.warning(tc, MessageConstants.OPENAPI_CACHE_READ_ERROR_CWWKO1688W, applicationName, e.toString());
             return null;
         }
 
@@ -408,7 +406,7 @@ public class CacheEntry {
             }
         } catch (Exception e) {
             // warn upon unexpected failure
-            Tr.warning(tc, "An unexpected error occurred while writing the cache for application {0}. The error is {1}", appName, e.toString());
+            Tr.warning(tc, MessageConstants.OPENAPI_CACHE_WRITE_ERROR_CWWKO1689W, appName, e.toString());
         }
     }
 

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/MessageConstants.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/MessageConstants.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.microprofile.openapi20.internal.utils;
 
@@ -42,6 +39,8 @@ public class MessageConstants {
     public static final String OPENAPI_MP_CONFIG_REDUNDANT_CWWKO1685I = "OPENAPI_MP_CONFIG_REDUNDANT_CWWKO1685I";
     public static final String OPENAPI_MP_CONFIG_CONFLICTS_CWWKO1686W = "OPENAPI_MP_CONFIG_CONFLICTS_CWWKO1686W";
     public static final String OPENAPI_ANNOTATION_TOO_NEW_CWWKO1687W = "OPENAPI_ANNOTATION_TOO_NEW_CWWKO1687W";
+    public static final String OPENAPI_CACHE_READ_ERROR_CWWKO1688W = "OPENAPI_CACHE_READ_ERROR_CWWKO1688W";
+    public static final String OPENAPI_CACHE_WRITE_ERROR_CWWKO1689W = "OPENAPI_CACHE_WRITE_ERROR_CWWKO1689W";
 
     private MessageConstants() {
         // This class is not meant to be instantiated.

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package io.openliberty.microprofile.openapi20.fat.cache;
 
@@ -19,7 +16,16 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
+import java.util.stream.Stream;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -31,6 +37,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.PropertiesAsset;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -194,6 +201,107 @@ public class CacheTest {
         assertThat(server.findStringsInTrace("Using Jandex index from cache"), not(empty()));
         assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
         assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+    }
+
+    @Test
+    @Mode(TestMode.EXPERIMENTAL) // Too slow and low-risk of breaking to be worth running regularly
+    @ExpectedFFDC("java.io.FileNotFoundException")
+    public void testCacheReadWarning() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "cacheTest.war")
+                                   .addPackage(CacheTest.class.getPackage());
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        // start server
+        server.startServer();
+
+        // check that document is generated and cache written
+        assertThat(server.findStringsInTrace("Building Jandex index"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+
+        // stop server without archiving it
+        server.stopServer(false);
+
+        // replace cached model with a directory to provoke cacheRead error
+        Path cacheDir = getCacheDir("cacheTest");
+        Path modelFile = cacheDir.resolve("model");
+        Files.delete(modelFile);
+        Files.createDirectory(modelFile);
+
+        // start server without clean (since that would clear the cache)
+        server.startServer(false);
+
+        // check the warning is emitted and cache is not used
+        assertThat(server.findStringsInLogs("CWWKO1688W.*cacheTest.*FileNotFoundException"), not(empty()));
+        assertThat(server.findStringsInTrace("Building Jandex index"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+
+        // Stop server, expecting error
+        server.stopServer("CWWKO1688W");
+    }
+
+    @Test
+    @Mode(TestMode.EXPERIMENTAL) // Too slow and low-risk of breaking to be worth running regularly
+    @ExpectedFFDC("java.io.IOException")
+    public void testCacheWriteWarning() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "cacheTest.war")
+                                   .addPackage(CacheTest.class.getPackage());
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        // start server
+        server.startServer();
+
+        // check that document is generated and cache written
+        assertThat(server.findStringsInTrace("Building Jandex index"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+
+        // stop server without archiving it
+        server.stopServer(false);
+
+        // replace cache directory with a file to provoke cacheWrite error
+        Path cacheDir = getCacheDir("cacheTest");
+        Files.walkFileTree(cacheDir, RECURSIVE_DELETE);
+        Files.createFile(cacheDir); // Create an empty file
+
+        // start server without clean (since that would clear the cache)
+        server.startServer(false);
+
+        // check the cache is not used and the warning is emitted when writing the new cache
+        assertThat(server.findStringsInTrace("Building Jandex index"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInLogs("CWWKO1689W.*cacheTest.*IOException"), not(empty()));
+
+        // Stop server, expecting error
+        server.stopServer("CWWKO1689W");
+    }
+
+    private static final FileVisitor<Path> RECURSIVE_DELETE = new SimpleFileVisitor<Path>() {
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            Files.delete(file);
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+            Files.delete(dir);
+            return FileVisitResult.CONTINUE;
+        }
+    };
+
+    private Path getCacheDir(String appName) throws IOException {
+        // cache dir is in workarea/org.eclipse.osgi/*/data/cache/appName
+        Path workarea = FileSystems.getDefault().getPath(server.getOsgiWorkAreaRoot());
+        try (Stream<Path> s = Files.list(workarea)) {
+            return s.filter(Files::isDirectory)
+                    .map(p -> p.resolve("data/cache/" + appName))
+                    .filter(Files::exists)
+                    .findAny()
+                    .orElseThrow(() -> new RuntimeException("Failed to find cache directory for " + appName + " in " + workarea));
+        }
     }
 
     @After

--- a/dev/io.openliberty.microprofile.openapi.internal.common/resources/io/openliberty/microprofile/openapi/internal/resources/OpenAPI.nlsprops
+++ b/dev/io.openliberty.microprofile.openapi.internal.common/resources/io/openliberty/microprofile/openapi/internal/resources/OpenAPI.nlsprops
@@ -1,13 +1,10 @@
-# Copyright (c) 2018, 2024 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 # -------------------------------------------------------------------------------------------------
 #CMVCPATHNAME N/A
 #COMPONENTPREFIX CWWKO
@@ -173,3 +170,11 @@ OPENAPI_MP_CONFIG_CONFLICTS_CWWKO1686W.useraction=Remove the MicroProfile Config
 OPENAPI_ANNOTATION_TOO_NEW_CWWKO1687W=CWWKO1687W: The {0} annotation element in the {1} class is ignored because it requires OpenAPI version {2} but the current OpenAPI version is {3}.
 OPENAPI_ANNOTATION_TOO_NEW_CWWKO1687W.explanation=The annotation element relates to a feature added to a newer version of the OpenAPI specification than the one configured. The OpenAPI version in use cannot represent this information, so it is excluded from the produced OpenAPI documentation.
 OPENAPI_ANNOTATION_TOO_NEW_CWWKO1687W.useraction=Consider removing the annotation element or setting the openAPIVersion configuration element to a version which supports it in the server.xml file.
+
+OPENAPI_CACHE_READ_ERROR_CWWKO1688W=CWWKO1688W: An error occurred when reading the OpenAPI cache for the {0} application. The cache will not be used. The error is {1}
+OPENAPI_CACHE_READ_ERROR_CWWKO1688W.explanation=The MicroProfile OpenAPI feature stores some data computed during application startup to avoid re-computing this data on future server starts if the application is unchanged. An error occurred when trying to read this data, so it will be recomputed.
+OPENAPI_CACHE_READ_ERROR_CWWKO1688W.useraction=Review the server message.log and FFDC logs to identify the problem.
+
+OPENAPI_CACHE_WRITE_ERROR_CWWKO1689W=CWWKO1689W: An error occurred when writing the OpenAPI cache for the {0} application. The cache will not be available on next startup. The error is {1}
+OPENAPI_CACHE_WRITE_ERROR_CWWKO1689W.explanation=The MicroProfile OpenAPI feature stores some data computed during application startup to avoid re-computing this data on future server starts if the application is unchanged. An error occurred when trying to write this data, so it will be recomputed next time the server is started.
+OPENAPI_CACHE_WRITE_ERROR_CWWKO1689W.useraction=Review the server message.log and FFDC logs to identify the problem.


### PR DESCRIPTION
These warnings messages should have been externalized for translation originally but were missed.

They're only output if an unexpected failure occurs when reading or writing the OpenAPI cache.

I've added tests to ensure that the messages are substituted and output correctly and I've run them manually, but I've left them excluded from the build since I think the risk and impact of breaking this is very low and the time taken to run the tests is relatively high due to multiple server restarts.

Fixes #28866

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
