### PR TITLE
Ensure update to Order.by(List) is not forgotten

### DIFF
--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/Order.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/Order.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ public class Order<T> implements Iterable<Sort<? super T>> {
         this.sortBy = sortBy;
     }
 
-    public static <T> Order<T> by(List<Sort<? super T>> sorts) {
+    public static <T> Order<T> by(List<? extends Sort<? super T>> sorts) {
         return new Order<T>(List.copyOf(sorts));
     }
 


### PR DESCRIPTION
This is for a bug in the spec interface. I'm including this update now (the actual fix won't go in until 1.1) given that it is trivial and very likely to be missed later on and continue to impact betas.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
