### PR TITLE
Test Coverage JPA 3.2 - Tests the availability of SEQUENCE, TABLE and UUID generated IDs on PrePersist

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/IdentityIdEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/IdentityIdEntity.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package io.openliberty.jpa.persistence.tests.models;
 
 import jakarta.persistence.Entity;

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/IdentityIdEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/IdentityIdEntity.java
@@ -1,0 +1,59 @@
+package io.openliberty.jpa.persistence.tests.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+
+@Entity
+public class IdentityIdEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    public static IdentityIdEntity of(String name) {
+        IdentityIdEntity uuidIdEntity = new IdentityIdEntity();
+        uuidIdEntity.setName(name);
+        return uuidIdEntity;
+    }
+
+    /**
+     * @return the id
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @PrePersist
+    private void prePersist() {
+        if (this.id == null) {
+            throw new IllegalStateException("Inside '@PrePersist', 'ID' is null");
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/SequenceIdEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/SequenceIdEntity.java
@@ -1,3 +1,14 @@
+
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package io.openliberty.jpa.persistence.tests.models;
 
 import jakarta.persistence.Entity;

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/SequenceIdEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/SequenceIdEntity.java
@@ -1,0 +1,59 @@
+package io.openliberty.jpa.persistence.tests.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+
+@Entity
+public class SequenceIdEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    private String name;
+
+    public static SequenceIdEntity of(String name) {
+        SequenceIdEntity uuidIdEntity = new SequenceIdEntity();
+        uuidIdEntity.setName(name);
+        return uuidIdEntity;
+    }
+
+    /**
+     * @return the id
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @PrePersist
+    private void prePersist() {
+        if (this.id == null) {
+            throw new IllegalStateException("Inside '@PrePersist', 'ID' is null");
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/TableIdEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/TableIdEntity.java
@@ -1,4 +1,4 @@
-package com.oracle.jpa.bugtest.domain;
+package io.openliberty.jpa.persistence.tests.models;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -9,50 +9,50 @@ import jakarta.persistence.PrePersist;
 @Entity
 public class TableIdEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.TABLE)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.TABLE)
+    private Long id;
 
-	private String name;
+    private String name;
 
-	public static TableIdEntity of(String name) {
-		TableIdEntity uuidIdEntity = new TableIdEntity();
-		uuidIdEntity.setName(name);
-		return uuidIdEntity;
-	}
+    public static TableIdEntity of(String name) {
+        TableIdEntity uuidIdEntity = new TableIdEntity();
+        uuidIdEntity.setName(name);
+        return uuidIdEntity;
+    }
 
-	/**
-	 * @return the id
-	 */
-	public Long getId() {
-		return id;
-	}
+    /**
+     * @return the id
+     */
+    public Long getId() {
+        return id;
+    }
 
-	/**
-	 * @param id the id to set
-	 */
-	public void setId(Long id) {
-		this.id = id;
-	}
+    /**
+     * @param id the id to set
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
 
-	/**
-	 * @return the name
-	 */
-	public String getName() {
-		return name;
-	}
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
 
-	/**
-	 * @param name the name to set
-	 */
-	public void setName(String name) {
-		this.name = name;
-	}
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	@PrePersist
-	private void prePersist() {
-		if(this.id == null) {
-			throw new IllegalStateException("Inside '@PrePersist', 'ID' is null");
-		}
-	}
+    @PrePersist
+    private void prePersist() {
+        if (this.id == null) {
+            throw new IllegalStateException("Inside '@PrePersist', 'ID' is null");
+        }
+    }
 }

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/TableIdEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/TableIdEntity.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package io.openliberty.jpa.persistence.tests.models;
 
 import jakarta.persistence.Entity;

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/TableIdEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/TableIdEntity.java
@@ -1,0 +1,58 @@
+package com.oracle.jpa.bugtest.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+
+@Entity
+public class TableIdEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.TABLE)
+	private Long id;
+
+	private String name;
+
+	public static TableIdEntity of(String name) {
+		TableIdEntity uuidIdEntity = new TableIdEntity();
+		uuidIdEntity.setName(name);
+		return uuidIdEntity;
+	}
+
+	/**
+	 * @return the id
+	 */
+	public Long getId() {
+		return id;
+	}
+
+	/**
+	 * @param id the id to set
+	 */
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@PrePersist
+	private void prePersist() {
+		if(this.id == null) {
+			throw new IllegalStateException("Inside '@PrePersist', 'ID' is null");
+		}
+	}
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/UUIDIdEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/UUIDIdEntity.java
@@ -1,0 +1,57 @@
+package io.openliberty.jpa.persistence.tests.models;
+
+import java.util.UUID;
+
+import jakarta.persistence.*;
+
+@Entity
+public class UUIDIdEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+
+    public static UUIDIdEntity of(String name) {
+        UUIDIdEntity uuidIdEntity = new UUIDIdEntity();
+        uuidIdEntity.setName(name);
+        return uuidIdEntity;
+    }
+
+    /**
+     * @return the id
+     */
+    public UUID getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @PrePersist
+    private void prePersist() {
+        if (this.id == null) {
+            throw new IllegalStateException("Inside '@PrePersist', 'ID' is null");
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/UUIDIdEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/UUIDIdEntity.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package io.openliberty.jpa.persistence.tests.models;
 
 import java.util.UUID;

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -10,6 +10,7 @@
 package io.openliberty.jpa.persistence.tests.web;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -17,7 +18,9 @@ import java.util.List;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
+import io.openliberty.jpa.persistence.tests.models.IdentityIdEntity;
 import io.openliberty.jpa.persistence.tests.models.SequenceIdEntity;
+import io.openliberty.jpa.persistence.tests.models.TableIdEntity;
 import io.openliberty.jpa.persistence.tests.models.UUIDIdEntity;
 import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
@@ -73,8 +76,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     public void testPrimaryKeyAvailabilityInUUIDGenerationType() throws Exception {
         UUIDIdEntity uuiIdEntity = UUIDIdEntity.of("uuid entity 1");
-        tx.begin();
         try {
+            tx.begin();
             em.persist(uuiIdEntity);
             tx.commit();
         } catch (IllegalStateException e) {
@@ -98,8 +101,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     public void testPrimaryKeyAvailabilityInSequenceIdGenerationType() throws Exception {
         SequenceIdEntity sequenceIdEntity = SequenceIdEntity.of("SequenceIdEntity 1");
-        tx.begin();
         try {
+            tx.begin();
             em.persist(sequenceIdEntity);
             tx.commit();
         } catch (IllegalStateException e) {
@@ -108,6 +111,57 @@ public class JakartaPersistenceServlet extends FATServlet {
         } catch (Exception e) {
             System.out.println("testPrimaryKeyAvailabilityInSequenceIdGenerationType: Unexpected Exception occured while persisting: " + e.getMessage());
             fail("Unexpected Exception occured while persisting sequenceIdEntity");
+        }
+    }
+
+    /**
+     *
+     * https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a2202
+     * Primary key values generated using the SEQUENCE, TABLE, or UUID strategy are
+     * available in the PrePersist method. Primary key values generated using the
+     * IDENTITY strategy are not available in the PrePersist method
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPrimaryKeyAvailabilityInTableIdGenerationType() throws Exception {
+        TableIdEntity tableIdEntity = TableIdEntity.of("tableIdEntity 1");
+        try {
+            tx.begin();
+            em.persist(tableIdEntity);
+            tx.commit();
+        } catch (IllegalStateException e) {
+            System.out.println("testPrimaryKeyAvailabilityInTableIdGenerationType: Exception occured while persisting: " + e.getMessage());
+            fail("TABLE ID not available in PrePersist method. Primary key values generated using the TABLE strategy are expected to be available in the PrePersist method");
+        } catch (Exception e) {
+            System.out.println("testPrimaryKeyAvailabilityInTableIdGenerationType: Unexpected Exception occured while persisting: " + e.getMessage());
+            fail("Unexpected Exception occured while persisting tableIdEntity");
+        }
+    }
+
+    /**
+     *
+     * https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a2202
+     * Primary key values generated using the SEQUENCE, TABLE, or UUID strategy are
+     * available in the PrePersist method. Primary key values generated using the
+     * IDENTITY strategy are not available in the PrePersist method
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPrimaryKeyAvailabilityInIdentityIdGenerationType() throws Exception {
+        IdentityIdEntity identityIdEntity = IdentityIdEntity.of("identityIdEntity 1");
+        try {
+            tx.begin();
+            em.persist(identityIdEntity);
+            tx.commit();
+            fail("IDENTITY ID available in PrePersist method. Primary key values generated using the IDENTITY strategy are expected not to be available in the PrePersist method");
+        } catch (IllegalStateException e) {
+            System.out.println("testPrimaryKeyAvailabilityInIdentityIdGenerationType: Exception occured while persisting: " + e.getMessage());
+            assertTrue("Inside '@PrePersist', 'ID' is null".equals(e.getMessage()));
+        } catch (Exception e) {
+            System.out.println("testPrimaryKeyAvailabilityInIdentityIdGenerationType: Unexpected Exception occured while persisting: " + e.getMessage());
+            fail("Unexpected Exception occured while persisting identityIdEntity");
         }
     }
 

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -10,12 +10,14 @@
 package io.openliberty.jpa.persistence.tests.web;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.util.List;
 
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
+import io.openliberty.jpa.persistence.tests.models.UUIDIdEntity;
 import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -57,4 +59,30 @@ public class JakartaPersistenceServlet extends FATServlet {
                         .getResultList();
         assertNotNull(exceptResult);
     }
+
+    /**
+     *
+     * https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a2202
+     * Primary key values generated using the SEQUENCE, TABLE, or UUID strategy are
+     * available in the PrePersist method. Primary key values generated using the
+     * IDENTITY strategy are not available in the PrePersist method
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPrimaryKeyAvailabilityInUUIDGenerationType() throws Exception {
+        UUIDIdEntity uuiIdEntity = UUIDIdEntity.of("uuid entity 1");
+        tx.begin();
+        try {
+            em.persist(uuiIdEntity);
+            tx.commit();
+        } catch (IllegalStateException e) {
+            System.out.println("testPrimaryKeyAvailabilityInUUIDGenerationType: Exception occured while persisting: " + e.getMessage());
+            fail("ID not available in PrePersist method. Primary key values generated using the UUID strategy are expected to be available in the PrePersist method");
+        } catch (Exception e) {
+            System.out.println("testPrimaryKeyAvailabilityInUUIDGenerationType: Unexpected Exception occured while persisting: " + e.getMessage());
+            fail("Unexpected Exception occured while persisting uuiIdEntity");
+        }
+    }
+
 }

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
+import io.openliberty.jpa.persistence.tests.models.SequenceIdEntity;
 import io.openliberty.jpa.persistence.tests.models.UUIDIdEntity;
 import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
@@ -82,6 +83,31 @@ public class JakartaPersistenceServlet extends FATServlet {
         } catch (Exception e) {
             System.out.println("testPrimaryKeyAvailabilityInUUIDGenerationType: Unexpected Exception occured while persisting: " + e.getMessage());
             fail("Unexpected Exception occured while persisting uuiIdEntity");
+        }
+    }
+
+    /**
+     *
+     * https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a2202
+     * Primary key values generated using the SEQUENCE, TABLE, or UUID strategy are
+     * available in the PrePersist method. Primary key values generated using the
+     * IDENTITY strategy are not available in the PrePersist method
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPrimaryKeyAvailabilityInSequenceIdGenerationType() throws Exception {
+        SequenceIdEntity sequenceIdEntity = SequenceIdEntity.of("SequenceIdEntity 1");
+        tx.begin();
+        try {
+            em.persist(sequenceIdEntity);
+            tx.commit();
+        } catch (IllegalStateException e) {
+            System.out.println("testPrimaryKeyAvailabilityInSequenceIdGenerationType: Exception occured while persisting: " + e.getMessage());
+            fail("SEQUENCE ID not available in PrePersist method. Primary key values generated using the SEQUENCE strategy are expected to be available in the PrePersist method");
+        } catch (Exception e) {
+            System.out.println("testPrimaryKeyAvailabilityInSequenceIdGenerationType: Unexpected Exception occured while persisting: " + e.getMessage());
+            fail("Unexpected Exception occured while persisting sequenceIdEntity");
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Tests the availability of SEQUENCE, TABLE and UUID generated IDs on PrePersist. Primary key values generated using the SEQUENCE, TABLE, or UUID strategy are available in the PrePersist method. Primary key values generated using the IDENTITY strategy are not available in the PrePersist method