### PR TITLE
Get things building in eclipse again and fixing other misconfigurations

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -3002,6 +3002,11 @@
       <version>8.2.0.v20160908</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jnosql.mapping</groupId>
+      <artifactId>jnosql-mapping-semistructured</artifactId>
+      <version>1.1.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
       <version>1.1</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -596,6 +596,7 @@ org.eclipse.jetty:jetty-util:9.2.2.v20140723
 org.eclipse.jetty:jetty-util:9.4.39.v20210325
 org.eclipse.jetty:jetty-util:9.4.7.RC0
 org.eclipse.jetty:jetty-websocket:8.2.0.v20160908
+org.eclipse.jnosql.mapping:jnosql-mapping-semistructured:1.1.4
 org.eclipse.microprofile.config:microprofile-config-api:1.1
 org.eclipse.microprofile.config:microprofile-config-api:1.2.1
 org.eclipse.microprofile.config:microprofile-config-api:1.3

--- a/dev/com.ibm.ws.springboot.fat20.concurrency.app/.classpath
+++ b/dev/com.ibm.ws.springboot.fat20.concurrency.app/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
     <classpathentry kind="src" path="src/main/java"/>
-    <classpathentry kind="src" path="src/main/resources"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.springboot.fat20.concurrency.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.fat20.concurrency.app/bnd.bnd
@@ -20,8 +20,7 @@ instrument.disabled: true
 publish.wlp.jar.disabled: true
 
 src: \
-  src/main/java, \
-  src/main/resources
+  src/main/java
 
 # Specify bundles to be added to the classpath of a VM used in testing. 
 # Entries in the -testpath instruction enable the Eclipse Package Explorer 

--- a/dev/com.ibm.ws.springboot.fat20.jms.app/.classpath
+++ b/dev/com.ibm.ws.springboot.fat20.jms.app/.classpath
@@ -3,6 +3,6 @@
     <classpathentry kind="src" path="src/main/java"/>
     <classpathentry kind="src" path="src/main/resources"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
     <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.springboot.fat20.jms.app/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.springboot.fat20.jms.app/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,12 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.springboot.fat20.jms.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.fat20.jms.app/bnd.bnd
@@ -37,7 +37,9 @@ src: \
   org.springframework:spring-beans;${springVersion20}, \
   org.springframework:spring-context;${springVersion20}, \
   org.springframework:spring-core;${springVersion20}, \
+  org.springframework:spring-jdbc;${springVersion20}, \
   org.springframework:spring-jms;${springVersion20}, \
+  org.springframework:spring-tx;${springVersion20}, \
   org.springframework:spring-web;${springVersion20}, \
   org.slf4j:slf4j-api;version=1.7.36, \
   com.ibm.websphere.javaee.jms.2.0;version=latest

--- a/dev/io.openliberty.data.internal_fat_nosql/.classpath
+++ b/dev/io.openliberty.data.internal_fat_nosql/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="generated-src"/>
 	<classpathentry kind="src" path="test-applications/DataNoSQLApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">

--- a/dev/io.openliberty.data.internal_fat_nosql/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_nosql/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2024 IBM Corporation and others.
+# Copyright (c) 2022, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -36,3 +36,4 @@ fat.test.container.images: public.ecr.aws/docker/library/mongo:6.0.6
 	io.openliberty.jakarta.transaction.2.0,\
 	io.openliberty.org.eclipse.microprofile.config.3.0,\
 	io.openliberty.org.testcontainers;version=latest,\
+	org.eclipse.jnosql.mapping:jnosql-mapping-semistructured;version=1.1.4

--- a/dev/io.openliberty.microprofile71.internal_fat/.project
+++ b/dev/io.openliberty.microprofile71.internal_fat/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>io.openliberty.microProfile71.internal_fat</name>
+	<name>io.openliberty.microprofile71.internal_fat</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/dev/io.openliberty.org.apache.myfaces.4.0/bnd.bnd
+++ b/dev/io.openliberty.org.apache.myfaces.4.0/bnd.bnd
@@ -125,7 +125,6 @@ Import-Package: \
   com.ibm.ws.adaptable.module;version=latest,\
   com.ibm.ws.anno;version=latest,\
   com.ibm.ws.managedobject;version=latest,\
-  com.ibm.ws.jsp.jakarta;version=latest,\
   io.openliberty.jakarta.expressionLanguage.5.0;version=latest,\
   io.openliberty.jakarta.servlet.6.0;version=latest, \
   io.openliberty.jakarta.cdi.4.0;version=latest,\

--- a/dev/io.openliberty.springboot.fat30.concurrency.app/.classpath
+++ b/dev/io.openliberty.springboot.fat30.concurrency.app/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
     <classpathentry kind="src" path="src/main/java"/>
-    <classpathentry kind="src" path="src/main/resources"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.springboot.fat30.concurrency.app/bnd.bnd
+++ b/dev/io.openliberty.springboot.fat30.concurrency.app/bnd.bnd
@@ -23,8 +23,7 @@ javac.source: 17
 javac.target: 17
 
 src: \
-  src/main/java, \
-  src/main/resources
+  src/main/java
 
 # Specify bundles to be added to the classpath of a VM used in testing. 
 # Entries in the -testpath instruction enable the Eclipse Package Explorer 

--- a/dev/io.openliberty.springboot.fat30.jms.app/bnd.bnd
+++ b/dev/io.openliberty.springboot.fat30.jms.app/bnd.bnd
@@ -40,7 +40,9 @@ src: \
   org.springframework:spring-beans;${springVersion30}, \
   org.springframework:spring-context;${springVersion30}, \
   org.springframework:spring-core;${springVersion30}, \
+  org.springframework:spring-jdbc;${springVersion30}, \
   org.springframework:spring-jms;${springVersion30}, \
+  org.springframework:spring-tx;${springVersion30}, \
   org.springframework:spring-web;${springVersion30}, \
   org.slf4j:slf4j-api;version=1.7.36, \
   io.openliberty.jakarta.servlet.6.0, \

--- a/dev/io.openliberty.transport.ssl_fat/.classpath
+++ b/dev/io.openliberty.transport.ssl_fat/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-applications/app1/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
- Update .classpath and bnd.bnd files to remove empty source directories for concurrency springboot fat projects
- Correct .classpath and jdt.core.prefs files to match the expected Java version for springboot fat project
- Add missing compile dependencies to buildpath in bnd.bnd for springboot jms app projects that caused projects to not build in eclipse
- Add generated-src directory to .classpath and jnosql-mapping-semistructured dependency to bnd.bnd in data nosql fat project
- Fix case difference of microProfile vs microprofile in .project file to match the directory case
- Remove jsp dependency in myfaces.4.0 project since it isn't need any longer
- Remove nonexistent test-applications directory from transport.ssl_fat project

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
