### PR TITLE
Skip testMaxSessionIdleTimeout on s390x

### DIFF
--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/BasicTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/BasicTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -262,7 +262,12 @@ public class BasicTest {
     @Mode(TestMode.FULL)
     @Test
     public void testMaxSessionIdleTimeout() throws Exception {
-        at.testMaxSessionIdleTimeout();
+          String arch = System.getProperty("os.arch", "unidentified").toLowerCase();
+          if(arch.contains("s390x")) {
+            at.testMaxSessionIdleTimeout();
+          } else {
+               LOG.info("Skipped the test as it's running on s390x hardware! Known to be slow -- See defect 296687");
+          }
     }
 
     @Mode(TestMode.FULL)


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Skipping this test on s390x hardware. See my analysis for [defect 296687](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=296687)  

This won't completely fix it (slowness can occur on other platforms / networks), but it should reduce the number of occurrences for this defect. 
