### PR TITLE
Fix Classloader JarCacheDisabler URL generation String

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -104,7 +104,7 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
     private static class JarCacheDisabler {
         static {
             try {
-                URLConnection connection = new URL("jar:file://something.jar!/").openConnection();
+                URLConnection connection = new URL("jar:file:///something.jar!/").openConnection();
                 connection.setDefaultUseCaches(false);
             } catch (MalformedURLException e) {
                 Tr.warning(tc, "WARN_JARS_STILL_CACHED");


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

The String used for the URL generation in the `JarCacheDisabler` method in `com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java` is now throwing a `MalformedURLException` beginning in Java 25 build 23.

Possibly due to the changes in https://bugs.openjdk.org/browse/JDK-8353440

@jhanders34 believes the double forward slash `//` is triggering Java to treat this String as a host and not a file name.  We either need to use a single slash `/` or triple slash `///` to work around this.