### PR TITLE
SessionCacheConfigTestServlet session returns null

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/sessionCacheConfigApp/src/session/cache/infinispan/web/SessionCacheConfigTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/sessionCacheConfigApp/src/session/cache/infinispan/web/SessionCacheConfigTestServlet.java
@@ -406,6 +406,12 @@ public class SessionCacheConfigTestServlet extends FATServlet {
         Object value = toType(type, stringValue);
 
         HttpSession session = request.getSession(true);
+        if (session == null) {
+            // Retry getSession() as request.getSession(true) can not be null in the production world
+            System.out.println("Sleep 5 seconds due to session return null");
+            TimeUnit.SECONDS.sleep(5);
+            session = request.getSession(true);
+        }
         session.setAttribute(attrName, value);
 
         // Verify that attribute does not get persisted to the cache yet

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/sessionCacheConfigApp/src/session/cache/infinispan/web/SessionCacheConfigTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/sessionCacheConfigApp/src/session/cache/infinispan/web/SessionCacheConfigTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2019 IBM Corporation and others.
+ * Copyright (c) 2018,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
[5/28/25, 7:47:40:611 PDT] 000000ee id=00000000 com.ibm.ws.webcontainer.servlet.ServletWrapper               I init SRVE0242I: [sessionCacheConfigApp] [/sessionCacheConfigApp] [session.cache.infinispan.web.SessionCacheConfigTestServlet]: Initialization successful.
[5/28/25, 7:47:40:627 PDT] 000000ee id=00000000 SystemOut                                                    O >>> BEGIN: testSetAttribute
[5/28/25, 7:47:40:627 PDT] 000000ee id=00000000 SystemOut                                                    O Request URL: http://localhost:8010/sessionCacheConfigApp/SessionCacheConfigTestServlet?testMethod=testSetAttribute&attribute=testAddFeature0&value=AF0
[5/28/25, 7:47:40:643 PDT] 000000ee id=00000000 SystemErr                                                    R java.lang.NullPointerException: Cannot invoke "javax.servlet.http.HttpSession.setAttribute(java.lang.String, java.lang.Object)" because "session" is null
	at session.cache.infinispan.web.SessionCacheConfigTestServlet.testSetAttribute(SessionCacheConfigTestServlet.java:409)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:575)
	at componenttest.app.FATServlet.doGet(FATServlet.java:76)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:686)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:791)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1266)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:754)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:451)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1362)
	at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5096)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:328)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1047)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:293)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1284)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:500)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:459)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:569)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:503)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:363)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:330)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:169)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:77)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:516)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:586)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:970)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1059)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:298)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:857)