### PR TITLE
fix up wsscxf.* fips profiles and add comments

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/semeruFips140_3CustomProfile.properties
@@ -1,3 +1,5 @@
+# Needed to add a lot of constraints to allow for algorithms used in org.apache.wss4j open source library
+# TODO: Revisit this after https://github.com/OpenLiberty/open-liberty/issues/31846
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
@@ -27,8 +29,12 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
+# TODO: Allowing all in XMLDSigRI for now. Revisit after Semeru JDK fixes issue with having "#" in the constraint's algorithm name.
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
 
+# This was copied from the java.security file and removed the line that disallowed http://www.w3.org/2000/09/xmldsig#sha1
+# which was causing the test to fail when FIPS 140-3 is enabled.
+# TODO: Revisit later to see if there's a better way to allow or fix this issue.
 jdk.xml.dsig.secureValidationPolicy=\
     disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
     disallowAlg http://www.w3.org/2001/04/xmldsig-more#rsa-md5,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/semeruFips140_3CustomProfile.properties
@@ -30,25 +30,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
 # TODO: Allowing all in XMLDSigRI for now. Revisit after Semeru JDK fixes issue with having "#" in the constraint's algorithm name.
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
-
-# This was copied from the java.security file and removed the line that disallowed http://www.w3.org/2000/09/xmldsig#sha1
-# which was causing the test to fail when FIPS 140-3 is enabled.
-# TODO: Revisit later to see if there's a better way to allow or fix this issue.
-jdk.xml.dsig.secureValidationPolicy=\
-    disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#rsa-md5,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#hmac-md5,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#md5,\
-    disallowAlg http://www.w3.org/2000/09/xmldsig#dsa-sha1,\
-    disallowAlg http://www.w3.org/2000/09/xmldsig#rsa-sha1,\
-    disallowAlg http://www.w3.org/2007/05/xmldsig-more#sha1-rsa-MGF1,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1,\
-    maxTransforms 5,\
-    maxReferences 30,\
-    disallowReferenceUriSchemes file http https,\
-    minKeySize RSA 1024,\
-    minKeySize DSA 1024,\
-    minKeySize EC 224,\
-    noDuplicateIds,\
-    noRetrievalMethodLoops
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.apache.jcp.xml.dsig.internal.dom.XMLDSigRI

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/semeruFips140_3CustomProfile.properties
@@ -1,3 +1,6 @@
+# Needed to add a lot of constraints to allow for algorithms used in org.apache.wss4j open source library
+# TODO: This file was copied from wsscxf.1's custom profile and then added upon. Revisit later to see which constraints are not needed in wsscxf.2.
+# TODO: Revisit this after https://github.com/OpenLiberty/open-liberty/issues/31846
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
@@ -31,8 +34,12 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
+# TODO: Allowing all in XMLDSigRI for now. Revisit after Semeru JDK fixes issue with having "#" in the constraint's algorithm name.
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
 
+# This was copied from the java.security file and removed the line that disallowed http://www.w3.org/2000/09/xmldsig#sha1
+# which was causing the test to fail when FIPS 140-3 is enabled.
+# TODO: Revisit later to see if there's a better way to allow or fix this issue.
 jdk.xml.dsig.secureValidationPolicy=\
     disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
     disallowAlg http://www.w3.org/2001/04/xmldsig-more#rsa-md5,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/semeruFips140_3CustomProfile.properties
@@ -35,25 +35,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
 # TODO: Allowing all in XMLDSigRI for now. Revisit after Semeru JDK fixes issue with having "#" in the constraint's algorithm name.
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
-
-# This was copied from the java.security file and removed the line that disallowed http://www.w3.org/2000/09/xmldsig#sha1
-# which was causing the test to fail when FIPS 140-3 is enabled.
-# TODO: Revisit later to see if there's a better way to allow or fix this issue.
-jdk.xml.dsig.secureValidationPolicy=\
-    disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#rsa-md5,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#hmac-md5,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#md5,\
-    disallowAlg http://www.w3.org/2000/09/xmldsig#dsa-sha1,\
-    disallowAlg http://www.w3.org/2000/09/xmldsig#rsa-sha1,\
-    disallowAlg http://www.w3.org/2007/05/xmldsig-more#sha1-rsa-MGF1,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1,\
-    maxTransforms 5,\
-    maxReferences 30,\
-    disallowReferenceUriSchemes file http https,\
-    minKeySize RSA 1024,\
-    minKeySize DSA 1024,\
-    minKeySize EC 224,\
-    noDuplicateIds,\
-    noRetrievalMethodLoops
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.apache.jcp.xml.dsig.internal.dom.XMLDSigRI

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/semeruFips140_3CustomProfile.properties
@@ -14,8 +14,12 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecDKSign}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}, \
+    {MessageDigest, MD5, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
+    {MessageDigest, MD5, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBEWithMD5AndDES, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
+    {AlgorithmParameters, PBEWithMD5AndDES, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {KeyStore, JCEKS, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}, \
     {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \
@@ -33,6 +37,9 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.6 = sun.security.rsa.SunRsaSign [ \
+    {Signature, SHA1withRSA, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
+    {Signature, SHA1withRSA, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}]
 
 jdk.xml.dsig.secureValidationPolicy=\
     disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/semeruFips140_3CustomProfile.properties
@@ -1,3 +1,6 @@
+# Needed to add a lot of constraints to allow for algorithms used in org.apache.wss4j open source library
+# TODO: This file was copied from wsscxf.2's custom profile and then added upon. Revisit later to see which constraints are not needed in wsscxf.3.
+# TODO: Revisit this after https://github.com/OpenLiberty/open-liberty/issues/31846
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
@@ -36,11 +39,15 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
+# TODO: Allowing all in XMLDSigRI for now. Revisit after Semeru JDK fixes issue with having "#" in the constraint's algorithm name.
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.6 = sun.security.rsa.SunRsaSign [ \
     {Signature, SHA1withRSA, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {Signature, SHA1withRSA, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}]
 
+# This was copied from the java.security file and removed the line that disallowed http://www.w3.org/2000/09/xmldsig#sha1
+# which was causing the test to fail when FIPS 140-3 is enabled.
+# TODO: Revisit later to see if there's a better way to allow or fix this issue.
 jdk.xml.dsig.secureValidationPolicy=\
     disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
     disallowAlg http://www.w3.org/2001/04/xmldsig-more#rsa-md5,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/semeruFips140_3CustomProfile.properties
@@ -40,28 +40,7 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
 # TODO: Allowing all in XMLDSigRI for now. Revisit after Semeru JDK fixes issue with having "#" in the constraint's algorithm name.
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.apache.jcp.xml.dsig.internal.dom.XMLDSigRI
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.6 = sun.security.rsa.SunRsaSign [ \
     {Signature, SHA1withRSA, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {Signature, SHA1withRSA, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}]
-
-# This was copied from the java.security file and removed the line that disallowed http://www.w3.org/2000/09/xmldsig#sha1
-# which was causing the test to fail when FIPS 140-3 is enabled.
-# TODO: Revisit later to see if there's a better way to allow or fix this issue.
-jdk.xml.dsig.secureValidationPolicy=\
-    disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#rsa-md5,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#hmac-md5,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#md5,\
-    disallowAlg http://www.w3.org/2000/09/xmldsig#dsa-sha1,\
-    disallowAlg http://www.w3.org/2000/09/xmldsig#rsa-sha1,\
-    disallowAlg http://www.w3.org/2007/05/xmldsig-more#sha1-rsa-MGF1,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1,\
-    maxTransforms 5,\
-    maxReferences 30,\
-    disallowReferenceUriSchemes file http https,\
-    minKeySize RSA 1024,\
-    minKeySize DSA 1024,\
-    minKeySize EC 224,\
-    noDuplicateIds,\
-    noRetrievalMethodLoops

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/semeruFips140_3CustomProfile.properties
@@ -1,3 +1,6 @@
+# Needed to add a lot of constraints to allow for algorithms used in org.apache.wss4j open source library
+# TODO: This file was copied from wsscxf.2's custom profile. Revisit later to see which constraints are not needed in wsscxf.4.
+# TODO: Revisit this after https://github.com/OpenLiberty/open-liberty/issues/31846
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
@@ -31,8 +34,12 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
+# TODO: Allowing all in XMLDSigRI for now. Revisit after Semeru JDK fixes issue with having "#" in the constraint's algorithm name.
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
 
+# This was copied from the java.security file and removed the line that disallowed http://www.w3.org/2000/09/xmldsig#sha1
+# which was causing the test to fail when FIPS 140-3 is enabled.
+# TODO: Revisit later to see if there's a better way to allow or fix this issue.
 jdk.xml.dsig.secureValidationPolicy=\
     disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
     disallowAlg http://www.w3.org/2001/04/xmldsig-more#rsa-md5,\

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/semeruFips140_3CustomProfile.properties
@@ -35,25 +35,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
 # TODO: Allowing all in XMLDSigRI for now. Revisit after Semeru JDK fixes issue with having "#" in the constraint's algorithm name.
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.jcp.xml.dsig.internal.dom.XMLDSigRI
-
-# This was copied from the java.security file and removed the line that disallowed http://www.w3.org/2000/09/xmldsig#sha1
-# which was causing the test to fail when FIPS 140-3 is enabled.
-# TODO: Revisit later to see if there's a better way to allow or fix this issue.
-jdk.xml.dsig.secureValidationPolicy=\
-    disallowAlg http://www.w3.org/TR/1999/REC-xslt-19991116,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#rsa-md5,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#hmac-md5,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#md5,\
-    disallowAlg http://www.w3.org/2000/09/xmldsig#dsa-sha1,\
-    disallowAlg http://www.w3.org/2000/09/xmldsig#rsa-sha1,\
-    disallowAlg http://www.w3.org/2007/05/xmldsig-more#sha1-rsa-MGF1,\
-    disallowAlg http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1,\
-    maxTransforms 5,\
-    maxReferences 30,\
-    disallowReferenceUriSchemes file http https,\
-    minKeySize RSA 1024,\
-    minKeySize DSA 1024,\
-    minKeySize EC 224,\
-    noDuplicateIds,\
-    noRetrievalMethodLoops
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = org.apache.jcp.xml.dsig.internal.dom.XMLDSigRI


### PR DESCRIPTION
- fix the remaining fips 140-3 failures in wsscxf.3 fat via java security constraints
- remove `jdk.xml.dsig.secureValidationPolicy` workaround and fix the disallowed http://www.w3.org/2000/09/xmldsig#sha1 the correct way
    - turns out wss4j uses their own `org.apache.jcp.xml.dsig.internal.dom.XMLDSigRI` provider instead of using the `org.jcp.xml.dsig.internal.dom.XMLDSigRI` provider
- added comments with TODO's

Notes:
- using SunRsaSign:
    - the providers that include SHA1withRSA are SunRsaSign, SunJSSE, SunMSCAPI, and OracleUcrypto.
    - i decided to go with adding SunRsaSign instead of using SunJSSE because the docs say
`The SunRsaSign provider was introduced in JDK 1.3 as an enhanced replacement for the RSA signatures in the SunJSSE provider.`
    - https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SunRsaSignProvider