### PR TITLE
Tolerate EJB timer delays on slow systems

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryWeb.war/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/web/NpTimerConfigRetryServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/test-applications/NpTimerConfigRetryWeb.war/src/com/ibm/ws/ejbcontainer/timer/np/config/retry/web/NpTimerConfigRetryServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2024 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -344,7 +344,7 @@ public class NpTimerConfigRetryServlet extends FATServlet {
 
         // Tolerate the timer running a 3rd time on slow hardware due to catch-up timeouts
         long expectedCount = 2;
-        if (nextTimes.get(nextTimes.size() - 1) <= completedTime && count == 3) {
+        if (count == 3 && nextTimes.get(nextTimes.size() - 2) <= completedTime) {
             expectedCount = 3;
         }
 


### PR DESCRIPTION
- update test to allow an extra timer expiration if the last expected timer had a "next" scheudled timeout that is prior to the end of the test execution
- the test was checking the last timer (3), rather than the last expected timer (2), so subtracked one more from the index.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

