### PR TITLE
Test coverage JPA 3.2 NULL Precedence Test

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/Product.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/Product.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/Product.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/Product.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.persistence.tests.models;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+/**
+ * Recreate from io.openliberty.data.internal_fat
+ */
+@Entity
+public class Product {
+    public String description;
+
+    public String name;
+
+    @Id
+    @GeneratedValue
+    public UUID pk;
+
+    public float price;
+
+    @Version
+    public long version;
+
+    public static Product of(String description, String name, float price) {
+        Product inst = new Product();
+        inst.name = name;
+        inst.description = description;
+        inst.price = price;
+        return inst;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package io.openliberty.jpa.persistence.tests.web;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.List;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
+import io.openliberty.jpa.persistence.tests.models.Product;
 import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -56,5 +58,76 @@ public class JakartaPersistenceServlet extends FATServlet {
                                                    "SELECT o.name FROM Organization o", String.class)
                         .getResultList();
         assertNotNull(exceptResult);
+    }
+
+    /**
+     * Specifies the precedence of null values within query result sets.
+     * https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a5587
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testNullPrecedenceWithJPQL() throws Exception {
+        deleteAllEntities(Product.class);
+        Product product1 = Product.of("testSnapshot", "product1", 10.50f);
+        Product product2 = Product.of(null, "product2", 20.50f);
+        Product product3 = Product.of("sample products", "product3", 30.50f);
+        tx.begin();
+        em.persist(product1);
+        em.persist(product2);
+        em.persist(product3);
+        tx.commit();
+
+        /*
+         * Specifies the precedence of null values within query result sets.
+         */
+        List<Product> productsNullFirst;
+        try {
+
+            tx.begin();
+            productsNullFirst = em.createQuery("FROM Product ORDER BY description DESC NULLS FIRST",
+                                               Product.class)
+                            .getResultList();
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        }
+        assertEquals(3, productsNullFirst.size());
+        assertEquals("product2", productsNullFirst.get(0).name);
+
+        /*
+         * Null values occur at the end of the result set.
+         */
+        List<Product> productsNullLast;
+        try {
+
+            tx.begin();
+            productsNullLast = em.createQuery("FROM Product ORDER BY description DESC NULLS LAST",
+                                              Product.class)
+                            .getResultList();
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        }
+        assertEquals(3, productsNullLast.size());
+        assertEquals("product2", productsNullLast.get(2).name);
+
+    }
+
+    /**
+     * Utility method to drop all entities from table.
+     *
+     * Order to tests is not guaranteed and thus we should be pessimistic and
+     * delete all entities when we reuse an entity between tests.
+     *
+     * @param clazz - the entity class
+     */
+    private void deleteAllEntities(Class<?> clazz) throws Exception {
+        tx.begin();
+        em.createQuery("DELETE FROM " + clazz.getSimpleName())
+                        .executeUpdate();
+        tx.commit();
     }
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

This test case to test the NULL Precedence support in Jakarta Persistence 3.2 when ordering JPQL and Criteria Queries.
