### PR TITLE
fix: concurrent TCK debugging

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -241,7 +241,7 @@ public class TCKRunner {
         }
 
         // Configure a simple formatter
-        loggingProperties.put("java.util.logging.SimpleFormatter.format", "[%1$tm/%1$td/%1$tY %1$tH:%1$tM:%1$tS %1$tZ] %4$.1s %2$s %n %5$4s %6$4s %n");
+        loggingProperties.put("java.util.logging.SimpleFormatter.format", "[%1$tm/%1$td/%1$tY %1$tH:%1$tM:%1$tS:%1$tL %1$tZ] %4$.1s %2$s %5$4s %6$4s %n");
 
         // Log warning to console
         loggingProperties.put("java.util.logging.ConsoleHandler.formatter", "java.util.logging.SimpleFormatter");

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/tck/TCKRunner.java
@@ -241,7 +241,7 @@ public class TCKRunner {
         }
 
         // Configure a simple formatter
-        loggingProperties.put("java.util.logging.SimpleFormatter.format", "[%1$tm/%1$te/%1$tY %1$tT:%1$tM %1$tZ] %2$s %4$.1s %5$s %6$s %n");
+        loggingProperties.put("java.util.logging.SimpleFormatter.format", "[%1$tm/%1$td/%1$tY %1$tH:%1$tM:%1$tS %1$tZ] %4$.1s %2$s %n %5$4s %6$4s %n");
 
         // Log warning to console
         loggingProperties.put("java.util.logging.ConsoleHandler.formatter", "java.util.logging.SimpleFormatter");

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherFull.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherFull.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -93,7 +93,8 @@ public class ConcurrentTckLauncherFull {
                         .withAdditionalMvnProps(additionalProps)
                         .withLogging(Map.of("ee.jakarta.tck.concurrent", Level.ALL,
                                             "org.jboss.arquillian", Level.ALL, //TODO reduce logging after debugging defect 300064 is finished
-                                            "io.openliberty.arquillian", Level.ALL)) //TODO reduce logging after debugging defect 300064 is finished
+                                            "io.openliberty.arquillian", Level.ALL, //TODO reduce logging after debugging defect 300064 is finished
+                                            "com.ibm.ws.fat.util.tck", Level.ALL)) //TODO reduce logging after debugging defect 300064 is finished
                         .runTCK();
     }
 }

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherWeb.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/fat/src/io/openliberty/jakarta/enterprise/concurrent/tck/ConcurrentTckLauncherWeb.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -89,7 +89,8 @@ public class ConcurrentTckLauncherWeb {
                         .withAdditionalMvnProps(additionalProps)
                         .withLogging(Map.of("ee.jakarta.tck.concurrent", Level.ALL,
                                             "org.jboss.arquillian", Level.ALL, //TODO reduce logging after debugging defect 300064 is finished
-                                            "io.openliberty.arquillian", Level.ALL)) //TODO reduce logging after debugging defect 300064 is finished
+                                            "io.openliberty.arquillian", Level.ALL, //TODO reduce logging after debugging defect 300064 is finished
+                                            "com.ibm.ws.fat.util.tck", Level.ALL)) //TODO reduce logging after debugging defect 300064 is finished
                         .runTCK();
     }
 }

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKFullServer/bootstrap.properties
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKFullServer/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ com.ibm.ws.logging.trace.specification=\
 *=info:\
 org.jboss.arquillian=all:\
 ee.jakarta.tck.concurrent=all:\
+com.ibm.ws.fat.util.tck=all:\
 concurrent=all:\
 concurrencyPolicy=all:\
 context=all:\

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKWebServer/bootstrap.properties
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/servers/ConcurrentTCKWebServer/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ com.ibm.ws.logging.trace.specification=\
 *=info:\
 org.jboss.arquillian=all:\
 ee.jakarta.tck.concurrent=all:\
+com.ibm.ws.fat.util.tck=all:\
 concurrent=all:\
 concurrencyPolicy=all:\
 context=all:\

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/src/test/java/io/openliberty/jakarta/concurrency/tck/ArquillianLoadableExtension.java
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/src/test/java/io/openliberty/jakarta/concurrency/tck/ArquillianLoadableExtension.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jakarta.concurrency.tck;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import com.ibm.ws.fat.util.tck.AbstractArquillianLoadableExtension;
+import com.ibm.ws.fat.util.tck.TCKArchiveModifications;
+
+public class ArquillianLoadableExtension extends AbstractArquillianLoadableExtension {
+    @Override
+    public Set<TCKArchiveModifications> getModifications() {
+        return EnumSet.of(TCKArchiveModifications.TEST_LOGGER);
+    }
+}

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+io.openliberty.jakarta.concurrency.tck.ArquillianLoadableExtension


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Fix Tck logging timestamp
- add logging observer to track when Arquillian thinks it is running a test
