### PR TITLE
Enable Netty for SIP with SO_REUSEADDR set to true  (TESTING only) netty-transport-http branch

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/metatype/metatype.xml
@@ -94,7 +94,7 @@
             type="String" required="false"/>
 
 		<AD name="internal" description="internal" id="useNettyTransport"
-			required="false" type="Boolean" default="false" />
+			required="false" type="Boolean" default="true" />
 
 	</OCD>
 


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

