### PR TITLE
Test Coverage JPA 3.2 Null Precedence Test

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -2130,6 +2130,62 @@ public class JakartaDataRecreateServlet extends FATServlet {
         assertEquals(27.97f, totals.get(0), 0.01);
 
     }
+    
+    /**
+     * Specifies the precedence of null values within query result sets.
+     * https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a5587
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testNullPrecedenceWithJPQL() throws Exception {
+        deleteAllEntities(Product.class);
+        Product product1 = Product.of("testSnapshot", "product1", 10.50f);
+        Product product2 = Product.of(null, "product2", 20.50f);
+        Product product3 = Product.of("sample products", "product3", 30.50f);
+        tx.begin();
+        em.persist(product1);
+        em.persist(product2);
+        em.persist(product3);
+        tx.commit();
+
+        /*
+         * Specifies the precedence of null values within query result sets.
+         */
+        List<Product> productsNullFirst;
+        try {
+
+            tx.begin();
+            productsNullFirst = em.createQuery("FROM Product ORDER BY description DESC NULLS FIRST",
+                                               Product.class)
+                            .getResultList();
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        }
+        assertEquals(3, productsNullFirst.size());
+        assertEquals("product2", productsNullFirst.get(0).name);
+
+        /*
+         * Null values occur at the end of the result set.
+         */
+        List<Product> productsNullLast;
+        try {
+
+            tx.begin();
+            productsNullLast = em.createQuery("FROM Product ORDER BY description DESC NULLS LAST",
+                                              Product.class)
+                            .getResultList();
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        }
+        assertEquals(3, productsNullLast.size());
+        assertEquals("product2", productsNullLast.get(2).name);
+    }
+    
 
     /**
      * Utility method to drop all entities from table.

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -83,6 +83,10 @@ import jakarta.persistence.LockModeType;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.PersistenceException;
 import jakarta.persistence.Query;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Nulls;
+import jakarta.persistence.criteria.Root;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.transaction.RollbackException;
 import jakarta.transaction.UserTransaction;
@@ -2186,7 +2190,65 @@ public class JakartaDataRecreateServlet extends FATServlet {
         assertEquals("product2", productsNullLast.get(2).name);
     }
     
+	 /**
+     * Specifies the precedence of null values within query result sets.
+     * https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#nulls
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testNullPrecedenceWithCriteriaBilder() throws Exception {
+        deleteAllEntities(Product.class);
+        Product p1 = Product.of("testSnapshot", "product1", 10.50f);
+        Product p2 = Product.of(null, "product2", 20.50f);
+        Product p3 = Product.of("sample products", "product3", 30.50f);
+        tx.begin();
+        em.persist(p1);
+        em.persist(p2);
+        em.persist(p3);
+        tx.commit();
 
+        /*
+         * Null values occur at the beginning of the result set.
+         */
+        List<Product> productsNullFirst;
+        try {
+            tx.begin();
+            CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+            CriteriaQuery<Product> criteriaQuery = criteriaBuilder.createQuery(Product.class);
+            Root<Product> from = criteriaQuery.from(Product.class);
+            CriteriaQuery<Product> select = criteriaQuery.select(from);
+            criteriaQuery.orderBy(criteriaBuilder.desc(from.get("description"), Nulls.FIRST));
+            productsNullFirst = em.createQuery(criteriaQuery).getResultList();
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        }
+        assertEquals(3, productsNullFirst.size());
+        assertEquals("product2", productsNullFirst.get(0).name);
+
+        /*
+         * Null values occur at the end of the result set.
+         */
+        List<Product> productsNullLast;
+        try {
+
+            tx.begin();
+            CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+            CriteriaQuery<Product> criteriaQuery = criteriaBuilder.createQuery(Product.class);
+            Root<Product> from = criteriaQuery.from(Product.class);
+            CriteriaQuery<Product> select = criteriaQuery.select(from);
+            criteriaQuery.orderBy(criteriaBuilder.desc(from.get("description"), Nulls.LAST));
+            productsNullLast = em.createQuery(criteriaQuery).getResultList();
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        }
+        assertEquals(3, productsNullLast.size());
+        assertEquals("product2", productsNullLast.get(2).name);
+    }
     /**
      * Utility method to drop all entities from table.
      *


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

This test case is to test the NULL Precedence support when ordering JPQL and Criteria Queries.
