### PR TITLE
Fix git status showing extra changes

### DIFF
--- a/dev/ant_build.js/.gitignore
+++ b/dev/ant_build.js/.gitignore
@@ -16,7 +16,7 @@ lib/carbon/carbon-components-10.44.0/
 lib/jshint/*.jar
 lib/nodejs/*.gz
 lib/nodejs/*.exe
-lib/orion/orion-6.19.0/
+lib/orion/orion-6.19.0-20250520/
 lib/orion/*.jar
 lib/svg4everybody/svg4everybody-2.1.9/
 lib/svg4everybody/*.jar

--- a/dev/io.openliberty.data.internal_fat_nosql/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_nosql/build.gradle
@@ -34,13 +34,14 @@ dependencies {
 
 def metaModelDir = file("build/libs/generated/sources/annotationProcessor/java/main") 
 
-// this code copy the metamodels generated to the "generated-src" directory
+// this code copies the metamodels generated code to the "generated-src" directory and hardcodes the date to avoid file change just from the date
 assemble.doLast {
   copy{
     from metaModelDir
     into "generated-src"
-    }
+    filter { line -> line.startsWith('@Generated') ? line.replaceAll('date = ".*"', 'date = "2025-05-30T11:32:09.226355"') : line }
   }
+}
 
 task addJNoSQL(type: Copy) {
   mustRunAfter jar


### PR DESCRIPTION
- Update ant_build.js .gitignore for the orion version update causing a new directory name for the orion code introduced with PR #31616
- When copying over generated source in data nosql fat, use a hardcoded date to not cause building the fat to think there is a change when only the date is updated.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
