### PR TITLE
Attempt to reproduce intermittent table creation bug

### DIFF
--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -199,6 +199,13 @@ public class DataExperimentalServlet extends FATServlet {
      */
     @Test
     public void testCharSequence() {
+        // We once saw EclipseLink fail here when running locally with the error
+        // java.sql.SQLSyntaxErrorException: Table/View 'YEARLYTOTAL' does not exist.
+        // Error Code: 20000 Call: DELETE FROM YearlyTotal
+        // Query: DeleteAllQuery(referenceClass=YearlyTotal sql="DELETE FROM YearlyTotal")
+        // but it did not reproduce. If it ever occurs again, collect the logs and
+        // report an issue to EclipseLink or the Persistence Service for it.
+        yearlyTotals.erase();
 
         yearlyTotals.publish(YearlyTotal.of(Year.of(2025),
                                             MonthDay.of(Month.JANUARY, 1),
@@ -794,6 +801,13 @@ public class DataExperimentalServlet extends FATServlet {
      */
     @Test
     public void testPartialDates() {
+        // We once saw EclipseLink fail here when running locally with the error
+        // java.sql.SQLSyntaxErrorException: Table/View 'YEARLYTOTAL' does not exist.
+        // Error Code: 20000 Call: DELETE FROM YearlyTotal
+        // Query: DeleteAllQuery(referenceClass=YearlyTotal sql="DELETE FROM YearlyTotal")
+        // but it did not reproduce. If it ever occurs again, collect the logs and
+        // report an issue to EclipseLink or the Persistence Service for it.
+        yearlyTotals.erase();
 
         yearlyTotals.publish(YearlyTotal.of(Year.of(2025),
                                             MonthDay.of(Month.JUNE, 15),


### PR DESCRIPTION
Attempt to reproduce the following intermittent error that occurred once when a test case attempts a DELETE query before doing anything else and the automatic table creation either wasn't triggered or didn't finish,
```
java.sql.SQLSyntaxErrorException: Table/View 'YEARLYTOTAL' does not exist. Error Code: 20000 Call: DELETE FROM YearlyTotal Query: DeleteAllQuery(referenceClass=YearlyTotal sql="DELETE FROM YearlyTotal")
```

This was observed once while writing the test case, but it never reproduced locally. Hopefully by including the code path in autmoated tests, it will eventually be seen again and logs can be collected in order to investigate and report the bug.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
