### PR TITLE
Allow AppClassLoader reference in ThreadContextClassLoaders to GC

### DIFF
--- a/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
+++ b/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
@@ -104,6 +104,10 @@ cls.library.path.invalid=CWWKL0019W: The [{0}] library specifies a path with the
 cls.library.path.invalid.explanation=To add a path to a library in the server configuration, you must specify a path that exists.
 cls.library.path.invalid.useraction=Edit the server configuration and modify the path attribute of the library element.
 
+app.classloader.removed=CWWKL0020W: The thread context class loader for thread [{0}] no longer references stopped application [{1}].
+app.classloader.removed.explanation=app.classloader.removed.explanation=When an application starts a new thread, the application thread context class loader is inherited by the new thread.  If the application is stopped but this new thread continues to run, the thread's context class loader will no longer be able to reference the stopped application.
+app.classloader.removed.useraction=Validate that all threads started by an application are stopped when the application is stopped. 
+
 ####################### CLASS PROVIDER MESSAGES 0030-0039 ####################### 
 #################################################################################
 

--- a/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
+++ b/dev/com.ibm.ws.classloading/resources/com/ibm/ws/classloading/internal/resources/ClassLoadingServiceMessages.nlsprops
@@ -104,9 +104,9 @@ cls.library.path.invalid=CWWKL0019W: The [{0}] library specifies a path with the
 cls.library.path.invalid.explanation=To add a path to a library in the server configuration, you must specify a path that exists.
 cls.library.path.invalid.useraction=Edit the server configuration and modify the path attribute of the library element.
 
-app.classloader.removed=CWWKL0020W: The thread context class loader for thread [{0}] no longer references stopped application [{1}].
-app.classloader.removed.explanation=app.classloader.removed.explanation=When an application starts a new thread, the application thread context class loader is inherited by the new thread.  If the application is stopped but this new thread continues to run, the thread's context class loader will no longer be able to reference the stopped application.
-app.classloader.removed.useraction=Validate that all threads started by an application are stopped when the application is stopped. 
+app.classloader.removed=CWWKL0020W: The thread context class loader for the [{0}] thread no longer references the [{1}] application, which is stopped.
+app.classloader.removed.explanation=app.classloader.removed.explanation=When an application starts a thread, the application thread context class loader is inherited by the new thread.  If the thread continues to run after the application stops, its context class loader no longer references the stopped application.
+app.classloader.removed.useraction=Validate that the application stops all threads that it starts when the application stops. 
 
 ####################### CLASS PROVIDER MESSAGES 0030-0039 ####################### 
 #################################################################################

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderRef.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderRef.java
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.classloading.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.security.ProtectionDomain;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Enumeration;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.osgi.framework.Bundle;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.classloading.LibertyClassLoader;
+import com.ibm.wsspi.classloading.ApiType;
+import com.ibm.wsspi.classloading.ClassLoaderIdentity;
+
+/**
+ * This class is used to create weak references to AppClassLoaders
+ */
+@Trivial
+public class ClassLoaderRef extends LibertyLoader implements SpringLoader {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
+    private static final TraceComponent tc = Tr.register(ClassLoaderRef.class);
+
+    private final AtomicBoolean warningEmitted = new AtomicBoolean(false);
+
+    private final String key;
+
+    private final WeakReference<AppClassLoader> classLoaderWeakRef;
+
+    /**
+     * To mimic AppClassLoader, this class has a smartClassPath field for calling the getClassPath method.
+     * This variable MUST be named smartClassPath because the WebsphereLibertyClassLoaderHandler class in the open source classgraph
+     * library is doing reflection in order to call the getClassPath() method on the AppClassLoader, smartClassPath field.
+     * To make it simple, this field just references <code>this</code> instance and there is a getClassPath() method on this class.
+     * See the findClassOrder method in classgraph:
+     * https://github.com/classgraph/classgraph/blob/latest/src/main/java/nonapi/io/github/classgraph/classloaderhandler/WebsphereLibertyClassLoaderHandler.java
+     * classgraph is used by Eclipse JNoSQL and without this logic tests in io.openliberty.data.internal_fat_nosql fat bucket will fail.
+     */
+    public final ClassLoaderRef smartClassPath = this;
+
+    ClassLoaderRef(AppClassLoader appClassLoader) {
+        super(appClassLoader.getParent());
+        ClassLoaderIdentity identity = appClassLoader.getKey();
+        key = identity == null ? null : identity.toString();
+        classLoaderWeakRef = new WeakReference<>(appClassLoader);
+    }
+
+    @Override
+    protected final Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        return loadClass(name, resolve, false, false);
+    }
+
+    /**
+     * Returns the application class loader if it is still referenced
+     * and puts out a warning one time if it is not referenced any longer
+     *
+     * @return the AppClassLoader or null
+     */
+    private AppClassLoader getAppLoader() {
+        AppClassLoader appCL = classLoaderWeakRef.get();
+        if (appCL == null) {
+            if (key != null && warningEmitted.compareAndSet(false, true)) {
+                Tr.warning(tc, "app.classloader.removed", Thread.currentThread().getName(), key);
+            }
+        }
+        return appCL;
+    }
+
+    AppClassLoader getReferent() {
+        return classLoaderWeakRef.get();
+    }
+
+    @Override
+    public URL getResource(String resName) {
+        AppClassLoader appCL = getAppLoader();
+        return appCL != null ? appCL.getResource(resName) : parent.getResource(resName);
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String resName) {
+        AppClassLoader appCL = getAppLoader();
+        return appCL != null ? appCL.getResourceAsStream(resName) : parent.getResourceAsStream(resName);
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String resName) throws IOException {
+        AppClassLoader appCL = getAppLoader();
+        return appCL != null ? appCL.getResources(resName) : parent.getResources(resName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof ClassLoaderRef) {
+            return Objects.equals(classLoaderWeakRef.get(), ((ClassLoaderRef) o).classLoaderWeakRef.get());
+        }
+        return false;
+    }
+
+    @Override
+    public boolean addTransformer(ClassFileTransformer cft) {
+        AppClassLoader appCL = getAppLoader();
+        if (appCL != null) {
+            return appCL.addTransformer(cft);
+        }
+        return false;
+    }
+
+    @Override
+    public ClassLoader getThrowawayClassLoader() {
+        AppClassLoader appCL = getAppLoader();
+        return appCL != null ? appCL.getThrowawayClassLoader() : this;
+    }
+
+    @Override
+    public Class<?> publicDefineClass(String name, byte[] b, ProtectionDomain protectionDomain) {
+        AppClassLoader appCL = getAppLoader();
+        return appCL != null ? appCL.publicDefineClass(name, b, protectionDomain) : defineClass(name, b, 0, b.length, protectionDomain);
+    }
+
+    @Override
+    public EnumSet<ApiType> getApiTypeVisibility() {
+        AppClassLoader appCL = classLoaderWeakRef.get();
+        if (appCL != null) {
+            return appCL.getApiTypeVisibility();
+        }
+        if (parent instanceof DeclaredApiAccess) {
+            return ((DeclaredApiAccess) parent).getApiTypeVisibility();
+        }
+        if (parent instanceof LibertyClassLoader) {
+            return ((LibertyClassLoader) parent).getApiTypeVisibility();
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(super.toString());
+        sb.append(": Application ClassLoader ");
+        sb.append(classLoaderWeakRef.get());
+        return sb.toString();
+    }
+
+    @Override
+    protected Class<?> loadClass(String className, boolean resolve, boolean onlySearchSelf, boolean returnNull) throws ClassNotFoundException {
+        AppClassLoader appCL = getAppLoader();
+        if (appCL == null) {
+            if (onlySearchSelf) {
+                return findClass(className, returnNull);
+            }
+
+            if (parent instanceof NoClassNotFoundLoader) {
+                Class<?> result = ((NoClassNotFoundLoader) parent).loadClassNoException(className);
+                if (result == null) {
+                    if (returnNull) {
+                        return null;
+                    }
+                    throw new ClassNotFoundException(className);
+                }
+
+                return result;
+            } else {
+                try {
+                    return parent.loadClass(className);
+                } catch (ClassNotFoundException e) {
+                    if (returnNull) {
+                        return null;
+                    }
+                    throw e;
+                }
+            }
+        }
+
+        return appCL.loadClass(className, resolve, onlySearchSelf, returnNull);
+    }
+
+    @Override
+    protected Class<?> findClass(String className, boolean returnNull) throws ClassNotFoundException {
+        if (returnNull) {
+            return null;
+        }
+        throw new ClassNotFoundException(className);
+    }
+
+    @Override
+    public Bundle getBundle() {
+        return parent instanceof GatewayClassLoader ? ((GatewayClassLoader) parent).getBundle() : parent instanceof LibertyLoader ? ((LibertyLoader) parent).getBundle() : null;
+    }
+
+    /**
+     * This method is called by the classgraph open source library doing reflection on
+     * AppClassLoader. Since ClassLoaderRef now is used instead of AppClassLoader in
+     * ThreadContextClassLoader, we need to be able to still allow classgraph to work.
+     * See more details in the smartClassPath javadoc above.
+     *
+     * @return AppClassLoader.getClassPath() result
+     */
+    public Collection<Collection<URL>> getClassPath() {
+        AppClassLoader appCL = classLoaderWeakRef.get();
+        if (appCL != null) {
+            return appCL.getClassPath();
+        }
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ThreadContextClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ThreadContextClassLoader.java
@@ -47,14 +47,26 @@ public class ThreadContextClassLoader extends UnifiedClassLoader implements Keye
     private final AtomicReference<Bundle> bundle = new AtomicReference<Bundle>();
     protected final String key;
     private final AtomicInteger refCount = new AtomicInteger(0);
+
+    /**
+     * This variable MUST be named appLoader because the WebsphereLibertyClassLoaderHandler class in the open source classgraph
+     * library is doing reflection in order to call the getClassPath() method on the AppClassLoader's smartClassPath field.
+     * See the findClassOrder method in classgraph:
+     * https://github.com/classgraph/classgraph/blob/latest/src/main/java/nonapi/io/github/classgraph/classloaderhandler/WebsphereLibertyClassLoaderHandler.java
+     * classgraph is used by Eclipse JNoSQL and without this logic tests in io.openliberty.data.internal_fat_nosql fat bucket will fail.
+     */
     private final ClassLoader appLoader;
     private final ClassLoadingServiceImpl clSvc;
 
     public ThreadContextClassLoader(GatewayClassLoader augLoader, ClassLoader appLoader, String key, ClassLoadingServiceImpl clSvc) {
-        super(appLoader instanceof ParentLastClassLoader ? appLoader : augLoader, appLoader instanceof ParentLastClassLoader ? augLoader : appLoader);
+        this(augLoader, appLoader, key, clSvc, appLoader instanceof AppClassLoader ? new ClassLoaderRef((AppClassLoader) appLoader) : appLoader);
+    }
+
+    private ThreadContextClassLoader(GatewayClassLoader augLoader, ClassLoader appLoader, String key, ClassLoadingServiceImpl clSvc, ClassLoader appLoaderRef) {
+        super(appLoader instanceof ParentLastClassLoader ? appLoaderRef : augLoader, appLoader instanceof ParentLastClassLoader ? augLoader : appLoaderRef);
         bundle.set(augLoader.getBundle());
         this.key = key;
-        this.appLoader = appLoader;
+        this.appLoader = appLoaderRef;
         this.clSvc = clSvc;
     }
 
@@ -125,7 +137,7 @@ public class ThreadContextClassLoader extends UnifiedClassLoader implements Keye
     }
 
     /**
-     * The ClassLoadingService implementation should call this method when it's
+     * The ClassLoadingService implementation should call this method when its
      * createThreadContextClassLoader method is called, both for new and pre-existing
      * instances. Each call to createTCCL should increment this ref counter - likewise,
      * each call to destroy should call decrementRefCount();
@@ -143,7 +155,7 @@ public class ThreadContextClassLoader extends UnifiedClassLoader implements Keye
         ClassNotFoundException cnfe = null;
         Class<?> c = null;
         try {
-            c =  super.findClass(className, returnNull);
+            c = super.findClass(className, returnNull);
         } catch (ClassNotFoundException x) {
             cnfe = x;
         }
@@ -213,13 +225,26 @@ public class ThreadContextClassLoader extends UnifiedClassLoader implements Keye
     }
 
     final boolean isFor(ClassLoader classLoader) {
-        return classLoader == appLoader;
+        ClassLoader classLoaderToCompare = appLoader;
+        if (appLoader instanceof ClassLoaderRef) {
+            classLoaderToCompare = ((ClassLoaderRef) appLoader).getReferent();
+        }
+        return classLoader == classLoaderToCompare;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(super.toString());
+        sb.append(": Application ClassLoader ");
+        sb.append(appLoader);
+        return sb.toString();
     }
 
     // This is reflectively called by Spring for GLIBC proxy classes.
     // To work properly with package private application class beans these proxies
     // must be defined with the app loader so they have proper visibility to their
     // super classes.
+    @Override
     public Class<?> publicDefineClass(String name, byte[] b, ProtectionDomain protectionDomain) {
         if (appLoader instanceof SpringLoader) {
             return ((SpringLoader) appLoader).publicDefineClass(name, b, protectionDomain);

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/CreateThreadContextClassLoaderTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/CreateThreadContextClassLoaderTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,17 +18,27 @@ import static com.ibm.ws.classloading.internal.TestUtil.getOtherClassesURL;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Rule;
 import org.junit.Test;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.classloading.internal.TestUtil.ClassSource;
 import com.ibm.wsspi.classloading.ClassLoadingService;
+
+import test.common.SharedOutputManager;
 
 public class CreateThreadContextClassLoaderTest {
 
@@ -52,5 +62,134 @@ public class CreateThreadContextClassLoaderTest {
         assertThat("Creating ThreadContextClassLoaders from two AppClassLoaders with the same ID should produce two differents instances.",
                    tccl1,
                    is(not(sameInstance(tccl2))));
+    }
+
+    @Test
+    public void testThreadContextClassLoaderMemoryLeakParentLast() throws Exception {
+        testThreadContextClassLoaderMemoryLeak(true, false);
+    }
+
+    @Test
+    public void testThreadContextClassLoaderMemoryLeakParentFirst() throws Exception {
+        testThreadContextClassLoaderMemoryLeak(false, false);
+    }
+
+    @Test
+    public void testThreadContextClassLoaderMemoryLeakParentLastSecondThread() throws Exception {
+        testThreadContextClassLoaderMemoryLeak(true, true);
+    }
+
+    @Test
+    public void testThreadContextClassLoaderMemoryLeakParentFirstSecondThread() throws Exception {
+        testThreadContextClassLoaderMemoryLeak(false, true);
+    }
+
+    private void testThreadContextClassLoaderMemoryLeak(boolean parentLast, boolean secondThread) throws Exception {
+        // create two class loaders with the same ID
+        String id = "testThreadContextClassLoaderMemoryLeak " + parentLast;
+        URL url = getOtherClassesURL(ClassSource.A);
+        AppClassLoader appLoader = createAppClassloader(id, url, parentLast);
+
+        ClassLoadingService cls = getClassLoadingService(null);
+        ClassLoader tccl = cls.createThreadContextClassLoader(appLoader);
+
+        assertTrue(((ThreadContextClassLoader) tccl).isFor(appLoader));
+
+        // Set the AppClassLoader into the thread to keep it in memory outside of in this method
+        Thread.currentThread().setContextClassLoader(appLoader);
+
+        WeakReference<ClassLoader> weakRef = new WeakReference<>(appLoader);
+
+        doGarbageCollectCheck(weakRef, false);
+        assertNotNull("AppClassLoader instance should not garbage collect", weakRef.get());
+
+        tccl.loadClass("test.DummyServlet");
+
+        Thread.currentThread().setContextClassLoader(tccl);
+
+        // Do a second thread scenario to show that the new thread inherits the Thread context classloader of
+        // the current thread
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> exception = new AtomicReference<>();
+        Thread newThread = null;
+        if (secondThread) {
+            newThread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        latch.await();
+                        doLoadClassAfterGC(outputManager, "secondThread", true);
+                    } catch (Exception e) {
+                        exception.set(e);
+                    }
+                }
+            }, "secondThread");
+            assertSame(tccl, newThread.getContextClassLoader());
+            newThread.start();
+        }
+
+        appLoader = null;
+        tccl = null;
+
+        doGarbageCollectCheck(weakRef, true);
+        assertNull("AppClassLoader instance should have been able to garbage collect", weakRef.get());
+
+        tccl = Thread.currentThread().getContextClassLoader();
+
+        assertTrue(((ThreadContextClassLoader) tccl).isFor(null));
+
+        if (secondThread) {
+            assertTrue("Thread isn't alive", newThread.isAlive());
+            latch.countDown();
+            newThread.join(10000);
+            assertFalse("Thread didn't complete", newThread.isAlive());
+            Exception e = exception.get();
+            assertNull(e);
+            outputManager.resetStreams();
+        }
+
+        doLoadClassAfterGC(outputManager, id, !secondThread);
+    }
+
+    static void doLoadClassAfterGC(SharedOutputManager outputManager, String threadName, boolean expectMessage) throws Exception {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        try {
+            tccl.loadClass("test.DummyServlet");
+            fail("Expected a ClassNotFoundException");
+        } catch (ClassNotFoundException e) {
+            // expected since the app classloader has garbage collected
+        }
+
+        // If we change to output the message for every thread, this test will fail and need to be updated to be assertTrue
+        assertEquals(expectMessage, outputManager.checkForMessages("CWWKL0020W: .*" + threadName + ".*"));
+        outputManager.resetStreams();
+
+        // verify that you can still load a Java class from a ThreadContextClassLoader that has had
+        // its app class loader garbage collected. If we didn't call the parent still when the app
+        // class loader garbage collects this scenario would fail
+        tccl.loadClass("java.nio.charset.StandardCharsets");
+
+        // The message should only come out once.
+        assertFalse(outputManager.checkForMessages("CWWKL0020W: .*" + threadName));
+    }
+
+    private void doGarbageCollectCheck(WeakReference<ClassLoader> weakRef, boolean nullExpected) {
+        for (int i = 0; i < 10; ++i) {
+            System.out.println("doGarbageCollectCheck calling system gc i " + i);
+            System.gc();
+            // give the GC some time to actually do its thing
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            if (nullExpected && weakRef.get() == null) {
+                break;
+            }
+
+            if (!nullExpected && weakRef.get() != null) {
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
- Keep a WeakReference to AppClassLoader instances in ThreadContextClassLoader to allow for AppClassLoaders to garbage collect when an application is stopped, but a ThreadContextClassLoader is still set on a user initiated thread.
- Output a warning when someone tries to use a thread context classloader where the AppClassLoader has been garbage collected.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
