### PR TITLE
Infinispan session test unable to init Cache

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/sessionCacheConfigApp/src/session/cache/infinispan/web/SessionCacheConfigTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/sessionCacheConfigApp/src/session/cache/infinispan/web/SessionCacheConfigTestServlet.java
@@ -421,14 +421,12 @@ public class SessionCacheConfigTestServlet extends FATServlet {
 
         HttpSession session = request.getSession(true);
         if (session == null) {
-            // Retry getSession() as request.getSession(true) can not be null in the production world
-            System.out.println("Sleep 5 seconds due to session return null");
             try {
-                
+                // Retry getSession() as request.getSession(true) can not be null in the production world
+                System.out.println("Sleep 5 seconds due to session return null");
+                TimeUnit.SECONDS.sleep(5);                
             } catch (Exception e) {
-                // TODO: handle exception
             }
-            TimeUnit.SECONDS.sleep(5);
             session = request.getSession(true);
         }
         session.setAttribute(attrName, value);

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/sessionCacheConfigApp/src/session/cache/infinispan/web/SessionCacheConfigTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/sessionCacheConfigApp/src/session/cache/infinispan/web/SessionCacheConfigTestServlet.java
@@ -119,9 +119,20 @@ public class SessionCacheConfigTestServlet extends FATServlet {
      * Obtains the session id for the current session and writes it to the servlet response
      */
     public void getSessionId(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String sessionId = request.getSession().getId();
-        System.out.println("session id is " + sessionId);
-        response.getWriter().write("session id: [" + sessionId + "]");
+        HttpSession session = request.getSession();
+        if (session == null) {
+            // Retry getSession(), most likely due to SESN0307E: Unable to start JGroups Channel
+            System.out.println("Sleep 5 seconds due to session return null ...");
+            TimeUnit.SECONDS.sleep(5);
+            session = request.getSession();
+        }
+        if (session != null) {
+            String sessionId = session.getId();
+            System.out.println("session id is " + sessionId);
+            response.getWriter().write("session id: [" + sessionId + "]");            
+        } else {
+            System.out.println("Unable to get session from the servlet request, most likely due to exception occurred when initializing the cache. Return instead of NPE, please check the logs.");
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/sessionCacheConfigApp/src/session/cache/infinispan/web/SessionCacheConfigTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/test-applications/sessionCacheConfigApp/src/session/cache/infinispan/web/SessionCacheConfigTestServlet.java
@@ -121,9 +121,12 @@ public class SessionCacheConfigTestServlet extends FATServlet {
     public void getSessionId(HttpServletRequest request, HttpServletResponse response) throws IOException {
         HttpSession session = request.getSession();
         if (session == null) {
-            // Retry getSession(), most likely due to SESN0307E: Unable to start JGroups Channel
-            System.out.println("Sleep 5 seconds due to session return null ...");
-            TimeUnit.SECONDS.sleep(5);
+            try {
+                // Retry getSession(), most likely due to SESN0307E: Unable to start JGroups Channel
+                System.out.println("Sleep 5 seconds due to session return null ...");
+                TimeUnit.SECONDS.sleep(5);                
+            } catch (Exception e) {
+            }
             session = request.getSession();
         }
         if (session != null) {
@@ -420,6 +423,11 @@ public class SessionCacheConfigTestServlet extends FATServlet {
         if (session == null) {
             // Retry getSession() as request.getSession(true) can not be null in the production world
             System.out.println("Sleep 5 seconds due to session return null");
+            try {
+                
+            } catch (Exception e) {
+                // TODO: handle exception
+            }
             TimeUnit.SECONDS.sleep(5);
             session = request.getSession(true);
         }


### PR DESCRIPTION
session.cache.infinispan.web.SessionCacheConfigTestServlet.getSession() return null due to Cache init failure:

[6/3/25, 23:43:45:106 PDT] 00000079 id=00000000 com.ibm.ws.session.store.cache.CacheHashMap                  E SESN0307E: An exception occurred when initializing the cache. The exception is: org.infinispan.manager.EmbeddedCacheManagerStartupException: org.infinispan.commons.CacheException: Unable to start JGroups Channel
	at org.infinispan.manager.DefaultCacheManager.internalStart(DefaultCacheManager.java:746)
	at org.infinispan.manager.DefaultCacheManager.start(DefaultCacheManager.java:712)
	at org.infinispan.manager.DefaultCacheManager.<init>(DefaultCacheManager.java:390)
	at org.infinispan.jcache.embedded.JCacheManager.<init>(JCacheManager.java:75)
	at org.infinispan.jcache.embedded.JCachingProvider.createCacheManager(JCachingProvider.java:46)
	at org.infinispan.jcache.AbstractJCachingProvider.getCacheManager(AbstractJCachingProvider.java:67)
	at com.ibm.ws.session.store.cache.CacheStoreService.lambda$activateLazily$0(CacheStoreService.java:250)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:569)
	at com.ibm.ws.session.store.cache.CacheStoreService.activateLazily(CacheStoreService.java:205)
	at com.ibm.ws.session.store.cache.CacheHashMap.cacheInit(CacheHashMap.java:152)
	at com.ibm.ws.session.store.cache.CacheHashMap.lambda$new$0(CacheHashMap.java:138)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
	at com.ibm.ws.session.store.cache.CacheHashMap.lambda$new$1(CacheHashMap.java:138)
	at io.openliberty.checkpoint.spi.CheckpointPhase.onRestore(CheckpointPhase.java:377)
	at com.ibm.ws.session.store.cache.CacheHashMap.<init>(CacheHashMap.java:138)
	at com.ibm.ws.session.store.cache.CacheStore.<init>(CacheStore.java:35)
	at com.ibm.ws.session.store.cache.CacheStoreService.createStore(CacheStoreService.java:357)
	at com.ibm.ws.session.SessionContext.createStore(SessionContext.java:344)
	at com.ibm.ws.session.SessionContext.createCoreSessionManager(SessionContext.java:260)
	at com.ibm.ws.session.SessionContext.<init>(SessionContext.java:163)
	at com.ibm.ws.webcontainer.session.impl.HttpSessionContextImpl.<init>(HttpSessionContextImpl.java:67)
	at com.ibm.ws.webcontainer31.session.impl.HttpSessionContext31Impl.<init>(HttpSessionContext31Impl.java:39)
	at com.ibm.ws.webcontainer31.session.impl.SessionContextRegistry31Impl.createSessionContextObject(SessionContextRegistry31Impl.java:42)
	at com.ibm.ws.webcontainer.session.impl.SessionContextRegistryImpl.createSessionContext(SessionContextRegistryImpl.java:86)
	at com.ibm.ws.webcontainer.session.impl.SessionContextRegistryImpl.getSessionContext(SessionContextRegistryImpl.java:309)
	at com.ibm.ws.webcontainer.WebContainer.getSessionContext(WebContainer.java:708)
	at com.ibm.ws.webcontainer.VirtualHost.getSessionContext(VirtualHost.java:190)
	at com.ibm.ws.webcontainer.webapp.WebGroup.getSessionContext(WebGroup.java:158)
	at com.ibm.ws.webcontainer.webapp.WebApp.createSessionContext(WebApp.java:1340)
	at com.ibm.ws.webcontainer.webapp.WebApp.commonInitializationStart(WebApp.java:1323)
	at com.ibm.ws.webcontainer.osgi.webapp.WebApp.commonInitializationStart(WebApp.java:256)
	at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:1035)
	at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:6722)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApp(DynamicVirtualHost.java:484)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApplication(DynamicVirtualHost.java:479)
	at com.ibm.ws.webcontainer.osgi.WebContainer.startWebApplication(WebContainer.java:1208)
	at com.ibm.ws.webcontainer.osgi.WebContainer.access$100(WebContainer.java:113)
	at com.ibm.ws.webcontainer.osgi.WebContainer$3.run(WebContainer.java:996)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:298)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:842)
Caused by: org.infinispan.commons.CacheException: Unable to start JGroups Channel
	at org.infinispan.remoting.transport.jgroups.JGroupsTransport.startJGroupsChannelIfNeeded(JGroupsTransport.java:512)
	at org.infinispan.remoting.transport.jgroups.JGroupsTransport.start(JGroupsTransport.java:437)
	at org.infinispan.remoting.transport.jgroups.CorePackageImpl$1.start(CorePackageImpl.java:37)
	at org.infinispan.remoting.transport.jgroups.CorePackageImpl$1.start(CorePackageImpl.java:24)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.invokeStart(BasicComponentRegistryImpl.java:587)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.doStartWrapper(BasicComponentRegistryImpl.java:578)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.startWrapper(BasicComponentRegistryImpl.java:547)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.access$700(BasicComponentRegistryImpl.java:30)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl$ComponentWrapper.running(BasicComponentRegistryImpl.java:770)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.startDependencies(BasicComponentRegistryImpl.java:605)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.doStartWrapper(BasicComponentRegistryImpl.java:569)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.startWrapper(BasicComponentRegistryImpl.java:547)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.access$700(BasicComponentRegistryImpl.java:30)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl$ComponentWrapper.running(BasicComponentRegistryImpl.java:770)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.startDependencies(BasicComponentRegistryImpl.java:605)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.doStartWrapper(BasicComponentRegistryImpl.java:569)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.startWrapper(BasicComponentRegistryImpl.java:547)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl.access$700(BasicComponentRegistryImpl.java:30)
	at org.infinispan.factories.impl.BasicComponentRegistryImpl$ComponentWrapper.running(BasicComponentRegistryImpl.java:770)
	at org.infinispan.factories.AbstractComponentRegistry.internalStart(AbstractComponentRegistry.java:344)
	at org.infinispan.factories.AbstractComponentRegistry.start(AbstractComponentRegistry.java:240)
	at org.infinispan.manager.DefaultCacheManager.internalStart(DefaultCacheManager.java:741)
	... 43 more
Caused by: java.lang.UnsupportedOperationException
	at java.base/sun.nio.ch.DatagramChannelImpl.innerJoin(DatagramChannelImpl.java:1543)
	at java.base/sun.nio.ch.DatagramChannelImpl.join(DatagramChannelImpl.java:1559)
	at java.base/sun.nio.ch.DatagramSocketAdaptor.joinGroup(DatagramSocketAdaptor.java:535)
	at java.base/sun.nio.ch.DatagramSocketAdaptor.joinGroup(DatagramSocketAdaptor.java:481)
	at java.base/java.net.MulticastSocket.joinGroup(MulticastSocket.java:325)
	at org.jgroups.protocols.UDP.createSockets(UDP.java:408)
	at org.jgroups.protocols.UDP.start(UDP.java:294)
	at org.jgroups.stack.ProtocolStack.startStack(ProtocolStack.java:888)
	at org.jgroups.JChannel.startStack(JChannel.java:980)
	at org.jgroups.JChannel._preConnect(JChannel.java:844)
	at org.jgroups.JChannel.connect(JChannel.java:349)
	at org.jgroups.JChannel.connect(JChannel.java:343)
	at org.infinispan.remoting.transport.jgroups.JGroupsTransport.startJGroupsChannelIfNeeded(JGroupsTransport.java:510)
	... 64 more
.
[6/3/25, 23:43:45:109 PDT] 00000079 id=00000000 com.ibm.ws.webcontainer.internal.WebContainer                E getSessionContext SRVE8059E: An unexpected exception occurred when trying to retrieve the session context
java.lang.RuntimeException: Internal Server Error
	at com.ibm.ws.session.store.cache.CacheHashMap.cacheInit(CacheHashMap.java:252)
	at com.ibm.ws.session.store.cache.CacheHashMap.lambda$new$0(CacheHashMap.java:138)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
	at com.ibm.ws.session.store.cache.CacheHashMap.lambda$new$1(CacheHashMap.java:138)
	at io.openliberty.checkpoint.spi.CheckpointPhase.onRestore(CheckpointPhase.java:377)
	at com.ibm.ws.session.store.cache.CacheHashMap.<init>(CacheHashMap.java:138)
	at com.ibm.ws.session.store.cache.CacheStore.<init>(CacheStore.java:35)
	at com.ibm.ws.session.store.cache.CacheStoreService.createStore(CacheStoreService.java:357)