### PR TITLE
Add waitForSSL function to handle slow systems like Windows.

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessJavaEEToMicroProfileTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessJavaEEToMicroProfileTest.java
@@ -14,15 +14,11 @@ package com.ibm.ws.feature.tests;
 
 import java.util.Collection;
 
-import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import com.ibm.ws.feature.tests.util.PlatformConstants;
-
-import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.LibertyServerFactory;
 
 // @formatter:off
 
@@ -35,12 +31,6 @@ public class VersionlessJavaEEToMicroProfileTest extends VersionlessTest {
     public static final String SERVER_NAME_EE11 = "ee11toMP";
 
     public static final String[] ALLOWED_ERRORS = { "CWWKF0001E", "CWWKF0048E" };
-
-    @After
-    public void after() throws Exception {
-        LibertyServer server = LibertyServerFactory.getLibertyServer(getTestCase().serverName);
-        server.stopServer(ALLOWED_ERRORS);
-    }
 
     public static TestCase[] TEST_CASES = new TestCase[] {
         new TestCase("ee7toHealthAndMetricsMax",
@@ -125,6 +115,11 @@ public class VersionlessJavaEEToMicroProfileTest extends VersionlessTest {
     @Test
     public void versionless_javaEEToMicroProfileTest() throws Exception {
         test(getTestCase());
+    }
+
+    @Override
+    protected boolean waitForSSL() {
+        return true;
     }
 }
 // @formatter:on

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessTest.java
@@ -114,6 +114,9 @@ public class VersionlessTest {
 
         server.startServer();
         try {
+            if (waitForSSL()) {
+                server.waitForSSLStart();
+            }
             action.accept(server);
         } finally {
             server.stopServerAlways(allowedErrors);
@@ -227,6 +230,14 @@ public class VersionlessTest {
                 return true;
             }
         }
+        return false;
+    }
+
+    /**
+     * If a subclass of this class has servers that enable SSL
+     * this method should be overridden to return true
+     */
+    protected boolean waitForSSL() {
         return false;
     }
 }


### PR DESCRIPTION
- Undo the previous change in PR #29295 
- Add waitForSSLStart() call so that we wait to run the test until the SSL port is in a listening state.  keytool takes a long time on Windows test systems which ends up holding a reference to the directory while it is trying to make the key store that is used.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
