### PR TITLE
Used Tr.debug, instead of printStackTrace in Logging components

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseFFDCService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseFFDCService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2013 IBM Corporation and others.
+ * Copyright (c) 2010, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseFFDCService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseFFDCService.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -154,11 +154,11 @@ public class BaseFFDCService implements FFDCFilterService {
      * Process an exception
      *
      * @param th
-     *            The exception to be processed
+     *                     The exception to be processed
      * @param sourceId
-     *            The source id of the reporting code
+     *                     The source id of the reporting code
      * @param probeId
-     *            The probe of the reporting code
+     *                     The probe of the reporting code
      */
     @Override
     public void processException(Throwable th, String sourceId, String probeId) {
@@ -169,13 +169,13 @@ public class BaseFFDCService implements FFDCFilterService {
      * Process an exception
      *
      * @param th
-     *            The exception to be processed
+     *                       The exception to be processed
      * @param sourceId
-     *            The source id of the reporting code
+     *                       The source id of the reporting code
      * @param probeId
-     *            The probe of the reporting code
+     *                       The probe of the reporting code
      * @param callerThis
-     *            The instance of the reporting code
+     *                       The instance of the reporting code
      */
 
     @Override
@@ -187,13 +187,13 @@ public class BaseFFDCService implements FFDCFilterService {
      * Process an exception
      *
      * @param th
-     *            The exception to be processed
+     *                        The exception to be processed
      * @param sourceId
-     *            The source id of the reporting code
+     *                        The source id of the reporting code
      * @param probeId
-     *            The probe of the reporting code
+     *                        The probe of the reporting code
      * @param objectArray
-     *            An array of additional interesting objects
+     *                        An array of additional interesting objects
      */
     @Override
     public void processException(Throwable th, String sourceId, String probeId, Object[] objectArray) {
@@ -204,15 +204,15 @@ public class BaseFFDCService implements FFDCFilterService {
      * Process an exception
      *
      * @param th
-     *            The exception to be processed
+     *                        The exception to be processed
      * @param sourceId
-     *            The source id of the reporting code
+     *                        The source id of the reporting code
      * @param probeId
-     *            The probe of the reporting code
+     *                        The probe of the reporting code
      * @param callerThis
-     *            The instance of the reporting code
+     *                        The instance of the reporting code
      * @param objectArray
-     *            An array of additional interesting objects
+     *                        An array of additional interesting objects
      */
     @Override
     public void processException(Throwable th, String sourceId, String probeId, Object callerThis, Object[] objectArray) {
@@ -223,18 +223,18 @@ public class BaseFFDCService implements FFDCFilterService {
      * Log a problem to the global incident stream (creating it if necessary
      *
      * @param txt
-     *            A description of the incident (the name of the exception)
+     *                        A description of the incident (the name of the exception)
      * @param sourceId
-     *            The source id of the reporting code
+     *                        The source id of the reporting code
      * @param probeId
-     *            The probe id of the reporting code
+     *                        The probe id of the reporting code
      * @param th
-     *            The exception
+     *                        The exception
      * @param callerThis
-     *            The instance of the reporting code (null if no specific
-     *            instance)
+     *                        The instance of the reporting code (null if no specific
+     *                        instance)
      * @param objectArray
-     *            Additional interesting object (null if there aren't any)
+     *                        Additional interesting object (null if there aren't any)
      */
     @FFDCIgnore(PrivilegedActionException.class)
     private void log(String sourceId, String probeId, Throwable th, Object callerThis, Object[] objectArray) {
@@ -322,7 +322,9 @@ public class BaseFFDCService implements FFDCFilterService {
                 } catch (FileNotFoundException e) {
                     // This is FFDC not being able to find itself... we're in bad
                     // shape if this doesn't work..
-                    e.printStackTrace();
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "A FileNotFoundException occurred when creating the FFDC incident summary file.", e);
+                    }
                 } catch (IOException e) {
                 } finally {
                     LoggingFileUtils.tryToClose(os);

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1645,9 +1645,10 @@ public class BaseTraceService implements TrService {
                         return InetAddress.getLocalHost().getCanonicalHostName();
                     }
                 });
-
             } catch (Exception e) {
-                e.printStackTrace();
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "An exception occurred when retrieving the server hostname.", e);
+                }
                 serverHostName = "";
             }
         } else {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/JsonLogHandler.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/JsonLogHandler.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,11 +19,14 @@ import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.logging.collector.CollectorConstants;
 import com.ibm.ws.logging.collector.CollectorJsonHelpers;
 import com.ibm.ws.logging.collector.CollectorJsonUtils;
 import com.ibm.ws.logging.collector.Formatter;
 import com.ibm.ws.logging.data.GenericData;
+import com.ibm.ws.logging.internal.NLSConstants;
 import com.ibm.wsspi.collector.manager.BufferManager;
 import com.ibm.wsspi.collector.manager.CollectorManager;
 import com.ibm.wsspi.collector.manager.SynchronousHandler;
@@ -49,6 +52,8 @@ public abstract class JsonLogHandler implements SynchronousHandler, Formatter {
 
     protected CollectorManager collectorMgr = null;
 
+    private static TraceComponent tc = Tr.register(JsonLogHandler.class, NLSConstants.GROUP, NLSConstants.LOGGING_NLS);
+
     @Override
     public void init(CollectorManager collectorManager) {
         try {
@@ -56,7 +61,9 @@ public abstract class JsonLogHandler implements SynchronousHandler, Formatter {
             collectorMgr.subscribe(this, convertToSourceIDList(sourcesList));
             isInit = true;
         } catch (Exception e) {
-            e.printStackTrace();
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught an exception when subscribing to the Collector Manager.", e);
+            }
         }
     }
 
@@ -64,8 +71,8 @@ public abstract class JsonLogHandler implements SynchronousHandler, Formatter {
      * Constructor for the JsonLoghandler which will establish server information needed
      * to fill in the fields of the JSON data object
      *
-     * @param serverName The wlp servername
-     * @param wlpUserDir The wlp user directory
+     * @param serverName  The wlp servername
+     * @param wlpUserDir  The wlp user directory
      * @param sourcesList The first sourceList to subscribe to collectorManager with
      */
     public JsonLogHandler(String serverName, String wlpUserDir, List<String> sourcesList) {
@@ -95,7 +102,9 @@ public abstract class JsonLogHandler implements SynchronousHandler, Formatter {
                 });
 
             } catch (Exception e) {
-                e.printStackTrace();
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "An exception occurred when retrieving the server hostname.", e);
+                }
                 serverHostName = "";
             }
         } else {
@@ -137,7 +146,9 @@ public abstract class JsonLogHandler implements SynchronousHandler, Formatter {
 
             sourcesList = newSources; //new primary sourcesList
         } catch (Exception e) {
-            e.printStackTrace();
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught an exception when subscribing/unsubscribing the Collector Manager", e);
+            }
         }
     }
 

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/JsonLogHandler.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/JsonLogHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #31498
- For better formatting consistency and best practices, we should use `Tr.debug`, whenever we want to print exception stack traces in try/catch blocks.