### PR TITLE
EXTRACT temporal fields in Jakarta Data queries

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2173,6 +2173,51 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Verify that JPQL SELECT and ORDER BY clauses can EXTRACT the YEAR from a
+     * LocalDateTime.
+     */
+    @Test
+    public void testExtractYearInSelectAndOrderBy() {
+        rebates.reset();
+
+        Rebate r1 = new Rebate(525001, //
+                        10.00f, //
+                        "testExtractYearInSelectAndOrderBy-1", //
+                        LocalTime.now(), //
+                        LocalDate.of(2024, Month.APRIL, 5), //
+                        Rebate.Status.PAID, //
+                        LocalDateTime.of(2024, Month.JULY, 10, 9, 15, 00), //
+                        3);
+
+        Rebate r2 = new Rebate(525002, //
+                        2.50f, //
+                        "TestExtractYearInSelectAndOrderBy-2", //
+                        LocalTime.now(), //
+                        LocalDate.of(2022, Month.SEPTEMBER, 22), //
+                        Rebate.Status.DENIED, //
+                        LocalDateTime.of(2022, Month.OCTOBER, 5, 15, 01, 00), //
+                        4);
+
+        Rebate r3 = new Rebate(525003, //
+                        3.75f, //
+                        "TestExtractYearInSelectAndOrderBy-3", //
+                        LocalTime.now(), //
+                        LocalDate.of(2025, Month.MAY, 18), //
+                        Rebate.Status.SUBMITTED, //
+                        LocalDateTime.of(2025, Month.JUNE, 11, 14, 59, 53), //
+                        2);
+
+        rebates.addAll(r1, r2, r3);
+
+        assertEquals(List.of(2025,
+                             2024,
+                             2022),
+                     rebates.yearUpdated());
+
+        rebates.reset();
+    }
+
+    /**
      * Verify the EXTRACT WEEK function to compare the week-of-year part of a date.
      */
     @OnlyIfSysProp(DB_Not_Default) // Derby doesn't support a WEEK function in SQL

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2004,6 +2004,51 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Verify that JPQL can be used to EXTRACT the DATE from a LocalDateTime.
+     */
+    // TODO enable once EclipseLink bug #31802 is fixed
+    //@Test
+    public void testExtractDate() {
+        rebates.reset();
+
+        Rebate r1 = new Rebate(54001, //
+                        1.40f, //
+                        "TestExtractDate-1", //
+                        LocalTime.now(), //
+                        LocalDate.of(2025, Month.MAY, 21), //
+                        Rebate.Status.SUBMITTED, //
+                        LocalDateTime.of(2025, Month.JUNE, 11, 13, 06, 00), //
+                        1);
+
+        Rebate r2 = new Rebate(54002, //
+                        2.30f, //
+                        "TestExtractDate-2", //
+                        LocalTime.now(), //
+                        LocalDate.of(2025, Month.MAY, 14), //
+                        Rebate.Status.SUBMITTED, //
+                        LocalDateTime.of(2025, Month.JUNE, 12, 12, 30, 00), //
+                        1);
+
+        Rebate r3 = new Rebate(54003, //
+                        3.20f, //
+                        "TestExtractDate-3", //
+                        LocalTime.now(), //
+                        LocalDate.of(2025, Month.MAY, 15), //
+                        Rebate.Status.PAID, //
+                        LocalDateTime.of(2025, Month.JUNE, 11, 8, 45, 00), //
+                        1);
+
+        rebates.addAll(r1, r2, r3);
+
+        assertEquals(List.of("TestExtractDate-3", "TestExtractDate-1"),
+                     rebates.updatedOn(LocalDate.of(2025, Month.JUNE, 11))
+                                     .map(Rebate::customerId)
+                                     .collect(Collectors.toList()));
+
+        rebates.reset();
+    }
+
+    /**
      * Verify EXTRACT YEAR/QUARTER/MONTH/DAY functions to compare different parts
      * of a date.
      */
@@ -2080,6 +2125,51 @@ public class DataJPATestServlet extends FATServlet {
                      creditCards.findByIssuedOnWithDayBetween(20, 29)
                                      .map(cc -> cc.number)
                                      .collect(Collectors.toList()));
+    }
+
+    /**
+     * Verify that JPQL can be used to EXTRACT the TIME from a LocalDateTime.
+     */
+    // TODO enable once EclipseLink bug #31802 is fixed
+    //@Test
+    public void testExtractTime() {
+        rebates.reset();
+
+        Rebate r1 = new Rebate(520001, //
+                        10.00f, //
+                        "TestExtractTime-1", //
+                        LocalTime.now(), //
+                        LocalDate.of(2025, Month.MAY, 10), //
+                        Rebate.Status.PAID, //
+                        LocalDateTime.of(2025, Month.JUNE, 6, 11, 34, 30), //
+                        3);
+
+        Rebate r2 = new Rebate(520002, //
+                        2.50f, //
+                        "TestExtractTime-2", //
+                        LocalTime.now(), //
+                        LocalDate.of(2025, Month.MAY, 12), //
+                        Rebate.Status.SUBMITTED, //
+                        LocalDateTime.of(2025, Month.JUNE, 6, 12, 38, 00), //
+                        1);
+
+        Rebate r3 = new Rebate(520003, //
+                        3.75f, //
+                        "TestExtractTime-3", //
+                        LocalTime.now(), //
+                        LocalDate.of(2025, Month.MAY, 14), //
+                        Rebate.Status.DENIED, //
+                        LocalDateTime.of(2025, Month.JUNE, 7, 9, 55, 20), //
+                        2);
+
+        rebates.addAll(r1, r2, r3);
+
+        assertEquals(List.of(LocalTime.of(12, 38, 00),
+                             LocalTime.of(9, 55, 20),
+                             LocalTime.of(11, 34, 30)),
+                     rebates.timeUpdated());
+
+        rebates.reset();
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Rebates.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Rebates.java
@@ -124,4 +124,8 @@ public interface Rebates { // Do not allow this interface to inherit from other 
 
     @Query("WHERE EXTRACT(DATE FROM updatedAt) = ?1 ORDER BY amount DESC")
     Stream<Rebate> updatedOn(LocalDate date);
+
+    @Query("SELECT EXTRACT(YEAR FROM updatedAt)" +
+           " ORDER BY EXTRACT(YEAR FROM updatedAt) DESC")
+    List<Integer> yearUpdated();
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Rebates.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Rebates.java
@@ -16,11 +16,13 @@ import static jakarta.data.repository.By.ID;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
@@ -110,6 +112,16 @@ public interface Rebates { // Do not allow this interface to inherit from other 
     @Delete
     void removeMultiple(ArrayList<Rebate> r);
 
+    @Delete
+    void reset();
+
     @Find
     Optional<Rebate.Status> status(int id);
+
+    @Query("SELECT EXTRACT(TIME FROM updatedAt)")
+    @OrderBy("amount")
+    List<LocalTime> timeUpdated();
+
+    @Query("WHERE EXTRACT(DATE FROM updatedAt) = ?1 ORDER BY amount DESC")
+    Stream<Rebate> updatedOn(LocalDate date);
 }


### PR DESCRIPTION
Adds the ability to select an extracted portion of a date or time.
Extracting the date or time portion of a datetime is broken in EclipseLink, so I added disabled tests for that.
Adds a working test for selecting a different extracted component of a date.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
