### PR TITLE
fix: hostname canonicalization for oracle kerberos

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
@@ -71,7 +71,8 @@ public class OracleKerberosTest extends FATServletClient {
     public static void setUp() throws Exception {
         // Generate krb5.conf in server/security directory
         Path krbConfPath = Paths.get(server.getServerRoot(), "security", "krb5.conf");
-        FATSuite.krb5.generateConf(krbConfPath);
+        // Avoid service principle canonicalization on systems where kerberos version is >= 1.18
+        FATSuite.krb5.generateConf(krbConfPath, "dns_canonicalize_hostname = false", "qualify_shortname = \"\"");
 
         // Generate krb5.keytab in KDC container, and then copy it to server/security directory
         Path krb5KeytabPath = Paths.get(server.getServerRoot(), "security", "krb5.keytab");

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/containers/KerberosContainer.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/containers/KerberosContainer.java
@@ -97,6 +97,7 @@ public class KerberosContainer extends GenericContainer<KerberosContainer> {
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
         String udp99 = containerInfo.getNetworkSettings().getPorts().getBindings().get(new ExposedPort(99, InternetProtocol.UDP))[0].getHostPortSpec();
         udp_99 = Integer.valueOf(udp99);
+        debugKerberosVersion();
     }
 
     @Override
@@ -208,6 +209,36 @@ public class KerberosContainer extends GenericContainer<KerberosContainer> {
             krbConf = krbConf.replace("[" + section + "]", "[" + section + "]\n\t" + key + " = " + value);
         }
         return krbConf;
+    }
+
+    private void debugKerberosVersion() {
+        final String m = "debugKerberosVersion";
+        final String nl = "\n";
+
+        ProcessBuilder builder = new ProcessBuilder("ktutil", "--version");
+        StringBuilder output = new StringBuilder().append(nl);
+        try {
+            Process proc = builder.start();
+            if (!proc.waitFor(15, TimeUnit.SECONDS)) {
+                Log.info(c, m, "Proc timed out... destroying forcibly");
+                proc.destroyForcibly();
+            }
+
+            output.append("STDOUT:").append(nl);
+            output.append(readInputStream(proc.getInputStream())).append(nl);
+            output.append("STDERR:").append(nl);
+            output.append(readInputStream(proc.getErrorStream())).append(nl);
+
+            Log.info(c, m, "Process output:");
+            Log.info(c, m, output.toString());
+
+            if (proc.exitValue() != 0) {
+                Log.info(c, m, "Execution failed with exit code: " + proc.exitValue());
+            }
+        } catch (Exception e) {
+            Log.info(c, m, "Execution of command failed with message: " + e.getMessage());
+        }
+
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/containers/KerberosContainer.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/containers/KerberosContainer.java
@@ -117,34 +117,51 @@ public class KerberosContainer extends GenericContainer<KerberosContainer> {
         }
     }
 
-    public void generateConf(Path outputPath) throws IOException {
-        String conf = "[libdefaults]\n" +
-                      "        rdns = false\n" +
-                      "        renew_lifetime = 7d\n" +
-                      "        ticket_lifetime = 24h\n" +
-                      "        dns_lookup_realm = false\n" +
-                      "        default_realm = " + KRB5_REALM.toUpperCase() + "\n" +
-                      "\n" +
-                      "# The following krb5.conf variables are only for MIT Kerberos.\n" +
-                      "        kdc_timesync = 1\n" +
-                      "        ccache_type = 4\n" +
-                      "        forwardable = true\n" +
-                      "        proxiable = true\n" +
-                      "\n" +
-                      "# The following libdefaults parameters are only for Heimdal Kerberos.\n" +
-                      "        fcc-mit-ticketflags = true\n" +
-                      "\n" +
-                      "[realms]\n" +
-                      "        " + KRB5_REALM.toUpperCase() + " = {\n" +
-                      "                kdc = " + getHost() + ":" + getMappedPort(99) + "\n" +
-                      "                admin_server = " + getHost() + "\n" +
-                      "        }\n" +
-                      "\n" +
-                      "[domain_realm]\n" +
-                      "        ." + KRB5_REALM.toLowerCase() + " = " + KRB5_REALM.toUpperCase() + "\n" +
-                      "        " + KRB5_REALM.toLowerCase() + " = " + KRB5_REALM.toUpperCase() + "\n";
+    public void generateConf(Path outputPath, String... additionalLibDefaults) throws IOException {
+        String nl = "\n";
+        String tab = "\t";
+
+        StringBuilder conf = new StringBuilder();
+        conf.append("[libdefaults]").append(nl);
+        conf.append(tab).append("rdns = false").append(nl);
+        conf.append(tab).append("renew_lifetime = 7d").append(nl);
+        conf.append(tab).append("ticket_lifetime = 24h").append(nl);
+        conf.append(tab).append("dns_lookup_realm = false").append(nl);
+        conf.append(tab).append("default_realm = " + KRB5_REALM.toUpperCase()).append(nl);
+        conf.append(nl);
+
+        conf.append("# The following krb5.conf variables are only for MIT Kerberos.").append(nl);
+        conf.append(tab).append("kdc_timesync = 1").append(nl);
+        conf.append(tab).append("ccache_type = 4").append(nl);
+        conf.append(tab).append("forwardable = true").append(nl);
+        conf.append(tab).append("proxiable = true").append(nl);
+        conf.append(nl);
+
+        conf.append("# The following libdefaults parameters are only for Heimdal Kerberos.").append(nl);
+        conf.append(tab).append("fcc-mit-ticketflags = true").append(nl);
+        conf.append(nl);
+
+        if (additionalLibDefaults != null && additionalLibDefaults.length > 0) {
+            conf.append("# Additional configurations for this test case.").append(nl);
+            for (String config : additionalLibDefaults) {
+                conf.append(tab).append(config).append(nl);
+            }
+            conf.append(nl);
+        }
+
+        conf.append("[realms]").append(nl);
+        conf.append(tab).append(KRB5_REALM.toUpperCase() + " = {").append(nl);
+        conf.append(tab).append(tab).append("kdc = " + getHost() + ":" + getMappedPort(99)).append(nl);
+        conf.append(tab).append(tab).append("admin_server = " + getHost()).append(nl);
+        conf.append(tab).append("}").append(nl);
+        conf.append(nl);
+
+        conf.append("[domain_realm]").append(nl);
+        conf.append(tab).append("." + KRB5_REALM.toLowerCase() + " = " + KRB5_REALM.toUpperCase()).append(nl);
+        conf.append(tab).append(KRB5_REALM.toLowerCase() + " = " + KRB5_REALM.toUpperCase()).append(nl);
+
         outputPath.getParent().toFile().mkdirs();
-        Files.write(outputPath, conf.getBytes(StandardCharsets.UTF_8));
+        Files.write(outputPath, conf.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     /**


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Some of our test systems have a version of kerberos installed that is incorrectly generating a service name with a canonicalized name instead of using the provided hostname configured on the docker container. Resulting in the following kerberos error: 

```
[5/28/25, 12:06:27:548 PDT] 0000002b SystemOut O >>>KRBError:
[5/28/25, 12:06:27:549 PDT] 0000002b SystemOut O    sTime is Wed May 28 12:06:27 PDT 2025 1748459187000
[5/28/25, 12:06:27:549 PDT] 0000002b SystemOut O    suSec is 57976
[5/28/25, 12:06:27:549 PDT] 0000002b SystemOut O    error code is 7
[5/28/25, 12:06:27:549 PDT] 0000002b SystemOut O    error Message is Server not found in Kerberos database
[5/28/25, 12:06:27:550 PDT] 0000002b SystemOut O    crealm is EXAMPLE.COM
[5/28/25, 12:06:27:550 PDT] 0000002b SystemOut O    cname is ORACLEUSR@EXAMPLE.COM
[5/28/25, 12:06:27:550 PDT] 0000002b SystemOut O    sname is FREE/oracle.<canonical.host.name>@EXAMPLE.COM
[5/28/25, 12:06:27:551 PDT] 0000002b SystemOut O    msgType is 30
```

Where we would expect the following: 
```
[5/29/25, 10:32:34:635 CDT] 00000045 SystemOut O >>> DEBUG: ----Credentials----
[5/29/25, 10:32:34:636 CDT] 00000045 SystemOut O client: ORACLEUSR@EXAMPLE.COM
[5/29/25, 10:32:34:636 CDT] 00000045 SystemOut O server: FREE/oracle@EXAMPLE.COM
[5/29/25, 10:32:34:638 CDT] 00000045 SystemOut O ticket: sname: FREE/oracle@EXAMPLE.COM
[5/29/25, 10:32:34:640 CDT] 00000045 SystemOut O startTime: 1748532751000
[5/29/25, 10:32:34:640 CDT] 00000045 SystemOut O endTime: 1748575946000
[5/29/25, 10:32:34:641 CDT] 00000045 SystemOut O ----Credentials end----
```