### PR TITLE
use -Djava.security.properties to append custom fips 140-3 profile in fats

### DIFF
--- a/dev/build.sharedResources/usrShared/resources/security/semeruFips140_3CustomProfile.properties
+++ b/dev/build.sharedResources/usrShared/resources/security/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,12 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -30,6 +30,9 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -677,7 +680,8 @@ public class LibertyClient {
                                                    + " with IBM Java 17, adding required JVM arguments to run with FIPS 140-3 enabled");
                                                    
                 JVM_ARGS += " -Dsemeru.fips=true";
-                JVM_ARGS += " -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-withPKCS12";
+                JVM_ARGS += " -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Custom";
+                JVM_ARGS += " -Djava.security.properties=" + getSemeruFips140_3CustomProfileLocationAndPrintFileContents();
                 JVM_ARGS += " -Dcom.ibm.fips.mode=140-3";
                 // JVM_ARGS += " -Djavax.net.debug=all";  // Uncomment as needed for additional debugging
             } else if (javaInfo.majorVersion() == 8) {
@@ -851,6 +855,27 @@ public class LibertyClient {
         }
         postStopClientArchive();
         return output;
+    }
+
+    private String getSemeruFips140_3CustomProfileLocationAndPrintFileContents() throws Exception {
+        Properties localProperties = getLocalProperties();
+        String basedir = localProperties.getProperty("basedir");
+        String location = basedir + "/semeruFips140_3CustomProfile.properties";
+
+        byte[] fileContents = Files.readAllBytes(Paths.get(location));
+        Log.info(c, "getSemeruFips140_3CustomProfileLocationAndPrintFileContents",
+                 "semeruFips140_3CustomProfile.properties contents:\n" + new String(fileContents, StandardCharsets.UTF_8));
+
+        return location;
+    }
+
+    public Properties getLocalProperties() throws Exception {
+        String localPropertiesLocation = System.getProperty("local.properties");
+        Properties localProperties = new Properties();
+        FileInputStream in = new FileInputStream(localPropertiesLocation);
+        localProperties.load(in);
+        in.close();
+        return localProperties;
     }
 
     private void addJava2SecurityPropertiesToBootstrapFile(RemoteFile f) throws Exception {

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -36,7 +36,9 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.security.AccessController;
 import java.security.KeyStore;
@@ -8105,7 +8107,8 @@ public class LibertyServer implements LogMonitorClient {
                          "FIPS 140-3 global build properties is set for server " + getServerName()
                                                  + " with IBM Java 17, adding required JVM arguments to run with FIPS 140-3 enabled");
                 opts.put("-Dsemeru.fips", "true");
-                opts.put("-Dsemeru.customprofile", "OpenJCEPlusFIPS.FIPS140-3-withPKCS12");
+                opts.put("-Dsemeru.customprofile", "OpenJCEPlusFIPS.FIPS140-3-Custom");
+                opts.put("-Djava.security.properties", getSemeruFips140_3CustomProfileLocationAndPrintFileContents());
             } else if (info.majorVersion() == 8) {
                 Log.info(c, "getFipsJvmOptions", "FIPS 140-3 global build properties is set for server "
                                                  + getServerName()
@@ -8131,6 +8134,27 @@ public class LibertyServer implements LogMonitorClient {
             }
         }
         return opts;
+    }
+
+    private String getSemeruFips140_3CustomProfileLocationAndPrintFileContents() throws Exception {
+        Properties localProperties = getLocalProperties();
+        String basedir = localProperties.getProperty("basedir");
+        String location = basedir + "/semeruFips140_3CustomProfile.properties";
+
+        byte[] fileContents = Files.readAllBytes(Paths.get(location));
+        Log.info(c, "getSemeruFips140_3CustomProfileLocationAndPrintFileContents",
+                 "semeruFips140_3CustomProfile.properties contents:\n" + new String(fileContents, StandardCharsets.UTF_8));
+
+        return location;
+    }
+
+    public Properties getLocalProperties() throws Exception {
+        String localPropertiesLocation = System.getProperty("local.properties");
+        Properties localProperties = new Properties();
+        FileInputStream in = new FileInputStream(localPropertiesLocation);
+        localProperties.load(in);
+        in.close();
+        return localProperties;
     }
 
     public void setKeysAndJVMOptsForFips() throws Exception {

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -341,10 +341,15 @@ task autoFVT {
       defaultCopyLTPAFIPSKeys(filesBaseDir)
     }
 
-    // Copy Semeru FIPS 140-3 custom profile
-    def securitySharedResourcesDir = new File(rootProject.projectDir, 'build.sharedResources/usrShared/resources/security')
+    // Copy Semeru FIPS 140-3 custom profile from the FAT's project directory if it exists,
+    // if not, then copy the common one from the build.sharedResources security directory
+    def semeruFips140_3CustomProfile = new File(projectDir, "semeruFips140_3CustomProfile.properties")
+    if (!semeruFips140_3CustomProfile.exists()) {
+      def securitySharedResourcesDir = new File(rootProject.projectDir, 'build.sharedResources/usrShared/resources/security')
+      semeruFips140_3CustomProfile = new File(securitySharedResourcesDir, 'semeruFips140_3CustomProfile.properties')
+    }
     copy {
-      from new File(securitySharedResourcesDir, 'semeruFips140_3CustomProfile.properties')
+      from semeruFips140_3CustomProfile
       into autoFvtDir
     }
 

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -341,6 +341,13 @@ task autoFVT {
       defaultCopyLTPAFIPSKeys(filesBaseDir)
     }
 
+    // Copy Semeru FIPS 140-3 custom profile
+    def securitySharedResourcesDir = new File(rootProject.projectDir, 'build.sharedResources/usrShared/resources/security')
+    copy {
+      from new File(securitySharedResourcesDir, 'semeruFips140_3CustomProfile.properties')
+      into autoFvtDir
+    }
+
     // Copy the logging libraries over for use while running FATs
     /*copy {
       from project(':com.ibm.ws.logging.core').buildDir


### PR DESCRIPTION
update fat's to copy over `semeruFips140_3CustomProfile.properties` from `build.sharedResources` to the `autoFVT` directory, so when running semeru fips 140-3 we can point to it using `-Djava.security.properties=` to append to the `java.security` file. 

this is beneficial over the current approach of changing the actual `java.security` file and allows us to try out different custom profiles in our branches when running the fips soe.