### PR TITLE
key elements for cursor based pagination

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3382,7 +3382,7 @@ public class QueryInfo {
                     // id(this)
                     attributeName = entityInfo.attributeNames.get(By.ID);
                     if (attributeName == null && failIfNotFound)
-                        throw exc(UnsupportedOperationException.class,
+                        throw exc(MappingException.class,
                                   "CWWKD1093.fn.not.applicable",
                                   name,
                                   entityInfo.getType().getName(),
@@ -3392,7 +3392,7 @@ public class QueryInfo {
                 } else if (len == 13 && name.regionMatches(true, 0, "version", 0, 7)) {
                     // version(this)
                     if (entityInfo.versionAttributeName == null && failIfNotFound)
-                        throw exc(UnsupportedOperationException.class,
+                        throw exc(MappingException.class,
                                   "CWWKD1093.fn.not.applicable",
                                   name,
                                   entityInfo.getType().getName(),
@@ -3471,16 +3471,15 @@ public class QueryInfo {
      */
     @Trivial
     Object[] getCursorValues(Object entity) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
         ArrayList<Object> cursorValues = new ArrayList<>();
         for (Sort<?> sort : sorts)
             try {
                 List<Member> accessors = entityInfo.attributeAccessors.get(sort.property());
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "getCursorValues for " + loggable(entity),
                              accessors);
                 Object value = entity;
-                // TODO is it possible for accessors to be null here?
-                // Could sort.property() being VERSION(THIS) or some invalid name cause this?
                 for (Member accessor : accessors)
                     if (accessor instanceof Method)
                         value = ((Method) accessor).invoke(value);
@@ -3490,6 +3489,8 @@ public class QueryInfo {
             } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException x) {
                 throw new DataException(x instanceof InvocationTargetException ? x.getCause() : x);
             }
+        if (trace && tc.isDebugEnabled())
+            Tr.debug(this, tc, "getCursorValues: " + loggable(cursorValues));
         return cursorValues.toArray();
     }
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -60,6 +60,7 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1009E.*storeNothing", // Save method without parameters
                                    "CWWKD1009E.*storeInDatabase", // Save method with multiple parameters
                                    "CWWKD1010E.*nameAndZipCode", // Record return type with invalid attribute name
+                                   "CWWKD1010E.*selectByBirthday", // Sort with invalid attribute name
                                    "CWWKD1010E.*sortedByEndOfAddress", // OrderBy with invalid function
                                    "CWWKD1010E.*sortedByZipCode", // OrderBy with invalid attribute name
                                    "CWWKD1011E.*findByIgnoreCaseContains", // missing entity attribute name
@@ -102,6 +103,7 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1086E.*withAddressShorterThan", // Param used for positional parameter
                                    "CWWKD1090E.*findByAddressOrderBy", // OrderBy anno/keyword conflict
                                    "CWWKD1091E.*deleteByAddressOrderByName", // OrderBy without return type
+                                   "CWWKD1093E.*selectByBirthday", // VERSION(THIS) used when there is no version
                                    "CWWKD1094E.*register", // incompatible return type
                                    "CWWKD1096E.*discardInOrder", // OrderBy annotation without return type
                                    "CWWKD1097E.*discardLimited", // Limit parameter on Delete method

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -795,6 +795,27 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Cursor-based pagination using the version and id as key elements,
+     * referring to the version with the query language, VERSION(THIS),
+     * and the id with the query language, ID(THIS).
+     */
+    @Test
+    public void testCursorKeyIncludesVersion() {
+        Order<City> order = Order.by(Sort.asc("VERSION(THIS)"),
+                                     Sort.asc("ID(THIS)"));
+        CursoredPage<City> page;
+        page = cities.findByStateNameGreaterThan("Iowa",
+                                                 PageRequest.ofSize(4),
+                                                 order);
+        assertEquals(4, page.content().size());
+
+        page = cities.findByStateNameGreaterThan("Iowa",
+                                                 page.nextPageRequest(),
+                                                 order);
+        assertEquals(4, page.content().size());
+    }
+
+    /**
      * Demonstrates inconsistency and wrong behavior in how EclipseLink returns an
      * entity attribute that is an ElementCollection vs an entity attribute of the
      * same type that is not an ElementCollection. Note that the former is not


### PR DESCRIPTION
Add test coverage for VERSION(THIS) as a key element for cursor-based pagination, both valid and invalid, depending on whether the entity has a version. Also cover other invalid usage, such as a name that is not an entity attribute and a function that does not exist.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
