### PR TITLE
CWWKD1035E message reports incorrect PageRequest mode

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -86,7 +86,7 @@ public class PageImpl<T> implements Page<T> {
         if (pageRequest.mode() != Mode.OFFSET)
             throw exc(IllegalArgumentException.class,
                       "CWWKD1035.incompat.page.mode",
-                      Mode.OFFSET,
+                      pageRequest.mode(),
                       queryInfo.method.getName(),
                       queryInfo.repositoryInterface.getName(),
                       queryInfo.method.getGenericReturnType().getTypeName(),


### PR DESCRIPTION
The CWWKD1035E error message is reporting that OFFSET pagination cannot be used with methods that return Page,
`CWWKD1035E: A page request with the OFFSET pagination mode must not be supplied to ...`
This is wrong. OFFSET is actually the only PageRequest mode that can be used with methods that return Page. The other two modes are for CursoredPage only. In this case, the area is being raised in the appropriate place where a user has attempted to use CURSOR_NEXT or CURSOR_PREVIOUS with a method that returns Page, but the code is erroneously reporting the value that was supplied as OFFSET instead, causing a very confusing error message.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
