### PR TITLE
FIPS 140-3 Custom Profile for JSP 2.3 Bucket

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspJava11Server/jvm.options
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspJava11Server/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.tools.attach.enable=no

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspJava17Server/jvm.options
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspJava17Server/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.tools.attach.enable=no

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspJava7Server/jvm.options
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspJava7Server/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.tools.attach.enable=no

--- a/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspJava8Server/jvm.options
+++ b/dev/com.ibm.ws.jsp.2.3_fat/publish/servers/jspJava8Server/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.tools.attach.enable=no

--- a/dev/com.ibm.ws.jsp.2.3_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.jsp.2.3_fat/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,17 @@
+# Allowing for JDK module and class java.rmi/sun.rmi.server.Util
+# TODO: Revsit usage and allowance of SHA-1
+# SHA-1 is used by default ("hard-coded") in the JDK module/class to create a MessageDigest instance
+# https://github.com/openjdk/jdk/blob/e57a214e2a1059109dd028369d518298cfa5d5b4/src/java.rmi/share/classes/sun/rmi/server/Util.java#L339
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.rmi/sun.rmi.server.Util}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

----

- Added JVM options file to servers in the JSP 2.3 bucket with the `-Dcom.ibm.tools.attach.enable=no` flag
- Added a FIPS 140-3 custom profile to allow SHA-1 usage at the JDK level due to usage being hard-coded (will be revisited)
