### PR TITLE
SessionCacheTestServlet get null session

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -741,7 +741,6 @@ public class SessionCacheTestServlet extends FATServlet {
             System.out.println("Session was null and was expecting null value.");
             return;
         } else if (session == null) {
-
             // Retry getSession() as session may need time to replicate to server B
             TimeUnit.SECONDS.sleep(5);
             session = request.getSession(false);

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2025 IBM Corporation and others.
+ * Copyright (c) 2017,2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -48,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import javax.cache.Cache;
 import javax.cache.Caching;
 import javax.cache.management.CacheMXBean;
 import javax.cache.management.CacheStatisticsMXBean;
@@ -58,14 +59,13 @@ import javax.naming.InitialContext;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionListener;
 import javax.sql.DataSource;
 
 import org.junit.Assume;
 
 import com.ibm.websphere.servlet.session.IBMSession;
-import com.ibm.websphere.simplicity.config.HttpSession;
-import com.ibm.websphere.simplicity.config.cache.Cache;
 
 import componenttest.app.FATServlet;
 

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2024 IBM Corporation and others.
+ * Copyright (c) 2017,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
session.cache.web.SessionCacheTestServlet.sessionGet() often get null session due to session may not replicate to the other server.

[5/13/25, 23:12:00:230 PDT] 00000077 id=00000000 SystemErr                                                    R java.lang.AssertionError: Was expecting to get testMaxInactiveInterval-key=55901, but instead got a null session.
	at org.junit.Assert.fail(Assert.java:93)
	at session.cache.web.SessionCacheTestServlet.sessionGet(SessionCacheTestServlet.java:744)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at componenttest.app.FATServlet.doGet(FATServlet.java:76)