### PR TITLE
Propagate debug.server.* props in FAT execution for >1 server debug

### DIFF
--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -544,6 +544,7 @@
 						<propertyref prefix="env.fat.test." />
 						<propertyref prefix="env.fat.bucket." />
 						<propertyref prefix="env.ldap." />
+						<propertyref prefix="env.debug.server." />
 						<mapper type="glob" from="env.*" to="*" />
 					</syspropertyset>
 					<syspropertyset>


### PR DESCRIPTION
Without this fix, a FAT test with more than one server will start each server in debug mode attempting to bind to the same port, 7777 by default.

With this fix a FAT test may be executed with debug enabled for more than 1 server, e.g
` ./gradlew com.ibm.ws.transport.http2_fat:buildandrun -Ddebug.framework=true  -Ddebug.server.http2ClientRuntime=7777  -Ddebug.server.com.ibm.ws.transport.http2.fat=7778`
or
`./gradlew com.ibm.ws.transport.http2_fat:buildandrun -Ddebug.server.http2ClientRuntime=7780  -Ddebug.server.com.ibm.ws.transport.http2.fat=7779`

You can still use  `-Ddebug.server` to get the existing behavior.

This [wiki section](https://github.com/OpenLiberty/open-liberty/wiki/FAT-Tests#debugging-a-fat) could be updated when this is merged.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).   **N/A**
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".      **N/A**

