### PR TITLE
Fix: Prevent NullPointerException in MCWrapper.getConnection when connection is aborted

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
@@ -1933,7 +1933,21 @@ public final class MCWrapper implements com.ibm.ws.j2c.MCWrapper, JCAPMIHelper {
         // Get the a Connection from the ManagedConnection to return to our caller, and increment the
         // number of open connections for this ManagedConnection.
         try {
-            connection = mc.getConnection(subj, cri);
+            if (!aborted && !do_not_reuse_mcw) {
+                connection = mc.getConnection(subj, cri);
+            } else {
+                if (do_not_reuse_mcw) {
+                    if (isTracingEnabled && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "Connection error occurred for this mcw " + this + ", mcw will not be reused");
+                    }
+                    markStale();
+                    ResourceException e = new ResourceException("Resource adapter called connection error event during getConnection " +
+                                                                "processing and did not throw a resource exception.  The reason for " +
+                                                                "this failure may have been logged during the connection error event " +
+                                                                "logging.");
+                    throw e;
+                }
+            }
             if (isValidating.get() != null && Boolean.FALSE.equals(testConnection()))
                 throw new ResourceAllocationException("ManagedConnection.testConnection() indicates connection is not valid.");
             if (_supportsReAuth) {


### PR DESCRIPTION
Fixes Apar #PH66522
Fixes Issue [#31549](https://github.com/OpenLiberty/open-liberty/issues/31549)


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This change prevents a NullPointerException by adding checks for the aborted and do_not_reuse_mcw flags before attempting to retrieve a connection via mc.getConnection(...).
Previously, if a connection was aborted (e.g., due to a connection error event), it could still be accessed from the pool, resulting in a NullPointerException.

The updated logic ensures that if the connection is not reusable, the MCWrapper is marked as stale and a ResourceException is thrown instead of proceeding to use the null connection.

This improves reliability and error handling in scenarios where connections are asynchronously aborted or marked invalid before reuse.

