### PR TITLE
updating classes that specify constants for hash salts

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -9,6 +9,8 @@
 *******************************************************************************/
 package com.ibm.ws.common.crypto;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -90,6 +92,7 @@ public class CryptoUtils {
     public static final int AES_256_KEY_LENGTH_BYTES = 32;
 
     public static final int DESEDE_KEY_LENGTH_BYTES = 24;
+    public static final int FIPS_SALT_BYTE_LENGTH_MINIMUM = 32;
 
     private static boolean fips140_3Enabled = isFips140_3Enabled();
     private static boolean fipsEnabled = fips140_3Enabled;
@@ -357,6 +360,54 @@ public class CryptoUtils {
             fips140_3Checked = true;
             return fips140_3Enabled;
         }
+    }
+
+    /**
+     *
+     * @param saltString a salt value that is intended to be used to generate a hash via the property PasswordUtil.PROPERTY_HASH_SALT.
+     * @return if FIPS 140-3 is enabled and saltsString.length() < 32, the string is repeated until it's length is 32 or over.
+     *         For example, if saltString is 'discombobulated' the output string would be 'discombobulateddiscombobulateddiscombobulated'
+     */
+    public static String getFipsCompatibleSalt(String saltString) {
+        if (!checkFipsCompatibleSalt(saltString, false)) {
+            StringBuilder builder = new StringBuilder(saltString);
+            while (builder.length() < FIPS_SALT_BYTE_LENGTH_MINIMUM) {
+                builder.append(saltString);
+            }
+            saltString = builder.toString();
+        }
+        return saltString;
+    }
+
+    /**
+     *
+     * @param saltString                  a salt value that is intended to be used to generate a hash via the property PasswordUtil.PROPERTY_HASH_SALT.
+     *                                        null or empty strings are valid here because PasswordUtil will generate salt if that is the case.
+     * @param throwExceptionIfSaltInvalid if true, an exception is thrown if saltString is not compatible with FIPS140-3.
+     * @return true if compatible, false otherwise, exception if false and throwExceptionIfSaltInvalid is true.
+     */
+    public static boolean checkFipsCompatibleSalt(String saltString, boolean logIfIncompatible) {
+        boolean isCompatible = true;
+        if (CryptoUtils.isFips140_3Enabled() && saltString != null && !saltString.isEmpty() && saltString.length() < FIPS_SALT_BYTE_LENGTH_MINIMUM) {
+            isCompatible = false;
+        }
+        // TODO delete this logging
+        if (!isCompatible && logIfIncompatible) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                try {
+                    throw new Exception("checkFipsCompatibleSalt failed!");
+                } catch (Exception e) {
+                    StringWriter sw = new StringWriter();
+                    PrintWriter pw = new PrintWriter(sw);
+                    e.printStackTrace(pw);
+                    Tr.debug(tc, "isCompatible: false, saltString: " + saltString + "\n" + sw.toString());
+                }
+
+            }
+        }
+        // TODO delete this logging
+
+        return isCompatible;
     }
 
     /**

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -25,10 +25,13 @@ import java.util.Map;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.kernel.service.util.JavaInfo;
 
 public class CryptoUtils {
     private static final TraceComponent tc = Tr.register(CryptoUtils.class);
+
+    private static boolean issuedBetaMessage = false;
 
     public final static String MESSAGE_DIGEST_ALGORITHM_SHA256 = "SHA-256";
     public final static String MESSAGE_DIGEST_ALGORITHM_SHA384 = "SHA-384";
@@ -337,6 +340,23 @@ public class CryptoUtils {
 
     public static boolean isSemeruFips() {
         return "true".equals(getPropertyLowerCase("semeru.fips", "false"));
+    }
+
+    public static boolean isFips140_3EnabledWithBetaGuard() {
+        return isRunningBetaMode() && isFips140_3Enabled();
+    }
+
+    private static boolean isRunningBetaMode() {
+        if (!ProductInfo.getBetaEdition()) {
+            return false;
+        } else {
+            // Running beta exception, issue message if we haven't already issued one for this class
+            if (!issuedBetaMessage) {
+                Tr.info(tc, "BETA: A beta method has been invoked for the class CryptoUtils for the first time.");
+                issuedBetaMessage = true;
+            }
+            return true;
+        }
     }
 
     public static boolean isFips140_3Enabled() {

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -96,6 +96,7 @@ public class CryptoUtils {
 
     public static final int DESEDE_KEY_LENGTH_BYTES = 24;
     public static final int FIPS_SALT_BYTE_LENGTH_MINIMUM = 32;
+    public static final int FIPS_HASH_BIT_LENGTH_MINIMUM = 112;
 
     private static boolean fips140_3Enabled = isFips140_3Enabled();
     private static boolean fipsEnabled = fips140_3Enabled;
@@ -408,7 +409,7 @@ public class CryptoUtils {
      */
     public static boolean checkFipsCompatibleSalt(String saltString, boolean logIfIncompatible) {
         boolean isCompatible = true;
-        if (CryptoUtils.isFips140_3Enabled() && saltString != null && !saltString.isEmpty() && saltString.length() < FIPS_SALT_BYTE_LENGTH_MINIMUM) {
+        if (CryptoUtils.isFips140_3EnabledWithBetaGuard() && saltString != null && !saltString.isEmpty() && saltString.length() < FIPS_SALT_BYTE_LENGTH_MINIMUM) {
             isCompatible = false;
         }
         // TODO delete this logging

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20Constants.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20Constants.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.oauth.core.internal.oauth20;
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.ibm.oauth.core.internal.OAuthConstants;
+import com.ibm.ws.common.crypto.CryptoUtils;
 
 public interface OAuth20Constants extends OAuthConstants {
 
@@ -189,7 +190,7 @@ public interface OAuth20Constants extends OAuthConstants {
 
     public static final String REFRESH_TOKEN_ORIGINAL_GT = "originalGrantType";
     public static final String HASH = "hash"; // matches result from PasswordUtil.getCryptoAlgorithm
-    public static final String APP_PASSWORD_HASH_SALT = "notrandom";
+    public static final String APP_PASSWORD_HASH_SALT = CryptoUtils.getFipsCompatibleSalt("notrandom");
     public static final String PLAIN_ENCODING = "plain";
     public static final String APP_PASSWORD_TOKEN_STATE_ID = "iamapppasswordorapptokenstateid";
     public final static String XOR = "xor"; // matches result from PasswordUtil.getCryptoAlgorithm

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/HashSecretUtils.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/HashSecretUtils.java
@@ -39,7 +39,7 @@ public class HashSecretUtils {
 
     public static final int DEFAULT_SALTSIZE = 32;
     public static final int DEFAULT_ITERATIONS = 2048;
-    public static final int DEFAULT_KEYSIZE = 32;
+    public static final int DEFAULT_KEYSIZE = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? CryptoUtils.FIPS_HASH_BIT_LENGTH_MINIMUM : 32;
 
     private static final int generateSaltSize = DEFAULT_SALTSIZE;
 
@@ -103,6 +103,7 @@ public class HashSecretUtils {
                 hashProps.put(PasswordUtil.PROPERTY_HASH_SALT, salt);
                 hashProps.put(PasswordUtil.PROPERTY_HASH_ITERATION, iteration == 0 ? String.valueOf(DEFAULT_ITERATIONS) : String.valueOf(iteration));
                 hashProps.put(PasswordUtil.PROPERTY_HASH_LENGTH, length == 0 ? String.valueOf(DEFAULT_KEYSIZE) : String.valueOf(length));
+                System.out.println("JAKE: " + length);
 
                 return PasswordUtil.encode_password(secretToHash, OAuth20Constants.HASH, hashProps);
             } else {

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/HashSecretUtils.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/HashSecretUtils.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,6 +22,7 @@ import com.ibm.websphere.crypto.PasswordUtil;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.ws.common.crypto.CryptoUtils;
 import com.ibm.ws.common.encoder.Base64Coder;
 
 /**
@@ -98,6 +99,7 @@ public class HashSecretUtils {
             if (secretType == null || !secretType.equals(OAuth20Constants.HASH)) {
                 Map<String, String> hashProps = new HashMap<String, String>();
                 hashProps.put(PasswordUtil.PROPERTY_HASH_ALGORITHM, algorithm == null ? DEFAULT_HASH : algorithm);
+                CryptoUtils.checkFipsCompatibleSalt(salt, true);
                 hashProps.put(PasswordUtil.PROPERTY_HASH_SALT, salt);
                 hashProps.put(PasswordUtil.PROPERTY_HASH_ITERATION, iteration == 0 ? String.valueOf(DEFAULT_ITERATIONS) : String.valueOf(iteration));
                 hashProps.put(PasswordUtil.PROPERTY_HASH_LENGTH, length == 0 ? String.valueOf(DEFAULT_KEYSIZE) : String.valueOf(length));

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/HashSecretUtils.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/HashSecretUtils.java
@@ -103,7 +103,6 @@ public class HashSecretUtils {
                 hashProps.put(PasswordUtil.PROPERTY_HASH_SALT, salt);
                 hashProps.put(PasswordUtil.PROPERTY_HASH_ITERATION, iteration == 0 ? String.valueOf(DEFAULT_ITERATIONS) : String.valueOf(iteration));
                 hashProps.put(PasswordUtil.PROPERTY_HASH_LENGTH, length == 0 ? String.valueOf(DEFAULT_KEYSIZE) : String.valueOf(length));
-                System.out.println("JAKE: " + length);
 
                 return PasswordUtil.encode_password(secretToHash, OAuth20Constants.HASH, hashProps);
             } else {

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/MessageDigestUtil.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/MessageDigestUtil.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,12 +17,12 @@ import java.security.NoSuchAlgorithmException;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.common.crypto.CryptoUtils;
 import com.ibm.ws.common.encoder.Base64Coder;
 
 public class MessageDigestUtil {
 
-    private static final TraceComponent tc =
-            Tr.register(MessageDigestUtil.class);
+    private static final TraceComponent tc = Tr.register(MessageDigestUtil.class);
 
     private static Object locker = new Object(); // @GK1
     private static MessageDigest md = null;
@@ -32,7 +32,8 @@ public class MessageDigestUtil {
 
     static {
         try {
-            md = MessageDigest.getInstance("SHA-1");
+            String algorithm = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? "SHA-256" : "SHA-1";
+            md = MessageDigest.getInstance(algorithm);
         } catch (NoSuchAlgorithmException e) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "Internal error initializing message digest", e);
@@ -41,9 +42,9 @@ public class MessageDigestUtil {
     }
 
     /**
-     * Calculate the message digest of the given String and convert 
+     * Calculate the message digest of the given String and convert
      * it to a hexadecimal String
-     * 
+     *
      * @param value input String
      * @return  message digest hexadecimal String
      */
@@ -66,7 +67,7 @@ public class MessageDigestUtil {
 
     /**
      * Convert a byte array to a String of hex characters
-     * 
+     *
      * @param bytes
      * @return  Hexadecimal String
      */

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -8117,6 +8117,7 @@ public class LibertyServer implements LogMonitorClient {
             }
             if (includeGlobalArgs) {
                 opts.put("-Dglobal.fips_140-3", "true");
+                opts.put("-Dcom.ibm.ws.beta.edition", "true");
             }
         } else if (isFIPS140_2EnabledAndSupported(info, false)) {
             if (info.majorVersion() == 8) {


### PR DESCRIPTION
there are areas in the oauth code where < 32 byte salt is specified which isn't valid when fips is enabled. Adding a check which repeats the salt value until it's >= 32 