### PR TITLE
Add versionless compatibility testing to the EE 9, 10 and 11 fat buckets

### DIFF
--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10FeatureCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -85,6 +85,10 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
 
     public Set<String> getVersionedFeatures() {
         return ee10Features.getVersionedFeatures(openLibertyOnly());
+    }
+
+    public Set<String> getVersionlessFeatures() {
+        return ee10Features.getVersionlessFeatures(openLibertyOnly());
     }
 
     public Set<String> getCompatibleFeatures() {
@@ -246,6 +250,36 @@ public class EE10FeatureCompatibilityTest extends FATServletClient {
         if (!errors.isEmpty()) {
             FATLogger.dumpErrors(c, method, "EE10: Feature compatibility errors:", errors);
             Assert.fail("EE10 compatibility errors");
+        }
+    }
+
+    @Test
+    public void testVersionlessFeaturesMP60() {
+        testVersionlessFeatures("microProfile-6.0");
+    }
+
+    @Test
+    public void testVersionlessFeaturesMP61() {
+        testVersionlessFeatures("microProfile-6.1");
+    }
+
+    @Test
+    public void testVersionlessFeaturesMP70() {
+        testVersionlessFeatures("microProfile-7.0");
+    }
+
+    @Test
+    public void testVersionlessFeaturesMP71() {
+        testVersionlessFeatures("microProfile-7.1");
+    }
+
+    private void testVersionlessFeatures(String mpPlatform) {
+        Set<String> versionlessFeatures = getVersionlessFeatures();
+        List<String> errors = FATFeatureTester.testVersionlessFeatures(versionlessFeatures, ee10Features.getIncompatibleVersionlessFeatures(), mpPlatform);
+
+        if (!errors.isEmpty()) {
+            FATLogger.dumpErrors(c, "testVersionlessFeatures", "EE10: Versionless feature errors:", errors);
+            Assert.fail("EE10 versionless feature errors. " + errors);
         }
     }
 

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10Features.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10Features.java
@@ -34,6 +34,10 @@ public class EE10Features {
         return FeatureUtilities.rejectVersionless(features);
     }
 
+    public static Set<String> getVersionlessFeatures(Set<String> features) {
+        return FeatureUtilities.selectVersionless(features);
+    }
+
     public static final Set<String> getTestFeatures() {
         return FeatureUtilities.allTestFeatures();
     }
@@ -120,6 +124,7 @@ public class EE10Features {
         FeatureUtilities.removeTestAutoFeatures(new File(installRoot));
         this.serverFeatures_ol = getInstalledFeatures(installRoot, OPEN_LIBERTY_ONLY);
         this.versionedFeatures_ol = getVersionedFeatures(serverFeatures_ol);
+        this.versionlessFeatures_ol = getVersionlessFeatures(serverFeatures_ol);
 
         this.compatibleFeatures_ol = getCompatibleFeatures(versionedFeatures_ol, OPEN_LIBERTY_ONLY);
         this.extendedCompatibleFeatures_ol = getExtendedCompatibleFeatures(compatibleFeatures_ol, OPEN_LIBERTY_ONLY);
@@ -130,6 +135,7 @@ public class EE10Features {
 
         this.serverFeatures_wl = getInstalledFeatures(installRoot, !OPEN_LIBERTY_ONLY);
         this.versionedFeatures_wl = getVersionedFeatures(serverFeatures_wl);
+        this.versionlessFeatures_wl = getVersionlessFeatures(serverFeatures_wl);
 
         this.compatibleFeatures_wl = getCompatibleFeatures(versionedFeatures_wl, !OPEN_LIBERTY_ONLY);
         this.extendedCompatibleFeatures_wl = getExtendedCompatibleFeatures(compatibleFeatures_wl, !OPEN_LIBERTY_ONLY);
@@ -137,21 +143,31 @@ public class EE10Features {
         this.incompatibleFeatures_wl = getIncompatibleFeatures(versionedFeatures_wl,
                                                                compatibleFeatures_wl,
                                                                !OPEN_LIBERTY_ONLY);
+        this.incompatibleVersionlessFeatures = new HashSet<>();
+        incompatibleVersionlessFeatures.add("connectorsInboundSecurity"); // Removed in EE 10
+        incompatibleVersionlessFeatures.add("data"); // Added in EE 11
+        incompatibleVersionlessFeatures.add("dataContainer"); // Added in EE 11
+        incompatibleVersionlessFeatures.add("jcaInboundSecurity"); // Removed in EE 10
+        incompatibleVersionlessFeatures.add("j2eeManagement"); // Removed in EE 9
+        incompatibleVersionlessFeatures.add("mpOpenTracing"); // Removed in MP 6
     }
 
     //
 
     private final Set<String> serverFeatures_ol;
     private final Set<String> versionedFeatures_ol;
+    private final Set<String> versionlessFeatures_ol;
     private final Set<String> compatibleFeatures_ol;
     private final Set<String> extendedCompatibleFeatures_ol;
     private final Set<String> incompatibleFeatures_ol;
 
     private final Set<String> serverFeatures_wl;
     private final Set<String> versionedFeatures_wl;
+    private final Set<String> versionlessFeatures_wl;
     private final Set<String> compatibleFeatures_wl;
     private final Set<String> extendedCompatibleFeatures_wl;
     private final Set<String> incompatibleFeatures_wl;
+    private final Set<String> incompatibleVersionlessFeatures;
 
     public Set<String> getServerFeatures(boolean openLiberty) {
         return openLiberty ? serverFeatures_ol : serverFeatures_wl;
@@ -159,6 +175,10 @@ public class EE10Features {
 
     public Set<String> getVersionedFeatures(boolean openLiberty) {
         return openLiberty ? versionedFeatures_ol : versionedFeatures_wl;
+    }
+
+    public Set<String> getVersionlessFeatures(boolean openLiberty) {
+        return openLiberty ? versionlessFeatures_ol : versionlessFeatures_wl;
     }
 
     public Set<String> getCompatibleFeatures(boolean openLiberty) {
@@ -171,6 +191,10 @@ public class EE10Features {
 
     public Set<String> getIncompatibleFeatures(boolean openLiberty) {
         return openLiberty ? incompatibleFeatures_ol : incompatibleFeatures_wl;
+    }
+
+    public Set<String> getIncompatibleVersionlessFeatures() {
+        return incompatibleVersionlessFeatures;
     }
 
     //

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jarkartaee10/internal/tests/util/FATFeatureResolver.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jarkartaee10/internal/tests/util/FATFeatureResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -84,5 +84,13 @@ public class FATFeatureResolver {
                                         EMPTY_DEFS, rootFeatures,
                                         EMPTY_STRINGS,
                                         false);
+    }
+
+    public static FeatureResolver.Result resolve(Collection<String> rootFeatures, Collection<String> platforms) {
+        return resolver.resolve(repository,
+                                EMPTY_DEFS, rootFeatures,
+                                EMPTY_STRINGS,
+                                false,
+                                platforms);
     }
 }

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11FeatureCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -84,6 +84,10 @@ public class EE11FeatureCompatibilityTest extends FATServletClient {
 
     public Set<String> getVersionedFeatures() {
         return ee11Features.getVersionedFeatures(openLibertyOnly());
+    }
+
+    public Set<String> getVersionlessFeatures() {
+        return ee11Features.getVersionlessFeatures(openLibertyOnly());
     }
 
     public Set<String> getCompatibleFeatures() {
@@ -248,6 +252,42 @@ public class EE11FeatureCompatibilityTest extends FATServletClient {
         }
     }
 
+    @Test
+    public void testVersionlessFeaturesMP70() {
+        testVersionlessFeatures("microProfile-7.0");
+    }
+
+    @Test
+    public void testVersionlessFeaturesMP71() {
+        testVersionlessFeatures("microProfile-7.1");
+    }
+
+    private void testVersionlessFeatures(String mpPlatform) {
+        Set<String> versionlessFeatures = getVersionlessFeatures();
+        List<String> errors = FATFeatureTester.testVersionlessFeatures(versionlessFeatures, ee11Features.getIncompatibleVersionlessFeatures(), mpPlatform);
+
+        if (!errors.isEmpty()) {
+            FATLogger.dumpErrors(c, "testVersionlessFeatures", "EE11: Versionless feature errors:", errors);
+            Assert.fail("EE11 versionless feature errors. " + errors);
+        }
+    }
+
+    /**
+     * Verify that SSL transport (ssl-1.0) resolves correctly for EE11 compatible
+     * features.
+     *
+     * Verify that compatible features which enable SSL resolve as singletons
+     * without conflicts.
+     *
+     * Verify that compatible features which do not enable SSL resolve successfully
+     * with SSL added to the root features.
+     *
+     * Verify that compatible features which do not enable SSL resolve successfully
+     * when either jsonp-2.0 or jsonb-2.0 is added to the root features.
+     *
+     * Successful resolution means that no conflicts occur, and SSL security
+     * (transport-security-1.0) is a resolved feature.
+     */
     @Test
     public void testTransportResolution() {
         String method = "testTransportResolution";

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11Features.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11Features.java
@@ -35,6 +35,10 @@ public class EE11Features {
         return FeatureUtilities.rejectVersionless(features);
     }
 
+    public static Set<String> getVersionlessFeatures(Set<String> features) {
+        return FeatureUtilities.selectVersionless(features);
+    }
+
     private static final Set<String> EMPTY_STRINGS = Collections.<String> emptySet();
 
     public static String getEE11Replacement(String feature) {
@@ -129,6 +133,7 @@ public class EE11Features {
         FeatureUtilities.removeTestAutoFeatures(new File(installRoot));
         this.serverFeatures_ol = getInstalledFeatures(installRoot, OPEN_LIBERTY_ONLY);
         this.versionedFeatures_ol = getVersionedFeatures(serverFeatures_ol);
+        this.versionlessFeatures_ol = getVersionlessFeatures(serverFeatures_ol);
 
         this.compatibleFeatures_ol = getCompatibleFeatures(versionedFeatures_ol, OPEN_LIBERTY_ONLY);
         this.extendedCompatibleFeatures_ol = getExtendedCompatibleFeatures(compatibleFeatures_ol, OPEN_LIBERTY_ONLY);
@@ -139,6 +144,7 @@ public class EE11Features {
 
         this.serverFeatures_wl = getInstalledFeatures(installRoot, !OPEN_LIBERTY_ONLY);
         this.versionedFeatures_wl = getVersionedFeatures(serverFeatures_wl);
+        this.versionlessFeatures_wl = getVersionlessFeatures(serverFeatures_wl);
 
         this.compatibleFeatures_wl = getCompatibleFeatures(versionedFeatures_wl, !OPEN_LIBERTY_ONLY);
         this.extendedCompatibleFeatures_wl = getExtendedCompatibleFeatures(compatibleFeatures_wl, !OPEN_LIBERTY_ONLY);
@@ -146,21 +152,30 @@ public class EE11Features {
         this.incompatibleFeatures_wl = getIncompatibleFeatures(versionedFeatures_wl,
                                                                compatibleFeatures_wl,
                                                                !OPEN_LIBERTY_ONLY);
+        this.incompatibleVersionlessFeatures = new HashSet<>();
+        incompatibleVersionlessFeatures.add("connectorsInboundSecurity"); // Removed in EE 10
+        incompatibleVersionlessFeatures.add("jcaInboundSecurity"); // Removed in EE 10
+        incompatibleVersionlessFeatures.add("j2eeManagement"); // Removed in EE 9
+        incompatibleVersionlessFeatures.add("managedBeans"); // Removed in EE 11
+        incompatibleVersionlessFeatures.add("mpOpenTracing"); // Removed in MP 6
     }
 
     //
 
     private final Set<String> serverFeatures_ol;
     private final Set<String> versionedFeatures_ol;
+    private final Set<String> versionlessFeatures_ol;
     private final Set<String> compatibleFeatures_ol;
     private final Set<String> extendedCompatibleFeatures_ol;
     private final Set<String> incompatibleFeatures_ol;
 
     private final Set<String> serverFeatures_wl;
     private final Set<String> versionedFeatures_wl;
+    private final Set<String> versionlessFeatures_wl;
     private final Set<String> compatibleFeatures_wl;
     private final Set<String> extendedCompatibleFeatures_wl;
     private final Set<String> incompatibleFeatures_wl;
+    private final Set<String> incompatibleVersionlessFeatures;
 
     public Set<String> getServerFeatures(boolean openLiberty) {
         return openLiberty ? serverFeatures_ol : serverFeatures_wl;
@@ -168,6 +183,10 @@ public class EE11Features {
 
     public Set<String> getVersionedFeatures(boolean openLiberty) {
         return openLiberty ? versionedFeatures_ol : versionedFeatures_wl;
+    }
+
+    public Set<String> getVersionlessFeatures(boolean openLiberty) {
+        return openLiberty ? versionlessFeatures_ol : versionlessFeatures_wl;
     }
 
     public Set<String> getCompatibleFeatures(boolean openLiberty) {
@@ -180,6 +199,10 @@ public class EE11Features {
 
     public Set<String> getIncompatibleFeatures(boolean openLiberty) {
         return openLiberty ? incompatibleFeatures_ol : incompatibleFeatures_wl;
+    }
+
+    public Set<String> getIncompatibleVersionlessFeatures() {
+        return incompatibleVersionlessFeatures;
     }
 
     //

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/util/FATFeatureResolver.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/util/FATFeatureResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -84,5 +84,13 @@ public class FATFeatureResolver {
                                         EMPTY_DEFS, rootFeatures,
                                         EMPTY_STRINGS,
                                         false);
+    }
+
+    public static FeatureResolver.Result resolve(Collection<String> rootFeatures, Collection<String> platforms) {
+        return resolver.resolve(repository,
+                                EMPTY_DEFS, rootFeatures,
+                                EMPTY_STRINGS,
+                                false,
+                                platforms);
     }
 }

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/util/FATFeatureTester.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/util/FATFeatureTester.java
@@ -1,10 +1,17 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package io.openliberty.jakartaee11.internal.tests.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -154,6 +161,90 @@ public class FATFeatureTester {
             }
             FATLogger.info(c, method, prefix + resultText);
         }
+    }
+
+    public static List<String> testVersionlessFeatures(Set<String> versionlessFeatures, Set<String> incompatibleVersionlessFeatures, String mpPlatform) {
+        List<String> errors = new ArrayList<>();
+        String method = "testVersionlessFeature";
+
+        List<String> platforms = new ArrayList<>(2);
+        platforms.add("jakartaee-11.0");
+        platforms.add(mpPlatform);
+
+        for (String feature : versionlessFeatures) {
+            String prefix = "resolving [ " + feature + " ] ...";
+            FATLogger.info(c, method, prefix);
+
+            Result result = FATFeatureResolver.resolve(Collections.singleton(feature), platforms);
+
+            boolean hasErrors = result.hasErrors();
+            boolean expectsIncompatible = incompatibleVersionlessFeatures.contains(feature);
+
+            StringBuilder sb = new StringBuilder();
+            // If this versionless feature is suppose to not be valid for EE 11, but we didn't get
+            // any errors when calling resolve, that is a test failure
+            if (!hasErrors && expectsIncompatible) {
+                sb.append(feature);
+                sb.append(" expected to be incompatible with EE 11 / MP 7.0+, but resolve did not find any errors");
+            } else if (hasErrors && !expectsIncompatible) {
+                Set<String> missingPlatforms = result.getMissingPlatforms();
+                Map<String, Set<String>> missingBasePlatforms = result.getNoPlatformVersionless();
+                Set<String> missingFeatures = result.getMissing();
+                Map<String, Collection<Chain>> conflicts = result.getConflicts();
+                String resolvedFeature = result.getVersionlessFeatures().get(feature);
+                if (resolvedFeature == null) {
+                    sb.append(feature);
+                    sb.append(" did not resolve to a versioned feature");
+                }
+                if (!conflicts.isEmpty()) {
+                    if (sb.length() == 0) {
+                        sb.append(feature);
+                        sb.append(" failed due to");
+                    } else {
+                        sb.append(',');
+                    }
+                    sb.append(" conflicts ").append(conflicts);
+                }
+                if (!missingPlatforms.isEmpty()) {
+                    if (sb.length() == 0) {
+                        sb.append(feature);
+                        sb.append(" failed due to");
+                    } else {
+                        sb.append(',');
+                    }
+                    sb.append(" missing platforms ").append(missingPlatforms);
+                }
+                if (!missingBasePlatforms.isEmpty()) {
+                    if (sb.length() == 0) {
+                        sb.append(feature);
+                        sb.append(" failed due to");
+                    } else {
+                        sb.append(',');
+                    }
+                    sb.append(" missing base platforms ").append(missingBasePlatforms);
+                }
+                if (!missingFeatures.isEmpty()) {
+                    if (sb.length() == 0) {
+                        sb.append(feature);
+                        sb.append(" failed due to");
+                    } else {
+                        sb.append(',');
+                    }
+                    sb.append(" missing features ").append(missingFeatures);
+                }
+            }
+
+            String resultText;
+            if (sb.length() != 0) {
+                resultText = " failed";
+                errors.add(sb.toString());
+            } else {
+                resultText = " passed";
+            }
+            FATLogger.info(c, method, prefix + resultText);
+        }
+
+        return errors;
     }
 
     /**

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9FeatureCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -80,6 +80,10 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
 
     public Set<String> getVersionedFeatures() {
         return ee9Features.getVersionedFeatures(openLibertyOnly());
+    }
+
+    public Set<String> getVersionlessFeatures() {
+        return ee9Features.getVersionlessFeatures(openLibertyOnly());
     }
 
     public Set<String> getCompatibleFeatures() {
@@ -255,6 +259,17 @@ public class EE9FeatureCompatibilityTest extends FATServletClient {
         if (!errors.isEmpty()) {
             FATLogger.dumpErrors(c, method, "EE9: Feature compatibility errors:", errors);
             Assert.fail("EE9 compatibility errors. " + errors);
+        }
+    }
+
+    @Test
+    public void testVersionlessFeatures() {
+        Set<String> versionlessFeatures = getVersionlessFeatures();
+        List<String> errors = FATFeatureTester.testVersionlessFeatures(versionlessFeatures, ee9Features.getIncompatibleVersionlessFeatures());
+
+        if (!errors.isEmpty()) {
+            FATLogger.dumpErrors(c, "testVersionlessFeatures", "EE9: Versionless feature errors:", errors);
+            Assert.fail("EE9 versionless feature errors. " + errors);
         }
     }
 

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9Features.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/EE9Features.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,6 +34,10 @@ public class EE9Features {
 
     public static Set<String> getVersionedFeatures(Set<String> features) {
         return FeatureUtilities.rejectVersionless(features);
+    }
+
+    public static Set<String> getVersionlessFeatures(Set<String> features) {
+        return FeatureUtilities.selectVersionless(features);
     }
 
     private static final Set<String> EMPTY_STRINGS = Collections.<String> emptySet();
@@ -123,6 +127,7 @@ public class EE9Features {
         FeatureUtilities.removeTestAutoFeatures(new File(installRoot));
         this.serverFeatures_ol = getInstalledFeatures(installRoot, OPEN_LIBERTY_ONLY);
         this.versionedFeatures_ol = getVersionedFeatures(serverFeatures_ol);
+        this.versionlessFeatures_ol = getVersionlessFeatures(serverFeatures_ol);
 
         this.compatibleFeatures_ol = getCompatibleFeatures(versionedFeatures_ol, OPEN_LIBERTY_ONLY);
         this.extendedCompatibleFeatures_ol = getExtendedCompatibleFeatures(compatibleFeatures_ol, OPEN_LIBERTY_ONLY);
@@ -133,6 +138,7 @@ public class EE9Features {
 
         this.serverFeatures_wl = getInstalledFeatures(installRoot, !OPEN_LIBERTY_ONLY);
         this.versionedFeatures_wl = getVersionedFeatures(serverFeatures_wl);
+        this.versionlessFeatures_wl = getVersionlessFeatures(serverFeatures_wl);
 
         this.compatibleFeatures_wl = getCompatibleFeatures(versionedFeatures_wl, !OPEN_LIBERTY_ONLY);
         this.extendedCompatibleFeatures_wl = getExtendedCompatibleFeatures(compatibleFeatures_wl, !OPEN_LIBERTY_ONLY);
@@ -140,21 +146,29 @@ public class EE9Features {
         this.incompatibleFeatures_wl = getIncompatibleFeatures(versionedFeatures_wl,
                                                                compatibleFeatures_wl,
                                                                !OPEN_LIBERTY_ONLY);
+        this.incompatibleVersionlessFeatures = new HashSet<>();
+        incompatibleVersionlessFeatures.add("data"); // Added in EE 11
+        incompatibleVersionlessFeatures.add("dataContainer"); // Added in EE 11
+        incompatibleVersionlessFeatures.add("j2eeManagement"); // Removed in EE 9
+        incompatibleVersionlessFeatures.add("mpTelemetry"); // Added in MP 6
     }
 
     //
 
     private final Set<String> serverFeatures_ol;
     private final Set<String> versionedFeatures_ol;
+    private final Set<String> versionlessFeatures_ol;
     private final Set<String> compatibleFeatures_ol;
     private final Set<String> extendedCompatibleFeatures_ol;
     private final Set<String> incompatibleFeatures_ol;
 
     private final Set<String> serverFeatures_wl;
     private final Set<String> versionedFeatures_wl;
+    private final Set<String> versionlessFeatures_wl;
     private final Set<String> compatibleFeatures_wl;
     private final Set<String> extendedCompatibleFeatures_wl;
     private final Set<String> incompatibleFeatures_wl;
+    private final Set<String> incompatibleVersionlessFeatures;
 
     public Set<String> getServerFeatures(boolean openLiberty) {
         return openLiberty ? serverFeatures_ol : serverFeatures_wl;
@@ -162,6 +176,10 @@ public class EE9Features {
 
     public Set<String> getVersionedFeatures(boolean openLiberty) {
         return openLiberty ? versionedFeatures_ol : versionedFeatures_wl;
+    }
+
+    public Set<String> getVersionlessFeatures(boolean openLiberty) {
+        return openLiberty ? versionlessFeatures_ol : versionlessFeatures_wl;
     }
 
     public Set<String> getCompatibleFeatures(boolean openLiberty) {
@@ -174,6 +192,10 @@ public class EE9Features {
 
     public Set<String> getIncompatibleFeatures(boolean openLiberty) {
         return openLiberty ? incompatibleFeatures_ol : incompatibleFeatures_wl;
+    }
+
+    public Set<String> getIncompatibleVersionlessFeatures() {
+        return incompatibleVersionlessFeatures;
     }
 
     //

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/util/FATFeatureResolver.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/util/FATFeatureResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -84,5 +84,13 @@ public class FATFeatureResolver {
                                         EMPTY_DEFS, rootFeatures,
                                         EMPTY_STRINGS,
                                         false);
+    }
+
+    public static FeatureResolver.Result resolve(Collection<String> rootFeatures, Collection<String> platforms) {
+        return resolver.resolve(repository,
+                                EMPTY_DEFS, rootFeatures,
+                                EMPTY_STRINGS,
+                                false,
+                                platforms);
     }
 }

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/util/FATFeatureTester.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/util/FATFeatureTester.java
@@ -1,10 +1,17 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package io.openliberty.jakartaee9.internal.tests.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -154,6 +161,90 @@ public class FATFeatureTester {
             }
             FATLogger.info(c, method, prefix + resultText);
         }
+    }
+
+    public static List<String> testVersionlessFeatures(Set<String> versionlessFeatures, Set<String> incompatibleVersionlessFeatures) {
+        List<String> errors = new ArrayList<>();
+        String method = "testVersionlessFeature";
+
+        List<String> platforms = new ArrayList<>(2);
+        platforms.add("jakartaee-9.1");
+        platforms.add("microProfile-5.0");
+
+        for (String feature : versionlessFeatures) {
+            String prefix = "resolving [ " + feature + " ] ...";
+            FATLogger.info(c, method, prefix);
+
+            Result result = FATFeatureResolver.resolve(Collections.singleton(feature), platforms);
+
+            boolean hasErrors = result.hasErrors();
+            boolean expectsIncompatible = incompatibleVersionlessFeatures.contains(feature);
+
+            StringBuilder sb = new StringBuilder();
+            // If this versionless feature is suppose to not be valid for EE 9, but we didn't get
+            // any errors when calling resolve, that is a test failure
+            if (!hasErrors && expectsIncompatible) {
+                sb.append(feature);
+                sb.append(" expected to be incompatible with EE 9 / MP 5, but resolve did not find any errors");
+            } else if (hasErrors && !expectsIncompatible) {
+                Set<String> missingPlatforms = result.getMissingPlatforms();
+                Map<String, Set<String>> missingBasePlatforms = result.getNoPlatformVersionless();
+                Set<String> missingFeatures = result.getMissing();
+                Map<String, Collection<Chain>> conflicts = result.getConflicts();
+                String resolvedFeature = result.getVersionlessFeatures().get(feature);
+                if (resolvedFeature == null) {
+                    sb.append(feature);
+                    sb.append(" did not resolve to a versioned feature");
+                }
+                if (!conflicts.isEmpty()) {
+                    if (sb.length() == 0) {
+                        sb.append(feature);
+                        sb.append(" failed due to");
+                    } else {
+                        sb.append(',');
+                    }
+                    sb.append(" conflicts ").append(conflicts);
+                }
+                if (!missingPlatforms.isEmpty()) {
+                    if (sb.length() == 0) {
+                        sb.append(feature);
+                        sb.append(" failed due to");
+                    } else {
+                        sb.append(',');
+                    }
+                    sb.append(" missing platforms ").append(missingPlatforms);
+                }
+                if (!missingBasePlatforms.isEmpty()) {
+                    if (sb.length() == 0) {
+                        sb.append(feature);
+                        sb.append(" failed due to");
+                    } else {
+                        sb.append(',');
+                    }
+                    sb.append(" missing base platforms ").append(missingBasePlatforms);
+                }
+                if (!missingFeatures.isEmpty()) {
+                    if (sb.length() == 0) {
+                        sb.append(feature);
+                        sb.append(" failed due to");
+                    } else {
+                        sb.append(',');
+                    }
+                    sb.append(" missing features ").append(missingFeatures);
+                }
+            }
+
+            String resultText;
+            if (sb.length() != 0) {
+                resultText = " failed";
+                errors.add(sb.toString());
+            } else {
+                resultText = " passed";
+            }
+            FATLogger.info(c, method, prefix + resultText);
+        }
+
+        return errors;
     }
 
     /**


### PR DESCRIPTION
- Validate that all versionless features resolve when using EE 9, 10 and 11 that are supported for those versions and for those that are not, that they get resolution errors

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".