### PR TITLE
Do not reuse entity objects from failed transaction

### DIFF
--- a/dev/io.openliberty.springboot.fat30.data.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.data.app/build.gradle
@@ -10,10 +10,10 @@
  ********************************************************************************/
 
 plugins {
-  id 'org.springframework.boot' version '3.3.12'
+  id 'org.springframework.boot' version '3.4.6'
 }
+
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-def sv = springVersions[ '3.0' ]
 
 apply plugin: 'war'
 apply plugin: 'io.spring.dependency-management'


### PR DESCRIPTION
Hibernate has a change in behavior that prevents the use of entity objects from a failed transaction.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

