### PR TITLE
Added FIPS custom profile to transport.iiop.open_fat to allow SHA-1 usage in Apache Yoko class

### DIFF
--- a/dev/com.ibm.ws.transport.iiop.open_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.transport.iiop.open_fat/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,17 @@
+# Allowing for org.apache.yoko.rmi
+# TODO: Revsit usage and allowance of SHA-1
+# SHA-1 is used by default in Apache Yoko package to create a MessageDigest instance
+# https://github.com/OpenLiberty/yoko/blob/831d82ad44f93ac4bfe37f64c0a1faa7a49b0fe3/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/ValueDescriptor.java#L715
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.yoko.rmi.impl.ValueDescriptor}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

- Add FIPS 140-3 custom profile to the transport.iiop.open_fat bucket to allow SHA-1 usage in the Apache Yoko component (Investigation tracked by https://github.com/OpenLiberty/open-liberty/issues/31845)
