### PR TITLE
Re-enable SASL tests for Java 23 and later

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/checkpoint/CheckpointKafkaSaslPlainTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/checkpoint/CheckpointKafkaSaslPlainTest.java
@@ -22,7 +22,6 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKa
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClientProvider;
 import com.ibm.ws.microprofile.reactive.messaging.fat.repeats.ReactiveMessagingActions;
 import componenttest.annotation.CheckpointTest;
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -59,7 +58,6 @@ import static org.junit.Assert.assertNotNull;
  * Basic test using a kafka broker with TLS enabled
  */
 @RunWith(FATRunner.class)
-@MaximumJavaLevel(javaLevel = 22)
 @CheckpointTest
 public class CheckpointKafkaSaslPlainTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/LibertyLoginModuleTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/LibertyLoginModuleTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.secure.fat.suite.SaslPlainTests;
-import componenttest.annotation.MaximumJavaLevel;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -49,7 +48,6 @@ import componenttest.topology.impl.LibertyServer;
  * Test the login module with an aes encoded password and configured encryption key
  */
 @RunWith(FATRunner.class)
-@MaximumJavaLevel(javaLevel = 22)
 public class LibertyLoginModuleTest {
 
     private static final String APP_NAME = "kafkaLoginModuleTest";

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/none/LibertyLoginModuleNoEncTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/none/LibertyLoginModuleNoEncTest.java
@@ -19,7 +19,6 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaU
 import java.util.Map;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.secure.fat.suite.SaslPlainTests;
-import componenttest.annotation.MaximumJavaLevel;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -45,7 +44,6 @@ import componenttest.topology.impl.LibertyServer;
 /**
  * Test the login module with an unencoded password - should still work
  */
-@MaximumJavaLevel(javaLevel = 22)
 @RunWith(FATRunner.class)
 public class LibertyLoginModuleNoEncTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
@@ -19,7 +19,6 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaU
 import java.util.Map;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.secure.fat.suite.SaslPlainTests;
-import componenttest.annotation.MaximumJavaLevel;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -45,7 +44,6 @@ import componenttest.topology.impl.LibertyServer;
 /**
  * Test the login module with an unencoded password - should still work
  */
-@MaximumJavaLevel(javaLevel = 22)
 @RunWith(FATRunner.class)
 public class LibertyLoginModuleSpecialCharsTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/xor/LibertyLoginModuleXorTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/xor/LibertyLoginModuleXorTest.java
@@ -19,7 +19,6 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaU
 import java.util.Map;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.secure.fat.suite.SaslPlainTests;
-import componenttest.annotation.MaximumJavaLevel;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -49,7 +48,6 @@ import componenttest.topology.impl.LibertyServer;
  * Test the login module with xor encoded password
  */
 @RunWith(FATRunner.class)
-@MaximumJavaLevel(javaLevel = 22)
 @Mode(TestMode.FULL)
 public class LibertyLoginModuleXorTest {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/sasl_plain/KafkaSaslPlainTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/sasl_plain/KafkaSaslPlainTest.java
@@ -17,7 +17,6 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaU
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaStopServer;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.secure.fat.suite.SaslPlainTests;
-import componenttest.annotation.MaximumJavaLevel;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -46,7 +45,6 @@ import componenttest.topology.impl.LibertyServer;
  * Basic test using a kafka broker with TLS enabled
  */
 @RunWith(FATRunner.class)
-@MaximumJavaLevel(javaLevel = 22)
 public class KafkaSaslPlainTest {
 
     private static final String APP_NAME = "kafkaSaslTest";


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

With PR https://github.com/OpenLiberty/open-liberty/pull/31271 merged in, @jhanders34 suggested we try retesting the SASL tests with newer versions of Java (23+).

Fixes #29403 