### PR TITLE
Do not remove Netty InactivityTimeoutHandler from pipeline

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/HttpPipelineInitializer.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/HttpPipelineInitializer.java
@@ -129,7 +129,6 @@ public class HttpPipelineInitializer extends ChannelInitializerWrapper {
         } else {
             setupUnsecurePipeline(pipeline);
         }
-        pipeline.remove(NettyConstants.INACTIVITY_TIMEOUT_HANDLER_NAME);
 
         Tr.exit(tc, "initChannel");
     }


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

for https://github.com/OpenLiberty/open-liberty/issues/30935

Is there anyplace else we need to add this handler back in and test?


