### PR TITLE
Update security FAT client to wait for ORB

### DIFF
--- a/dev/com.ibm.ws.security.client_fat/test-applications/BasicCalculatorClient.jar/src/com/ibm/websphere/samples/technologysamples/basiccalcclient/BasicCalculatorClientJ2EEMain.java
+++ b/dev/com.ibm.ws.security.client_fat/test-applications/BasicCalculatorClient.jar/src/com/ibm/websphere/samples/technologysamples/basiccalcclient/BasicCalculatorClientJ2EEMain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2020 IBM Corporation and others.
+ * Copyright (c) 2001, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import com.ibm.websphere.samples.technologysamples.basiccalcclient.common.BasicC
 import com.ibm.websphere.samples.technologysamples.basiccalcclient.common.BasicCalculatorClientResultBean;
 
 public class BasicCalculatorClientJ2EEMain {
+    boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("win");
 
     /**
      * Displays a message to the user
@@ -170,11 +171,14 @@ public class BasicCalculatorClientJ2EEMain {
 
         for (int i = 0; i < maxCount; i++) {
             if (f.exists() || ff.exists()) {
-                System.out.println("The file exists. Resuming the operation after 1 second delay");
-                // this delay is for z/OS system. For some reason, if the code runs immediately after creating
-                // the keystore, the naming code throws a NameNotFoundException.
+                long orbWaitSeconds = isWindows ? 10 : 2; // delay for client orb to start in seconds
+                System.out.println("The file exists. Resuming the operation after " + orbWaitSeconds + " second delay");
+                // this delay is mostly for windows systems. For some reason, if the code runs immediately after creating
+                // the keystore, the naming code throws a NameNotFoundException; a smaller delay is used for other systems
+                // as the same error was also occurring elsewhere less frequently, especially z/OS.
+                // this delay provides time for the client side ORB to activate and register with naming.
                 try {
-                    Thread.sleep(1000);
+                    Thread.sleep(orbWaitSeconds * 1000);
                 } catch (InterruptedException e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace(); // do nothing
@@ -183,13 +187,6 @@ public class BasicCalculatorClientJ2EEMain {
                 return;
             }
             System.out.println("Wait for 2 seconds for a file creation of " + keyLocation);
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace(); // do nothing
-            }
-            System.out.println("Wait an additional 2 seconds for ORB to startup...");
             try {
                 Thread.sleep(2000);
             } catch (InterruptedException e) {


### PR DESCRIPTION
increase the wait time for the ORB to start from 1 to 2 seconds; 10 for windows.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".