### PR TITLE
Defect 292475: Wait an extra 600ms before making a wsoc connection

### DIFF
--- a/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/util/wsoc/WsocTestRunner.java
+++ b/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/util/wsoc/WsocTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -101,6 +101,9 @@ public class WsocTestRunner {
         LOG.info("Connecting to wsoc server container: " + c + " endpoint: " +
                  _clientEndpoint.getClass() + " config: " + _cfg + ", uri: " + _uri);
         Session sess = null;
+
+        Thread.sleep(600); // Wait for server just a little bit more. 
+
         if (_clientEndpoint instanceof Endpoint) {
             sess = c.connectToServer((Endpoint) _clientEndpoint, _cfg, _uri);
         } else {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Attempt to resolve defect 292475
```
testUserPropertiesOnServer:java.io.IOException: 2022-09-09-01:25:28:507 Connection future timeout 5000 ms for ws://localhost:8010/basic21/userproperties
    at org.eclipse.jetty.websocket.jakarta.client.internal.JakartaWebSocketClientContainer.connect(JakartaWebSocketClientContainer.java:209)
    at org.eclipse.jetty.websocket.jakarta.client.internal.JakartaWebSocketClientContainer.connectToServer(JakartaWebSocketClientContainer.java:253)
    at io.openliberty.wsoc.util.wsoc.WsocTestRunner.runTest(WsocTestRunner.java:105
 ```