### PR TITLE
[31741] - Have RESTEasy do the classloading and dynamically import the user feature bundle classes (mpRestClient-3.0+)

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/.classpath
@@ -17,6 +17,8 @@
 	<classpathentry kind="src" path="test-applications/produceConsumeApp/src"/>
 	<classpathentry kind="src" path="test-applications/propsApp/src"/>
 	<classpathentry kind="src" path="test-applications/sseApp/src"/>
+	<classpathentry kind="src" path="test-applications/MyRestClient/src"/>
+	<classpathentry kind="src" path="test-applications/MyRestClientBundle/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/bnd.bnd
@@ -28,6 +28,8 @@ src: \
   test-applications/hostnameVerifierApp/src,\
   test-applications/jsonbContextApp/src,\
   test-applications/multiClientCdiApp/src,\
+  test-applications/MyRestClient/src,\
+  test-applications/MyRestClientBundle/src,\
   test-applications/produceConsumeApp/src,\
   test-applications/propsApp/src,\
   test-applications/sseApp/src
@@ -35,49 +37,50 @@ src: \
 fat.project: true
 
 tested.features=\
-  mpRestClient-1.2,\
-  jdbc-4.2,\
   appSecurity-3.0,\
+  appSecurity-4.0,\
+  appSecurity-5.0,\
+  appSecurity-6.0,\
+  concurrent-3.0,\
+  concurrent-3.1,\
   connectors-2.1,\
+  enterpriseBeansLite-4.0,\
+  enterprisebeans-4.0,\
+  enterprisebeanshome-4.0,\
+  enterprisebeanspersistenttimer-4.0,\
+  enterprisebeansremote-4.0,\
+  jdbc-4.2,\
+  jsonb-2.0,\
+  jsonb-3.0,\
+  jsonp-2.1,\
   mdb-4.0,\
+  mpConfig-1.2,\
+  mpConfig-2.0,\
+  mpConfig-3.0,\
+  mpConfig-3.1,\
+  mpRestClient-1.2,\
   mpRestClient-1.3,\
   mpRestClient-1.4,\
   mpRestClient-2.0,\
   mpRestClient-3.0,\
   mpRestClient-4.0,\
-  mpConfig-1.2,\
-  mpConfig-2.0,\
-  mpConfig-3.0,\
-  mpConfig-3.1,\
   restfulWS-3.0,\
-  jsonb-2.0,\
-  jsonb-3.0,\
-  enterprisebeans-4.0,\
-  enterprisebeanshome-4.0,\
-  enterprisebeanspersistenttimer-4.0,\
-  enterpriseBeansLite-4.0,\
-  enterprisebeansremote-4.0,\
-  appSecurity-4.0,\
-  jsonp-2.1,\
-  servlet-6.0,\
-  servlet-6.1,\
-  concurrent-3.0,\
-  concurrent-3.1,\
   restfulWS-3.1,\
   restfulWS-4.0,\
-  appSecurity-5.0,\
-  appSecurity-6.0
+  servlet-6.0,\
+  servlet-6.1
+
 
 -buildpath: \
-  com.ibm.websphere.javaee.annotation.1.2;version=latest,\
-  com.ibm.websphere.javaee.cdi.2.0;version=latest,\
-  com.ibm.websphere.javaee.ejb.3.2;version=latest,\
-  com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
-  com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
-  com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-  com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
-  com.ibm.websphere.org.eclipse.microprofile.rest.client.1.3;version=latest,\
-  com.ibm.ws.cdi.interfaces;version=latest,\
-  com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
-  com.ibm.websphere.javaee.jsonb.1.0;version=latest,\
-  com.ibm.websphere.org.reactivestreams.reactive-streams.1.0
+	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
+	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
+	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
+	com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
+	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.rest.client.1.3;version=latest,\
+	com.ibm.ws.cdi.interfaces;version=latest,\
+	com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
+	com.ibm.websphere.javaee.jsonb.1.0;version=latest,\
+	com.ibm.websphere.org.reactivestreams.reactive-streams.1.0

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
@@ -35,11 +35,17 @@ import componenttest.rules.repeater.RepeatTests;
                 MultiClientCdiTest.class,
                 ProduceConsumeTest.class,
                 PropsTest.class,
+                RESTClientUserFeatureTest.class,
                 SseTest.class
 })
 public class FATSuite {
     private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
 
+    /*
+     * If you are adding a new MicroProfile version to this list of repeats, don't forget to update
+     * `publish/features/javax/MyRESTClient.mf` and `publish/features/jakarta/MyRESTClient.mf` to
+     * tolerate the new versions.
+     */
     public static RepeatTests repeatMP13Up(String...servers) {
 
         // To avoid bogus timeout build-breaks on slow Windows hardware only run a few versions on

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/RESTClientUserFeatureTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/RESTClientUserFeatureTest.java
@@ -9,9 +9,7 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.rest.client.fat;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -22,11 +20,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.RepeatTestFilter;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEEAction;
-import componenttest.rules.repeater.MicroProfileActions;
-import componenttest.rules.repeater.RepeatActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -40,7 +34,7 @@ import io.openliberty.mprestclient.fat.myrestclient.servlet.MyRestClientTestServ
 public class RESTClientUserFeatureTest extends FATServletClient {
     
     private static final String appName = "MyRestClient";
-    private static final String bundleName = "MyRESTClientBundle";
+    private static final String bundleName = "MyRestClientBundle";
     private static final String serverName = "MyRESTClientServer";
 
     @ClassRule
@@ -80,12 +74,6 @@ public class RESTClientUserFeatureTest extends FATServletClient {
             server.uninstallUserBundle(bundleName);
         }
     }
-
-    @Before
-    public void beforeTest() {}
-
-    @After
-    public void afterTest() {}
     
     private static String getUserFeatureFile() throws Exception {
         if (JakartaEEAction.isEE9OrLaterActive()) {

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/RESTClientUserFeatureTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/RESTClientUserFeatureTest.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.rest.client.fat;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEEAction;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.mprestclient.fat.myrestclient.servlet.MyRestClientTestServlet;
+
+/*
+ * This test is to test a MicroProfile REST Client in a user feature and make sure there
+ * are no classloading issues.
+ */
+@RunWith(FATRunner.class)
+public class RESTClientUserFeatureTest extends FATServletClient {
+    
+    private static final String appName = "MyRestClient";
+    private static final String bundleName = "MyRESTClientBundle";
+    private static final String serverName = "MyRESTClientServer";
+
+    @ClassRule
+    public static RepeatTests r = FATSuite.repeatMP13Up(serverName);
+    
+    @Server(serverName)
+    @TestServlet(servlet = MyRestClientTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Build an application and export it to the dropins directory
+        // We need to overwrite the app so that the javax tests don't fail when the jakarta version runs first.
+        ShrinkHelper.defaultDropinApp(server, appName,  new DeployOptions[] { DeployOptions.OVERWRITE }, "io.openliberty.mprestclient.fat.myrestclient.app", "io.openliberty.mprestclient.fat.myrestclient.servlet");
+
+        /*
+         * Build and install the user feature (wlp/usr/extension/lib)
+         */
+        ShrinkHelper.defaultUserFeatureArchive(server, bundleName, "io.openliberty.mprestclient.fat.myrestclient.bundle");
+        server.installUserFeature(getUserFeatureFile());
+        Thread.sleep(5000);
+
+        // Make sure we don't fail because we try to start an
+        // already started server
+        try {
+            server.startServer(true);
+        } catch (Exception e) {
+            System.out.println(e.toString());
+        }
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        if (server != null) {
+            server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+            server.uninstallUserFeature("MyRESTClient");
+            server.uninstallUserBundle(bundleName);
+        }
+    }
+
+    @Before
+    public void beforeTest() {}
+
+    @After
+    public void afterTest() {}
+    
+    private static String getUserFeatureFile() throws Exception {
+        if (JakartaEEAction.isEE9OrLaterActive()) {
+            return "jakarta/MyRESTClient";
+        } else {
+            return "javax/MyRESTClient";
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/RESTClientUserFeatureTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/RESTClientUserFeatureTest.java
@@ -53,7 +53,8 @@ public class RESTClientUserFeatureTest extends FATServletClient {
         /*
          * Build and install the user feature (wlp/usr/extension/lib)
          */
-        ShrinkHelper.defaultUserFeatureArchive(server, bundleName, "io.openliberty.mprestclient.fat.myrestclient.bundle");
+        ShrinkHelper.defaultUserFeatureArchive(server, bundleName, "io.openliberty.mprestclient.fat.myrestclient.bundle",
+                                                                   "io.openliberty.mprestclient.fat.myrestclient.internal");
         server.installUserFeature(getUserFeatureFile());
         Thread.sleep(5000);
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/features/jakarta/MyRESTClient.mf
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/features/jakarta/MyRESTClient.mf
@@ -1,6 +1,6 @@
 Subsystem-ManifestVersion: 1
 IBM-ShortName: MyRESTClient-1.0
-Subsystem-SymbolicName: MyRESTClient;visibility:=public
+Subsystem-SymbolicName: MyRESTClient-1.0;visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2
@@ -8,7 +8,7 @@ Subsystem-Vendor: IBM
 Subsystem-Content:
  io.openliberty.mprestclient.fat.myrestclient.jakarta;version="1.0",
  io.openliberty.mpConfig-3.0; type="osgi.subsystem.feature"; ibm.tolerates:="3.1",
- io.openliberty.mpRestClient-3.0; type="osgi.subsystem.feature"; ibm.tolerates:="3.1, 4.0",
+ io.openliberty.mpRestClient-3.0; type="osgi.subsystem.feature"; ibm.tolerates:="4.0",
  io.openliberty.restfulWSClient-3.0; type="osgi.subsystem.feature"; ibm.tolerates:="3.1, 4.0",
  io.openliberty.jsonp-2.0; type="osgi.subsystem.feature"; ibm.tolerates:="2.1"
 IBM-API-Package: io.openliberty.mprestclient.fat.myrestclient.bundle

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/features/jakarta/MyRESTClient.mf
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/features/jakarta/MyRESTClient.mf
@@ -1,0 +1,14 @@
+Subsystem-ManifestVersion: 1
+IBM-ShortName: MyRESTClient-1.0
+Subsystem-SymbolicName: MyRESTClient;visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Type: osgi.subsystem.feature
+IBM-Feature-Version: 2
+Subsystem-Vendor: IBM
+Subsystem-Content:
+ io.openliberty.mprestclient.fat.myrestclient.jakarta;version="1.0",
+ io.openliberty.mpConfig-3.0; type="osgi.subsystem.feature"; ibm.tolerates:="3.1",
+ io.openliberty.mpRestClient-3.0; type="osgi.subsystem.feature"; ibm.tolerates:="3.1, 4.0",
+ io.openliberty.restfulWSClient-3.0; type="osgi.subsystem.feature"; ibm.tolerates:="3.1, 4.0",
+ io.openliberty.jsonp-2.0; type="osgi.subsystem.feature"; ibm.tolerates:="2.1"
+IBM-API-Package: io.openliberty.mprestclient.fat.myrestclient.bundle

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/features/jakarta/MyRESTClient.mf
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/features/jakarta/MyRESTClient.mf
@@ -11,4 +11,5 @@ Subsystem-Content:
  io.openliberty.mpRestClient-3.0; type="osgi.subsystem.feature"; ibm.tolerates:="4.0",
  io.openliberty.restfulWSClient-3.0; type="osgi.subsystem.feature"; ibm.tolerates:="3.1, 4.0",
  io.openliberty.jsonp-2.0; type="osgi.subsystem.feature"; ibm.tolerates:="2.1"
-IBM-API-Package: io.openliberty.mprestclient.fat.myrestclient.bundle
+IBM-API-Package: 
+ io.openliberty.mprestclient.fat.myrestclient.bundle

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/features/javax/MyRESTClient.mf
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/features/javax/MyRESTClient.mf
@@ -1,0 +1,14 @@
+Subsystem-ManifestVersion: 1
+IBM-ShortName: MyRESTClient-1.0
+Subsystem-SymbolicName: MyRESTClient;visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Type: osgi.subsystem.feature
+IBM-Feature-Version: 2
+Subsystem-Vendor: IBM
+Subsystem-Content:
+ io.openliberty.mprestclient.fat.myrestclient;version="1.0",
+ com.ibm.websphere.appserver.mpConfig-1.2; type="osgi.subsystem.feature"; ibm.tolerates:="1.3, 1.4, 2.0",
+ com.ibm.websphere.appserver.mpRestClient-1.0; type="osgi.subsystem.feature"; ibm.tolerates:="1.1, 1.2, 1.3, 1.4, 2.0",
+ com.ibm.websphere.appserver.jaxrsClient-2.0; type="osgi.subsystem.feature"; ibm.tolerates:="2.1",
+ com.ibm.websphere.appserver.jsonp-1.0; type="osgi.subsystem.feature"; ibm.tolerates:="1.1"
+IBM-API-Package: io.openliberty.mprestclient.fat.myrestclient.bundle

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/features/javax/MyRESTClient.mf
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/features/javax/MyRESTClient.mf
@@ -1,6 +1,6 @@
 Subsystem-ManifestVersion: 1
 IBM-ShortName: MyRESTClient-1.0
-Subsystem-SymbolicName: MyRESTClient;visibility:=public
+Subsystem-SymbolicName: MyRESTClient-1.0;visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/MyRESTClientServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/MyRESTClientServer/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jaxrs*=all:org.apache.cxf.*=all:org.jboss.resteasy*=all
+com.ibm.ws.logging.max.file.size=0
+
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/MyRESTClientServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/MyRESTClientServer/server.xml
@@ -12,5 +12,7 @@
 
   <!--  Required to read the remote server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+  <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  <javaPermission className="java.lang.RuntimePermission" name="createClassLoader"/>
   
 </server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/MyRESTClientServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/MyRESTClientServer/server.xml
@@ -1,0 +1,16 @@
+<server>
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>jaxrs-2.0</feature>
+    <feature>mpConfig-1.2</feature>
+    <feature>mpRestClient-1.0</feature>
+    <feature>usr:MyRESTClient-1.0</feature>
+    <feature>servlet-3.1</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+  <!--  Required to read the remote server's port system property -->
+  <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+  
+</server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/MyRESTClientServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/MyRESTClientServer/server.xml
@@ -12,7 +12,7 @@
 
   <!--  Required to read the remote server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
-  <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
-  <javaPermission className="java.lang.RuntimePermission" name="createClassLoader"/>
+  <!-- <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  <javaPermission className="java.lang.RuntimePermission" name="createClassLoader"/> -->
   
 </server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic/server.xml
@@ -1,8 +1,10 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
+    <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
     <feature>ssl-1.0</feature>
+    <feature>servlet-3.1</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.collections/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.collections/server.xml
@@ -1,7 +1,9 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
+    <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
+    <feature>servlet-3.1</feature>
     <feature>ssl-1.0</feature>
   </featureManager>
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.handleresponses/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.handleresponses/server.xml
@@ -1,7 +1,9 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
+    <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
+    <feature>servlet-3.1</feature>
     <feature>ssl-1.0</feature>
   </featureManager>
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.headerPropagation/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.headerPropagation/server.xml
@@ -2,6 +2,7 @@
   <featureManager>
     <feature>componenttest-1.0</feature>
     <feature>jaxrs-2.0</feature>
+    <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
     <feature>appSecurity-2.0</feature>
     <feature>servlet-3.1</feature>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.props/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.props/server.xml
@@ -1,6 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
+    <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
     <feature>jaxrs-2.0</feature>
     <feature>servlet-3.1</feature>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.async/server.xml
@@ -2,6 +2,7 @@
     <featureManager>
         <feature>componenttest-1.0</feature>
         <feature>jaxrs-2.1</feature>
+        <feature>mpConfig-1.3</feature>
         <feature>mpRestClient-1.1</feature>
         <feature>jsonb-1.0</feature>
         <feature>concurrent-1.0</feature>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/server.xml
@@ -1,6 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
+    <feature>mpConfig-1.3</feature>
     <feature>mpRestClient-1.1</feature>
     <feature>ssl-1.0</feature>
     <feature>servlet-3.1</feature>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient12.jsonbContext/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient12.jsonbContext/server.xml
@@ -3,6 +3,7 @@
     <feature>componenttest-1.0</feature>
     <feature>jaxrs-2.1</feature>
     <feature>jsonb-1.0</feature>
+    <feature>mpConfig-1.3</feature>
     <feature>mpRestClient-1.2</feature>
     <feature>ssl-1.0</feature>
     <feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient13.ssl/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient13.ssl/server.xml
@@ -3,6 +3,7 @@
     <feature>componenttest-1.0</feature>
     <feature>jaxrs-2.1</feature>
     <feature>jsonb-1.0</feature>
+    <feature>mpConfig-1.3</feature>
     <feature>mpRestClient-1.3</feature>
     <feature>ssl-1.0</feature>
     <feature>servlet-4.0</feature>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient20.sse/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient20.sse/server.xml
@@ -1,6 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
+    <feature>mpConfig-2.0</feature>
     <feature>mpRestClient-2.0</feature>
     <feature>jaxrs-2.1</feature>
     <feature>jsonb-1.0</feature>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClient/src/io/openliberty/mprestclient/fat/myrestclient/app/MyRestApp.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClient/src/io/openliberty/mprestclient/fat/myrestclient/app/MyRestApp.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mprestclient.fat.myrestclient.app;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+@Path("rest")
+public class MyRestApp extends Application {
+
+    @GET
+    @Path("/greet")
+    @Produces({ "application/json" })
+    public String greet() {
+        return "Hello, World!";
+    }
+    
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClient/src/io/openliberty/mprestclient/fat/myrestclient/servlet/MyRestClientTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClient/src/io/openliberty/mprestclient/fat/myrestclient/servlet/MyRestClientTestServlet.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mprestclient.fat.myrestclient.servlet;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.mprestclient.fat.myrestclient.bundle.MyRESTClient;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/MyRestClientTestServlet")
+public class MyRestClientTestServlet extends FATServlet {
+
+    private static final String URI_CONTEXT_ROOT = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/MyRestClient";
+
+    private Client client;
+
+    @Override
+    public void before() throws ServletException {
+        client = ClientBuilder.newClient();
+    }
+
+    @Override
+    public void after() {
+        client.close();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testHelloWorld() throws MalformedURLException, InterruptedException {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("rest/greet")
+                        .request(MediaType.APPLICATION_JSON_TYPE)
+                        .get();
+
+        assertEquals(200, response.getStatus());
+        assertEquals("Hello, World!", response.readEntity(String.class));
+        
+        String result = MyRESTClient.getAPI(new URL(URI_CONTEXT_ROOT)).greet();
+        assertEquals("Hello, World!", result);
+    }
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/resources/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Bundle-ManifestVersion: 2
+Bundle-Name: io.openliberty.mprestclient.fat.myrestclient
+Bundle-SymbolicName: io.openliberty.mprestclient.fat.myrestclient
+Bundle-Version: 1.0.0
+Manifest-Version: 1.0
+Export-Package: io.openliberty.mprestclient.fat.myrestclient.bundle
+Import-Package: 
+ javax.ws.rs,
+ javax.ws.rs.core,
+ javax.ws.rs.ext,
+ org.eclipse.microprofile.rest.client,
+ org.eclipse.microprofile.rest.client.annotation,
+ org.eclipse.microprofile.rest.client.ext,
+ org.eclipse.microprofile.rest.client.inject

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/resources/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/resources/META-INF/MANIFEST.MF
@@ -3,7 +3,8 @@ Bundle-Name: io.openliberty.mprestclient.fat.myrestclient
 Bundle-SymbolicName: io.openliberty.mprestclient.fat.myrestclient
 Bundle-Version: 1.0.0
 Manifest-Version: 1.0
-Export-Package: io.openliberty.mprestclient.fat.myrestclient.bundle
+Export-Package: 
+ io.openliberty.mprestclient.fat.myrestclient.bundle
 Import-Package: 
  javax.ws.rs,
  javax.ws.rs.core,

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/src/io/openliberty/mprestclient/fat/myrestclient/bundle/MyRESTClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/src/io/openliberty/mprestclient/fat/myrestclient/bundle/MyRESTClient.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mprestclient.fat.myrestclient.bundle;
+
+import java.net.URL;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+public class MyRESTClient {
+    
+    public static MyRestAPI getAPI(URL url) {
+        return RestClientBuilder.newBuilder()
+                        .baseUrl(url)
+                        .build(MyRestAPI.class);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/src/io/openliberty/mprestclient/fat/myrestclient/bundle/MyRESTClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/src/io/openliberty/mprestclient/fat/myrestclient/bundle/MyRESTClient.java
@@ -13,12 +13,16 @@ import java.net.URL;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
+import io.openliberty.mprestclient.fat.myrestclient.internal.MyRestAPI;
+
 public class MyRESTClient {
     
-    public static MyRestAPI getAPI(URL url) {
-        return RestClientBuilder.newBuilder()
-                        .baseUrl(url)
-                        .build(MyRestAPI.class);
+    public static MyRestAPIWrapper getAPI(URL url) {
+        MyRestAPI restAPI = RestClientBuilder.newBuilder()
+                                .baseUrl(url)
+                                .build(MyRestAPI.class);
+        
+        return new MyRestAPIWrapper(restAPI);
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/src/io/openliberty/mprestclient/fat/myrestclient/bundle/MyRestAPI.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/src/io/openliberty/mprestclient/fat/myrestclient/bundle/MyRestAPI.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mprestclient.fat.myrestclient.bundle;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@Path("rest")
+public interface MyRestAPI {
+    
+    @GET
+    @Path("greet")
+    @Produces({ "application/json" })
+    public String greet();
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/src/io/openliberty/mprestclient/fat/myrestclient/bundle/MyRestAPIWrapper.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/src/io/openliberty/mprestclient/fat/myrestclient/bundle/MyRestAPIWrapper.java
@@ -9,19 +9,18 @@
  *******************************************************************************/
 package io.openliberty.mprestclient.fat.myrestclient.bundle;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import io.openliberty.mprestclient.fat.myrestclient.internal.MyRestAPI;
 
-import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-
-@RegisterRestClient
-@Path("rest")
-public interface MyRestAPI {
+public class MyRestAPIWrapper {
     
-    @GET
-    @Path("greet")
-    @Produces({ "application/json" })
-    public String greet();
+    private final MyRestAPI restAPI;
+
+    public MyRestAPIWrapper(MyRestAPI restAPI) {
+        this.restAPI = restAPI;
+    }
+
+    public String greet() {
+        return restAPI.greet();
+    }
 
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/src/io/openliberty/mprestclient/fat/myrestclient/internal/MyRestAPI.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/MyRestClientBundle/src/io/openliberty/mprestclient/fat/myrestclient/internal/MyRestAPI.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mprestclient.fat.myrestclient.internal;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+@Path("rest")
+public interface MyRestAPI {
+    
+    @GET
+    @Path("greet")
+    @Produces({ "application/json" })
+    public String greet();
+
+}

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3545,16 +3545,6 @@ public class LibertyServer implements LogMonitorClient {
                                                      "JsonbRxMessagingServer", //com.ibm.ws.microprofile.reactive.messaging_fat
 
                                                      "mpRestClient10.remoteServer", //com.ibm.ws.microprofile.rest.client_fat
-                                                     "mpRestClient11.async", //com.ibm.ws.microprofile.rest.client_fat
-                                                     "mpRestClient10.basic", //com.ibm.ws.microprofile.rest.client_fat
-                                                     "mpRestClient10.collections", //com.ibm.ws.microprofile.rest.client_fat
-                                                     "mpRestClient10.handleresponses", //com.ibm.ws.microprofile.rest.client_fat
-                                                     "mpRestClient10.headerPropagation", //com.ibm.ws.microprofile.rest.client_fat
-                                                     "mpRestClient13.ssl", //com.ibm.ws.microprofile.rest.client_fat
-                                                     "mpRestClient12.jsonbContext", //com.ibm.ws.microprofile.rest.client_fat
-                                                     "mpRestClient11.produceConsume", //com.ibm.ws.microprofile.rest.client_fat
-                                                     "mpRestClient10.props", //com.ibm.ws.microprofile.rest.client_fat
-                                                     "mpRestClient20.sse", //com.ibm.ws.microprofile.rest.client_fat
 
                                                      "opentracingFATServer1", //com.ibm.ws.opentracing.1.x_fat
                                                      "opentracingFATServer3", //com.ibm.ws.opentracing.1.x_fat

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/bnd.bnd
@@ -56,7 +56,8 @@ Import-Package: \
   *
 
 DynamicImport-Package: \
-  com.ibm.ws.microprofile.faulttolerance.cdi
+  com.ibm.ws.microprofile.faulttolerance.cdi,\
+  *
 
 Private-Package: \
   io.openliberty.microprofile.rest.client40.internal
@@ -73,37 +74,38 @@ Include-Resource:\
 
 
 -buildpath: \
-  org.jboss.resteasy.microprofile:microprofile-rest-client-base;strategy=exact;version=${resteasy-version},\
-  org.jboss.resteasy.microprofile:microprofile-rest-client;strategy=exact;version=${resteasy-version},\
-  com.ibm.ws.org.apache.commons.io,\
-  com.ibm.ws.org.apache.httpcomponents,\
-  io.openliberty.jakarta.activation.2.1,\
-  io.openliberty.jakarta.annotation.2.1,\
-  io.openliberty.jakarta.cdi.4.0; version=latest,\
-  io.openliberty.jakarta.interceptor.2.1,\
-  io.openliberty.jakarta.xmlBinding.4.0,\
-  io.openliberty.jakarta.restfulWS.3.1,\
-  io.openliberty.jakarta.jsonp.2.1,\
-  io.openliberty.jakarta.servlet.6.0,\
-  io.openliberty.jakarta.validation.3.0;version=latest,\
-  io.openliberty.jakarta.concurrency.3.0,\
-  io.openliberty.org.eclipse.microprofile.config.3.1;version=latest,\
-  io.openliberty.org.eclipse.microprofile.rest.client.4.0;version=latest,\
-  io.openliberty.org.jboss.resteasy.cdi.ee10;version=latest,\
-  io.openliberty.org.jboss.resteasy.common.ee10;version=latest,\
-  io.openliberty.webcontainer.security.internal;version=latest,\
-  com.ibm.websphere.org.osgi.core;version=latest,\
-  com.ibm.websphere.org.osgi.service.component;version=latest,\
-  com.ibm.ws.adaptable.module;version=latest,\
-  com.ibm.ws.anno;version=latest,\
-  com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
-  com.ibm.ws.classloading;version=latest,\
-  com.ibm.ws.container.service;version=latest,\
-  com.ibm.ws.container.service.compat;version=latest,\
-  com.ibm.ws.logging.core,\
-  com.ibm.ws.org.jboss.logging,\
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  com.ibm.ws.webcontainer.jakarta;version=latest,\
-  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-  com.ibm.websphere.appserver.api.basics,\
-  com.ibm.ws.kernel.service
+	org.jboss.resteasy.microprofile:microprofile-rest-client-base;strategy=exact;version='${resteasy-version}',\
+	org.jboss.resteasy.microprofile:microprofile-rest-client;strategy=exact;version='${resteasy-version}',\
+	com.ibm.ws.org.apache.commons.io,\
+	com.ibm.ws.org.apache.httpcomponents,\
+	io.openliberty.jakarta.activation.2.1,\
+	io.openliberty.jakarta.annotation.2.1,\
+	io.openliberty.jakarta.cdi.4.0;version=latest,\
+	io.openliberty.jakarta.interceptor.2.1,\
+	io.openliberty.jakarta.xmlBinding.4.0,\
+	io.openliberty.jakarta.restfulWS.3.1,\
+	io.openliberty.jakarta.jsonp.2.1,\
+	io.openliberty.jakarta.servlet.6.0,\
+	io.openliberty.jakarta.validation.3.0;version=latest,\
+	io.openliberty.jakarta.concurrency.3.0,\
+	io.openliberty.org.eclipse.microprofile.config.3.1;version=latest,\
+	io.openliberty.org.eclipse.microprofile.rest.client.4.0;version=latest,\
+	io.openliberty.org.jboss.resteasy.cdi.ee10;version=latest,\
+	io.openliberty.org.jboss.resteasy.common.ee10;version=latest,\
+	io.openliberty.webcontainer.security.internal;version=latest,\
+	com.ibm.websphere.org.osgi.core;version=latest,\
+	com.ibm.websphere.org.osgi.service.component;version=latest,\
+	com.ibm.ws.adaptable.module;version=latest,\
+	com.ibm.ws.anno;version=latest,\
+	com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
+	com.ibm.ws.classloading;version=latest,\
+	com.ibm.ws.container.service;version=latest,\
+	com.ibm.ws.container.service.compat;version=latest,\
+	com.ibm.ws.logging.core,\
+	com.ibm.ws.org.jboss.logging,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.webcontainer.jakarta;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.websphere.appserver.api.basics,\
+	com.ibm.ws.kernel.service,\
+	org.eclipse.osgi

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/bnd.bnd
@@ -106,5 +106,4 @@ Include-Resource:\
 	com.ibm.ws.webcontainer.jakarta;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.websphere.appserver.api.basics,\
-	com.ibm.ws.kernel.service,\
-	org.eclipse.osgi
+	com.ibm.ws.kernel.service

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/bnd.bnd
@@ -56,8 +56,7 @@ Import-Package: \
   *
 
 DynamicImport-Package: \
-  com.ibm.ws.microprofile.faulttolerance.cdi,\
-  *
+  com.ibm.ws.microprofile.faulttolerance.cdi
 
 Private-Package: \
   io.openliberty.microprofile.rest.client40.internal

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/io/openliberty/microprofile/rest/client40/internal/LibertyProxyClassLoader.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/io/openliberty/microprofile/rest/client40/internal/LibertyProxyClassLoader.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * 
+ * This file is based on Apache CXF's org.apache.cxf.common.util.ProxyClassLoader.
+ * https://github.com/apache/cxf/blob/main/core/src/main/java/org/apache/cxf/common/util/ProxyClassLoader.java
+ */
+package io.openliberty.microprofile.rest.client40.internal;
+
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+/**
+ * Utility class loader that can be used to create proxies in cases where
+ * the the client classes are not visible to the loader of the
+ * service class.
+ */
+public class LibertyProxyClassLoader extends ClassLoader {
+    private final Class<?>[] classes;
+    private final Set<ClassLoader> loaders = new HashSet<>();
+    private boolean checkSystem;
+
+    public LibertyProxyClassLoader(ClassLoader parent) {
+        super(parent);
+        classes = null;
+    }
+
+    public LibertyProxyClassLoader(ClassLoader parent, Class<?>[] cls) {
+        super(parent);
+        classes = cls;
+    }
+
+    public void addLoader(ClassLoader loader) {
+        if (loader == null) {
+            checkSystem = true;
+        } else {
+            // Liberty Change Start
+            if (!loaders.contains(loader)) {
+                loaders.add(loader);
+            }
+            // Liberty Change End
+        }
+    }
+
+    @Override
+    @FFDCIgnore({ ClassNotFoundException.class, NoClassDefFoundError.class}) // Liberty Change
+    public Class<?> findClass(String name) throws ClassNotFoundException {
+        if (classes != null) {
+            for (Class<?> c : classes) {
+                if (name.equals(c.getName())) {
+                    return c;
+                }
+            }
+        }
+        for (ClassLoader loader : loaders) {
+            try {
+                return loader.loadClass(name);
+            } catch (ClassNotFoundException | NoClassDefFoundError cnfe) {
+                // Try next
+            }
+        }
+        if (checkSystem) {
+            try {
+                return getSystemClassLoader().loadClass(name);
+            } catch (ClassNotFoundException | NoClassDefFoundError cnfe) {
+                // Try next
+            }
+        }
+        throw new ClassNotFoundException(name);
+    }
+
+    @Override
+    public URL findResource(String name) {
+        for (ClassLoader loader : loaders) {
+            URL url = loader.getResource(name);
+            if (url != null) {
+                return url;
+            }
+        }
+        return null;
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/io/openliberty/microprofile/rest/client40/internal/LibertyProxyClassLoader.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/io/openliberty/microprofile/rest/client40/internal/LibertyProxyClassLoader.java
@@ -18,7 +18,19 @@
  * 
  * This file is based on Apache CXF's org.apache.cxf.common.util.ProxyClassLoader.
  * https://github.com/apache/cxf/blob/main/core/src/main/java/org/apache/cxf/common/util/ProxyClassLoader.java
- */
+ *
+ *******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package io.openliberty.microprofile.rest.client40.internal;
 
 import java.net.URL;

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ot/DefaultMethodInvocationHandler.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ot/DefaultMethodInvocationHandler.java
@@ -40,10 +40,11 @@ public class DefaultMethodInvocationHandler implements InvocationHandler {
                                           final Object target,
                                           final Set<Object> providerInstances,
                                           final ResteasyClient client,
-                                          final BeanManager beanManager) {
+                                          final BeanManager beanManager,
+                                          final ClassLoader classLoader) {
         this.delegateHandler = new ProxyInvocationHandler(restClientInterface, target, providerInstances, client);
         this.restClientInterface = restClientInterface;
-        this.target = createDefaultMethodTarget(restClientInterface);
+        this.target = createDefaultMethodTarget(restClientInterface, classLoader);
     }
 
     @Override
@@ -54,9 +55,9 @@ public class DefaultMethodInvocationHandler implements InvocationHandler {
         return delegateHandler.invoke(proxy, method, args);
     }
 
-    private static Object createDefaultMethodTarget(Class<?> interfaceClass) {
+    private static Object createDefaultMethodTarget(Class<?> interfaceClass, ClassLoader classLoader) {
         return AccessController.doPrivileged((PrivilegedAction<Object>) () -> 
-            Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),new Class[]{interfaceClass}, (Object proxy, Method method, Object[] arguments) -> null));
+            Proxy.newProxyInstance(classLoader, new Class[]{interfaceClass}, (Object proxy, Method method, Object[] arguments) -> null));
     }
 
     private static Object invokeDefaultMethod(Class<?> declaringClass, Object o, Method m, Object[] params)

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ot/LibertyProxyInvocationHandler.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ot/LibertyProxyInvocationHandler.java
@@ -36,9 +36,10 @@ public class LibertyProxyInvocationHandler implements InvocationHandler {
                                   final Set<Object> providerInstances,
                                   final ResteasyClient client,
                                   final BeanManager beanManager,
-                                  final Map<Method, List<InterceptorInvoker>> interceptorInvokers) {
+                                  final Map<Method, List<InterceptorInvoker>> interceptorInvokers,
+                                  final ClassLoader classLoader) {
         this.interceptorInvokers = interceptorInvokers;
-        this.delegateHandler = new DefaultMethodInvocationHandler(restClientInterface, target, providerInstances, client, beanManager);
+        this.delegateHandler = new DefaultMethodInvocationHandler(restClientInterface, target, providerInstances, client, beanManager, classLoader);
     }
 
     @Override

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
@@ -1,7 +1,7 @@
 /*
  * JBoss, Home of Professional Open Source.
  *
- * Copyright 2024 Red Hat, Inc., and individual contributors
+ * Copyright 2024, 2025 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
@@ -41,7 +41,6 @@ import org.jboss.resteasy.microprofile.client.DefaultMediaTypeFilter;
 import org.jboss.resteasy.microprofile.client.DefaultResponseExceptionMapper;
 import org.jboss.resteasy.microprofile.client.ExceptionMapping;
 import org.jboss.resteasy.microprofile.client.MethodInjectionFilter;
-import org.jboss.resteasy.microprofile.client.ProxyInvocationHandler;
 import org.jboss.resteasy.microprofile.client.RestClientBuilderImpl;
 import org.jboss.resteasy.microprofile.client.RestClientListeners;
 import org.jboss.resteasy.microprofile.client.RestClientProxy;
@@ -110,7 +109,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -123,7 +121,6 @@ import static org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder.PROPERTY_PRO
 
 import org.jboss.resteasy.concurrent.ContextualExecutorService;
 import org.jboss.resteasy.concurrent.ContextualExecutors;
-import org.eclipse.osgi.internal.loader.EquinoxClassLoader;
 
 /**
  * @author Bill Burke (initial commit according to GitHub history)

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
@@ -141,8 +141,8 @@ public class LibertyRestClientBuilderImpl implements RestClientBuilder {
     public static final ClientHeadersRequestFilter HEADERS_REQUEST_FILTER = new ClientHeadersRequestFilter();
 
     private static final Class<?> FT_ANNO_CLASS = getFTAnnotationClass(); // Liberty Change
-    private static final ClassLoader myClassLoader; // liberty change
-    private static final boolean isOSGiEnv; // liberty change
+    private static final ClassLoader myClassLoader; // Liberty change
+    private static final boolean isOSGiEnv; // Liberty change
 
     static ResteasyProviderFactory PROVIDER_FACTORY;
     
@@ -150,7 +150,7 @@ public class LibertyRestClientBuilderImpl implements RestClientBuilder {
         Collections.addAll(IGNORED_METHODS, Closeable.class.getMethods());
         Collections.addAll(IGNORED_METHODS, AutoCloseable.class.getMethods());
         
-        // liberty change start
+        // Liberty Change Start
         myClassLoader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
             @Override
             public ClassLoader run() {
@@ -164,7 +164,7 @@ public class LibertyRestClientBuilderImpl implements RestClientBuilder {
             // not running in an OSGi environment
         }
         isOSGiEnv = isOSGi;
-        // liberty change end
+        // Liberty Change End
     }
 
     public static void setProviderFactory(ResteasyProviderFactory providerFactory) {

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2024 IBM Corporation and others.
+# Copyright (c) 2021, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
@@ -54,7 +54,8 @@ Import-Package: \
   *
 
 DynamicImport-Package: \
-  com.ibm.ws.microprofile.faulttolerance.cdi
+  com.ibm.ws.microprofile.faulttolerance.cdi,\
+  *
 
 Private-Package: \
   io.openliberty.microprofile.rest.client30.internal
@@ -70,39 +71,40 @@ Include-Resource:\
 
 
 -buildpath: \
-  io.openliberty.org.jboss.resteasy.common,\
-  io.openliberty.org.jboss.resteasy.cdi,\
-  org.jboss.resteasy:resteasy-client-microprofile-base;strategy=exact;version=${resteasy-version},\
-  org.jboss.resteasy:resteasy-client-microprofile;strategy=exact;version=${resteasy-version},\
-  com.ibm.ws.org.apache.commons.io,\
-  com.ibm.ws.org.apache.httpcomponents,\
-  com.ibm.websphere.javaee.annotation.1.3,\
-  com.ibm.websphere.javaee.cdi.2.0,\
-  io.openliberty.jakarta.cdi.3.0; version=latest,\
-  com.ibm.websphere.javaee.interceptor.1.2,\
-  com.ibm.websphere.javaee.jaxb.2.2,\
-  com.ibm.websphere.javaee.jaxrs.2.1,\
-  com.ibm.websphere.javaee.jsonp.1.1,\
-  com.ibm.websphere.javaee.servlet.4.0,\
-  com.ibm.websphere.javaee.validation.2.0;version=latest,\
-  com.ibm.websphere.javaee.concurrent.1.0,\
-  io.openliberty.org.eclipse.microprofile.config.2.0;version=latest,\
-  io.openliberty.org.eclipse.microprofile.rest.client.2.0;version=latest,\
-  com.ibm.websphere.org.osgi.core;version=latest,\
-  com.ibm.websphere.org.osgi.service.component;version=latest,\
-  com.ibm.ws.adaptable.module;version=latest,\
-  com.ibm.ws.anno;version=latest,\
-  com.ibm.ws.cdi.interfaces;version=latest,\
-  com.ibm.ws.classloading;version=latest,\
-  com.ibm.ws.container.service;version=latest,\
-  com.ibm.ws.container.service.compat;version=latest,\
-  com.ibm.ws.jaxrs.2.0.common;version=latest,\
-  com.ibm.ws.logging.core,\
-  com.ibm.ws.org.jboss.logging,\
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  com.ibm.ws.webcontainer;version=latest,\
-  com.ibm.ws.webcontainer.security;version=latest,\
-  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-  javax.activation:activation;version=1.1,\
-  com.ibm.websphere.appserver.api.basics,\
-  com.ibm.ws.kernel.service
+	io.openliberty.org.jboss.resteasy.common,\
+	io.openliberty.org.jboss.resteasy.cdi,\
+	org.jboss.resteasy:resteasy-client-microprofile-base;strategy=exact;version='${resteasy-version}',\
+	org.jboss.resteasy:resteasy-client-microprofile;strategy=exact;version='${resteasy-version}',\
+	com.ibm.ws.org.apache.commons.io,\
+	com.ibm.ws.org.apache.httpcomponents,\
+	com.ibm.websphere.javaee.annotation.1.3,\
+	com.ibm.websphere.javaee.cdi.2.0,\
+	io.openliberty.jakarta.cdi.3.0;version=latest,\
+	com.ibm.websphere.javaee.interceptor.1.2,\
+	com.ibm.websphere.javaee.jaxb.2.2,\
+	com.ibm.websphere.javaee.jaxrs.2.1,\
+	com.ibm.websphere.javaee.jsonp.1.1,\
+	com.ibm.websphere.javaee.servlet.4.0,\
+	com.ibm.websphere.javaee.validation.2.0;version=latest,\
+	com.ibm.websphere.javaee.concurrent.1.0,\
+	io.openliberty.org.eclipse.microprofile.config.2.0;version=latest,\
+	io.openliberty.org.eclipse.microprofile.rest.client.2.0;version=latest,\
+	com.ibm.websphere.org.osgi.core;version=latest,\
+	com.ibm.websphere.org.osgi.service.component;version=latest,\
+	com.ibm.ws.adaptable.module;version=latest,\
+	com.ibm.ws.anno;version=latest,\
+	com.ibm.ws.cdi.interfaces;version=latest,\
+	com.ibm.ws.classloading;version=latest,\
+	com.ibm.ws.container.service;version=latest,\
+	com.ibm.ws.container.service.compat;version=latest,\
+	com.ibm.ws.jaxrs.2.0.common;version=latest,\
+	com.ibm.ws.logging.core,\
+	com.ibm.ws.org.jboss.logging,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.webcontainer;version=latest,\
+	com.ibm.ws.webcontainer.security;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	javax.activation:activation;version='1.1',\
+	com.ibm.websphere.appserver.api.basics,\
+	com.ibm.ws.kernel.service,\
+	org.eclipse.osgi

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
@@ -105,5 +105,4 @@ Include-Resource:\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	javax.activation:activation;version='1.1',\
 	com.ibm.websphere.appserver.api.basics,\
-	com.ibm.ws.kernel.service,\
-	org.eclipse.osgi
+	com.ibm.ws.kernel.service

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/bnd.bnd
@@ -54,8 +54,7 @@ Import-Package: \
   *
 
 DynamicImport-Package: \
-  com.ibm.ws.microprofile.faulttolerance.cdi,\
-  *
+  com.ibm.ws.microprofile.faulttolerance.cdi
 
 Private-Package: \
   io.openliberty.microprofile.rest.client30.internal

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/io/openliberty/microprofile/rest/client30/internal/LibertyProxyClassLoader.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/io/openliberty/microprofile/rest/client30/internal/LibertyProxyClassLoader.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * 
+ * This file is based on Apache CXF's org.apache.cxf.common.util.ProxyClassLoader.
+ * https://github.com/apache/cxf/blob/main/core/src/main/java/org/apache/cxf/common/util/ProxyClassLoader.java
+ */
+package io.openliberty.microprofile.rest.client30.internal;
+
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+/**
+ * Utility class loader that can be used to create proxies in cases where
+ * the the client classes are not visible to the loader of the
+ * service class.
+ */
+public class LibertyProxyClassLoader extends ClassLoader {
+    private final Class<?>[] classes;
+    private final Set<ClassLoader> loaders = new HashSet<>();
+    private boolean checkSystem;
+
+    public LibertyProxyClassLoader(ClassLoader parent) {
+        super(parent);
+        classes = null;
+    }
+
+    public LibertyProxyClassLoader(ClassLoader parent, Class<?>[] cls) {
+        super(parent);
+        classes = cls;
+    }
+
+    public void addLoader(ClassLoader loader) {
+        if (loader == null) {
+            checkSystem = true;
+        } else {
+            // Liberty Change Start
+            if (!loaders.contains(loader)) {
+                loaders.add(loader);
+            }
+            // Liberty Change End
+        }
+    }
+
+    @Override
+    @FFDCIgnore({ ClassNotFoundException.class, NoClassDefFoundError.class}) // Liberty Change
+    public Class<?> findClass(String name) throws ClassNotFoundException {
+        if (classes != null) {
+            for (Class<?> c : classes) {
+                if (name.equals(c.getName())) {
+                    return c;
+                }
+            }
+        }
+        for (ClassLoader loader : loaders) {
+            try {
+                return loader.loadClass(name);
+            } catch (ClassNotFoundException | NoClassDefFoundError cnfe) {
+                // Try next
+            }
+        }
+        if (checkSystem) {
+            try {
+                return getSystemClassLoader().loadClass(name);
+            } catch (ClassNotFoundException | NoClassDefFoundError cnfe) {
+                // Try next
+            }
+        }
+        throw new ClassNotFoundException(name);
+    }
+
+    @Override
+    public URL findResource(String name) {
+        for (ClassLoader loader : loaders) {
+            URL url = loader.getResource(name);
+            if (url != null) {
+                return url;
+            }
+        }
+        return null;
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/io/openliberty/microprofile/rest/client30/internal/LibertyProxyClassLoader.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/io/openliberty/microprofile/rest/client30/internal/LibertyProxyClassLoader.java
@@ -18,7 +18,19 @@
  * 
  * This file is based on Apache CXF's org.apache.cxf.common.util.ProxyClassLoader.
  * https://github.com/apache/cxf/blob/main/core/src/main/java/org/apache/cxf/common/util/ProxyClassLoader.java
- */
+ *
+ *******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package io.openliberty.microprofile.rest.client30.internal;
 
 import java.net.URL;

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/DefaultMethodInvocationHandler.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/DefaultMethodInvocationHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -41,10 +41,11 @@ public class DefaultMethodInvocationHandler implements InvocationHandler {
                                           final Object target,
                                           final Set<Object> providerInstances,
                                           final ResteasyClient client,
-                                          final BeanManager beanManager) {
+                                          final BeanManager beanManager,
+                                          final ClassLoader classLoader) {
         this.delegateHandler = new ProxyInvocationHandler(restClientInterface, target, providerInstances, client, beanManager);
         this.restClientInterface = restClientInterface;
-        this.target = createDefaultMethodTarget(restClientInterface);
+        this.target = createDefaultMethodTarget(restClientInterface, classLoader);
     }
 
     @Override
@@ -55,9 +56,9 @@ public class DefaultMethodInvocationHandler implements InvocationHandler {
         return delegateHandler.invoke(proxy, method, args);
     }
 
-    private static Object createDefaultMethodTarget(Class<?> interfaceClass) {
+    private static Object createDefaultMethodTarget(Class<?> interfaceClass, ClassLoader classLoader) {
         return AccessController.doPrivileged((PrivilegedAction<Object>) () -> 
-            Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),new Class[]{interfaceClass}, (Object proxy, Method method, Object[] arguments) -> null));
+            Proxy.newProxyInstance(classLoader, new Class[]{interfaceClass}, (Object proxy, Method method, Object[] arguments) -> null));
     }
 
     private static Object invokeDefaultMethod(Class<?> declaringClass, Object o, Method m, Object[] params)

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyProxyInvocationHandler.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyProxyInvocationHandler.java
@@ -36,9 +36,10 @@ public class LibertyProxyInvocationHandler implements InvocationHandler {
                                   final Set<Object> providerInstances,
                                   final ResteasyClient client,
                                   final BeanManager beanManager,
-                                  final Map<Method, List<InterceptorInvoker>> interceptorInvokers) {
+                                  final Map<Method, List<InterceptorInvoker>> interceptorInvokers,
+                                  final ClassLoader classLoader) {
         this.interceptorInvokers = interceptorInvokers;
-        this.delegateHandler = new DefaultMethodInvocationHandler(restClientInterface, target, providerInstances, client, beanManager);
+        this.delegateHandler = new DefaultMethodInvocationHandler(restClientInterface, target, providerInstances, client, beanManager, classLoader);
     }
 
     @Override

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
@@ -133,13 +133,13 @@ public class LibertyRestClientBuilderImpl implements RestClientBuilder {
     public static final ClientHeadersRequestFilter HEADERS_REQUEST_FILTER = new ClientHeadersRequestFilter();
 
     private static final Class<?> FT_ANNO_CLASS = getFTAnnotationClass();
-    private static final ClassLoader myClassLoader; // liberty change
-    private static final boolean isOSGiEnv; // liberty change
+    private static final ClassLoader myClassLoader; // Liberty change
+    private static final boolean isOSGiEnv; // Liberty change
 
     static ResteasyProviderFactory PROVIDER_FACTORY;
     
     static {
-        // liberty change start
+        // Liberty Change Start
         myClassLoader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
             @Override
             public ClassLoader run() {
@@ -153,7 +153,7 @@ public class LibertyRestClientBuilderImpl implements RestClientBuilder {
             // not running in an OSGi environment
         }
         isOSGiEnv = isOSGi;
-        // liberty change end
+        // Liberty Change End
     }
 
     public static void setProviderFactory(ResteasyProviderFactory providerFactory) {

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
@@ -1,7 +1,7 @@
 /*
  * JBoss, Home of Professional Open Source.
  *
- * Copyright 2021 Red Hat, Inc., and individual contributors
+ * Copyright 2021, 2025 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
@@ -134,28 +134,9 @@ public class LibertyRestClientBuilderImpl implements RestClientBuilder {
     public static final ClientHeadersRequestFilter HEADERS_REQUEST_FILTER = new ClientHeadersRequestFilter();
 
     private static final Class<?> FT_ANNO_CLASS = getFTAnnotationClass();
-    private static final LibertyProxyClassLoader myClassLoader; // Liberty change
-    private static final boolean isOSGiEnv; // Liberty change
+    private  final LibertyProxyClassLoader myClassLoader; // Liberty change
 
     static ResteasyProviderFactory PROVIDER_FACTORY;
-    
-    static {
-        // Liberty Change Start
-        myClassLoader = AccessController.doPrivileged(new PrivilegedAction<LibertyProxyClassLoader>() {
-            @Override
-            public LibertyProxyClassLoader run() {
-                return new LibertyProxyClassLoader(LibertyRestClientBuilderImpl.class.getClassLoader());
-            }
-        });
-        boolean isOSGi = false;
-        try {
-            isOSGi = myClassLoader.getParent() instanceof EquinoxClassLoader;
-        } catch (Throwable t) {
-            // not running in an OSGi environment
-        }
-        isOSGiEnv = isOSGi;
-        // Liberty Change End
-    }
 
     public static void setProviderFactory(ResteasyProviderFactory providerFactory) {
         PROVIDER_FACTORY = providerFactory;
@@ -178,6 +159,15 @@ public class LibertyRestClientBuilderImpl implements RestClientBuilder {
     }
 
     public LibertyRestClientBuilderImpl() {
+        // Liberty Change Start
+        myClassLoader = AccessController.doPrivileged(new PrivilegedAction<LibertyProxyClassLoader>() {
+            @Override
+            public LibertyProxyClassLoader run() {
+                return new LibertyProxyClassLoader(LibertyRestClientBuilderImpl.class.getClassLoader());
+            }
+        });
+        // Liberty Change End
+        
         builderDelegate = new MpClientBuilderImpl();
 
         if (PROVIDER_FACTORY != null) {
@@ -872,7 +862,8 @@ public class LibertyRestClientBuilderImpl implements RestClientBuilder {
         return AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key, def));
     }
 
-    private static ClassLoader getClassLoader(Class<?> clazz) {
+    // Liberty Change Start
+    private ClassLoader getClassLoader(Class<?> clazz) {
         ClassLoader clazzLoader = null;
         if (System.getSecurityManager() == null) {
             clazzLoader = clazz.getClassLoader();
@@ -880,21 +871,11 @@ public class LibertyRestClientBuilderImpl implements RestClientBuilder {
             clazzLoader = AccessController.doPrivileged((PrivilegedAction<ClassLoader>) clazz::getClassLoader);
         }
 
-        // We need make sure the correct classloader is used to load files when MPRestClient 
-        // is provided via user OSGI bundles via user feature.
-        // !isOSGiEnv is the case where it is not an OSGi environment.  Mainly this scenario is the TCK scenario.
-        // clazzLoader instanceof EquinoxClassLoader means it is from a Liberty bundle instead of an application
-        try {
-            if (!isOSGiEnv || clazzLoader == null || clazzLoader instanceof EquinoxClassLoader) {
-                myClassLoader.addLoader(clazzLoader);
-                clazzLoader = myClassLoader;
-            }
-        } catch (Throwable t) {
-            // This catch block is a just in case scenario that shouldn't happen, but if it did...
-            clazzLoader = myClassLoader;
-        }
-        return clazzLoader;
+        myClassLoader.addLoader(clazzLoader);
+        
+        return myClassLoader;
     }
+    // Liberty Change End
 
     private static Map<Method, List<InterceptorInvoker>> initInterceptorInvokers(BeanManager beanManager,
                                                                                  Class<?> restClient) {

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/ot/LibertyRestClientBuilderImpl.java
@@ -28,7 +28,6 @@ import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
-import org.eclipse.osgi.internal.loader.EquinoxClassLoader;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.cdi.CdiInjectorFactory;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
@@ -115,8 +114,6 @@ import java.util.stream.Collectors;
 import static org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder.PROPERTY_PROXY_HOST;
 import static org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder.PROPERTY_PROXY_PORT;
 import static org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder.PROPERTY_PROXY_SCHEME;
-
-import org.eclipse.osgi.internal.loader.EquinoxClassLoader;
 
 /**
  * @author Bill Burke (initial commit according to GitHub history)


### PR DESCRIPTION
RESTEasy needs to do the classloading and it needs to be able to find classes from the user feature's OSGI bundle.

The solution for this problem is similar to what was done in PR #29145 for RESTful Web Services function in the non MP Rest Client function in RESTEasy

Fixes #31741

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


