### PR TITLE
Fix reuse of closed Statement after transaction commit in executeDDL

### DIFF
--- a/dev/com.ibm.ws.jpa_testframework/src/com/ibm/ws/testtooling/vehicle/web/AbstractDatabaseManagementServlet.java
+++ b/dev/com.ibm.ws.jpa_testframework/src/com/ibm/ws/testtooling/vehicle/web/AbstractDatabaseManagementServlet.java
@@ -167,7 +167,8 @@ public abstract class AbstractDatabaseManagementServlet extends HttpServlet {
             final DatabaseMetaData dbMeta = conn.getMetaData();
             dumpDBMeta(dbMeta);
 
-            final Statement stmt = conn.createStatement();
+            System.out.println("Creating statement.");
+            Statement stmt = conn.createStatement();
             final String defaultSchemaName = (overrideDefaultSchema == null || "".equals(overrideDefaultSchema.trim())) ? //
                             sanitize(dbMeta.getUserName()) : // Usually the default schema name
                             sanitize(overrideDefaultSchema); // But always allow for test client to override
@@ -177,15 +178,21 @@ public abstract class AbstractDatabaseManagementServlet extends HttpServlet {
             for (String command : commands) {
 
                 // Check if more than 1 minute has passed
-                if ((System.currentTimeMillis() - timestart) > 60000) {
-                    System.out.println("More than 1 minute has passed. Committing and beginning a new transaction.");
+                if ((System.currentTimeMillis() - timestart) > 500) {
+                    System.out.println("Half a second passed. Committing and beginning a new transaction.");
 
                     // Commit the current transaction and begin a new one
                     tx.commit();
                     tx.begin();
 
+                    System.out.println("Creating new statement after timeout.");
+                    stmt = conn.createStatement();
+
                     // Reset the start time
                     timestart = System.currentTimeMillis();
+                }
+                else {
+                    System.out.println("Continuing with current transaction.");
                 }
 
                 final String sql = command.replace("${schemaname}", defaultSchemaName).trim();


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This PR fixes reuse of closed Statement after transaction commit in executeDDL.
This possibly resolves intermittent CREATE TABLE failures observed in DB2 when execution takes long time (more than one minute).

