### PR TITLE
Solve issue where linux installation and packaging registry is in use…

### DIFF
--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesTest.java
@@ -61,10 +61,10 @@ public class InstallPackagesTest extends InstallPackagesToolTest {
         Boolean testsPassed = false;
 
         Log.info(c, METHOD_NAME, "Installing package:" + packageExt);
-        ProgramOutput po1 = installOldPackage(METHOD_NAME, packageExt);
+        ProgramOutput po1 = retryInstallOldPackage(METHOD_NAME, packageExt);
 
         Log.info(c, METHOD_NAME, "Updating package");
-        ProgramOutput po2 = installCurrentPackage(METHOD_NAME, packageExt);
+        ProgramOutput po2 = retryInstallCurrentPackage(METHOD_NAME, packageExt);
 
         Log.info(c, METHOD_NAME, "Roll back package");
         ProgramOutput po3 = rollbackPackage(METHOD_NAME, packageExt);

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesToolTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesToolTest.java
@@ -297,6 +297,38 @@ public abstract class InstallPackagesToolTest {
         return po1;
 
     }
+    
+    /**
+     * Install older test version of package. Only to be used as part of testing updates. If the older version of the package couldn't be installed, we will retry until a suitable number of attempts have occured.
+     *
+     * @param METHOD_NAME
+     * @param packageExt
+     * @return
+     * @throws Exception
+     */
+    protected static ProgramOutput retryInstallOldPackage(String METHOD_NAME, String packageExt) throws Exception {
+
+        ProgramOutput po = null;
+        int retries = 0;
+        
+        while (retries < 15) {
+            retries++;
+            
+            po = installOldPackage(METHOD_NAME, packageExt);
+            
+            if (po.getReturnCode() == 0) {
+                break;
+            }
+            
+            Thread.sleep(10000);
+        }
+        
+        return po;
+        
+
+    }
+    
+    
 
     /**
      * Install current version of package.
@@ -324,6 +356,36 @@ public abstract class InstallPackagesToolTest {
         }
 
         return po2;
+
+    }
+    
+    /**
+     * Install the current version of package. If the version of the package couldn't be installed, we will retry until a suitable number of attempts have occured.
+     *
+     * @param METHOD_NAME
+     * @param packageExt
+     * @return
+     * @throws Exception
+     */
+    protected static ProgramOutput retryInstallCurrentPackage(String METHOD_NAME, String packageExt) throws Exception {
+
+        ProgramOutput po = null;
+        int retries = 0;
+        
+        while (retries < 15) {
+            retries++;
+            
+            po = installCurrentPackage(METHOD_NAME, packageExt);
+            
+            if (po.getReturnCode() == 0) {
+                break;
+            }
+            
+            Thread.sleep(10000);
+        }
+        
+        return po;
+        
 
     }
 

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/ServicesTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/ServicesTest.java
@@ -69,7 +69,7 @@ public class ServicesTest extends InstallPackagesToolTest {
 
         //Install package
         Log.info(c, METHOD_NAME, "Installing Open Liberty package.");
-        ProgramOutput po1 = installCurrentPackage(METHOD_NAME, packageExt);
+        ProgramOutput po1 = retryInstallCurrentPackage(METHOD_NAME, packageExt);
 
         // append JAVA_HOME to server.env
         Log.info(c, METHOD_NAME, "Configure Open Liberty to use test java.");


### PR DESCRIPTION
… by another process by adding retries to wait until registry is not locked anymore.
for #31795
This issue only appears when release builds are run and thus can only be closed once release builds succeed.