### PR TITLE
disable fips140-3 on idp server 

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/BeanValidationTests.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/BeanValidationTests.war/resources/WEB-INF/web.xml
@@ -22,6 +22,16 @@
         <param-value>server</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIConfigByACP.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIConfigByACP.war/resources/WEB-INF/web.xml
@@ -24,6 +24,16 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Development</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesFlows.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesFlows.war/resources/WEB-INF/web.xml
@@ -37,4 +37,14 @@
     <url-pattern>*.xhtml</url-pattern>
   </servlet-mapping>
 
+  	<context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesInMetaInf.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesInMetaInf.war/resources/WEB-INF/web.xml
@@ -24,6 +24,16 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Development</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesInWebXML.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDIFacesInWebXML.war/resources/WEB-INF/web.xml
@@ -32,6 +32,16 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Development</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDITests.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/CDITests.war/resources/WEB-INF/web.xml
@@ -24,6 +24,16 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Development</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/JSF22FacesFlows.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/JSF22FacesFlows.war/resources/WEB-INF/web.xml
@@ -37,4 +37,14 @@
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PH06008.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PH06008.war/resources/WEB-INF/web.xml
@@ -31,4 +31,15 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+    
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI46218Flow1.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI46218Flow1.war/resources/WEB-INF/web.xml
@@ -30,4 +30,15 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI46218Flow2.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI46218Flow2.war/resources/WEB-INF/web.xml
@@ -30,4 +30,14 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI47600.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI47600.war/resources/WEB-INF/web.xml
@@ -31,5 +31,15 @@
 	<welcome-file-list>
 		<welcome-file>/faces/index.xhtml</welcome-file>
 	</welcome-file-list>
+
+	<context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 	
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI50108.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI50108.war/resources/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <param-value>false</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI51038.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI51038.war/resources/WEB-INF/web.xml
@@ -24,6 +24,16 @@
     </context-param>
 
     <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
+    <context-param>
         <param-name>org.apache.myfaces.SUPPORT_EL_3_IMPORT_HANDLER</param-name>
         <param-value>true</param-value>
     </context-param>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI51038_Default.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI51038_Default.war/resources/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <param-value>false</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI57255CDI.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI57255CDI.war/resources/WEB-INF/web.xml
@@ -30,4 +30,15 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+    
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI57255Default.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI57255Default.war/resources/WEB-INF/web.xml
@@ -30,4 +30,14 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI59422.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI59422.war/resources/WEB-INF/web.xml
@@ -30,4 +30,14 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI63135.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI63135.war/resources/WEB-INF/web.xml
@@ -32,4 +32,14 @@
         <param-name>javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL</param-name>
         <param-value>true</param-value>
     </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI64714.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI64714.war/resources/WEB-INF/web.xml
@@ -46,4 +46,15 @@
         <param-name>javax.faces.VALIDATE_EMPTY_FIELDS</param-name>
         <param-value>true</param-value>
     </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI64718.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI64718.war/resources/WEB-INF/web.xml
@@ -42,4 +42,14 @@
         <param-value>true</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI67525.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI67525.war/resources/WEB-INF/web.xml
@@ -33,4 +33,14 @@
         <param-value>1</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI89168.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI89168.war/resources/WEB-INF/web.xml
@@ -22,4 +22,14 @@
         <servlet-name>Faces Servlet</servlet-name>
         <url-pattern>*.xhtml</url-pattern>
     </servlet-mapping>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI90391.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI90391.war/resources/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <param-value>Development</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI90507.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/PI90507.war/resources/WEB-INF/web.xml
@@ -39,4 +39,14 @@
         <param-name>com.ibm.ws.jsf.DisableFaceletActionListenerPreDestroy</param-name>
         <param-value>true</param-value>
     </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/ViewScopedCDIBean.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/ViewScopedCDIBean.war/resources/WEB-INF/web.xml
@@ -34,4 +34,14 @@
         <welcome-file>index.jsf</welcome-file>
     </welcome-file-list>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/ViewScopedJSFBean.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/test-applications/ViewScopedJSFBean.war/resources/WEB-INF/web.xml
@@ -34,4 +34,14 @@
         <welcome-file>index.jsf</welcome-file>
     </welcome-file-list>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ActionListener.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ActionListener.war/resources/WEB-INF/web.xml
@@ -22,6 +22,17 @@
     <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
     <param-value>server</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	<param-value>HmacSHA256</param-value>
+  </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>
     <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22AppConfigPop.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22AppConfigPop.war/resources/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <param-value>server</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22BackwardCompatibilityTests.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22BackwardCompatibilityTests.war/resources/WEB-INF/web.xml
@@ -23,6 +23,16 @@
         <param-value>server</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ClientWindow.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ClientWindow.war/resources/WEB-INF/web.xml
@@ -28,6 +28,16 @@
         <param-value>server</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ClientWindowFaces40.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ClientWindowFaces40.war/resources/WEB-INF/web.xml
@@ -28,6 +28,16 @@
         <param-value>server</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ComponentRenderer.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ComponentRenderer.war/resources/WEB-INF/web.xml
@@ -37,4 +37,12 @@
         <param-name>javax.faces.PROJECT_STAGE</param-name>
         <param-value>Development</param-value>
     </context-param>
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ComponentTester.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ComponentTester.war/resources/WEB-INF/web.xml
@@ -39,6 +39,16 @@
         <param-value>Development</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <!-- Increase buffer size so the response is not committed. -->
     <context-param>
         <param-name>jakarta.faces.FACELETS_BUFFER_SIZE</param-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22FaceletsResourceResolverAnnotation.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22FaceletsResourceResolverAnnotation.war/resources/WEB-INF/web.xml
@@ -34,5 +34,15 @@
 	<welcome-file-list>
     	<welcome-file>index.xhtml</welcome-file>
   	</welcome-file-list>
+
+	<context-param>
+    	<param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    	<param-value>HmacSHA256</param-value>
+  	</context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
 	 
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22FlashEvents.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22FlashEvents.war/resources/WEB-INF/web.xml
@@ -22,6 +22,16 @@
     <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
     <param-value>server</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	<param-value>HmacSHA256</param-value>
+  </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22HTML5.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22HTML5.war/resources/WEB-INF/web.xml
@@ -21,6 +21,17 @@
         <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
         <param-value>server</param-value>
     </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22InputFile.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22InputFile.war/resources/WEB-INF/web.xml
@@ -37,6 +37,16 @@
         <welcome-file>fileUploadTest.jsf</welcome-file>
     </welcome-file-list>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <!-- Required for testAjaxInputFile to ensure any errors are alerted  -->
     <context-param>
         <param-name>javax.faces.PROJECT_STAGE</param-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22LocalizationTester.war/resources/WEB-INF/web.xml
@@ -41,6 +41,16 @@
         <param-value>false</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+        <param-value>HmacSHA256</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>org.apache.myfaces.ALGORITHM</param-name>
+        <param-value>AES</param-value>
+    </context-param>
+
     <!-- Temp solution for defect 294367; need to look into o.a.m.ALWAYS_FORCE_SESSION_CREATION for 4.0 -->
     <context-param>
         <param-name>jakarta.faces.FACELETS_BUFFER_SIZE</param-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22SimpleHTML.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22SimpleHTML.war/resources/WEB-INF/web.xml
@@ -18,15 +18,26 @@
     
   <display-name>JSF22SimpleHTML</display-name>
 
-    <context-param>
-        <param-name>javax.faces.PROJECT_STAGE</param-name>
-        <param-value>Development</param-value>
-    </context-param>
+  <context-param>
+    <param-name>javax.faces.PROJECT_STAGE</param-name>
+    <param-value>Development</param-value>
+  </context-param>
   
   <context-param>
     <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
     <param-value>server</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
+
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>
     <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22TestResources.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22TestResources.war/resources/WEB-INF/web.xml
@@ -30,6 +30,16 @@
         <param-value>WEB-INF/resources</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	    <param-value>HmacSHA256</param-value>
+    </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
+
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ViewPooling.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22ViewPooling.war/resources/WEB-INF/web.xml
@@ -22,6 +22,16 @@
     <param-name>javax.faces.PROJECT_STAGE</param-name>
     <param-value>Production</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	<param-value>HmacSHA256</param-value>
+  </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
  
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSF2.2.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSF2.2.war/resources/WEB-INF/web.xml
@@ -22,6 +22,17 @@
     <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
     <param-value>server</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+    <param-value>HmacSHA256</param-value>
+  </context-param>
+
+  <context-param>
+    <param-name>org.apache.myfaces.ALGORITHM</param-name>
+    <param-value>AES</param-value>
+  </context-param>
+
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>
     <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSF22ViewAction.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSF22ViewAction.war/resources/WEB-INF/web.xml
@@ -32,5 +32,15 @@
     <servlet-name>Faces Servlet</servlet-name>
     <url-pattern>*.jsf</url-pattern>
   </servlet-mapping>
+
+  <context-param>
+    <param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  	<param-value>HmacSHA256</param-value>
+  </context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
   
 </web-app>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSFEL.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestJSFEL.war/resources/WEB-INF/web.xml
@@ -29,7 +29,16 @@
 	     <param-name>javax.faces.FACELETS_LIBRARIES</param-name>
          <param-value>/WEB-INF/custom-taglib.xml</param-value>
     </context-param>
-	
+
+	<context-param>
+    	<param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  		<param-value>HmacSHA256</param-value>
+  	</context-param>
+
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
 
 	<!-- Faces Servlet -->
 	<servlet>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContracts.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContracts.war/resources/WEB-INF/web.xml
@@ -24,6 +24,14 @@
         <param-name>org.apache.myfaces.LOG_WEB_CONTEXT_PARAMS</param-name>
         <param-value>false</param-value>
     </context-param>
+    	<context-param>
+    	<param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  		<param-value>HmacSHA256</param-value>
+  	</context-param>
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
 
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContractsDirectory.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContractsDirectory.war/resources/WEB-INF/web.xml
@@ -28,6 +28,14 @@
         <param-name>javax.faces.WEBAPP_CONTRACTS_DIRECTORY</param-name>
         <param-value>myContracts</param-value>
     </context-param>
+    	<context-param>
+    	<param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  		<param-value>HmacSHA256</param-value>
+  	</context-param>
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContractsFromJar.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/TestResourceContractsFromJar.war/resources/WEB-INF/web.xml
@@ -24,7 +24,14 @@
         <param-name>org.apache.myfaces.LOG_WEB_CONTEXT_PARAMS</param-name>
         <param-value>false</param-value>
     </context-param>
-
+    	<context-param>
+    	<param-name>org.apache.myfaces.MAC_ALGORITHM</param-name>
+  		<param-value>HmacSHA256</param-value>
+  	</context-param>
+	<context-param>
+		<param-name>org.apache.myfaces.ALGORITHM</param-name>
+		<param-value>AES</param-value>
+	</context-param>
     <servlet>
         <servlet-name>Faces Servlet</servlet-name>
         <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTest.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -304,7 +304,7 @@ public class CommonTest extends com.ibm.ws.security.fat.common.CommonTest {
             if (miscBootstrapParms != null) {
                 aTestServer.addMiscBootstrapParms(miscBootstrapParms);
             }
-
+            aTestServer.getServer().setServerLevelFips(true);
             if (testType.equals(Constants.IDP_SERVER_TYPE)) {
                 // we're having an issue with the in memory LDAP server on z/OS, added a method to see if it can accept requests,
                 // if NOT, we'll use a "external" LDAP server (Shibboleth allows for failover to additional LDAP servers, but,
@@ -312,6 +312,7 @@ public class CommonTest extends com.ibm.ws.security.fat.common.CommonTest {
                 // this method will add properties to bootstrap.properties that will point to a hopefully working LDAP server
                 usingExternalLDAPServer = shibbolethHelpers.updateToUseExternalLDaPIfInMemoryIsBad(aTestServer);
                 shibbolethHelpers.setShibbolethPropertiesForTestMachine(aTestServer);
+                aTestServer.getServer().setServerLevelFips(false);
                 //                CommonLocalLDAPServerSuite one = new CommonLocalLDAPServerSuite();
                 //                CommonLocalLDAPServerSuite two = new CommonLocalLDAPServerSuite();
                 //                one.ldapSetUp();

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.3/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -308,6 +308,7 @@ public class SAMLCommonTest extends CommonTest {
 
                 usingExternalLDAPServer = shibbolethHelpers.updateToUseExternalLDaPIfInMemoryIsBad(aTestServer);
                 shibbolethHelpers.setShibbolethPropertiesForTestMachine(aTestServer);
+                aTestServer.getServer().setServerLevelFips(false);
 
 //                CommonLocalLDAPServerSuite one = new CommonLocalLDAPServerSuite();
 //                CommonLocalLDAPServerSuite two = new CommonLocalLDAPServerSuite();
@@ -326,6 +327,9 @@ public class SAMLCommonTest extends CommonTest {
 //                                                                                                   Integer.toString(one.getLdapSSLPort()), Integer.toString(two.getLdapPort()),
 //                                                                                                   Integer.toString(two.getLdapSSLPort()));
 //                shibbolethHelpers.setShibbolethPropertiesForTestMachine(aTestServer);
+            } else {
+                //SAML SP Server
+                aTestServer.getServer().setServerLevelFips(true);
             }
 
             transformApps(aTestServer);

--- a/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.ibm_security_logout/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.ibm_security_logout/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -266,7 +266,7 @@ public class LibertyServer implements LogMonitorClient {
 
     // Allow configuration updates to wait for messages in the log longer than other log
     // searches. Configuration updates may take some time on slow test systems.
-    protected static int LOG_SEARCH_TIMEOUT_CONFIG_UPDATE = (FAT_TEST_LOCALRUN ? 12 : 180) * 1000;
+    protected static int LOG_SEARCH_TIMEOUT_CONFIG_UPDATE = (FAT_TEST_LOCALRUN ? 18 : 180) * 1000;
 
     protected Set<String> installedApplications;
 
@@ -334,6 +334,8 @@ public class LibertyServer implements LogMonitorClient {
     private String openLibertyVersion;
 
     private String archiveMarker = null;
+    
+    private boolean serverLevelFipsEnabled = GLOBAL_FIPS_140_3;
 
     /**
      * This returns whether or not debugging is "programatically" allowed
@@ -7819,6 +7821,7 @@ public class LibertyServer implements LogMonitorClient {
         if (logOutput && GLOBAL_FIPS_140_3) {
             Log.info(c, methodName, "Liberty server is running JDK version: " + serverJavaInfo.majorVersion()
                                     + " and vendor: " + serverJavaInfo.VENDOR);
+            Log.info(c, methodName, "Server level fips property is : " + serverLevelFipsEnabled);
             if (isIBMJVM8) {
                 Log.info(c, methodName, "global build properties FIPS_140_3 is set for server " + getServerName() +
                                         " and IBM java 8 is available to run with FIPS 140-3 enabled.");
@@ -7830,7 +7833,7 @@ public class LibertyServer implements LogMonitorClient {
                                            ",  but no IBM java on liberty server to run with FIPS 140-3 enabled.");
             }
         }
-        return GLOBAL_FIPS_140_3 && (isIBMJVM8 || isIBMJVMGreaterOrEqualTo11);
+        return GLOBAL_FIPS_140_3 && (isIBMJVM8 || isIBMJVMGreaterOrEqualTo11) && serverLevelFipsEnabled;
     }
 
     public boolean isFIPS140_3EnabledAndSupported() throws IOException {
@@ -7839,6 +7842,10 @@ public class LibertyServer implements LogMonitorClient {
 
     public boolean isFIPS140_3EnabledAndSupported(JavaInfo info) throws IOException {
         return isFIPS140_3EnabledAndSupported(info, true);
+    }
+    
+    public void setServerLevelFips(boolean enabled) {
+        serverLevelFipsEnabled = enabled;
     }
 
     public boolean isFIPS140_2EnabledAndSupported(JavaInfo serverJavaInfo, boolean logOutput) throws IOException {

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -266,7 +266,7 @@ public class LibertyServer implements LogMonitorClient {
 
     // Allow configuration updates to wait for messages in the log longer than other log
     // searches. Configuration updates may take some time on slow test systems.
-    protected static int LOG_SEARCH_TIMEOUT_CONFIG_UPDATE = (FAT_TEST_LOCALRUN ? 18 : 180) * 1000;
+    protected static int LOG_SEARCH_TIMEOUT_CONFIG_UPDATE = (FAT_TEST_LOCALRUN ? 12 : 180) * 1000;
 
     protected Set<String> installedApplications;
 


### PR DESCRIPTION
test updates 
- saml sso tests updates to run with custom profile (when semerufips140-3 is ON)
- update test framework (for saml sso and BCL saml test projects), so IDP will run with semerufips140-3 OFF
