### PR TITLE
Added additional tracing to investigate gRPC defect

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/test-applications/StoreProducerApp.war/src/com/ibm/testapp/g3store/grpcProducer/api/ProducerGrpcServiceClientImpl.java
+++ b/dev/com.ibm.ws.grpc_fat/test-applications/StoreProducerApp.war/src/com/ibm/testapp/g3store/grpcProducer/api/ProducerGrpcServiceClientImpl.java
@@ -904,6 +904,7 @@ public class ProducerGrpcServiceClientImpl extends ProducerGrpcServiceClient {
             // Error on the reply from the server service
             errorMessage = t.getMessage();
             log.info("grpcTwoWayStreamApp: onError received from server service: " + errorMessage);
+            log.log(Level.SEVERE, "Error received...", t);
             latch.countDown();
         }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Adding tracing to gRPC FAT for investigating RTC defect failures related to `CANCELLED: Failed to read message`
