### PR TITLE
Record test validity for simple deliveryDelay test

### DIFF
--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/test-applications/DeliveryDelay/src/deliverydelay/web/DeliveryDelayServlet.java
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/test-applications/DeliveryDelay/src/deliverydelay/web/DeliveryDelayServlet.java
@@ -353,16 +353,16 @@ public class DeliveryDelayServlet extends HttpServlet {
 
     public void testSetDeliveryDelay(HttpServletRequest request, HttpServletResponse response) throws JMSException, TestException {
         emptyQueue(jmsQCFBindings, jmsQueue);
-         if (!testSetDeliveryDelay(jmsQCFBindings, jmsQueue, false)) testNotValid(response);;
+         if (!testSetDeliveryDelay(jmsQCFBindings, jmsQueue, false)) testNotValid(response);
     }
 
     public void testSetDeliveryDelay_Tcp(HttpServletRequest request, HttpServletResponse response) throws JMSException, TestException {
         emptyQueue(jmsQCFTCP, jmsQueue);
-        if (!testSetDeliveryDelay(jmsQCFTCP, jmsQueue, false)) testNotValid(response);;
+        if (!testSetDeliveryDelay(jmsQCFTCP, jmsQueue, false)) testNotValid(response);
     }
 
     public void testSetDeliveryDelayTopic(HttpServletRequest request, HttpServletResponse response) throws JMSException, TestException {
-        if (!testSetDeliveryDelay(jmsTCFBindings, jmsTopic, false)) testNotValid(response)9;
+        if (!testSetDeliveryDelay(jmsTCFBindings, jmsTopic, false)) testNotValid(response);
     }
 
     public void testSetDeliveryDelayTopic_Tcp(HttpServletRequest request, HttpServletResponse response) throws JMSException, TestException {
@@ -378,7 +378,6 @@ public class DeliveryDelayServlet extends HttpServlet {
             HttpServletRequest request, HttpServletResponse response) throws JMSException, TestException {
     	boolean valid = testSetDeliveryDelay(jmsTCFTCP, jmsTopic, true);
     }
-    
     
     /**
      * 
@@ -531,9 +530,9 @@ public class DeliveryDelayServlet extends HttpServlet {
     
     public void testSetDeliveryDelayTopicClassicApi(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
-    	
+
     	if (!testSetDeliveryDelayTopicClassicApi(jmsTCFBindings, jmsTopic, false)) testNotValid(response);
-    	
+
     }
     
     public void testSetDeliveryDelayTopicClassicApi_Tcp(

--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/test-applications/DeliveryDelay/src/deliverydelay/web/DeliveryDelayServlet.java
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/test-applications/DeliveryDelay/src/deliverydelay/web/DeliveryDelayServlet.java
@@ -1,5 +1,5 @@
 /* =============================================================================
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/test-applications/DeliveryDelay/src/deliverydelay/web/DeliveryDelayServlet.java
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/test-applications/DeliveryDelay/src/deliverydelay/web/DeliveryDelayServlet.java
@@ -65,6 +65,25 @@ import javax.servlet.http.HttpServletResponse;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
+/**
+ * DeliveryDelayServlet
+
+ * The JMS spec defines the delivery delay as the minimum amount of time that
+ * must elapse before a message becomes available to be received. This can
+ * introduce a few complications when testing. In particular, if a short delivery
+ * delay value is specified on a send operation, factors such as resource
+ * restriction might mean that this time could elapse before the send call itself
+ * has completed and returned. In such cases, it is not possible to determine
+ * whether the delivery delay time expired before the message became available.
+ * One approach to addressing this would be to use longer delivery delay values,
+ * but this could add up and cause the test bucket to take too long to run.
+ * Instead, assuming that such restrictions are likely to be transient environmental
+ * issues, the tests will record in the httpResponse instances where the message
+ * send took longer than the delivery delay time. This can then be used by the
+ * calling test to determine that, while the test didn't explicitly fail, it did
+ * not obtain a meaningful result.
+ */
+
 @SuppressWarnings("serial")
 public class DeliveryDelayServlet extends HttpServlet {
 
@@ -316,25 +335,38 @@ public class DeliveryDelayServlet extends HttpServlet {
         }
     }
 
+    private void testNotValid(HttpServletResponse response) throws TestException{
+    	
+    	PrintWriter out;
+		try {
+            out = response.getWriter();
+            out.println("TEST NOT VALID.");
+		} catch (IOException e) {
+			TestException t = new TestException(e.getMessage());
+			t.initCause(e);
+			throw t;
+		}
+    }
+    
     
     // Simple deliveryDelay tests using the JMS2.0 Simplified API
 
     public void testSetDeliveryDelay(HttpServletRequest request, HttpServletResponse response) throws JMSException, TestException {
         emptyQueue(jmsQCFBindings, jmsQueue);
-        testSetDeliveryDelay(jmsQCFBindings, jmsQueue, false);
+         if (!testSetDeliveryDelay(jmsQCFBindings, jmsQueue, false)) testNotValid(response);;
     }
 
     public void testSetDeliveryDelay_Tcp(HttpServletRequest request, HttpServletResponse response) throws JMSException, TestException {
         emptyQueue(jmsQCFTCP, jmsQueue);
-        testSetDeliveryDelay(jmsQCFTCP, jmsQueue, false);
+        if (!testSetDeliveryDelay(jmsQCFTCP, jmsQueue, false)) testNotValid(response);;
     }
 
     public void testSetDeliveryDelayTopic(HttpServletRequest request, HttpServletResponse response) throws JMSException, TestException {
-        testSetDeliveryDelay(jmsTCFBindings, jmsTopic, false);
+        if (!testSetDeliveryDelay(jmsTCFBindings, jmsTopic, false)) testNotValid(response)9;
     }
 
     public void testSetDeliveryDelayTopic_Tcp(HttpServletRequest request, HttpServletResponse response) throws JMSException, TestException {
-        testSetDeliveryDelay(jmsTCFTCP, jmsTopic, false);
+        boolean valid = testSetDeliveryDelay(jmsTCFTCP, jmsTopic, false);
     }
     
     public void testSetDeliveryDelayTopicDurSub(
@@ -344,8 +376,9 @@ public class DeliveryDelayServlet extends HttpServlet {
     
     public void testSetDeliveryDelayTopicDurSub_Tcp(
             HttpServletRequest request, HttpServletResponse response) throws JMSException, TestException {
-    	testSetDeliveryDelay(jmsTCFTCP, jmsTopic, true);
+    	boolean valid = testSetDeliveryDelay(jmsTCFTCP, jmsTopic, true);
     }
+    
     
     /**
      * 
@@ -359,11 +392,14 @@ public class DeliveryDelayServlet extends HttpServlet {
      * @param connectionFactory
      * @param destination
      * @param useDurableSubscriber
+     * @return whether the test run was valid, that is, the send operation completed in less time than the delivery delay value
      * @throws JMSException
      * @throws TestException
      */
-    private void testSetDeliveryDelay(ConnectionFactory connectionFactory, Destination destination, boolean useDurableSubscriber) throws JMSException, TestException {
+    private boolean testSetDeliveryDelay(ConnectionFactory connectionFactory, Destination destination, boolean useDurableSubscriber) throws JMSException, TestException {
 
+    	boolean testIsValid = true;
+    	
     	// Do an initial check that we haven't been asked for a durableSubscriber but only been given a Queue destination
     	if ( useDurableSubscriber && !(destination instanceof Topic)) {
     		throw new TestException("Incompatible parameters. useDurablSubscriber specified, but destination was not a Topic: " + destination);
@@ -389,6 +425,10 @@ public class DeliveryDelayServlet extends HttpServlet {
 
             long beforeSend = this.sendAndCheckDeliveryTime(jmsProducer, destination, sentMessage);
 
+            // If we took longer to send the message than the delivery delay value, then we don't know whether the delivery delay was honoured or not
+            // We can continue with the rest of the test, just in case something else goes wrong.
+            if (System.currentTimeMillis() - beforeSend > defaultTestDeliveryDelay) testIsValid = false;
+            
             TextMessage receivedMessage = (TextMessage) jmsConsumer.receive(defaultTestDeliveryDelay * 2 );
             long afterReceive = System.currentTimeMillis();
 
@@ -413,11 +453,9 @@ public class DeliveryDelayServlet extends HttpServlet {
             if(afterReceive - beforeSend < defaultTestDeliveryDelay )
                 throw new TestException("Message received too soon, beforeSend: " + beforeSend + " afterReceive: " + afterReceive + " deliveryDelay: " + defaultTestDeliveryDelay
                         + "\nreceivedMessage:\n" + receivedMessage);            
-
-            
             
         }
-        return;
+        return testIsValid;
     }
 
     
@@ -429,7 +467,7 @@ public class DeliveryDelayServlet extends HttpServlet {
             HttpServletRequest request, HttpServletResponse response) throws Exception {
     	
     	emptyQueue(jmsQCFBindings, jmsQueue1);
-    	testSetDeliveryDelayQueueClassicApi(jmsQCFBindings, jmsQueue1);
+    	if (!testSetDeliveryDelayQueueClassicApi(jmsQCFBindings, jmsQueue1)) testNotValid(response);
   
     }
     
@@ -437,7 +475,7 @@ public class DeliveryDelayServlet extends HttpServlet {
             HttpServletRequest request, HttpServletResponse response) throws Exception {
     	
     	emptyQueue(jmsQCFTCP, jmsQueue1);
-    	testSetDeliveryDelayQueueClassicApi(jmsQCFTCP, jmsQueue1);
+    	if(!testSetDeliveryDelayQueueClassicApi(jmsQCFTCP, jmsQueue1)) testNotValid(response);
     	
     }
     
@@ -446,10 +484,12 @@ public class DeliveryDelayServlet extends HttpServlet {
      * 
      * @param queueConnectionFactory
      * @param queue
+     * @return whether the test run was valid, that is, the send operation completed in less time than the delivery delay value
      * @throws Exception
      */
-    private void testSetDeliveryDelayQueueClassicApi(QueueConnectionFactory connectionFactory, Queue queue) throws Exception {
+    private boolean testSetDeliveryDelayQueueClassicApi(QueueConnectionFactory connectionFactory, Queue queue) throws Exception {
     	
+    	boolean testIsValid = true;
     	
     	try ( QueueConnection connection = connectionFactory.createQueueConnection();
     		  QueueSession session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);) {
@@ -465,6 +505,10 @@ public class DeliveryDelayServlet extends HttpServlet {
         	
             long beforeSend = sendAndCheckDeliveryTime(sender, queue, sentMessage);
             
+            // If we took longer to send the message than the delivery delay value, then we don't know whether the delivery delay was honoured or not
+            // We can continue with the rest of the test, just in case something else goes wrong.
+            if (System.currentTimeMillis() - beforeSend > defaultTestDeliveryDelay) testIsValid = false;
+
             TextMessage receivedMessage = (TextMessage) receiver.receive(defaultTestDeliveryDelay * 2);
             long afterReceive = System.currentTimeMillis();
 
@@ -478,7 +522,7 @@ public class DeliveryDelayServlet extends HttpServlet {
     		
     	}
     	
-    	return;
+    	return testIsValid;
     }
     
 
@@ -488,28 +532,28 @@ public class DeliveryDelayServlet extends HttpServlet {
     public void testSetDeliveryDelayTopicClassicApi(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
     	
-    	testSetDeliveryDelayTopicClassicApi(jmsTCFBindings, jmsTopic, false);
+    	if (!testSetDeliveryDelayTopicClassicApi(jmsTCFBindings, jmsTopic, false)) testNotValid(response);
     	
     }
     
     public void testSetDeliveryDelayTopicClassicApi_Tcp(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-    	testSetDeliveryDelayTopicClassicApi(jmsTCFTCP, jmsTopic, false);
+    	if (!testSetDeliveryDelayTopicClassicApi(jmsTCFTCP, jmsTopic, false)) testNotValid(response);
 
     }
 
     public void testSetDeliveryDelayTopicDurSubClassicApi(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-    	testSetDeliveryDelayTopicClassicApi(jmsTCFBindings, jmsTopic, true);
+    	if (!testSetDeliveryDelayTopicClassicApi(jmsTCFBindings, jmsTopic, true)) testNotValid(response);
 
     }
 
     public void testSetDeliveryDelayTopicDurSubClassicApi_Tcp(
             HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-    	testSetDeliveryDelayTopicClassicApi(jmsTCFTCP, jmsTopic, true);
+    	if (!testSetDeliveryDelayTopicClassicApi(jmsTCFTCP, jmsTopic, true)) testNotValid(response);
 
     }
     
@@ -519,10 +563,12 @@ public class DeliveryDelayServlet extends HttpServlet {
      * @param connnectionFactory
      * @param topic
      * @param useDurableSubscriber whether to create a durable or nondurable subscriber
+     * @return whether the test run was valid, that is, the send operation completed in less time than the delivery delay value
      * @throws Exception
      */
-    private void testSetDeliveryDelayTopicClassicApi( TopicConnectionFactory connectionFactory, Topic topic, boolean useDurableSubscriber) throws Exception {
+    private boolean testSetDeliveryDelayTopicClassicApi( TopicConnectionFactory connectionFactory, Topic topic, boolean useDurableSubscriber) throws Exception {
 
+    	boolean testIsValid = true;
     	String durableSubscriberName = methodName() + "_dursub";
 
     	try (TopicConnection connection = connectionFactory.createTopicConnection();
@@ -544,7 +590,10 @@ public class DeliveryDelayServlet extends HttpServlet {
 
             TextMessage sentMessage = session.createTextMessage(methodName() + " at " + timeStamp());
             long beforeSend = sendAndCheckDeliveryTime(publisher, topic, sentMessage);
-            
+
+            // If we took longer to send the message than the delivery delay value, then we don't know whether the delivery delay was honoured or not
+            // We can continue with the rest of the test, just in case something else goes wrong.
+            if (System.currentTimeMillis() - beforeSend > defaultTestDeliveryDelay) testIsValid = false;
             
             TextMessage receivedMessage = (TextMessage) subscriber.receive(defaultTestDeliveryDelay * 2);
             long afterReceive = System.currentTimeMillis();
@@ -576,7 +625,7 @@ public class DeliveryDelayServlet extends HttpServlet {
 
     	}
     	
-    	return;
+    	return testIsValid;
     	
      }
     
@@ -660,7 +709,7 @@ public class DeliveryDelayServlet extends HttpServlet {
 		return;
 	}
     
-	// Externally visible variants oftestDeliveryDelayForDifferentDelays()
+	// Externally visible variants of testDeliveryDelayForDifferentDelays()
 	
 	// Simplified API variants
 	


### PR DESCRIPTION
- [ x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
################################################################################################

Update some of the delivery delay tests to provide an indication of whether the test is valid or whether the test ran too slowly to give meaningful results. This can later be used by the calling JUnit tests to determine how to report the results.