### PR TITLE
Removing reference to Cloudant from Generated Doc of CouchDB

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/couchdb-1.0/resources/l10n/com.ibm.websphere.appserver.couchdb-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/couchdb-1.0/resources/l10n/com.ibm.websphere.appserver.couchdb-1.0.properties
@@ -17,7 +17,6 @@
 #
 
 description=This feature has been stabilized. \
-The strategic alternative to this feature is the cloudant-1.0 feature. \
 This feature enables connections to CouchDB by providing a connector instance configured \
  in the server configuration, which can be injected or accessed through JNDI.  Applications use the \
  ektorp client library to utilize the connector instance to work with CouchDB.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/couchdb-1.0/resources/l10n/com.ibm.websphere.appserver.couchdb-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/couchdb-1.0/resources/l10n/com.ibm.websphere.appserver.couchdb-1.0.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2012, 2019 IBM Corporation and others.
+# Copyright (c) 2012, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/couchdb-1.0/resources/l10n/com.ibm.websphere.appserver.couchdb-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/couchdb-1.0/resources/l10n/com.ibm.websphere.appserver.couchdb-1.0.properties
@@ -17,6 +17,7 @@
 #
 
 description=This feature has been stabilized. \
-This feature enables connections to CouchDB by providing a connector instance configured \
+ The strategic alternative to this feature is create a CDI Producer by following the technique as described in https://openliberty.io/blog/2019/02/19/mongodb-with-open-liberty.html \
+ This feature enables connections to CouchDB by providing a connector instance configured \
  in the server configuration, which can be injected or accessed through JNDI.  Applications use the \
  ektorp client library to utilize the connector instance to work with CouchDB.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

CouchDB-1.0 and Cloudant-1.0, both are stabilised and two independent NoSQL features. CouchDB is not an exact replacement of Cloudant. Hence removing the reference of cloudant feature from generated document of couchdb in open liberty. 