### PR TITLE
Handle messaging connection case where failure List is empty or null

### DIFF
--- a/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/trm/client/Utils.java
+++ b/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/trm/client/Utils.java
@@ -44,22 +44,17 @@ public class Utils {
   public static String getFailureMessage (List failure) {
     if (tc.isEntryEnabled()) SibTr.entry(tc, "getFailureMessage", new Object[] { failure });
 
-    int len = 0;
-    String[] insert;
+    final String rc;
+    if (null == failure || failure.isEmpty()) {
+      rc = "NULL"; // this is an error and "NULL" is easier to debug than ""
+    } else {
+      int len = failure.size();
+      assert len >= 1;
+      String[] insert = new String[len - 1];
+      for (int i = 1; i < len; i++) insert[i-1] = (String) failure.get(i);
+      rc = nls.getFormattedMessage((String)failure.get(0), insert, null);
+    }
 
-    if (failure != null) len = failure.size();
-
-    if (len > 0) {
-      insert = new String[len - 1];
-
-      for (int i = 0; i < (len - 1); i++) {
-        insert[i] = (String) failure.get(i + 1);
-      }
-    } else
-      insert = new String[0];
-
-    String rc = nls.getFormattedMessage((String)failure.get(0), insert, null);
-    
     if (tc.isEntryEnabled()) SibTr.exit(tc, "getFailureMessage", rc);
     return rc;
   }

--- a/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/trm/client/Utils.java
+++ b/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/trm/client/Utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2005 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -44,12 +44,19 @@ public class Utils {
   public static String getFailureMessage (List failure) {
     if (tc.isEntryEnabled()) SibTr.entry(tc, "getFailureMessage", new Object[] { failure });
 
-    int len = failure.size();
-    String[] insert = new String[len-1];
+    int len = 0;
+    String[] insert;
 
-    for (int i=0; i < (len-1); i++) {
-      insert[i] = (String)failure.get(i+1);
-    }
+    if (failure != null) len = failure.size();
+
+    if (len > 0) {
+      insert = new String[len - 1];
+
+      for (int i = 0; i < (len - 1); i++) {
+        insert[i] = (String) failure.get(i + 1);
+      }
+    } else
+      insert = new String[0];
 
     String rc = nls.getFormattedMessage((String)failure.get(0), insert, null);
     


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

For #28805 
If a client attempts to connect to a messaging endpoint (Messaging Engine) but fails, the code parses the response failure message when constructing the Exception to throw. If the failure message is null or empty, the parsing code can throw a NullPointerException. While the end Exception is still thrown as expected, the contents are difficult to interpret.

By handling the null/empty case, even if no failure message can be recorded, the resulting Exception should be more understandable. This doesn't entirely fix the original issue, it will act as a first step in making the error more understandable.

