### PR TITLE
Adding stabilized statement for Cloudant-1.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cloudant-1.0/resources/l10n/com.ibm.websphere.appserver.cloudant-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cloudant-1.0/resources/l10n/com.ibm.websphere.appserver.cloudant-1.0.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025 IBM Corporation and others.
+# Copyright (c) 2016, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cloudant-1.0/resources/l10n/com.ibm.websphere.appserver.cloudant-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cloudant-1.0/resources/l10n/com.ibm.websphere.appserver.cloudant-1.0.properties
@@ -16,7 +16,8 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=This feature has been stabilized in 2025.This feature enables connections to Cloudant databases \
+description=This feature has been stabilized . \
+ This feature enables connections to Cloudant databases \
  by providing a connector instance that's configured in the server configuration and can be injected \
  or accessed through Java Naming and Directory Interface (JNDI). Applications use the \
  Cloudant client library to access the connector instance.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cloudant-1.0/resources/l10n/com.ibm.websphere.appserver.cloudant-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cloudant-1.0/resources/l10n/com.ibm.websphere.appserver.cloudant-1.0.properties
@@ -16,6 +16,7 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=This feature enables connections to Cloudant databases by providing a connector instance that's configured \
- in the server configuration and can be injected or accessed through Java Naming and Directory Interface (JNDI). Applications use the \
+description=This feature has been stabilized in 2025.This feature enables connections to Cloudant databases \
+ by providing a connector instance that's configured in the server configuration and can be injected \
+ or accessed through Java Naming and Directory Interface (JNDI). Applications use the \
  Cloudant client library to access the connector instance.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cloudant-1.0/resources/l10n/com.ibm.websphere.appserver.cloudant-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cloudant-1.0/resources/l10n/com.ibm.websphere.appserver.cloudant-1.0.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016 IBM Corporation and others.
+# Copyright (c) 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=This feature has been stabilized . \
+description=This feature has been stabilized. \
  This feature enables connections to Cloudant databases \
  by providing a connector instance that's configured in the server configuration and can be injected \
  or accessed through Java Naming and Directory Interface (JNDI). Applications use the \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cloudant-1.0/resources/l10n/com.ibm.websphere.appserver.cloudant-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cloudant-1.0/resources/l10n/com.ibm.websphere.appserver.cloudant-1.0.properties
@@ -17,6 +17,7 @@
 #
 
 description=This feature has been stabilized. \
+ The strategic alternative to this feature is to create a CDI Producer by following the technique as described in https://openliberty.io/blog/2019/02/19/mongodb-with-open-liberty.html \
  This feature enables connections to Cloudant databases \
  by providing a connector instance that's configured in the server configuration and can be injected \
  or accessed through Java Naming and Directory Interface (JNDI). Applications use the \


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Cloudant-1.0 No SQL feature has been stabilised by IBM in 2025, but the details were not added to the document in liberty. This PR adds the stabilized statement for Clodant-1.0.