### PR TITLE
Calling old resolve features method doesn't break with versionless features

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -421,8 +421,10 @@ public class FeatureResolverImpl implements FeatureResolver {
      */
     private List<String> normalizeRootPlatforms(Collection<String> rootPlatforms){
         List<String> normalizedPlatforms = new ArrayList<String>();
-        for(String plat : rootPlatforms){
-            normalizedPlatforms.add(plat.trim().toLowerCase());
+        if(rootPlatforms != null){
+            for(String plat : rootPlatforms){
+                normalizedPlatforms.add(plat.trim().toLowerCase());
+            }
         }
         return normalizedPlatforms;
     }

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/BaselineResolutionErrorCaseTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/BaselineResolutionErrorCaseTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/BaselineResolutionErrorCaseTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/BaselineResolutionErrorCaseTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.feature.tests;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+
+import com.ibm.ws.feature.tests.util.FeatureUtil;
+import com.ibm.ws.feature.tests.util.RepositoryUtil;
+import com.ibm.ws.kernel.feature.ProcessType;
+import com.ibm.ws.kernel.feature.internal.FeatureResolverImpl;
+import com.ibm.ws.kernel.feature.provisioning.ProvisioningFeatureDefinition;
+import com.ibm.ws.kernel.feature.resolver.FeatureResolver;
+import com.ibm.ws.kernel.feature.resolver.FeatureResolver.Result;
+
+/**
+ * Feature resolution testing.
+ */
+public class BaselineResolutionErrorCaseTest {
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        // RepositoryUtil.setupFeatures();
+        RepositoryUtil.setupProfiles();
+
+        RepositoryUtil.setupRepo("FeatureResolverTest");
+    }
+
+    @Before
+    public void setupTest() throws Exception {
+        doSetupResolver();
+    }
+
+    public FeatureResolverImpl resolver;
+
+    public void doSetupResolver() throws Exception {
+        resolver = new FeatureResolverImpl();
+    }
+
+    public void doClearResolver() throws Exception {
+        resolver = null;
+    }
+
+    public Result resolveFeatures(Collection<String> features, Collection<String> platforms) throws Exception {
+        try{
+            return resolver.resolve(RepositoryUtil.getRepository(),
+                                    Collections.EMPTY_LIST,
+                                    features,
+                                    Collections.<String> emptySet(), // pre-resolved feature names
+                                    false,
+                                    EnumSet.allOf(ProcessType.class),
+                                    platforms);
+        }
+        catch (Exception e) {
+            throw e;
+        }
+    }
+
+    public Result oldResolveFeatures(Collection<String> features) throws Exception {
+        try{
+            return resolver.resolveFeatures(RepositoryUtil.getRepository(),
+                                    Collections.EMPTY_LIST,
+                                    features,
+                                    Collections.<String> emptySet(), // pre-resolved feature names
+                                    false,
+                                    EnumSet.allOf(ProcessType.class));
+        }
+        catch (Exception e) {
+            throw e;
+        }
+    }
+
+    //Set root platforms to null, test to make sure getNoPlatforms gets populated
+    @Test
+    public void nullPlatformTests() {
+        Set<String> features = new HashSet<String>();
+        Set<String> platforms = null;
+        features.add("servlet");
+
+        Result result;
+        try {
+            result = resolveFeatures(features, platforms);
+
+            assertEquals(result.getNoPlatformVersionless().get("com.ibm.websphere.appserver.eeCompatible"), features);
+        }
+        catch(Exception e){
+            fail("Unexpected Exception: " + e);
+        }
+    }
+
+    //test the old feature resolver call that doesn't allow for root platforms to be set, test to make sure getNoPlatforms gets populated
+    @Test
+    public void oldResolverWithVersionlessTest() {
+        Set<String> features = new HashSet<String>();
+        features.add("servlet");
+
+        Result result;
+        try {
+            result = oldResolveFeatures(features);
+
+            assertEquals(result.getNoPlatformVersionless().get("com.ibm.websphere.appserver.eeCompatible"), features);
+        }
+        catch(Exception e){
+            fail("Unexpected Exception: " + e);
+        }
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/FATSuite.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/FATSuite.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/FATSuite.java
@@ -18,6 +18,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+                BaselineResolutionErrorCaseTest.class,
                 ReportFeaturesUnitTest.class,
                 // ReportImagesUnitTest.class, // Disabled: See issue 29079
                 // FeatureDetailsUnitTest.class, // Disabled: Not getting features in WL.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Versionless features may not resolve correctly if using the old resolve features call since there is no concept of root platforms in the old resolve features call (this works as intended). However, it should error out appropriately and not with an NPE.