### PR TITLE
Enable Netty for SIP with SO_REUSEADDR set to false netty-transport-http branch

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/metatype/metatype.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 IBM Corporation and others.
+    Copyright (c) 2019, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-
-    Contributors:
-        IBM Corporation - initial API and implementation
 -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0"
 	xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
@@ -94,7 +91,7 @@
             type="String" required="false"/>
 
 		<AD name="internal" description="internal" id="useNettyTransport"
-			required="false" type="Boolean" default="false" />
+			required="false" type="Boolean" default="true" />
 
 	</OCD>
 

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPConfigurationImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -79,7 +79,7 @@ public class UDPConfigurationImpl implements BootstrapConfiguration {
      */
     @Override
     public void applyConfiguration(Bootstrap bootstrap) {
-        bootstrap.option(ChannelOption.SO_REUSEADDR, true);
+        bootstrap.option(ChannelOption.SO_REUSEADDR, false);
         int receiveBufferSize = getReceiveBufferSize();
         if ((receiveBufferSize >= UDPConfigConstants.RECEIVE_BUFFER_SIZE_MIN)
                 && (receiveBufferSize <= UDPConfigConstants.RECEIVE_BUFFER_SIZE_MAX)) {

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPUtils.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPUtils.java
@@ -68,16 +68,16 @@ public class UDPUtils {
 		return bs;
 	}
 
-	private static ChannelFuture bind(NettyFrameworkImpl framework, BootstrapExtended bootstrap, final Channel channel, String inetHost,
-			int inetPort, final int retryCount, final int retryDelay, ChannelFutureListener bindListener) {
-		ChannelFuture bindFuture = null;
+	private static ChannelFuture open(NettyFrameworkImpl framework, BootstrapExtended bootstrap, final Channel channel, String inetHost,
+			int inetPort, final int retryCount, final int retryDelay, ChannelFutureListener openListener) {
+		ChannelFuture openFuture = null;
 
 		final UDPConfigurationImpl config = ((UDPConfigurationImpl) bootstrap.getConfiguration());
 
 		if (config.isInboundChannel()) {
-			bindFuture = channel.bind(new InetSocketAddress(inetHost, inetPort));
+			openFuture = channel.bind(new InetSocketAddress(inetHost, inetPort));
 		} else {
-			bindFuture = channel.connect(new InetSocketAddress(inetHost, inetPort));
+			openFuture = channel.connect(new InetSocketAddress(inetHost, inetPort));
 		}
 
 		if (inetHost.equals("*")) {
@@ -85,13 +85,13 @@ public class UDPUtils {
 		}
 		final String newHost = inetHost;
 
-		if (bindListener != null) {
-			bindFuture.addListener(bindListener);
+		if (openListener != null) {
+			openFuture.addListener(openListener);
 		}
 
 		final String channelName = ((UDPConfigurationImpl) bootstrap.getConfiguration()).getExternalName();
 
-		bindFuture.addListener(future -> {
+		openFuture.addListener(future -> {
 			if (future.isSuccess()) {
 
 				// add the new channel to the set of active channels, and set a close future to
@@ -137,7 +137,7 @@ public class UDPUtils {
 				}
 			} else {
 				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-					Tr.debug(tc, "bindHelper failed due to: " + future.cause().getMessage());
+					Tr.debug(tc, "open failed due to: " + future.cause().getMessage());
 				}
 
 				if (retryCount > 0) {
@@ -148,7 +148,7 @@ public class UDPUtils {
 						return;
 					}
 					if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-						Tr.debug(tc, "attempt to bind again after a wait of " + retryDelay + "ms; " + retryCount
+						Tr.debug(tc, "attempt to open again after a wait of " + retryDelay + "ms; " + retryCount
 								+ " attempts remaining");
 					}
 					// recurse until we either complete successfully or run out of retries;
@@ -160,7 +160,7 @@ public class UDPUtils {
 							Tr.debug(tc, "sleep caught InterruptedException.  will proceed.");
 						}
 					}
-					bind(framework, bootstrap, channel, newHost, inetPort, retryCount - 1, retryDelay, bindListener);
+					open(framework, bootstrap, channel, newHost, inetPort, retryCount - 1, retryDelay, openListener);
 				} else {
 					if(!channel.isOpen()) {
 						if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -180,7 +180,7 @@ public class UDPUtils {
 				}
 			}
 		});
-		return bindFuture;
+		return openFuture;
 	}
 
 	/**
@@ -190,16 +190,16 @@ public class UDPUtils {
 	 * @param bootstrap
 	 * @param inetHost
 	 * @param inetPort
-	 * @param bindListener
+	 * @param openListener
 	 * @return
 	 * @throws NettyException
 	 */
 	public static Channel startOutbound(NettyFrameworkImpl framework, BootstrapExtended bootstrap,
-			String inetHost, int inetPort, ChannelFutureListener bindListener) throws NettyException {
+			String inetHost, int inetPort, ChannelFutureListener openListener) throws NettyException {
 		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-			Tr.debug(tc, "startOutbound (UDP): attempt to bind a channel at host " + inetHost + " port " + inetPort);
+			Tr.debug(tc, "startOutbound (UDP): attempt to connect to host " + inetHost + " port " + inetPort);
 		}
-		return startHelper(framework, bootstrap, inetHost, inetPort, bindListener);
+		return startHelper(framework, bootstrap, inetHost, inetPort, openListener);
 	}
 
 	/**
@@ -209,20 +209,20 @@ public class UDPUtils {
 	 * @param bootstrap
 	 * @param inetHost
 	 * @param inetPort
-	 * @param bindListener
+	 * @param openListener
 	 * @return
 	 * @throws NettyException
 	 */
 	public static Channel start(NettyFrameworkImpl framework, BootstrapExtended bootstrap, String inetHost,
-			int inetPort, ChannelFutureListener bindListener) throws NettyException {
+			int inetPort, ChannelFutureListener openListener) throws NettyException {
 		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
 			Tr.debug(tc, "start (UDP): attempt to bind a channel at host " + inetHost + " port " + inetPort);
 		}
-		return startHelper(framework, bootstrap, inetHost, inetPort, bindListener);
+		return startHelper(framework, bootstrap, inetHost, inetPort, openListener);
 	}
 
 	private static Channel startHelper(NettyFrameworkImpl framework, BootstrapExtended bootstrap, String inetHost,
-			int inetPort, ChannelFutureListener bindListener) throws NettyException {
+			int inetPort, ChannelFutureListener openListener) throws NettyException {
 		if(framework.isStopping()){ // Framework already started and is no longer active
 			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
 				Tr.debug(tc, "server is stopping, channel will not be started");
@@ -235,8 +235,8 @@ public class UDPUtils {
 				@Override
 				public ChannelFuture call() throws NettyException {
 					UDPConfigurationImpl config = (UDPConfigurationImpl) bootstrap.getConfiguration();
-					int bindRetryCount = config.getRetryCount();
-					int bindRetryInterval = config.getRetryInterval();
+					int retryCount = config.getRetryCount();
+					int retryInterval = config.getRetryInterval();
 					InetSocketAddress address = null;
 					String newHost = inetHost;
 					if (newHost.equals("*")) {
@@ -253,8 +253,8 @@ public class UDPUtils {
 								"local address unresolved for " + channelName + " - " + hostLogString + ":" + inetPort);
 					}
 
-					return bind(framework, bootstrap, channel, newHost, inetPort, bindRetryCount, bindRetryInterval,
-							bindListener);
+					return open(framework, bootstrap, channel, newHost, inetPort, retryCount, retryInterval,
+							openListener);
 				}
 			});
 			return channel;

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPUtils.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -70,7 +70,16 @@ public class UDPUtils {
 
 	private static ChannelFuture bind(NettyFrameworkImpl framework, BootstrapExtended bootstrap, final Channel channel, String inetHost,
 			int inetPort, final int retryCount, final int retryDelay, ChannelFutureListener bindListener) {
-		ChannelFuture bindFuture = channel.bind(new InetSocketAddress(inetHost, inetPort));
+		ChannelFuture bindFuture = null;
+
+		final UDPConfigurationImpl config = ((UDPConfigurationImpl) bootstrap.getConfiguration());
+
+		if (config.isInboundChannel()) {
+			bindFuture = channel.bind(new InetSocketAddress(inetHost, inetPort));
+		} else {
+			bindFuture = channel.connect(new InetSocketAddress(inetHost, inetPort));
+		}
+
 		if (inetHost.equals("*")) {
 			inetHost = NettyConstants.INADDR_ANY;
 		}
@@ -79,7 +88,7 @@ public class UDPUtils {
 		if (bindListener != null) {
 			bindFuture.addListener(bindListener);
 		}
-		final UDPConfigurationImpl config = ((UDPConfigurationImpl) bootstrap.getConfiguration());
+
 		final String channelName = ((UDPConfigurationImpl) bootstrap.getConfiguration()).getExternalName();
 
 		bindFuture.addListener(future -> {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

for https://github.com/OpenLiberty/open-liberty/issues/18520

Merging to netty-transport-http so we can enable `useNettyTransport` on the SIP feature so that we can get additional testing in our full fat beta builds.