### PR TITLE
fix: kerberos test classrules

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
@@ -27,6 +27,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -36,6 +37,7 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jdbc.fat.krb5.containers.DB2KerberosContainer;
 import com.ibm.ws.jdbc.fat.krb5.containers.KerberosContainer;
+import com.ibm.ws.jdbc.fat.krb5.rules.KerberosPlatformRule;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
@@ -57,8 +59,10 @@ public class DB2KerberosTest extends FATServletClient {
 
     public static final String APP_NAME = "krb5-db2-app";
 
-    @ClassRule
     public static final DB2KerberosContainer db2 = new DB2KerberosContainer(FATSuite.network);
+
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(KerberosPlatformRule.instance()).around(db2);
 
     @Server("com.ibm.ws.jdbc.fat.krb5")
     @TestServlet(servlet = DB2KerberosTestServlet.class, contextRoot = APP_NAME)

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/ErrorPathTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/ErrorPathTest.java
@@ -22,6 +22,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -30,6 +31,7 @@ import com.ibm.websphere.simplicity.config.Kerberos;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jdbc.fat.krb5.containers.DB2KerberosContainer;
+import com.ibm.ws.jdbc.fat.krb5.rules.KerberosPlatformRule;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
@@ -48,8 +50,10 @@ public class ErrorPathTest extends FATServletClient {
     @Server("com.ibm.ws.jdbc.fat.krb5")
     public static LibertyServer server;
 
-    @ClassRule
     public static final DB2KerberosContainer db2 = DB2KerberosTest.db2;
+
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(KerberosPlatformRule.instance()).around(db2);
 
     private static final String APP_NAME = DB2KerberosTest.APP_NAME;
 

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/FATSuite.java
@@ -57,9 +57,9 @@ public class FATSuite extends TestContainerSuite {
         // Manually apply rule so that the AlwaysPassesTest runs since having zero test results is considered an error
         if (KerberosPlatformRule.shouldRun(null)) {
             try {
-                network.close();
-            } finally {
                 krb5.stop();
+            } finally {
+                network.close();
             }
         }
     }

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jdbc.fat.krb5.containers.OracleKerberosContainer;
 import com.ibm.ws.jdbc.fat.krb5.rules.IBMJava8Rule;
+import com.ibm.ws.jdbc.fat.krb5.rules.KerberosPlatformRule;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MaximumJavaLevel;
@@ -60,12 +61,10 @@ public class OracleKerberosTest extends FATServletClient {
     @TestServlet(servlet = OracleKerberosTestServlet.class, contextRoot = APP_NAME)
     public static LibertyServer server;
 
-    public static IBMJava8Rule skipOnIBMJava8 = new IBMJava8Rule();
-
     public static OracleKerberosContainer oracle = new OracleKerberosContainer(FATSuite.network);
 
     @ClassRule
-    public static RuleChain chain = RuleChain.outerRule(skipOnIBMJava8).around(oracle);
+    public static RuleChain chain = RuleChain.outerRule(KerberosPlatformRule.instance()).around(IBMJava8Rule.instance()).around(oracle);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/PostgresKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/PostgresKerberosTest.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jdbc.fat.krb5.containers.PostgresKerberosContainer;
+import com.ibm.ws.jdbc.fat.krb5.rules.KerberosPlatformRule;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -58,7 +59,7 @@ public class PostgresKerberosTest extends FATServletClient {
                                     .fullFATOnly());
 
     @ClassRule
-    public static RuleChain chain = RuleChain.outerRule(postgresql).around(repeat);
+    public static RuleChain chain = RuleChain.outerRule(KerberosPlatformRule.instance()).around(postgresql).around(repeat);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/rules/IBMJava8Rule.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/rules/IBMJava8Rule.java
@@ -39,7 +39,7 @@ public class IBMJava8Rule implements TestRule {
                 if (shouldRun(desc)) {
                     stmt.evaluate();
                 } else {
-                    Log.info(IBMJava8Rule.class, "evaluate", "Rule chain borken, skipping next statement: " + stmt.toString());
+                    Log.info(IBMJava8Rule.class, "evaluate", "Rule chain broken, skipping next statement: " + stmt.toString());
                 }
             }
         };

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/rules/IBMJava8Rule.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/rules/IBMJava8Rule.java
@@ -27,6 +27,10 @@ import componenttest.topology.impl.JavaInfo.Vendor;
  */
 public class IBMJava8Rule implements TestRule {
 
+    public static IBMJava8Rule instance() {
+        return new IBMJava8Rule();
+    }
+
     @Override
     public Statement apply(Statement stmt, Description desc) {
         return new Statement() {
@@ -34,6 +38,8 @@ public class IBMJava8Rule implements TestRule {
             public void evaluate() throws Throwable {
                 if (shouldRun(desc)) {
                     stmt.evaluate();
+                } else {
+                    Log.info(IBMJava8Rule.class, "evaluate", "Rule chain borken, skipping next statement: " + stmt.toString());
                 }
             }
         };

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/rules/KerberosPlatformRule.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/rules/KerberosPlatformRule.java
@@ -36,9 +36,8 @@ import componenttest.topology.impl.JavaInfo.Vendor;
  */
 public class KerberosPlatformRule implements TestRule {
 
-    static {
-        // Needed for IBM JDK 8 support.
-        java.lang.System.setProperty("com.ibm.jsse2.overrideDefaultTLS", "true");
+    public static KerberosPlatformRule instance() {
+        return new KerberosPlatformRule();
     }
 
     @Override
@@ -48,6 +47,8 @@ public class KerberosPlatformRule implements TestRule {
             public void evaluate() throws Throwable {
                 if (shouldRun(desc)) {
                     stmt.evaluate();
+                } else {
+                    Log.info(KerberosPlatformRule.class, "evaluate", "Rule chain broken, skipping next statement: " + stmt.toString());
                 }
             }
         };


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

A prior change added a ClassRule to the FATSuite class to make the test easier to manage.
However, one of the rules meant that when that rule failed it prevented any tests from running.
Our reporting system cannot handle that situation and sees 0 test results as a failure. 
This PR fixes that.
