### PR TITLE
Use new getCRIUSupport method in Semeru

### DIFF
--- a/dev/io.openliberty.org.eclipse.openj9.criu/src/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/dev/io.openliberty.org.eclipse.openj9.criu/src/org/eclipse/openj9/criu/CRIUSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -77,6 +77,17 @@ public final class CRIUSupport {
 	 */
 	public static String getErrorMessage() {
 		return null;
+	}
+	/**
+	 * Returns the singleton CRIUSupport object.
+	 *
+	 * Most methods of class {@code CRIUSupport} are instance methods and must be
+	 * invoked via this object.
+	 *
+	 * @return the singleton {@code CRIUSupport} object
+	 */
+	public static CRIUSupport getCRIUSupport() {
+		return new CRIUSupport(null);
 	}
 
 	/**


### PR DESCRIPTION
Semeru has deprecated the constructor of CRIUSupport. Instead there is a static method to get the singleton instance of CRIUSupport.


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

