### PR TITLE
Non functional change - Improve code clarity in javaeesec test bucket 

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/CustomIdentityStoreHandlerTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/CustomIdentityStoreHandlerTest.java
@@ -126,7 +126,7 @@ public class CustomIdentityStoreHandlerTest extends JavaEESecTestBase {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         myServer.resetLogMarks();
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                          LocalLdapServer.PASSWORD,
+                                                          LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.USER1, Constants.getRemoteUserFound + LocalLdapServer.USER1);
         verifyRealm(response, "127.0.0.1:" + portNumber);
@@ -154,7 +154,7 @@ public class CustomIdentityStoreHandlerTest extends JavaEESecTestBase {
     public void testCustomIDSHandlerBAWith2ndISonly_AllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.ANOTHERUSER1,
-                                                          LocalLdapServer.ANOTHERPASSWORD,
+                                                          LocalLdapServer.ANOTHER_SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.ANOTHERUSER1, Constants.getRemoteUserFound + LocalLdapServer.ANOTHERUSER1);
         verifyRealm(response, "localhost:" + portNumber);
@@ -183,7 +183,7 @@ public class CustomIdentityStoreHandlerTest extends JavaEESecTestBase {
     public void testCustomIDSHandlerBAWith1stISfail2ndISsuccess_AllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                          LocalLdapServer.ANOTHERPASSWORD,
+                                                          LocalLdapServer.ANOTHER_SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.USER1, Constants.getRemoteUserFound + LocalLdapServer.USER1);
         verifyRealm(response, "localhost:" + portNumber);
@@ -227,7 +227,7 @@ public class CustomIdentityStoreHandlerTest extends JavaEESecTestBase {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         myServer.setMarkToEndOfLog();
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.INVALIDUSER,
-                                                          LocalLdapServer.PASSWORD,
+                                                          LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_FORBIDDEN);
         verifyMessageReceivedInMessageLog("CWWKS9104A:.*" + LocalLdapServer.INVALIDUSER + ".*" + LocalLdapServer.GRANTEDGROUP);
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
@@ -250,7 +250,7 @@ public class CustomIdentityStoreHandlerTest extends JavaEESecTestBase {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         myServer.setMarkToEndOfLog();
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                          LocalLdapServer.INVALIDPASSWORD,
+                                                          LocalLdapServer.INVALID_SAMPLE_DATA,
                                                           HttpServletResponse.SC_UNAUTHORIZED);
         verifyMessageReceivedInMessageLog("CWWKS1652A:.*");
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/CustomIdentityStoreHandlerTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/CustomIdentityStoreHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
@@ -169,7 +169,7 @@ public class EJBModuleRealmTest extends JavaEESecTestBase {
         queryString = EJB_REALM1_WAR_PATH + SIMPLE_SERVLET_REALM1 + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                   LocalLdapServer.PASSWORD,
+                                                   LocalLdapServer.SAMPLE_DATA,
                                                    HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -186,7 +186,7 @@ public class EJBModuleRealmTest extends JavaEESecTestBase {
         queryString = EJB_REALM2_WAR_PATH + SIMPLE_SERVLET_REALM2 + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                   LocalLdapServer.ANOTHERPASSWORD,
+                                                   LocalLdapServer.ANOTHER_SAMPLE_DATA,
                                                    HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -252,7 +252,7 @@ public class EJBModuleRealmTest extends JavaEESecTestBase {
         queryString = EJB_REALM1_WAR_PATH + SIMPLE_SERVLET_REALM1 + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                   LocalLdapServer.PASSWORD,
+                                                   LocalLdapServer.SAMPLE_DATA,
                                                    HttpServletResponse.SC_FORBIDDEN);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -268,7 +268,7 @@ public class EJBModuleRealmTest extends JavaEESecTestBase {
         queryString = EJB_REALM2_WAR_PATH + SIMPLE_SERVLET_REALM2 + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                   LocalLdapServer.ANOTHERPASSWORD,
+                                                   LocalLdapServer.ANOTHER_SAMPLE_DATA,
                                                    HttpServletResponse.SC_FORBIDDEN);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleDBRunAsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleDBRunAsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleDBRunAsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleDBRunAsTest.java
@@ -76,9 +76,9 @@ public class MultipleModuleDBRunAsTest extends JavaEESecTestBase {
     protected static String MODULE2_TITLE_CUSTOMLOGIN_PAGE = "Custom Login Sample by using JSF";
 
     protected static String REALM1_USER = "realm1user";
-    protected static String REALM1_PASSWORD = "s3cur1ty";
+    protected static String REALM1_SAMPLE_DATA = "s3cur1ty";
     protected static String REALM2_USER = "realm2user";
-    protected static String REALM2_PASSWORD = "s3cur1ty";
+    protected static String REALM2_SAMPLE_DATA = "s3cur1ty";
 
     protected static String IS1_REALM_NAME = "127.0.0.1:" + portNumber;
     protected static String IS2_REALM_NAME = "localhost:" + portNumber;
@@ -188,7 +188,7 @@ public class MultipleModuleDBRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS, Constants.DB_USER1);
@@ -198,7 +198,7 @@ public class MultipleModuleDBRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on the other module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // since runas user is authenticated by IS1, the realm name of IS1 shows up in the response, therefore skip validating invalid realm.
@@ -209,7 +209,7 @@ public class MultipleModuleDBRunAsTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // since runas user is authenticated by IS1, the realm name of IS1 shows up in the response, therefore skip validating invalid realm.
@@ -222,7 +222,7 @@ public class MultipleModuleDBRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS, Constants.DB_USER2);
@@ -233,7 +233,7 @@ public class MultipleModuleDBRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in another module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // since runas user is authenticated by IS2, the realm name of IS2 shows up in the response, therefore skip validating invalid realm.
@@ -243,7 +243,7 @@ public class MultipleModuleDBRunAsTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // since runas user is authenticated by IS2, the realm name of IS2 shows up in the response, therefore skip validating invalid realm.

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertTest.java
@@ -69,7 +69,7 @@ public class MultipleModuleGlobalClientCertTest extends JavaEESecTestBase {
     protected final static String CERTUSER2_KEYFILE = "certuser2.jks";
     protected final static String CERTUSER3_KEYFILE = "certuser3.jks";
     protected final static String CERTUSER4_KEYFILE = "certuser4.jks";
-    protected final static String KEYSTORE_PASSWORD = "s3cur1ty";
+    protected final static String KEYSTORE_SAMPLE_DATA = "s3cur1ty";
     protected final static String LDAP_UR_REALM_NAME = "MyLdapRealm";
     protected final static String LDAP_UR_GROUPS = "group:MyLdapRealm/cn=certgroup1,ou=groups,o=ibm,c=us";
 
@@ -431,7 +431,7 @@ public class MultipleModuleGlobalClientCertTest extends JavaEESecTestBase {
 
     private void setupClient(String certFile) {
         String ksFile = myServer.pathToAutoFVTTestFiles + "/clientcert/" + certFile;
-        SSLHelper.establishSSLContext(httpclient, myServer.getHttpDefaultSecurePort(), myServer, ksFile, KEYSTORE_PASSWORD, null, null);
+        SSLHelper.establishSSLContext(httpclient, myServer.getHttpDefaultSecurePort(), myServer, ksFile, KEYSTORE_SAMPLE_DATA, null, null);
     }
 
 }

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleRunAsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleRunAsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleRunAsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleRunAsTest.java
@@ -88,13 +88,13 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
     protected static String MODULE2_TITLE_CUSTOMLOGIN_PAGE = "Custom Login Sample by using JSF";
 
     protected static String REALM1_USER = "realm1user";
-    protected static String REALM1_PASSWORD = "s3cur1ty";
+    protected static String REALM1_SAMPLE_DATA = "s3cur1ty";
     protected static String REALM2_USER = "realm2user";
-    protected static String REALM2_PASSWORD = "s3cur1ty";
+    protected static String REALM2_SAMPLE_DATA = "s3cur1ty";
     protected static String BASIC_USER1 = "basicuser1";
-    protected static String BASIC_USER1_PASSWORD = "s3cur1ty";
+    protected static String BASIC_USER1_SAMPLE_DATA = "s3cur1ty";
     protected static String BASIC_RUNASUSER1 = "basicrunasuser1";
-    protected static String BASIC_RUNASUSER1_PASSWORD = "s3cur1ty";
+    protected static String BASIC_RUNASUSER1_SAMPLE_DATA = "s3cur1ty";
 
     protected static String IS1_REALM_NAME = "127.0.0.1:" + portNumber;
     protected static String IS2_REALM_NAME = "localhost:" + portNumber;
@@ -203,7 +203,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS, LocalLdapServer.RUNASUSER1);
@@ -213,7 +213,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on the other module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // since runas user is authenticated by IS1, the realm name of IS1 shows up in the response, therefore skip validating invalid realm.
@@ -224,7 +224,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // since runas user is authenticated by IS1, the realm name of IS1 shows up in the response, therefore skip validating invalid realm.
@@ -237,7 +237,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS, LocalLdapServer.ANOTHERRUNASUSER1);
@@ -248,7 +248,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in another module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // since runas user is authenticated by IS2, the realm name of IS2 shows up in the response, therefore skip validating invalid realm.
@@ -258,7 +258,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // since runas user is authenticated by IS2, the realm name of IS2 shows up in the response, therefore skip validating invalid realm.
@@ -312,7 +312,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // make sure that runas subject is set as caller subject.
@@ -323,7 +323,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on the other module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // make sure that runas subject is set as caller subject.
@@ -334,7 +334,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // make sure that runas subject is set as caller subject.
@@ -347,7 +347,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // make sure that runas subject is set as caller subject.
@@ -359,7 +359,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in another module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // make sure that runas subject is set as caller subject.
@@ -369,7 +369,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // make sure that runas subject is set as caller subject.
@@ -426,7 +426,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS, LocalLdapServer.RUNASUSER1);
@@ -436,7 +436,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on the other module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // since runas user is authenticated by IS1, the realm name of IS1 shows up in the response, therefore skip validating invalid realm.
@@ -447,7 +447,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // since runas user is authenticated by IS1, the realm name of IS1 shows up in the response, therefore skip validating invalid realm.
@@ -460,7 +460,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS, LocalLdapServer.ANOTHERRUNASUSER1);
@@ -471,7 +471,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in another module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // since runas user is authenticated by IS2, the realm name of IS2 shows up in the response, therefore skip validating invalid realm.
@@ -481,7 +481,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // since runas user is authenticated by IS2, the realm name of IS2 shows up in the response, therefore skip validating invalid realm.
@@ -491,7 +491,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         setupConnection();
         // ------------- accessing module3 ---------------
         // Execute Basic login for Non JavaEESec servlet.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP3_SERVLET, BASIC_USER1, BASIC_USER1_PASSWORD, HttpServletResponse.SC_OK);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP3_SERVLET, BASIC_USER1, BASIC_USER1_SAMPLE_DATA, HttpServletResponse.SC_OK);
 
         verifyResponse(response, BASIC_USER1, BASIC_REALM_NAME, IS1_GROUP_REALM_NAME, BASIC_GROUPS, BASIC_RUNASUSER1);
         httpclient.getConnectionManager().shutdown();
@@ -547,7 +547,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS, LocalLdapServer.RUNASUSER1);
@@ -557,7 +557,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on the other module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // since runas user is authenticated by IS1, the realm name of IS1 shows up in the response, therefore skip validating invalid realm.
@@ -568,7 +568,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         // since runas user is authenticated by IS1, the realm name of IS1 shows up in the response, therefore skip validating invalid realm.
@@ -581,7 +581,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS, LocalLdapServer.ANOTHERRUNASUSER1);
@@ -592,7 +592,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in another module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // since runas user is authenticated by IS2, the realm name of IS2 shows up in the response, therefore skip validating invalid realm.
@@ -602,7 +602,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         // since runas user is authenticated by IS2, the realm name of IS2 shows up in the response, therefore skip validating invalid realm.
@@ -612,7 +612,7 @@ public class MultipleModuleRunAsTest extends JavaEESecTestBase {
         setupConnection();
         // ------------- accessing module3 ---------------
         // Execute Basic login for Non JavaEESec servlet.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP3_SERVLET, BASIC_USER1, BASIC_USER1_PASSWORD, HttpServletResponse.SC_OK);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP3_SERVLET, BASIC_USER1, BASIC_USER1_SAMPLE_DATA, HttpServletResponse.SC_OK);
 
         verifyResponse(response, BASIC_USER1, BASIC_REALM_NAME, IS1_GROUP_REALM_NAME, BASIC_GROUPS, BASIC_RUNASUSER1);
         httpclient.getConnectionManager().shutdown();

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertFailOverTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertFailOverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertFailOverTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalClientCertFailOverTest.java
@@ -90,7 +90,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
 
     protected final static String CERTUSER1_KEYFILE = "certuser1.jks";
     protected final static String CERTUSER4_KEYFILE = "certuser4.jks";
-    protected final static String KEYSTORE_PASSWORD = "s3cur1ty";
+    protected final static String KEYSTORE_SAMPLE_DATA = "s3cur1ty";
     protected final static String LDAP_UR_REALM_NAME = "MyLdapRealm";
     protected final static String LDAP_UR_GROUPS = "group:MyLdapRealm/cn=certgroup1,ou=groups,o=ibm,c=us";
 
@@ -269,7 +269,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         // ------------- accessing module1 ---------------
         // since the certificate won't be sent, fallback to the specified BasicAuth.
         setupClient(CERTUSER4_KEYFILE);
-        String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP1_SERVLET, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, HttpServletResponse.SC_OK);
+        String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP1_SERVLET, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
         httpclient.getConnectionManager().shutdown();
         // ------------- accessing module2 ---------------
@@ -277,7 +277,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         setupConnection();
         setupClient(CERTUSER4_KEYFILE);
         // since the certificate won't be sent, fallback to the specified BasicAuth.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP2_SERVLET, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, HttpServletResponse.SC_OK);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP2_SERVLET, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
     }
@@ -336,7 +336,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         // ------------- accessing module1 ---------------
         // since the certificate won't be sent, fallback to the specified BasicAuth.
         setupClient(CERTUSER4_KEYFILE);
-        String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + NOJAVAEESEC_SERVLET_FORM, LocalLdapServer.USER3, LocalLdapServer.PASSWORD,
+        String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + NOJAVAEESEC_SERVLET_FORM, LocalLdapServer.USER3, LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         verifyResponse(response, LocalLdapServer.USER3, LDAP_UR_REALM_NAME, IS2_GROUP_REALM_NAME, LDAP_UR_GROUPS);
         httpclient.getConnectionManager().shutdown();
@@ -345,7 +345,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         setupConnection();
         setupClient(CERTUSER4_KEYFILE);
         // since the certificate won't be sent, fallback to the specified BasicAuth.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + NOJAVAEESEC_SERVLET_BASIC, LocalLdapServer.USER3, LocalLdapServer.PASSWORD, HttpServletResponse.SC_OK);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + NOJAVAEESEC_SERVLET_BASIC, LocalLdapServer.USER3, LocalLdapServer.SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyResponse(response, LocalLdapServer.USER3, LDAP_UR_REALM_NAME, IS1_GROUP_REALM_NAME, LDAP_UR_GROUPS);
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
     }
@@ -410,7 +410,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         setupClient(CERTUSER4_KEYFILE);
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, false, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -422,7 +422,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         // since the certificate won't be sent, custom form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -486,7 +486,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         // since the certificate won't be sent, fallback to the specified Form Login.
         setupClient(CERTUSER4_KEYFILE);
         String response = getFormLoginPage(httpclient, urlBase + NOJAVAEESEC_SERVLET_FORM, true, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + GLOBAL_LOGIN_FORM, LocalLdapServer.USER3, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + GLOBAL_LOGIN_FORM, LocalLdapServer.USER3, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + NOJAVAEESEC_SERVLET_FORM);
         verifyResponse(response, LocalLdapServer.USER3, LDAP_UR_REALM_NAME, IS2_GROUP_REALM_NAME, LDAP_UR_GROUPS);
@@ -497,7 +497,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         setupClient(CERTUSER4_KEYFILE);
         // since the certificate won't be sent, fallback to the specified Form login.
         response = getFormLoginPage(httpclient, urlBase + NOJAVAEESEC_SERVLET_BASIC, true, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + GLOBAL_LOGIN_FORM, LocalLdapServer.USER3, LocalLdapServer.PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + GLOBAL_LOGIN_FORM, LocalLdapServer.USER3, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + NOJAVAEESEC_SERVLET_BASIC);
         verifyResponse(response, LocalLdapServer.USER3, LDAP_UR_REALM_NAME, IS1_GROUP_REALM_NAME, LDAP_UR_GROUPS);
@@ -563,7 +563,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         setupClient(CERTUSER4_KEYFILE);
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -575,7 +575,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         // since the certificate won't be sent, custom form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -638,7 +638,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         // since the certificate won't be sent, fallback to the specified BasicAuth.
         setupClient(CERTUSER4_KEYFILE);
         String response = getFormLoginPage(httpclient, urlBase + NOJAVAEESEC_SERVLET_FORM, true, urlBase + NOJAVAEESEC_LOGIN_PAGE, NOJAVAEESEC_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + NOJAVAEESEC_LOGIN_FORM, LocalLdapServer.USER3, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + NOJAVAEESEC_LOGIN_FORM, LocalLdapServer.USER3, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + NOJAVAEESEC_SERVLET_FORM);
         verifyResponse(response, LocalLdapServer.USER3, LDAP_UR_REALM_NAME, IS2_GROUP_REALM_NAME, LDAP_UR_GROUPS);
@@ -648,7 +648,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
         setupConnection();
         setupClient(CERTUSER4_KEYFILE);
         // since the certificate won't be sent, fallback to the specified BasicAuth.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + NOJAVAEESEC_SERVLET_BASIC, LocalLdapServer.USER3, LocalLdapServer.PASSWORD, HttpServletResponse.SC_OK);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + NOJAVAEESEC_SERVLET_BASIC, LocalLdapServer.USER3, LocalLdapServer.SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyResponse(response, LocalLdapServer.USER3, LDAP_UR_REALM_NAME, IS1_GROUP_REALM_NAME, LDAP_UR_GROUPS);
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
     }
@@ -675,7 +675,7 @@ public class MultipleModuleGlobalClientCertFailOverTest extends JavaEESecTestBas
 
     private void setupClient(String certFile) {
         String ksFile = myServer.pathToAutoFVTTestFiles + "/clientcert/" + certFile;
-        SSLHelper.establishSSLContext(httpclient, myServer.getHttpDefaultSecurePort(), myServer, ksFile, KEYSTORE_PASSWORD, null, null);
+        SSLHelper.establishSSLContext(httpclient, myServer.getHttpDefaultSecurePort(), myServer, ksFile, KEYSTORE_SAMPLE_DATA, null, null);
     }
 
 }

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalLoginTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalLoginTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalLoginTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleGlobalLoginTest.java
@@ -97,9 +97,9 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
     protected static String GLOBAL_TITLE_ERROR_PAGE = "Global Form Login Error Page";
 
     protected static String REALM1_USER = "realm1user";
-    protected static String REALM1_PASSWORD = "s3cur1ty";
+    protected static String REALM1_SAMPLE_DATA = "s3cur1ty";
     protected static String REALM2_USER = "realm2user";
-    protected static String REALM2_PASSWORD = "s3cur1ty";
+    protected static String REALM2_SAMPLE_DATA = "s3cur1ty";
     protected static String IS1_REALM_NAME = "127.0.0.1:" + portNumber;
     protected static String IS2_REALM_NAME = "localhost:" + portNumber;
     protected static String REALM1_REALM_NAME = "Realm1";
@@ -333,7 +333,7 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, false, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -343,7 +343,7 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on the other module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, false, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -353,7 +353,7 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, false, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, REALM1_USER, REALM1_REALM_NAME, IS1_GROUP_REALM_NAME, REALM1_GROUPS);
@@ -364,7 +364,7 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for custom identity store in the different module.
         // this should fail.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, false, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM2_USER, REALM2_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM2_USER, REALM2_SAMPLE_DATA, true);
         // Redirect to the given page, ensure that this is an error page since there is no user exist in the identitystores.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, GLOBAL_TITLE_ERROR_PAGE);
 
@@ -375,7 +375,7 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -386,7 +386,7 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in another module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -395,7 +395,7 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, REALM2_USER, REALM2_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, REALM2_USER, REALM2_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, REALM2_USER, REALM2_REALM_NAME, IS1_GROUP_REALM_NAME, REALM2_GROUPS);
@@ -404,7 +404,7 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in the different module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + GLOBAL_LOGIN_PAGE, GLOBAL_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, GLOBAL_TITLE_ERROR_PAGE);
     }
@@ -412,20 +412,20 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
     protected void runMultipulModuleBasicAuthScenario() throws Exception {
         // ------------- accessing module1 ---------------
         // Execute BA login
-        String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP1_SERVLET, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, HttpServletResponse.SC_OK);
+        String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP1_SERVLET, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
         httpclient.getConnectionManager().shutdown();
         setupConnection();
 
         // ExecuteBA login for LdapIdentityStoreDefinision on the other module.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP1_SERVLET, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, HttpServletResponse.SC_OK);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP1_SERVLET, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
 
         httpclient.getConnectionManager().shutdown();
         setupConnection();
 
         // Execute BA login for custom identity store in this module.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP1_SERVLET, REALM1_USER, REALM1_PASSWORD, HttpServletResponse.SC_OK);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP1_SERVLET, REALM1_USER, REALM1_SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyResponse(response, REALM1_USER, REALM1_REALM_NAME, IS1_GROUP_REALM_NAME, REALM1_GROUPS);
 
         httpclient.getConnectionManager().shutdown();
@@ -433,34 +433,34 @@ public class MultipleModuleGlobalLoginTest extends JavaEESecTestBase {
 
         // Execute BA login for custom identity store in the different module.
         // this should fail.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP1_SERVLET, REALM2_USER, REALM2_PASSWORD, HttpServletResponse.SC_UNAUTHORIZED);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP1_SERVLET, REALM2_USER, REALM2_SAMPLE_DATA, HttpServletResponse.SC_UNAUTHORIZED);
 
         httpclient.getConnectionManager().shutdown();
         setupConnection();
 
         // ------------- accessing module2 ---------------
         // Execute BA login with a user which exists in ldapidentitystore definision in this module.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP2_SERVLET, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, HttpServletResponse.SC_OK);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP2_SERVLET, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
 
         httpclient.getConnectionManager().shutdown();
         setupConnection();
 
         // Execute BA login with a user which exists in ldapidentitystore definision in another module.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP2_SERVLET, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, HttpServletResponse.SC_OK);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP2_SERVLET, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
         httpclient.getConnectionManager().shutdown();
         setupConnection();
 
         // Execute BA login for custom identity store in this module.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP2_SERVLET, REALM2_USER, REALM2_PASSWORD, HttpServletResponse.SC_OK);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP2_SERVLET, REALM2_USER, REALM2_SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyResponse(response, REALM2_USER, REALM2_REALM_NAME, IS1_GROUP_REALM_NAME, REALM2_GROUPS);
         httpclient.getConnectionManager().shutdown();
         setupConnection();
 
         // Execute BA login for custom identity store in the different module.
         // This should fail.
-        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP2_SERVLET, REALM1_USER, REALM1_PASSWORD, HttpServletResponse.SC_UNAUTHORIZED);
+        response = executeGetRequestBasicAuthCreds(httpclient, urlBase + APP2_SERVLET, REALM1_USER, REALM1_SAMPLE_DATA, HttpServletResponse.SC_UNAUTHORIZED);
     }
 
 }

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/NoIdentityStoreTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/NoIdentityStoreTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/NoIdentityStoreTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/NoIdentityStoreTest.java
@@ -108,7 +108,7 @@ public class NoIdentityStoreTest extends JavaEESecTestBase {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         myServer.setMarkToEndOfLog();
         String response = executeGetRequestBasicAuthCredsPreemptive(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                                    LocalLdapServer.PASSWORD,
+                                                                    LocalLdapServer.SAMPLE_DATA,
                                                                     HttpServletResponse.SC_OK);
         verifyMessageReceivedInMessageLog("CustomIdentityStoreHandler is being used.");
         verifyMessageReceivedInMessageLog("Number of identityStore : 0");

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestProtectedServlet.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestProtectedServlet.java
@@ -174,7 +174,7 @@ public class EJBModuleTestProtectedServlet extends JavaEESecTestBase {
         queryString = EJB_WAR_PATH + SIMPLE_SERVLET + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                   LocalLdapServer.PASSWORD,
+                                                   LocalLdapServer.SAMPLE_DATA,
                                                    HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -192,7 +192,7 @@ public class EJBModuleTestProtectedServlet extends JavaEESecTestBase {
         queryString = EJB_WAR_PATH + SIMPLE_SERVLET + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.INVALIDUSER,
-                                                   LocalLdapServer.PASSWORD,
+                                                   LocalLdapServer.SAMPLE_DATA,
                                                    HttpServletResponse.SC_FORBIDDEN);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -274,7 +274,7 @@ public class EJBModuleTestProtectedServlet extends JavaEESecTestBase {
         queryString = EJB_WAR_PATH + SIMPLE_SERVLET + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                   LocalLdapServer.PASSWORD,
+                                                   LocalLdapServer.SAMPLE_DATA,
                                                    HttpServletResponse.SC_UNAUTHORIZED);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-----Exiting isUserInRoleLDAPISWar1");
@@ -287,7 +287,7 @@ public class EJBModuleTestProtectedServlet extends JavaEESecTestBase {
         queryString = EJB_WAR2_PATH + SIMPLE_SERVLET2 + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.ANOTHERUSER1,
-                                                   LocalLdapServer.ANOTHERPASSWORD,
+                                                   LocalLdapServer.ANOTHER_SAMPLE_DATA,
                                                    HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -304,7 +304,7 @@ public class EJBModuleTestProtectedServlet extends JavaEESecTestBase {
         queryString = EJB_WAR_PATH + SIMPLE_SERVLET + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.ANOTHERUSER1,
-                                                   LocalLdapServer.ANOTHERPASSWORD,
+                                                   LocalLdapServer.ANOTHER_SAMPLE_DATA,
                                                    HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -424,7 +424,7 @@ public class EJBModuleTestProtectedServlet extends JavaEESecTestBase {
         queryString = EJB_WAR_PATH + RUNAS_SERVLET + "?testInstance=ejb01&testMethod=runAsSpecified";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER2,
-                                                   LocalLdapServer.PASSWORD,
+                                                   LocalLdapServer.SAMPLE_DATA,
                                                    HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -556,7 +556,7 @@ public class EJBModuleTestProtectedServlet extends JavaEESecTestBase {
         queryString = EJB_WAR_PATH + RUNAS_SERVLET + "?testInstance=ejb01&testMethod=runAsSpecified";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.RUNASUSER1,
-                                                   LocalLdapServer.PASSWORD,
+                                                   LocalLdapServer.SAMPLE_DATA,
                                                    HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestUnprotectedServlet.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestUnprotectedServlet.java
@@ -159,7 +159,7 @@ public class EJBModuleTestUnprotectedServlet extends JavaEESecTestBase {
         String queryString = EJB_WAR_PATH + SIMPLE_SERVLET + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                          LocalLdapServer.PASSWORD,
+                                                          LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -190,7 +190,7 @@ public class EJBModuleTestUnprotectedServlet extends JavaEESecTestBase {
         String queryString = EJB_WAR2_PATH + SIMPLE_SERVLET2 + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                          LocalLdapServer.PASSWORD,
+                                                          LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -224,7 +224,7 @@ public class EJBModuleTestUnprotectedServlet extends JavaEESecTestBase {
         String queryString = EJB_WAR_PATH + RUNAS_SERVLET + "?testInstance=ejb01&testMethod=runAsSpecified";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER2,
-                                                          LocalLdapServer.PASSWORD,
+                                                          LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -255,7 +255,7 @@ public class EJBModuleTestUnprotectedServlet extends JavaEESecTestBase {
         String queryString = EJB_WAR_PATH + SIMPLE_SERVLET + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.INVALIDUSER,
-                                                          LocalLdapServer.PASSWORD,
+                                                          LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -285,7 +285,7 @@ public class EJBModuleTestUnprotectedServlet extends JavaEESecTestBase {
         String queryString = EJB_WAR2_PATH + SIMPLE_SERVLET2 + "?testInstance=ejb03&testMethod=manager";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.INVALIDUSER,
-                                                          LocalLdapServer.PASSWORD,
+                                                          LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");
@@ -315,7 +315,7 @@ public class EJBModuleTestUnprotectedServlet extends JavaEESecTestBase {
         String queryString = EJB_WAR_PATH + RUNAS_SERVLET + "?testInstance=ejb01&testMethod=runAsSpecified";
         Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.INVALIDUSER,
-                                                          LocalLdapServer.PASSWORD,
+                                                          LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         Log.info(logClass, getCurrentTestName(), "-------------End of Response");
         Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FeatureTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FeatureTest.java
@@ -174,7 +174,7 @@ public class FeatureTest extends JavaEESecTestBase {
             queryString = EJB_WAR_PATH + SIMPLE_SERVLET + "?testInstance=ejb03&testMethod=manager";
             Log.info(logClass, getCurrentTestName(), "-------------Executing BasicAuthCreds");
             response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                       LocalLdapServer.PASSWORD,
+                                                       LocalLdapServer.SAMPLE_DATA,
                                                        HttpServletResponse.SC_OK);
             Log.info(logClass, getCurrentTestName(), "-------------End of Response");
             Log.info(logClass, getCurrentTestName(), "-------------Verifying Response");

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
@@ -141,7 +141,7 @@ public class FormHttpAuthenticationMechanismTest extends JavaEESecTestBase {
         myServer.setMarkToEndOfLog();
         String response = executeGetRequestFormCreds(httpclient, urlHttp + Constants.DEFAULT_FORM_LOGIN_PAGE, false, urlHttp + "/JavaEEsecFormAuth/login.jsp",
                                                      "login page for the form login test", urlHttp + "/JavaEEsecFormAuth/j_security_check",
-                                                     LocalLdapServer.USER1, LocalLdapServer.PASSWORD, HttpServletResponse.SC_OK);
+                                                     LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.USER1, Constants.getRemoteUserFound + LocalLdapServer.USER1);
     }
 
@@ -164,7 +164,7 @@ public class FormHttpAuthenticationMechanismTest extends JavaEESecTestBase {
         myServer.setMarkToEndOfLog();
         String response = executeGetRequestFormCreds(httpclient, urlHttp + Constants.DEFAULT_REDIRECT_FORM_LOGIN_PAGE, true, urlHttp + "/JavaEEsecFormAuthRedirect/login.jsp",
                                                      "login page for the form login test", urlHttp + "/JavaEEsecFormAuthRedirect/j_security_check",
-                                                     LocalLdapServer.USER1, LocalLdapServer.PASSWORD, HttpServletResponse.SC_OK);
+                                                     LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.USER1, Constants.getRemoteUserFound + LocalLdapServer.USER1);
     }
 }

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LdapIdentityStoreDeferredSettingsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LdapIdentityStoreDeferredSettingsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LdapIdentityStoreDeferredSettingsTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LdapIdentityStoreDeferredSettingsTest.java
@@ -82,13 +82,13 @@ public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {
 
     // LDAP Users
     private static final String LDAP_USER1_UID = "ldapuser1";
-    private static final String LDAP_USER1_PASSWORD = LDAP_USER1_UID + "pass";
+    private static final String LDAP_USER1_SAMPLE_DATA = LDAP_USER1_UID + "pass";
     private static final String LDAP_USER2_UID = "ldapuser2";
-    private static final String LDAP_USER2_PASSWORD = LDAP_USER2_UID + "pass";
+    private static final String LDAP_USER2_SAMPLE_DATA = LDAP_USER2_UID + "pass";
     private static final String LDAP_USER3_UID = "ldapuser3";
-    private static final String LDAP_USER3_PASSWORD = LDAP_USER3_UID + "pass";
+    private static final String LDAP_USER3_SAMPLE_DATA = LDAP_USER3_UID + "pass";
     private static final String LDAP_USER4_UID = "ldapuser4";
-    private static final String LDAP_USER4_PASSWORD = LDAP_USER4_UID + "pass";
+    private static final String LDAP_USER4_SAMPLE_DATA = LDAP_USER4_UID + "pass";
 
     //LDAP bind pass
     private final String password = "ldapuser1pass";
@@ -171,7 +171,7 @@ public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {
         entry.addAttribute("uid", LDAP_USER1_UID);
         entry.addAttribute("sn", LDAP_USER1_UID + "sn");
         entry.addAttribute("cn", LDAP_USER1_UID + "cn");
-        entry.addAttribute("userPassword", LDAP_USER1_PASSWORD);
+        entry.addAttribute("userPassword", LDAP_USER1_SAMPLE_DATA);
         ldapServer.add(entry);
 
         entry = new Entry(LDAP_USER2_DN);
@@ -183,7 +183,7 @@ public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {
         entry.addAttribute("sn", LDAP_USER2_UID + "sn");
         entry.addAttribute("cn", LDAP_USER2_UID + "cn");
         entry.addAttribute("memberOf", LDAP_GROUP1_DN);
-        entry.addAttribute("userPassword", LDAP_USER2_PASSWORD);
+        entry.addAttribute("userPassword", LDAP_USER2_SAMPLE_DATA);
         ldapServer.add(entry);
 
         entry = new Entry(LDAP_USER3_DN);
@@ -192,7 +192,7 @@ public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {
         entry.addAttribute("uid", LDAP_USER3_UID);
         entry.addAttribute("sn", LDAP_USER3_UID + "sn");
         entry.addAttribute("cn", LDAP_USER3_UID + "cn");
-        entry.addAttribute("userPassword", LDAP_USER3_PASSWORD);
+        entry.addAttribute("userPassword", LDAP_USER3_SAMPLE_DATA);
         ldapServer.add(entry);
 
         entry = new Entry(LDAP_USER4_DN);
@@ -204,7 +204,7 @@ public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {
         entry.addAttribute("sn", LDAP_USER4_UID + "sn");
         entry.addAttribute("cn", LDAP_USER4_UID + "cn");
         entry.addAttribute("memberOf", LDAP_GROUP2_DN);
-        entry.addAttribute("userPassword", LDAP_USER4_PASSWORD);
+        entry.addAttribute("userPassword", LDAP_USER4_SAMPLE_DATA);
         ldapServer.add(entry);
 
         entry = new Entry("cn=ldapgroup1," + LDAP_ROOT_PARTITION);
@@ -259,44 +259,44 @@ public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {
 
         /* ldapuser1 */
         if (code1 != null) {
-            response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER1_UID, LDAP_USER1_PASSWORD, code1);
+            response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER1_UID, LDAP_USER1_SAMPLE_DATA, code1);
             if (code1 == SC_OK) {
                 verifyUserResponse(response, getUserPrincipalFound + LDAP_USER1_UID, getRemoteUserFound + LDAP_USER1_UID);
             }
-//        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER1_PASSWORD); TODO Uncomment when ApacheDS logs are clean
+//        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER1_SAMPLE_DATA); TODO Uncomment when ApacheDS logs are clean
 
             resetConnection();
         }
 
         /* ldapuser2 */
         if (code2 != null) {
-            response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER2_UID, LDAP_USER2_PASSWORD, code2);
+            response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER2_UID, LDAP_USER2_SAMPLE_DATA, code2);
             if (code2 == SC_OK) {
                 verifyUserResponse(response, getUserPrincipalFound + LDAP_USER2_UID, getRemoteUserFound + LDAP_USER2_UID);
             }
-//        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER2_PASSWORD); TODO Uncomment when ApacheDS logs are clean
+//        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER2_SAMPLE_DATA); TODO Uncomment when ApacheDS logs are clean
 
             resetConnection();
         }
 
         /* ldapuser3 */
         if (code3 != null) {
-            response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER3_UID, LDAP_USER3_PASSWORD, code3);
+            response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER3_UID, LDAP_USER3_SAMPLE_DATA, code3);
             if (code3 == SC_OK) {
                 verifyUserResponse(response, getUserPrincipalFound + LDAP_USER3_UID, getRemoteUserFound + LDAP_USER3_UID);
             }
-//        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER3_PASSWORD); TODO Uncomment when ApacheDS logs are clean
+//        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER3_SAMPLE_DATA); TODO Uncomment when ApacheDS logs are clean
 
             resetConnection();
         }
 
         /* ldapuser4 */
         if (code4 != null) {
-            response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER4_UID, LDAP_USER4_PASSWORD, code4);
+            response = executeGetRequestBasicAuthCreds(httpclient, urlBase, LDAP_USER4_UID, LDAP_USER4_SAMPLE_DATA, code4);
             if (code4 == SC_OK) {
                 verifyUserResponse(response, getUserPrincipalFound + LDAP_USER4_UID, getRemoteUserFound + LDAP_USER4_UID);
             }
-//        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER4_PASSWORD); TODO Uncomment when ApacheDS logs are clean
+//        passwordChecker.checkForPasswordInAnyFormat(LDAP_USER4_SAMPLE_DATA); TODO Uncomment when ApacheDS logs are clean
 
             resetConnection();
         }
@@ -835,7 +835,7 @@ public class LdapIdentityStoreDeferredSettingsTest extends JavaEESecTestBase {
 
         Properties props = new Properties();
         props.put("bindDn", "uid=" + LDAP_USER1_UID + "," + LDAP_ROOT_PARTITION);
-        props.put("bindDnPassword", LDAP_USER1_PASSWORD);
+        props.put("bindDnPassword", LDAP_USER1_SAMPLE_DATA);
         props.put("callerBaseDn", "");
         props.put("callerNameAttribute", "uid");
         props.put("callerSearchBase", LDAP_ROOT_PARTITION);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LoginToContinueELTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LoginToContinueELTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LoginToContinueELTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/LoginToContinueELTest.java
@@ -89,8 +89,8 @@ public class LoginToContinueELTest extends JavaEESecTestBase {
     protected static String SETTING_MESSAGE = "ServletName: LoginToContinueTest";
 
     protected static String USERID = "jaspiuser1";
-    protected static String PASSWORD = "s3cur1ty";
-    protected static String INVALIDPASSWORD = "invalid";
+    protected static String SAMPLE_DATA = "s3cur1ty";
+    protected static String INVALID_SAMPLE_DATA = "invalid";
 
     protected DefaultHttpClient httpclient;
 
@@ -153,14 +153,14 @@ public class LoginToContinueELTest extends JavaEESecTestBase {
         accessPageNoChallenge(httpclient, urlBase + INVALID_IMMEDIATE_SETTING, HttpServletResponse.SC_OK, SETTING_MESSAGE);
         // 1st call.
         String response = getFormLoginPage(httpclient, urlBase + IMMEDIATE_SERVLET_NAME, true, urlBase + "/" + APP_IMMEDIATE_NAME + ORIGINAL_LOGIN, ORIGINAL_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_IMMEDIATE_URI, USERID, PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_IMMEDIATE_URI, USERID, SAMPLE_DATA, true);
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + IMMEDIATE_SERVLET_NAME);
         // restart the client.
         httpclient.getConnectionManager().shutdown();
         // invoke second time, and make sure that the original setting is still in effect.
         setupConnection();
         response = getFormLoginPage(httpclient, urlBase + IMMEDIATE_SERVLET_NAME, true, urlBase + "/" + APP_IMMEDIATE_NAME + ORIGINAL_LOGIN, ORIGINAL_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_IMMEDIATE_URI, USERID, PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_IMMEDIATE_URI, USERID, SAMPLE_DATA, true);
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + IMMEDIATE_SERVLET_NAME);
 
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
@@ -179,7 +179,7 @@ public class LoginToContinueELTest extends JavaEESecTestBase {
         accessPageNoChallenge(httpclient, urlBase + ORIGINAL_DEFERRED_SETTING, HttpServletResponse.SC_OK, SETTING_MESSAGE);
         // 1st call.
         String response = getFormLoginPage(httpclient, urlBase + DEFERRED_SERVLET_NAME, true, urlBase + "/" + APP_DEFERRED_NAME + ORIGINAL_LOGIN, ORIGINAL_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_DEFERRED_URI, USERID, PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_DEFERRED_URI, USERID, SAMPLE_DATA, true);
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + DEFERRED_SERVLET_NAME);
         // restart the client.
         httpclient.getConnectionManager().shutdown();
@@ -189,7 +189,7 @@ public class LoginToContinueELTest extends JavaEESecTestBase {
         accessPageNoChallenge(httpclient, urlBase + ALTERNATIVE_DEFERRED_SETTING, HttpServletResponse.SC_OK, SETTING_MESSAGE);
         // invoke 2nd time based on the config change.
         response = getFormLoginPage(httpclient, urlBase + DEFERRED_SERVLET_NAME, false, urlBase + "/" + APP_DEFERRED_NAME + ALTERNATIVE_LOGIN, ALTERNATIVE_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_DEFERRED_URI, USERID, PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_DEFERRED_URI, USERID, SAMPLE_DATA, true);
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + DEFERRED_SERVLET_NAME);
 
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
@@ -209,7 +209,7 @@ public class LoginToContinueELTest extends JavaEESecTestBase {
         accessPageNoChallenge(httpclient, urlBase + ORIGINAL_DEFERRED_SETTING, HttpServletResponse.SC_OK, SETTING_MESSAGE);
         // 1st call.
         String response = getFormLoginPage(httpclient, urlBase + DEFERRED_SERVLET_NAME, true, urlBase + "/" + APP_DEFERRED_NAME + ORIGINAL_LOGIN, ORIGINAL_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_DEFERRED_URI, USERID, INVALIDPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_DEFERRED_URI, USERID, INVALID_SAMPLE_DATA, true);
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, ORIGINAL_TITLE_ERROR_PAGE);
         // restart the client.
         httpclient.getConnectionManager().shutdown();
@@ -219,7 +219,7 @@ public class LoginToContinueELTest extends JavaEESecTestBase {
         accessPageNoChallenge(httpclient, urlBase + ALTERNATIVE_DEFERRED_SETTING, HttpServletResponse.SC_OK, SETTING_MESSAGE);
         // invoke 2nd time based on the config change.
         response = getFormLoginPage(httpclient, urlBase + DEFERRED_SERVLET_NAME, false, urlBase + "/" + APP_DEFERRED_NAME + ALTERNATIVE_LOGIN, ALTERNATIVE_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_DEFERRED_URI, USERID, INVALIDPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + LOGIN_FORM_DEFERRED_URI, USERID, INVALID_SAMPLE_DATA, true);
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, ALTERNATIVE_TITLE_ERROR_PAGE);
 
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplCustomTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplCustomTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplCustomTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplCustomTest.java
@@ -122,7 +122,7 @@ public class MultipleIdentityStoreApplCustomTest extends JavaEESecTestBase {
     @Test
     public void testMultipleISApplCustomWith1stIS_AllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
-        String response = accessWithCustomHeader(httpclient, urlBase + queryString, HEADER_NAME, LocalLdapServer.USER1 + ":" + LocalLdapServer.PASSWORD, HttpServletResponse.SC_OK);
+        String response = accessWithCustomHeader(httpclient, urlBase + queryString, HEADER_NAME, LocalLdapServer.USER1 + ":" + LocalLdapServer.SAMPLE_DATA, HttpServletResponse.SC_OK);
 
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.USER1, Constants.getRemoteUserFound + LocalLdapServer.USER1);
         verifyRealm(response, "127.0.0.1:" + portNumber);
@@ -148,7 +148,7 @@ public class MultipleIdentityStoreApplCustomTest extends JavaEESecTestBase {
     @Test
     public void testMultipleISApplCustomWith2ndISonly_AllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
-        String response = accessWithCustomHeader(httpclient, urlBase + queryString, HEADER_NAME, LocalLdapServer.ANOTHERUSER1 + ":" + LocalLdapServer.ANOTHERPASSWORD,
+        String response = accessWithCustomHeader(httpclient, urlBase + queryString, HEADER_NAME, LocalLdapServer.ANOTHERUSER1 + ":" + LocalLdapServer.ANOTHER_SAMPLE_DATA,
                                                  HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.ANOTHERUSER1, Constants.getRemoteUserFound + LocalLdapServer.ANOTHERUSER1);
         verifyRealm(response, "localhost:" + portNumber);
@@ -176,7 +176,7 @@ public class MultipleIdentityStoreApplCustomTest extends JavaEESecTestBase {
     @Test
     public void testMultipleISApplCustomWith1stISfail2ndISsuccess_AllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
-        String response = accessWithCustomHeader(httpclient, urlBase + queryString, HEADER_NAME, LocalLdapServer.USER1 + ":" + LocalLdapServer.ANOTHERPASSWORD,
+        String response = accessWithCustomHeader(httpclient, urlBase + queryString, HEADER_NAME, LocalLdapServer.USER1 + ":" + LocalLdapServer.ANOTHER_SAMPLE_DATA,
                                                  HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.USER1, Constants.getRemoteUserFound + LocalLdapServer.USER1);
         verifyRealm(response, "localhost:" + portNumber);
@@ -219,7 +219,7 @@ public class MultipleIdentityStoreApplCustomTest extends JavaEESecTestBase {
     public void testMultipleISApplCustomWith1stISuccess_DeniedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         myServer.setMarkToEndOfLog();
-        String response = accessWithCustomHeader(httpclient, urlBase + queryString, HEADER_NAME, LocalLdapServer.INVALIDUSER + ":" + LocalLdapServer.PASSWORD,
+        String response = accessWithCustomHeader(httpclient, urlBase + queryString, HEADER_NAME, LocalLdapServer.INVALIDUSER + ":" + LocalLdapServer.SAMPLE_DATA,
                                                  HttpServletResponse.SC_FORBIDDEN);
         verifyMessageReceivedInMessageLog("CWWKS9104A:.*" + LocalLdapServer.INVALIDUSER + ".*" + LocalLdapServer.GRANTEDGROUP);
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
@@ -241,7 +241,7 @@ public class MultipleIdentityStoreApplCustomTest extends JavaEESecTestBase {
     public void testMultipleISApplCustomWith1st2ndFail_DeniedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         myServer.setMarkToEndOfLog();
-        String response = accessWithCustomHeader(httpclient, urlBase + queryString, HEADER_NAME, LocalLdapServer.USER1 + ":" + LocalLdapServer.INVALIDPASSWORD,
+        String response = accessWithCustomHeader(httpclient, urlBase + queryString, HEADER_NAME, LocalLdapServer.USER1 + ":" + LocalLdapServer.INVALID_SAMPLE_DATA,
                                                  HttpServletResponse.SC_FORBIDDEN);
         verifyMessageReceivedInMessageLog("CWWKS1652A:.*");
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplLoginToContinueTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplLoginToContinueTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplLoginToContinueTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreApplLoginToContinueTest.java
@@ -147,7 +147,7 @@ public class MultipleIdentityStoreApplLoginToContinueTest extends JavaEESecTestB
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, true, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + redirectQueryString);
@@ -179,7 +179,7 @@ public class MultipleIdentityStoreApplLoginToContinueTest extends JavaEESecTestB
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, false, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + forwardQueryString);
@@ -215,7 +215,7 @@ public class MultipleIdentityStoreApplLoginToContinueTest extends JavaEESecTestB
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, true, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + redirectQueryString);
@@ -248,7 +248,7 @@ public class MultipleIdentityStoreApplLoginToContinueTest extends JavaEESecTestB
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, false, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.INVALIDUSER, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.INVALIDUSER, LocalLdapServer.SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns 403 due to authorization failure.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_FORBIDDEN, urlBase + forwardQueryString);
@@ -277,7 +277,7 @@ public class MultipleIdentityStoreApplLoginToContinueTest extends JavaEESecTestB
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, true, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.INVALIDPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.INVALID_SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, TITLE_ERROR_PAGE);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreBasicTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreBasicTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreBasicTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreBasicTest.java
@@ -123,7 +123,7 @@ public class MultipleIdentityStoreBasicTest extends JavaEESecTestBase {
     public void testMultipleISBasicAuthWith1stIS_AllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                          LocalLdapServer.PASSWORD,
+                                                          LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.USER1, Constants.getRemoteUserFound + LocalLdapServer.USER1);
         verifyRealm(response, "127.0.0.1:" + portNumber);
@@ -150,7 +150,7 @@ public class MultipleIdentityStoreBasicTest extends JavaEESecTestBase {
     public void testMultipleISBasicAuthWith2ndISonly_AllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.ANOTHERUSER1,
-                                                          LocalLdapServer.ANOTHERPASSWORD,
+                                                          LocalLdapServer.ANOTHER_SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.ANOTHERUSER1, Constants.getRemoteUserFound + LocalLdapServer.ANOTHERUSER1);
         verifyRealm(response, "localhost:" + portNumber);
@@ -179,7 +179,7 @@ public class MultipleIdentityStoreBasicTest extends JavaEESecTestBase {
     public void testMultipleISBasicAuthWith1stISfail2ndISsuccess_AllowedAccess() throws Exception {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                          LocalLdapServer.ANOTHERPASSWORD,
+                                                          LocalLdapServer.ANOTHER_SAMPLE_DATA,
                                                           HttpServletResponse.SC_OK);
         verifyUserResponse(response, Constants.getUserPrincipalFound + LocalLdapServer.USER1, Constants.getRemoteUserFound + LocalLdapServer.USER1);
         verifyRealm(response, "localhost:" + portNumber);
@@ -223,7 +223,7 @@ public class MultipleIdentityStoreBasicTest extends JavaEESecTestBase {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         myServer.setMarkToEndOfLog();
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.INVALIDUSER,
-                                                          LocalLdapServer.PASSWORD,
+                                                          LocalLdapServer.SAMPLE_DATA,
                                                           HttpServletResponse.SC_FORBIDDEN);
         verifyMessageReceivedInMessageLog("CWWKS9104A:.*" + LocalLdapServer.INVALIDUSER + ".*" + LocalLdapServer.GRANTEDGROUP);
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
@@ -246,7 +246,7 @@ public class MultipleIdentityStoreBasicTest extends JavaEESecTestBase {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         myServer.setMarkToEndOfLog();
         String response = executeGetRequestBasicAuthCreds(httpclient, urlBase + queryString, LocalLdapServer.USER1,
-                                                          LocalLdapServer.INVALIDPASSWORD,
+                                                          LocalLdapServer.INVALID_SAMPLE_DATA,
                                                           HttpServletResponse.SC_UNAUTHORIZED);
         verifyMessageReceivedInMessageLog("CWWKS1652A:.*");
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormPostTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormPostTest.java
@@ -160,7 +160,7 @@ public class MultipleIdentityStoreCustomFormPostTest extends JavaEESecTestBase {
                 response = postFormLoginPage(httpclient, urlBase + redirectQueryString, params, true, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
                 // Execute Form login and get redirect location.
-                String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+                String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
 
                 // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
                 response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, SERVLET_TITLE);
@@ -214,13 +214,13 @@ public class MultipleIdentityStoreCustomFormPostTest extends JavaEESecTestBase {
                 response = postFormLoginPage(httpclient, urlBase + redirectQueryString, params, true, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
                 String viewState = getViewState(response);
                 // Execute form login for failure.
-                String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.INVALIDPASSWORD, viewState);
+                String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.INVALID_SAMPLE_DATA, viewState);
                 // Redirect to the error page, ensure it is the original servlet request and it returns the right response.
                 response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, TITLE_ERROR_PAGE);
                 verifyMessageReceivedInMessageLog("CWWKS1652A:.*");
 
                 // Execute form login for retry
-                location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, viewState);
+                location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, viewState);
 
                 // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
                 response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, SERVLET_TITLE);
@@ -272,7 +272,7 @@ public class MultipleIdentityStoreCustomFormPostTest extends JavaEESecTestBase {
                 response = postFormLoginPage(httpclient, urlBase + forwardQueryString, params, false, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
                 // Execute Form login and get redirect location.
-                String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+                String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
 
                 // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
                 response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, SERVLET_TITLE);
@@ -328,13 +328,13 @@ public class MultipleIdentityStoreCustomFormPostTest extends JavaEESecTestBase {
                 String viewState = getViewState(response);
 
                 // Execute form login for failure.
-                String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.INVALIDPASSWORD, viewState);
+                String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.INVALID_SAMPLE_DATA, viewState);
                 // Redirect to the error page, ensure it is the original servlet request and it returns the right response.
                 response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, TITLE_ERROR_PAGE);
                 verifyMessageReceivedInMessageLog("CWWKS1652A:.*");
 
                 // Execute form login for retry
-                location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, viewState);
+                location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, viewState);
 
                 // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
                 response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, SERVLET_TITLE);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreCustomFormTest.java
@@ -152,7 +152,7 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location.
         String[] sessionCookie = { "LtpaToken2" };
-        String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response), sessionCookie);
+        String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response), sessionCookie);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         String[] wasReqURLCookie = { "WASReqURL" };
@@ -185,7 +185,7 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, REDIRECT, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + redirectQueryString);
@@ -221,7 +221,7 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, REDIRECT, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.USER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.USER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + redirectQueryString);
@@ -254,7 +254,7 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, REDIRECT, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.INVALIDUSER, LocalLdapServer.PASSWORD, getViewState(response));
+        String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.INVALIDUSER, LocalLdapServer.SAMPLE_DATA, getViewState(response));
 
         // Redirect to the given page, ensure it is the original servlet request and it returns 403 due to authorization failure.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_FORBIDDEN, urlBase + redirectQueryString);
@@ -284,7 +284,7 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, REDIRECT, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.USER1, LocalLdapServer.INVALIDPASSWORD, getViewState(response));
+        String location = executeCustomFormLogin(httpclient, urlBase + redirectLoginUri, LocalLdapServer.USER1, LocalLdapServer.INVALID_SAMPLE_DATA, getViewState(response));
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, TITLE_ERROR_PAGE);
@@ -314,7 +314,7 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, FORWARD, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+        String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + forwardQueryString);
@@ -346,7 +346,7 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, FORWARD, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + forwardQueryString);
@@ -382,7 +382,7 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, FORWARD, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.USER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.USER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + forwardQueryString);
@@ -415,7 +415,7 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, FORWARD, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.INVALIDUSER, LocalLdapServer.PASSWORD, getViewState(response));
+        String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.INVALIDUSER, LocalLdapServer.SAMPLE_DATA, getViewState(response));
 
         // Redirect to the given page, ensure it is the original servlet request and it returns 403 due to authorization failure.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_FORBIDDEN, urlBase + forwardQueryString);
@@ -445,7 +445,7 @@ public class MultipleIdentityStoreCustomFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, FORWARD, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.USER1, LocalLdapServer.INVALIDPASSWORD, getViewState(response));
+        String location = executeCustomFormLogin(httpclient, urlBase + forwardLoginUri, LocalLdapServer.USER1, LocalLdapServer.INVALID_SAMPLE_DATA, getViewState(response));
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, TITLE_ERROR_PAGE);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormPostTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormPostTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormPostTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormPostTest.java
@@ -165,7 +165,7 @@ public class MultipleIdentityStoreFormPostTest extends JavaEESecTestBase {
         String response = postFormLoginPage(httpclient, urlBase + redirectQueryString, params, true, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, SERVLET_NAME);
@@ -199,13 +199,13 @@ public class MultipleIdentityStoreFormPostTest extends JavaEESecTestBase {
         String response = postFormLoginPage(httpclient, urlBase + redirectQueryString, params, true, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute form login for failure.
-        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.INVALIDPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.INVALID_SAMPLE_DATA, true);
         // Redirect to the error page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, TITLE_ERROR_PAGE);
         verifyMessageReceivedInMessageLog("CWWKS1652A:.*");
 
         // Execute form login for retry
-        location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, SERVLET_NAME);
@@ -237,7 +237,7 @@ public class MultipleIdentityStoreFormPostTest extends JavaEESecTestBase {
         String response = postFormLoginPage(httpclient, urlBase + forwardQueryString, params, false, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, SERVLET_NAME);
@@ -271,13 +271,13 @@ public class MultipleIdentityStoreFormPostTest extends JavaEESecTestBase {
         String response = postFormLoginPage(httpclient, urlBase + forwardQueryString, params, false, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute form login for failure.
-        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.INVALIDPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.INVALID_SAMPLE_DATA, true);
         // Redirect to the error page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, TITLE_ERROR_PAGE);
         verifyMessageReceivedInMessageLog("CWWKS1652A:.*");
 
         // Execute form login for retry
-        location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, SERVLET_NAME);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleIdentityStoreFormTest.java
@@ -150,7 +150,7 @@ public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, REDIRECT, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + redirectQueryString);
@@ -184,7 +184,7 @@ public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location.
         String[] sessionCookie = { "LtpaToken2" };
-        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true, null, sessionCookie);
+        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true, null, sessionCookie);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         String[] wasReqURLCookie = { "WASReqURL" };
@@ -221,7 +221,7 @@ public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, REDIRECT, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + redirectQueryString);
@@ -254,7 +254,7 @@ public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, REDIRECT, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.INVALIDUSER, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.INVALIDUSER, LocalLdapServer.SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns 403 due to authorization failure.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_FORBIDDEN, urlBase + redirectQueryString);
@@ -284,7 +284,7 @@ public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + redirectQueryString, REDIRECT, urlBase + redirectLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.INVALIDPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + redirectLoginformUri, LocalLdapServer.USER1, LocalLdapServer.INVALID_SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, TITLE_ERROR_PAGE);
@@ -314,7 +314,7 @@ public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, FORWARD, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + forwardQueryString);
@@ -346,7 +346,7 @@ public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, FORWARD, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + forwardQueryString);
@@ -382,7 +382,7 @@ public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, FORWARD, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.USER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.USER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + forwardQueryString);
@@ -415,7 +415,7 @@ public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, FORWARD, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.INVALIDUSER, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.INVALIDUSER, LocalLdapServer.SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns 403 due to authorization failure.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_FORBIDDEN, urlBase + forwardQueryString);
@@ -445,7 +445,7 @@ public class MultipleIdentityStoreFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + forwardQueryString, FORWARD, urlBase + forwardLoginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.USER1, LocalLdapServer.INVALIDPASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + forwardLoginformUri, LocalLdapServer.USER1, LocalLdapServer.INVALID_SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, TITLE_ERROR_PAGE);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleExpandTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleExpandTest.java
@@ -86,9 +86,9 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
     protected static String MODULE2_TITLE_CUSTOMERROR_PAGE = "A Form login authentication failure occurred";
 
     protected static String REALM1_USER = "realm1user";
-    protected static String REALM1_PASSWORD = "s3cur1ty";
+    protected static String REALM1_SAMPLE_DATA = "s3cur1ty";
     protected static String REALM2_USER = "realm2user";
-    protected static String REALM2_PASSWORD = "s3cur1ty";
+    protected static String REALM2_SAMPLE_DATA = "s3cur1ty";
     protected static String COMMON_USER1 = "commonuser1";
     protected static String COMMON_USER2 = "commonuser2";
     protected static String IS1_REALM_NAME = "127.0.0.1:" + portNumber;
@@ -198,7 +198,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -208,7 +208,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on the other module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -218,7 +218,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, REALM1_USER, REALM1_REALM_NAME, IS1_GROUP_REALM_NAME, REALM1_GROUPS);
@@ -229,7 +229,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for custom identity store in the different module.
         // this should fail.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM2_USER, REALM2_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM2_USER, REALM2_SAMPLE_DATA, true);
         // Redirect to the given page, ensure that this is an error page since there is no user exist in the identitystores.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, MODULE1_TITLE_ERROR_PAGE);
 
@@ -240,7 +240,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -251,7 +251,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in another module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -260,7 +260,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, REALM2_USER, REALM2_REALM_NAME, IS1_GROUP_REALM_NAME, REALM2_GROUPS);
@@ -269,7 +269,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in the different module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM1_USER, REALM1_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM1_USER, REALM1_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, MODULE2_TITLE_CUSTOMERROR_PAGE);
 
@@ -317,7 +317,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -327,7 +327,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on the other module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -337,7 +337,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for custom identity store in this module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, REALM1_USER, REALM1_REALM_NAME, IS1_GROUP_REALM_NAME, REALM1_GROUPS);
@@ -347,7 +347,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for custom identity store in the different module.
         // this should fail.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM2_USER, REALM2_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM2_USER, REALM2_SAMPLE_DATA, true);
         // Redirect to the given page, ensure that this is an error page since there is no user exist in the identitystores.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, MODULE1_TITLE_ERROR_PAGE);
 
@@ -358,7 +358,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -368,7 +368,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in another module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -377,7 +377,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, REALM2_USER, REALM2_REALM_NAME, IS1_GROUP_REALM_NAME, REALM2_GROUPS);
@@ -386,7 +386,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in the different module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM1_USER, REALM1_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM1_USER, REALM1_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, MODULE2_TITLE_CUSTOMERROR_PAGE);
 
@@ -436,7 +436,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, COMMON_USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, COMMON_USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, COMMON_USER1, COMMON_REALM_NAME, IS2_GROUP_REALM_NAME, COMMONUSER_GROUPS);
@@ -447,7 +447,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
         // Execute Form login and get redirect location.
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, COMMON_USER2, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, COMMON_USER2, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, COMMON_USER2, COMMON_REALM_NAME, IS1_GROUP_REALM_NAME, COMMONUSER_GROUPS);
@@ -495,7 +495,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + COMMON_APP1_SERVLET, false, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + COMMON_APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -506,7 +506,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + COMMON_APP2_SERVLET, false, urlBase + MODULE2_LOGIN, MODULE2_TITLE_LOGIN_PAGE);
         // Execute Form login and get redirect location.
-        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + COMMON_APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -556,7 +556,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + COMMON_APP1_SERVLET, false, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + COMMON_APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -568,7 +568,7 @@ public class MultipleModuleExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + COMMON_APP2_SERVLET, false, urlBase + MODULE2_LOGIN, MODULE2_TITLE_LOGIN_PAGE);
         // Execute Form login and get redirect location.
-        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + COMMON_APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleNoExpandTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/MultipleModuleNoExpandTest.java
@@ -87,9 +87,9 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
     protected static String MODULE2_TITLE_CUSTOMERROR_PAGE = "A Form login authentication failure occurred";
 
     protected static String REALM1_USER = "realm1user";
-    protected static String REALM1_PASSWORD = "s3cur1ty";
+    protected static String REALM1_SAMPLE_DATA = "s3cur1ty";
     protected static String REALM2_USER = "realm2user";
-    protected static String REALM2_PASSWORD = "s3cur1ty";
+    protected static String REALM2_SAMPLE_DATA = "s3cur1ty";
     protected static String COMMON_USER1 = "commonuser1";
     protected static String COMMON_USER2 = "commonuser2";
     protected static String IS1_REALM_NAME = "127.0.0.1:" + portNumber;
@@ -198,7 +198,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -208,7 +208,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on the other module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -218,7 +218,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, REALM1_USER, REALM1_REALM_NAME, IS1_GROUP_REALM_NAME, REALM1_GROUPS);
@@ -229,7 +229,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for custom identity store in the different module.
         // this should fail.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM2_USER, REALM2_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM2_USER, REALM2_SAMPLE_DATA, true);
         // Redirect to the given page, ensure that this is an error page since there is no user exist in the identitystores.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, MODULE1_TITLE_ERROR_PAGE);
 
@@ -240,7 +240,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -251,7 +251,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in another module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -260,7 +260,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, REALM2_USER, REALM2_REALM_NAME, IS1_GROUP_REALM_NAME, REALM2_GROUPS);
@@ -269,7 +269,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in the different module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM1_USER, REALM1_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM1_USER, REALM1_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, MODULE2_TITLE_CUSTOMERROR_PAGE);
 
@@ -315,7 +315,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -325,7 +325,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for LdapIdentityStoreDefinision on the other module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -335,7 +335,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for custom identity store in this module.
 
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM1_USER, REALM1_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, REALM1_USER, REALM1_REALM_NAME, IS1_GROUP_REALM_NAME, REALM1_GROUPS);
@@ -345,7 +345,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location for custom identity store in the different module.
         // this should fail.
         response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
-        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM2_USER, REALM2_PASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, REALM2_USER, REALM2_SAMPLE_DATA, true);
         // Redirect to the given page, ensure that this is an error page since there is no user exist in the identitystores.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, MODULE1_TITLE_ERROR_PAGE);
 
@@ -356,7 +356,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in this module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -366,7 +366,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Execute Form login and get redirect location with a user which exists in ldapidentitystore definision in another module.
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -375,7 +375,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in this module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM2_USER, REALM2_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, REALM2_USER, REALM2_REALM_NAME, IS1_GROUP_REALM_NAME, REALM2_GROUPS);
@@ -384,7 +384,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
 
         // Execute Form login and get redirect location for custom identity store in the different module.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM1_USER, REALM1_PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, REALM1_USER, REALM1_SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, MODULE2_TITLE_CUSTOMERROR_PAGE);
 
@@ -432,7 +432,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + APP1_SERVLET, true, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, COMMON_USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, COMMON_USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP1_SERVLET);
         verifyResponse(response, COMMON_USER1, COMMON_REALM_NAME, IS2_GROUP_REALM_NAME, COMMONUSER_GROUPS);
@@ -443,7 +443,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + APP2_SERVLET, false, urlBase + MODULE2_CUSTOMLOGIN, MODULE2_TITLE_CUSTOMLOGIN_PAGE);
         // Execute Form login and get redirect location.
-        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, COMMON_USER2, LocalLdapServer.PASSWORD, getViewState(response));
+        location = executeCustomFormLogin(httpclient, urlBase + MODULE2_CUSTOMLOGIN, COMMON_USER2, LocalLdapServer.SAMPLE_DATA, getViewState(response));
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + APP2_SERVLET);
         verifyResponse(response, COMMON_USER2, COMMON_REALM_NAME, IS1_GROUP_REALM_NAME, COMMONUSER_GROUPS);
@@ -489,7 +489,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + COMMON_APP1_SERVLET, false, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + COMMON_APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -500,7 +500,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + COMMON_APP2_SERVLET, false, urlBase + MODULE2_LOGIN, MODULE2_TITLE_LOGIN_PAGE);
         // Execute Form login and get redirect location.
-        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + COMMON_APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);
@@ -548,7 +548,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         String response = getFormLoginPage(httpclient, urlBase + COMMON_APP1_SERVLET, false, urlBase + MODULE1_LOGIN, MODULE1_TITLE_LOGIN_PAGE);
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + MODULE1_LOGINFORM, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + COMMON_APP1_SERVLET);
         verifyResponse(response, LocalLdapServer.USER1, IS1_REALM_NAME, IS2_GROUP_REALM_NAME, IS1_GROUPS);
@@ -560,7 +560,7 @@ public class MultipleModuleNoExpandTest extends JavaEESecTestBase {
         // Send servlet query to get form login page. Since auto redirect is disabled, if forward is not set, this would return 302 and location.
         response = getFormLoginPage(httpclient, urlBase + COMMON_APP2_SERVLET, false, urlBase + MODULE2_LOGIN, MODULE2_TITLE_LOGIN_PAGE);
         // Execute Form login and get redirect location.
-        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHERPASSWORD, true);
+        location = executeFormLogin(httpclient, urlBase + MODULE2_LOGINFORM, LocalLdapServer.ANOTHERUSER1, LocalLdapServer.ANOTHER_SAMPLE_DATA, true);
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + COMMON_APP2_SERVLET);
         verifyResponse(response, LocalLdapServer.ANOTHERUSER1, IS2_REALM_NAME, IS1_GROUP_REALM_NAME, IS2_GROUPS);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/NoJavaEESecFormTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/NoJavaEESecFormTest.java
@@ -61,7 +61,7 @@ public class NoJavaEESecFormTest extends JavaEESecTestBase {
     private static String GROUP1 = "group1";
     private static String USER2 = "user2";
     private static String INVALIDUSER1 = "invaliduser1";
-    private static String PASSWORD = "s3cur1ty";
+    private static String SAMPLE_DATA = "s3cur1ty";
 
     protected DefaultHttpClient httpclient;
 
@@ -133,7 +133,7 @@ public class NoJavaEESecFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + queryString, REDIRECT, urlBase + loginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + loginformUri, LocalLdapServer.USER1, LocalLdapServer.PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + loginformUri, LocalLdapServer.USER1, LocalLdapServer.SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, urlBase + queryString);
@@ -165,7 +165,7 @@ public class NoJavaEESecFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + queryString, REDIRECT, urlBase + loginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + loginformUri, USER2, PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + loginformUri, USER2, SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns 403 due to authorization failure.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_FORBIDDEN, urlBase + queryString);
@@ -197,7 +197,7 @@ public class NoJavaEESecFormTest extends JavaEESecTestBase {
         String response = getFormLoginPage(httpclient, urlBase + queryString, REDIRECT, urlBase + loginUri, TITLE_LOGIN_PAGE);
 
         // Execute Form login and get redirect location.
-        String location = executeFormLogin(httpclient, urlBase + loginformUri, INVALIDUSER1, PASSWORD, true);
+        String location = executeFormLogin(httpclient, urlBase + loginformUri, INVALIDUSER1, SAMPLE_DATA, true);
 
         // Redirect to the given page, ensure it is the original servlet request and it returns the right response.
         response = accessPageNoChallenge(httpclient, location, HttpServletResponse.SC_OK, TITLE_ERROR_PAGE);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/NoJavaEESecFormTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/NoJavaEESecFormTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_helper/LocalLdapServer.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_helper/LocalLdapServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_helper/LocalLdapServer.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_helper/LocalLdapServer.java
@@ -35,9 +35,9 @@ public class LocalLdapServer {
     public static final String ANOTHERRUNASUSER1 = "anotherrunasuser1";
     public static final String CERTUSER1 = "certuser1";
     public static final String CERTUSER2 = "certuser2";
-    public static final String PASSWORD = "s3cur1ty";
-    public static final String ANOTHERPASSWORD = "an0thers3cur1ty";
-    public static final String INVALIDPASSWORD = "invalid";
+    public static final String SAMPLE_DATA = "s3cur1ty";
+    public static final String ANOTHER_SAMPLE_DATA = "an0thers3cur1ty";
+    public static final String INVALID_SAMPLE_DATA = "invalid";
     public static final String GROUP1 = "group1";
     public static final String GROUP2 = "group2";
     public static final String RUNASGROUP1 = "runasgroup1";
@@ -66,14 +66,14 @@ public class LocalLdapServer {
         }
 
         String USERS_BASE = "ou=" + USERS + "," + BASE_DN;
-        addUser(USERS_BASE, ADMINUSER, PASSWORD);
-        addUser(USERS_BASE, USER1, PASSWORD);
-        addUser(USERS_BASE, USER2, PASSWORD);
-        addUser(USERS_BASE, USER3, PASSWORD);
-        addUser(USERS_BASE, INVALIDUSER, PASSWORD);
-        addUser(USERS_BASE, RUNASUSER1, PASSWORD);
-        addUser(USERS_BASE, CERTUSER1, PASSWORD);
-        addUser(USERS_BASE, CERTUSER2, PASSWORD);
+        addUser(USERS_BASE, ADMINUSER, SAMPLE_DATA);
+        addUser(USERS_BASE, USER1, SAMPLE_DATA);
+        addUser(USERS_BASE, USER2, SAMPLE_DATA);
+        addUser(USERS_BASE, USER3, SAMPLE_DATA);
+        addUser(USERS_BASE, INVALIDUSER, SAMPLE_DATA);
+        addUser(USERS_BASE, RUNASUSER1, SAMPLE_DATA);
+        addUser(USERS_BASE, CERTUSER1, SAMPLE_DATA);
+        addUser(USERS_BASE, CERTUSER2, SAMPLE_DATA);
 
         String GROUPS_BASE = "ou=" + GROUPS + "," + BASE_DN;
         String[] GROUP1_MEMBERS = { "uid=" + USER1 + "," + USERS_BASE, "uid=" + USER2 + "," + USERS_BASE };
@@ -86,12 +86,12 @@ public class LocalLdapServer {
         addGroup(GROUPS_BASE, CERTGROUP1, CERTGROUP1_MEMBERS);
 
         String ANOTHERUSERS_BASE = "ou=" + ANOTHERUSERS + "," + BASE_DN;
-        addUser(ANOTHERUSERS_BASE, ADMINUSER, ANOTHERPASSWORD);
-        addUser(ANOTHERUSERS_BASE, USER1, ANOTHERPASSWORD);
-        addUser(ANOTHERUSERS_BASE, USER2, ANOTHERPASSWORD);
-        addUser(ANOTHERUSERS_BASE, ANOTHERUSER1, ANOTHERPASSWORD);
-        addUser(ANOTHERUSERS_BASE, INVALIDUSER, ANOTHERPASSWORD);
-        addUser(ANOTHERUSERS_BASE, ANOTHERRUNASUSER1, ANOTHERPASSWORD);
+        addUser(ANOTHERUSERS_BASE, ADMINUSER, ANOTHER_SAMPLE_DATA);
+        addUser(ANOTHERUSERS_BASE, USER1, ANOTHER_SAMPLE_DATA);
+        addUser(ANOTHERUSERS_BASE, USER2, ANOTHER_SAMPLE_DATA);
+        addUser(ANOTHERUSERS_BASE, ANOTHERUSER1, ANOTHER_SAMPLE_DATA);
+        addUser(ANOTHERUSERS_BASE, INVALIDUSER, ANOTHER_SAMPLE_DATA);
+        addUser(ANOTHERUSERS_BASE, ANOTHERRUNASUSER1, ANOTHER_SAMPLE_DATA);
 
         String ANOTHERGROUPS_BASE = "ou=" + ANOTHERGROUPS + "," + BASE_DN;
         String[] ANOTHERGROUP1_MEMBERS = { "uid=" + USER1 + "," + ANOTHERUSERS_BASE, "uid=" + USER2 + "," + ANOTHERUSERS_BASE, "uid=" + ANOTHERUSER1 + "," + ANOTHERUSERS_BASE,

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_singleIS/CustomFormHttpAuthenticationMechanismSingleISTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_singleIS/CustomFormHttpAuthenticationMechanismSingleISTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_singleIS/CustomFormHttpAuthenticationMechanismSingleISTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_singleIS/CustomFormHttpAuthenticationMechanismSingleISTest.java
@@ -45,7 +45,7 @@ public class CustomFormHttpAuthenticationMechanismSingleISTest extends JavaEESec
     private static final String BASE_DN = "o=ibm,c=us";
     private static final String USER = "jaspildapuser1";
     private static final String USER_DN = "uid=" + USER + "," + BASE_DN;
-    private static final String PASSWORD = "s3cur1ty";
+    private static final String SAMPLE_DATA = "s3cur1ty";
 
     public CustomFormHttpAuthenticationMechanismSingleISTest() {
         super(myServer, logClass);

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_singleIS/FormHttpAuthenticationMechanismTestSingleISTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_singleIS/FormHttpAuthenticationMechanismTestSingleISTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_singleIS/FormHttpAuthenticationMechanismTestSingleISTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat_singleIS/FormHttpAuthenticationMechanismTestSingleISTest.java
@@ -47,7 +47,7 @@ public class FormHttpAuthenticationMechanismTestSingleISTest extends JavaEESecTe
     private static final String BASE_DN = "o=ibm,c=us";
     private static final String USER = "jaspildapuser1";
     private static final String USER_DN = "uid=" + USER + "," + BASE_DN;
-    private static final String PASSWORD = "s3cur1ty";
+    private static final String SAMPLE_DATA = "s3cur1ty";
 
     public FormHttpAuthenticationMechanismTestSingleISTest() {
         super(myServer, logClass);

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-bundles/security.jaspic.user.feature.test/src/com/ibm/ws/security/jaspi/test/AuthModule.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-bundles/security.jaspic.user.feature.test/src/com/ibm/ws/security/jaspi/test/AuthModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-bundles/security.jaspic.user.feature.test/src/com/ibm/ws/security/jaspi/test/AuthModule.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-bundles/security.jaspic.user.feature.test/src/com/ibm/ws/security/jaspi/test/AuthModule.java
@@ -54,7 +54,7 @@ public class AuthModule implements ServerAuthModule {
     private static final String IS_MANDATORY_POLICY = "javax.security.auth.message.MessagePolicy.isMandatory";
     private static final String REGISTER_SESSION = "javax.servlet.http.registerSession";
     private static final String JASPI_USER = "com.ibm.websphere.jaspi.user";
-    private static final String JASPI_PASSWORD = "com.ibm.websphere.jaspi.password";
+    private static final String JASPI_SAMPLE_DATA = "com.ibm.websphere.jaspi.password";
     private static final String JASPI_WEB_REQUEST = "com.ibm.websphere.jaspi.request";
     private MessagePolicy requestPolicy;
     private CallbackHandler handler;
@@ -201,7 +201,7 @@ public class AuthModule implements ServerAuthModule {
         if (isLogin) {
             log.info("request is for method login()");
             String username = msgMap.get(JASPI_USER);
-            String password = msgMap.get(JASPI_PASSWORD);
+            String password = msgMap.get(JASPI_SAMPLE_DATA);
             status = handleUserPassword(username, password, rsp, msgMap, clientSubject, useCallbacks, cacheKey);
 
         } else if (isAuthenticate) {

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-bundles/security.jaspic.user.feature.test/src/com/ibm/ws/security/jaspi/test/AuthModule_1.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-bundles/security.jaspic.user.feature.test/src/com/ibm/ws/security/jaspi/test/AuthModule_1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-bundles/security.jaspic.user.feature.test/src/com/ibm/ws/security/jaspi/test/AuthModule_1.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-bundles/security.jaspic.user.feature.test/src/com/ibm/ws/security/jaspi/test/AuthModule_1.java
@@ -48,7 +48,7 @@ public class AuthModule_1 implements ServerAuthModule {
     private static Class[] supportedMessageTypes = new Class[] { HttpServletRequest.class, HttpServletResponse.class };
     private static final String IS_MANDATORY_POLICY = "javax.security.auth.message.MessagePolicy.isMandatory";
     private static final String JASPI_USER = "com.ibm.websphere.jaspi.user";
-    private static final String JASPI_PASSWORD = "com.ibm.websphere.jaspi.password";
+    private static final String JASPI_SAMPLE_DATA = "com.ibm.websphere.jaspi.password";
     private static final String JASPI_WEB_REQUEST = "com.ibm.websphere.jaspi.request";
     private MessagePolicy requestPolicy;
     private MessagePolicy responsePolicy;
@@ -127,7 +127,7 @@ public class AuthModule_1 implements ServerAuthModule {
         if (isLogin) {
             log.info("request is for method login()");
             String username = msgMap.get(JASPI_USER);
-            String password = msgMap.get(JASPI_PASSWORD);
+            String password = msgMap.get(JASPI_SAMPLE_DATA);
             status = handleUserPassword(username, password, rsp, msgMap, clientSubject, useCallbacks, cacheKey);
 
         } else if (isAuthenticate) {


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Rename hardcoded variables for more clarity in the code to avoid false-positives in security scans. 