### PR TITLE
Jd derby

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20Constants.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20Constants.java
@@ -192,7 +192,7 @@ public interface OAuth20Constants extends OAuthConstants {
     public static final String HASH = "hash"; // matches result from PasswordUtil.getCryptoAlgorithm
 
     // With FIPS enabled we want a 128 byte salt length minimum.
-    public static final String APP_PASSWORD_HASH_SALT = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? "notrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandom" : "notrandom";
+    public static final String APP_PASSWORD_HASH_SALT = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? "notrandomnotrandom" : "notrandom";
     public static final String PLAIN_ENCODING = "plain";
     public static final String APP_PASSWORD_TOKEN_STATE_ID = "iamapppasswordorapptokenstateid";
     public final static String XOR = "xor"; // matches result from PasswordUtil.getCryptoAlgorithm


### PR DESCRIPTION
Using the previous FIPS salt (`public static final String APP_PASSWORD_HASH_SALT = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? "notrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandomnotrandom" : "notrandom";`) our table columns could not contain the hashes because they were VARCHAR(256). 

this resulted in ffdc failures such as
```
------Start of DE processing------ = [6/14/25, 10:21:20:221 EDT]
Exception = java.sql.SQLDataException
Source = com.ibm.ws.security.oauth20.plugins.db.CachedDBOidcTokenStore
probeid = 476
Stack Dump = java.sql.SQLDataException: A truncation error was encountered trying to shrink VARCHAR '{hash}ARAAAAAUUEJLREYyV2l0aEhtYWNTSEE1MTIwAAAAh25vdHJhbmRvbW&' to length 256.
        at org.apache.derby.impl.jdbc.SQLExceptionFactory.getSQLException(Unknown Source)
        at org.apache.derby.impl.jdbc.Util.generateCsSQLException(Unknown Source)
        at org.apache.derby.impl.jdbc.TransactionResourceImpl.wrapInSQLException(Unknown Source)
        at org.apache.derby.impl.jdbc.TransactionResourceImpl.handleException(Unknown Source)
        at org.apache.derby.impl.jdbc.EmbedConnection.handleException(Unknown Source)
        at org.apache.derby.impl.jdbc.ConnectionChild.handleException(Unknown Source)
        at org.apache.derby.impl.jdbc.EmbedStatement.executeStatement(Unknown Source)
        at org.apache.derby.impl.jdbc.EmbedPreparedStatement.executeStatement(Unknown Source)
        at org.apache.derby.impl.jdbc.EmbedPreparedStatement.execute(Unknown Source)
        at com.ibm.ws.rsadapter.jdbc.WSJdbcPreparedStatement.execute(WSJdbcPreparedStatement.java:392)
        at com.ibm.ws.security.oauth20.plugins.db.CachedDBOidcTokenStore.add(CachedDBOidcTokenStore.java:615)
        at com.ibm.ws.security.oauth20.plugins.db.CachedDBOidcTokenStore.add(CachedDBOidcTokenStore.java:456)
        at com.ibm.oauth.core.internal.oauth20.token.OAuth20TokenFactory.persistToken(OAuth20TokenFactory.java:540)
        at com.ibm.oauth.core.internal.oauth20.token.OAuth20TokenFactory.createAccessTokenAsAppPasswordOrToken(OAuth20TokenFactory.java:403)
        at com.ibm.oauth.core.internal.oauth20.granttype.impl.OAuth20GrantTypeHandlerAppTokenAndPasswordImpl.buildTokensGrantType(OAuth20GrantTypeHandlerAppTokenAndPasswordImpl.java:178)
        at com.ibm.oauth.core.internal.oauth20.OAuth20ComponentImpl.processAppTokenRequest(OAuth20ComponentImpl.java:704)
        at com.ibm.ws.security.oauth20.web.TokenExchange.requestAppPasswordOrTokenJson(TokenExchange.java:1033)
        at com.ibm.ws.security.oauth20.web.TokenExchange.processCommonPost(TokenExchange.java:295)
        at com.ibm.ws.security.oauth20.web.TokenExchange.processCommon(TokenExchange.java:167)
        at com.ibm.ws.security.oauth20.web.TokenExchange.processAppPassword(TokenExchange.java:138)
        at com.ibm.ws.security.oauth20.web.OAuth20EndpointServices.handleEndpointRequest(OAuth20EndpointServices.java:283)
        at com.ibm.ws.security.openidconnect.web.OidcEndpointServices.handleOidcRequest(OidcEndpointServices.java:255)
        at com.ibm.ws.security.openidconnect.web.OidcEndpointServlet.handleRequest(OidcEndpointServlet.java:111)
        at com.ibm.ws.security.openidconnect.web.OidcEndpointServlet.doPost(OidcEndpointServlet.java:69)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:595)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:668)
        at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1266)
        at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:754)
        at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:451)
        at com.ibm.ws.webcontainer.filter.WebAppFilterChain.invokeTarget(WebAppFilterChain.java:197)
        at com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:100)
        at com.ibm.ws.security.openidconnect.web.OidcRequestFilter.setEndpointRequest(OidcRequestFilter.java:43)
        at com.ibm.ws.security.oauth20.web.OAuth20RequestFilter.doFilter(OAuth20RequestFilter.java:97)
        at com.ibm.ws.webcontainer.filter.FilterInstanceWrapper.doFilter(FilterInstanceWrapper.java:203)
        at com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:93)
        at com.ibm.ws.app.manager.wab.internal.OsgiDirectoryProtectionFilter.doFilter(OsgiDirectoryProtectionFilter.java:92)
        at com.ibm.ws.webcontainer.filter.FilterInstanceWrapper.doFilter(FilterInstanceWrapper.java:203)
        at com.ibm.ws.webcontainer.filter.WebAppFilterChain.doFilter(WebAppFilterChain.java:93)
        at com.ibm.ws.webcontainer.filter.WebAppFilterManager.doFilter(WebAppFilterManager.java:1069)
        at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1260)
        at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5096)
        at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:328)
        at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1047)
        at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:293)
        at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1284)
        at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:500)
        at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:459)
        at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:569)
        at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:503)
        at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:363)
        at com.ibm.ws.http.channel.internal.inbound.HttpICLReadCallback.complete(HttpICLReadCallback.java:72)
        at com.ibm.ws.channel.ssl.internal.SSLReadServiceContext$SSLReadCompletedCallback.complete(SSLReadServiceContext.java:1826)
        at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:516)
        at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:586)
        at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:970)
        at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1059)
        at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:298)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)

```