### PR TITLE
add FIPS 140-3 properties to ejbcontainer.legacy_fat for opensource apache.yoko SHA-1 usage

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,13 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.yoko.rmi.impl.ValueDescriptor}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################