### PR TITLE
java.lang.RuntimeException: Server stop failed RC1

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -78,6 +78,8 @@ public class SessionCacheOneServerTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         executor.shutdownNow();
+        Log.info(SessionCacheOneServerTest.class, "tearDown", "Wait for active tasks to stop...");
+        TimeUnit.SECONDS.sleep(5);
         server.stopServer();
 
         if (isZOS()) {


### PR DESCRIPTION
Server stop failed with RC 1. Stdout: Stopping server com.ibm.ws.session.cache.fat.infinispan.server. The command stop failed because of a communication error with the server. Server com.ibm.ws.session.cache.fat.infinispan.server stop failed. Check server logs for details. Stderr:

java.lang.RuntimeException: Server stop failed with RC 1.
Stdout:

Stopping server com.ibm.ws.session.cache.fat.infinispan.server.
The command stop failed because of a communication error with the server.
Server com.ibm.ws.session.cache.fat.infinispan.server stop failed. Check server logs for details.

Stderr:

at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3301)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3166)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3160)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3136)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3045)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3020)
at com.ibm.ws.session.cache.fat.infinispan.SessionCacheOneServerTest.tearDown(SessionCacheOneServerTest.java:81)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:149)
at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:401)
at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:203) 
