### PR TITLE
Enable Netty for SIP with SO_REUSEADDR set to false (TESTING only) integration

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/metatype/metatype.xml
@@ -94,7 +94,7 @@
             type="String" required="false"/>
 
 		<AD name="internal" description="internal" id="useNettyTransport"
-			required="false" type="Boolean" default="false" />
+			required="false" type="Boolean" default="true" />
 
 	</OCD>
 

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPConfigurationImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -79,7 +79,7 @@ public class UDPConfigurationImpl implements BootstrapConfiguration {
      */
     @Override
     public void applyConfiguration(Bootstrap bootstrap) {
-        bootstrap.option(ChannelOption.SO_REUSEADDR, true);
+        bootstrap.option(ChannelOption.SO_REUSEADDR, false);
         int receiveBufferSize = getReceiveBufferSize();
         if ((receiveBufferSize >= UDPConfigConstants.RECEIVE_BUFFER_SIZE_MIN)
                 && (receiveBufferSize <= UDPConfigConstants.RECEIVE_BUFFER_SIZE_MAX)) {


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

for https://github.com/OpenLiberty/open-liberty/issues/18520

Once testing is completed we only want to merge the change for so_reuseaddr!