### PR TITLE
Updates to not include more in autoFVT.zip files than necessary SPNEGO

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,18 @@ dependencies {
   requiredLibs project(':com.ibm.ws.com.meterware.httpunit.1.7'),
                project(':com.ibm.ws.security.jaas.common'),
                project(':com.ibm.ws.security.oauth.oidc_fat.common'),
+               project(':io.openliberty.org.apache.xercesImpl'),
+               project(':io.openliberty.org.apache.commons.codec'), // 1.15 (was 1.4)
+               project(':com.ibm.ws.org.apache.commons.lang3'), // 3.8 (was ????)
+               project(':com.ibm.ws.security.spnego.fat.common'),
+               project(':com.ibm.ws.security.fat.common'),
+               project(':com.ibm.ws.webcontainer.security_test.servlets'),
+               project(':com.ibm.ws.security.spnego.fat.common'),
+               project(':com.ibm.ws.net.oauth.jsontoken'),
+               project(':com.ibm.ws.org.joda.time'),
+               project(':com.ibm.ws.org.apache.httpcomponents'),
+               project(':com.ibm.ws.kernel.service'),
+               project(':com.ibm.ws.kernel.boot'),
                'jtidy:jtidy:4aug2000r7-dev',
                'org.apache.sshd:sshd-common:2.12.1',
                'org.apache.sshd:sshd-core:2.12.1',
@@ -22,15 +34,20 @@ dependencies {
                'net.sourceforge.htmlunit:htmlunit:2.44.0',
                'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
                'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
+               'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
                'rhino:js:1.6R5',
                'xalan:xalan:2.7.2',
                'org.brotli:dec:0.1.2',
-               project(':io.openliberty.org.apache.xercesImpl'),
-               project(':io.openliberty.org.apache.commons.codec'), // 1.15 (was 1.4)
                'org.apache.httpcomponents:httpclient:4.1.2',
                'org.apache.httpcomponents:httpcore:4.1.2',
-               project(':com.ibm.ws.org.apache.commons.lang3'), // 3.8 (was ????)
-               project(':com.ibm.ws.security.spnego.fat.common')
+               'org.apache.httpcomponents:httpmime:4.3.1',
+               'org.eclipse.birt.runtime.3_7_1:org.apache.xml.serializer:2.7.1'
+}
+
+configurations {
+  requiredLibs {
+    transitive = false
+  }
 }
 
 /******************************************************************

--- a/dev/com.ibm.ws.security.oidc.server_fat.spnego/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.server_fat.spnego/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,6 +16,9 @@ apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 configurations {
   derbyJar
   mongoJavaDriver
+  requiredLibs {
+    transitive = false
+  }
 }
 
 dependencies {
@@ -28,7 +31,18 @@ dependencies {
                project(':com.ibm.ws.security.oauth.oidc_fat.common'),
                project(':io.openliberty.org.apache.xercesImpl'),
                project(':com.ibm.ws.security.spnego.fat.common'),
+               project(':com.ibm.ws.security.fat.common'),
+               project(':com.ibm.ws.webcontainer.security_test.servlets'),
+               project(':com.ibm.ws.net.oauth.jsontoken'),
+               project(':com.ibm.ws.org.joda.time'),
+               project(':com.ibm.ws.org.apache.httpcomponents'),
+               project(':com.ibm.ws.kernel.service'),
+               project(':com.ibm.ws.kernel.boot'),
+               project(':com.ibm.ws.security.oauth'),
                'jtidy:jtidy:4aug2000r7-dev',
+               'org.apache.sshd:sshd-common:2.12.1',
+               'org.apache.sshd:sshd-core:2.12.1',
+               'net.sourceforge.htmlunit:htmlunit:2.44.0',
                'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',
                'net.sourceforge.htmlunit:neko-htmlunit:2.44.0',
                'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
@@ -38,7 +52,8 @@ dependencies {
                'org.brotli:dec:0.1.2',
                'rhino:js:1.6R5',
                'xalan:xalan:2.7.2',
-               'xml-apis:xml-apis:1.4.01'
+               'xml-apis:xml-apis:1.4.01',
+               'org.eclipse.birt.runtime.3_7_1:org.apache.xml.serializer:2.7.1'
 }
 
 /******************************************************************

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/Krb5Helper.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/Krb5Helper.java
@@ -28,8 +28,8 @@ import org.ietf.jgss.Oid;
 import com.ibm.websphere.security.auth.callback.WSCallbackHandlerImpl;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.common.encoder.Base64Coder;
-import com.ibm.ws.kernel.service.util.JavaInfo;
 
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 public class Krb5Helper {

--- a/dev/com.ibm.ws.security.spnego_fat.1/build.gradle
+++ b/dev/com.ibm.ws.security.spnego_fat.1/build.gradle
@@ -1,21 +1,32 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+configurations {
+  requiredLibs {
+    transitive = false
+  }
+}
+
 dependencies {
   requiredLibs 'org.apache.httpcomponents:httpclient:4.1.2',
                'org.apache.httpcomponents:httpcore:4.1.2',
+               'org.apache.sshd:sshd-common:2.12.1',
+               'org.apache.sshd:sshd-core:2.12.1',
+               'org.apache.sshd:sshd-scp:2.12.1',
                project(':io.openliberty.org.apache.commons.codec'),
-               project(':com.ibm.ws.security.spnego.fat.common')
+               project(':com.ibm.ws.security.spnego.fat.common'),
+               project(':com.ibm.ws.webcontainer.security_test.servlets'),
+               project(':com.ibm.ws.security.jaas.common')
 }
 
 addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.security.spnego_fat.2/build.gradle
+++ b/dev/com.ibm.ws.security.spnego_fat.2/build.gradle
@@ -1,21 +1,29 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+configurations {
+  requiredLibs {
+    transitive = false
+  }
+}
 
 dependencies {
   requiredLibs 'org.apache.httpcomponents:httpclient:4.1.2',
                'org.apache.httpcomponents:httpcore:4.1.2',
+               'org.apache.sshd:sshd-common:2.12.1',
+               'org.apache.sshd:sshd-core:2.12.1',
                project(':io.openliberty.org.apache.commons.codec'),
-               project(':com.ibm.ws.security.spnego.fat.common')
+               project(':com.ibm.ws.security.spnego.fat.common'),
+               project(':com.ibm.ws.webcontainer.security_test.servlets')
 }
 
 addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.security.spnego_fat/build.gradle
+++ b/dev/com.ibm.ws.security.spnego_fat/build.gradle
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,10 +14,19 @@
 dependencies {
   requiredLibs 'org.apache.httpcomponents:httpclient:4.1.2',
                'org.apache.httpcomponents:httpcore:4.1.2',
+               'org.apache.directory.server:apacheds-all:2.0.0-M24',
                project(':com.ibm.ws.org.slf4j.jdk14'),
                project(':com.ibm.ws.security.wim.adapter.ldap_fat.krb5.1'),
                project(':com.ibm.ws.security.spnego.fat.common'),
-               project(':io.openliberty.org.apache.commons.codec')
+               project(':io.openliberty.org.apache.commons.codec'),
+               project(':com.ibm.ws.webcontainer.security_test.servlets'),
+               project(':com.ibm.ws.security.jaas.common')
+}
+
+configurations {
+  requiredLibs {
+    transitive = false
+  }
 }
 
 addRequiredLibraries.dependsOn addJakartaTransformer


### PR DESCRIPTION
We don't need to include autoFVT.zip everytime we run these buckets. This causes issues in windows builds


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
