### PR TITLE
Increase OpenAPI customization timeout

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/UICustomizationTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/UICustomizationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -55,7 +55,7 @@ public class UICustomizationTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
 
-    private final static int TIMEOUT = 10000; // in ms
+    private final static int TIMEOUT = 30000; // in ms
     private final static int START_TIMEOUT = 60000; // in ms
 
     private final static String WARNING_CUSTOM_CSS_NOT_PROCESSED = "CWWKO1655W";


### PR DESCRIPTION
Increase the time we allow for the bundle to restart after OpenAPI UI customization files are updated.

Should resolve a rare build break timeout.

For RTC303270

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".