### PR TITLE
Add NLS message for the CWWKD1112W warning

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1138,13 +1138,15 @@ CWWKD1111.unsupported.convert.explanation=The AttributeConverter implementation 
 CWWKD1111.unsupported.convert.useraction=Update the AttributeConverter \
  implementation to convert values to one of the supported types.
 
-CWWKD1112.record.entity.verify.err=CWWKD1112W: An error occurred while defining \
- an entity class for the {0} record, which is used by one or more repository \
- interfaces ({1}) in the {2} application artifact. The error is: {3}.
+CWWKD1112.record.entity.verify.err=CWWKD1112W: An entity class for the {0} record \
+ is defined but might not work. The verification of the bytes of the Jakarta \
+ Persistence entity class, which was generated for the entity class, failed. \
+ The defined entity class is used by one or more repository interfaces ({1}) \
+ in the {2} application artifact. The error is: {3}.
 CWWKD1112.record.entity.verify.err.explanation=When a repository uses a record \
- entity, a Jakarta Persistence entity is generated to represent the entity. \
- An error was found when verifying the bytes of the generated Jakarta Persistence \
- entity class.
+ entity, a Jakarta Persistence entity is generated to represent the record entity. \
+ The verification of the bytes of the generated Jakarta Persistence entity class \
+ failed.
 CWWKD1112.record.entity.verify.err.useraction=Verify that the implementation of \
  the record entity adheres to the requirements and conventions for a record \
  entity.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1137,3 +1137,14 @@ CWWKD1111.unsupported.convert.explanation=The AttributeConverter implementation 
  values to an unsupported type.
 CWWKD1111.unsupported.convert.useraction=Update the AttributeConverter \
  implementation to convert values to one of the supported types.
+
+CWWKD1112.record.entity.verify.err=CWWKD1112W: An error occurred while defining \
+ an entity class for the {0} record, which is used by one or more repository \
+ interfaces ({1}) in the {2} application artifact. The error is: {3}.
+CWWKD1112.record.entity.verify.err.explanation=When a repository uses a record \
+ entity, a Jakarta Persistence entity is generated to represent the entity. \
+ An error was found when verifying the bytes of the generated Jakarta Persistence \
+ entity class.
+CWWKD1112.record.entity.verify.err.useraction=Verify that the implementation of \
+ the record entity adheres to the requirements and conventions for a record \
+ entity.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/RecordTransformer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/RecordTransformer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -310,15 +310,16 @@ public class RecordTransformer {
 
         byte[] classBytes = cw.toByteArray();
 
-        if (tc.isWarningEnabled()) {
-            StringWriter sw = new StringWriter();
-            CheckClassAdapter.verify(new ClassReader(classBytes), false, new PrintWriter(sw));
-            String result = sw.toString();
+        StringWriter sw = new StringWriter();
+        CheckClassAdapter.verify(new ClassReader(classBytes), false, new PrintWriter(sw));
+        String result = sw.toString();
 
-            if (!result.isBlank()) {
-                Tr.debug(tc, "Error found when verifying record entity class bytes", result); //TODO change to warning and NLS
-            }
-        }
+        if (!result.isBlank())
+            Tr.warning(tc, "CWWKD1112.record.entity.verify.err",
+                       recordClass.getName(),
+                       getClassNames(repositoryInterfaces),
+                       jeeName,
+                       result);
 
         return classBytes;
     }


### PR DESCRIPTION
Add the CWWKD1112W for the warning that occurs when generated entity class does not verify.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
