### PR TITLE
Awareness of stateful vs stateless

### DIFF
--- a/dev/io.openliberty.data.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.data.1.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -39,4 +39,6 @@ Private-Package: \
   com.ibm.wsspi.org.osgi.service.component.annotations,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   io.openliberty.data.internal,\
-  io.openliberty.jakarta.data.1.0
+  io.openliberty.jakarta.data.1.0,\
+  io.openliberty.jakarta.persistence.3.2
+  

--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -15,7 +15,10 @@ package io.openliberty.data.internal.v1_0;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.sql.Connection;
 import java.util.Set;
+
+import javax.sql.DataSource;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -27,7 +30,13 @@ import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.page.PageRequest;
+import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Save;
+import jakarta.data.repository.Update;
+import jakarta.persistence.EntityManager;
 
 /**
  * Capability that is specific to the version of Jakarta Data.
@@ -37,6 +46,62 @@ import jakarta.data.repository.Find;
            service = DataVersionCompatibility.class)
 public class Data_1_0 implements DataVersionCompatibility {
 
+    /**
+     * Annotations that represent lifecycle operations that are allowed for
+     * methods of a stateful repository.
+     */
+    private static final Set<Class<? extends Annotation>> LIFECYCLE_ANNOS_STATEFUL = //
+                    Set.of();
+
+    /**
+     * Annotations that represent lifecycle operations that are allowed for
+     * methods of a stateless repository.
+     */
+    private static final Set<Class<? extends Annotation>> LIFECYCLE_ANNOS_STATELESS = //
+                    Set.of(Delete.class,
+                           Insert.class,
+                           Update.class,
+                           Save.class);
+
+    /**
+     * Annotations that represent operations that are allowed for methods of a
+     * stateful repository.
+     */
+    private static final Set<Class<? extends Annotation>> OP_ANNOS_STATEFUL = //
+                    Set.of(Find.class,
+                           Query.class);
+
+    /**
+     * Annotations that represent operations that are allowed for methods of a
+     * stateless repository.
+     */
+    private static final Set<Class<? extends Annotation>> OP_ANNOS_STATELESS = //
+                    Set.of(Delete.class,
+                           Find.class,
+                           Insert.class,
+                           Query.class,
+                           Save.class,
+                           Update.class);
+
+    /**
+     * Classes that are valid as return types of resource accessor methods for a
+     * stateful repository.
+     */
+    private static final Set<Class<?>> RESOURCE_ACCESSOR_CLASSES_STATEFUL = //
+                    Set.of(Connection.class,
+                           DataSource.class,
+                           EntityManager.class);
+
+    /**
+     * Classes that are valid as return types of resource accessor methods for a
+     * stateless repository.
+     */
+    private static final Set<Class<?>> RESOURCE_ACCESSOR_CLASSES_STATELESS = //
+                    RESOURCE_ACCESSOR_CLASSES_STATEFUL;
+
+    /**
+     * Types that are valid as repository method special parameters.
+     */
     private static final Set<Class<?>> SPECIAL_PARAM_TYPES = //
                     Set.of(Limit.class, Order.class, PageRequest.class,
                            Sort.class, Sort[].class);
@@ -113,6 +178,25 @@ public class Data_1_0 implements DataVersionCompatibility {
     @Trivial
     public boolean hasOrAnnotation(Annotation[] annos) {
         return false;
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<? extends Annotation>> lifeCycleAnnoTypes(boolean stateful) {
+        return stateful ? LIFECYCLE_ANNOS_STATEFUL : LIFECYCLE_ANNOS_STATELESS;
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<? extends Annotation>> operationAnnoTypes(boolean stateful) {
+        return stateful ? OP_ANNOS_STATEFUL : OP_ANNOS_STATELESS;
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<?>> resourceAccessorTypes(boolean stateful) {
+        return stateful ? RESOURCE_ACCESSOR_CLASSES_STATEFUL //
+                        : RESOURCE_ACCESSOR_CLASSES_STATELESS;
     }
 
     @Override

--- a/dev/io.openliberty.data.1.1.internal/bnd.bnd
+++ b/dev/io.openliberty.data.1.1.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -40,4 +40,5 @@ Private-Package: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   io.openliberty.data,\
   io.openliberty.data.internal,\
-  io.openliberty.jakarta.data.1.1
+  io.openliberty.jakarta.data.1.1,\
+  io.openliberty.jakarta.persistence.3.2

--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -15,11 +15,14 @@ package io.openliberty.data.internal.v1_1;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.sql.DataSource;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -49,8 +52,14 @@ import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.exceptions.MappingException;
 import jakarta.data.page.PageRequest;
+import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Save;
 import jakarta.data.repository.Select;
+import jakarta.data.repository.Update;
+import jakarta.persistence.EntityManager;
 
 /**
  * Capability that is specific to the version of Jakarta Data.
@@ -82,6 +91,63 @@ public class Data_1_1 implements DataVersionCompatibility {
         FUNCTION_CALLS.put(Extract.Field.YEAR.name(), "EXTRACT (YEAR FROM ");
     }
 
+    /**
+     * Annotations that represent lifecycle operations that are allowed for
+     * methods of a stateful repository.
+     */
+    private static final Set<Class<? extends Annotation>> LIFECYCLE_ANNOS_STATEFUL = //
+                    Set.of(); // TODO 1.1 Detach, Merge, Persist, Refresh, Remove
+
+    /**
+     * Annotations that represent lifecycle operations that are allowed for
+     * methods of a stateless repository.
+     */
+    private static final Set<Class<? extends Annotation>> LIFECYCLE_ANNOS_STATELESS = //
+                    Set.of(Delete.class,
+                           Insert.class,
+                           Update.class,
+                           Save.class);
+
+    /**
+     * Annotations that represent operations that are allowed for methods of a
+     * stateful repository.
+     */
+    private static final Set<Class<? extends Annotation>> OP_ANNOS_STATEFUL = //
+                    Set.of(Find.class,
+                           // TODO 1.1 Merge, Persist, ...
+                           Query.class);
+
+    /**
+     * Annotations that represent operations that are allowed for methods of a
+     * stateless repository.
+     */
+    private static final Set<Class<? extends Annotation>> OP_ANNOS_STATELESS = //
+                    Set.of(Delete.class,
+                           Find.class,
+                           Insert.class,
+                           Query.class,
+                           Save.class,
+                           Update.class);
+
+    /**
+     * Classes that are valid as return types of resource accessor methods for a
+     * stateful repository.
+     */
+    private static final Set<Class<?>> RESOURCE_ACCESSOR_CLASSES_STATEFUL = //
+                    Set.of(Connection.class,
+                           DataSource.class,
+                           EntityManager.class);
+
+    /**
+     * Classes that are valid as return types of resource accessor methods for a
+     * stateless repository.
+     */
+    private static final Set<Class<?>> RESOURCE_ACCESSOR_CLASSES_STATELESS = //
+                    RESOURCE_ACCESSOR_CLASSES_STATEFUL; // TODO 1.1 entity agent
+
+    /**
+     * Types that are valid as repository method special parameters.
+     */
     private static final Set<Class<?>> SPECIAL_PARAM_TYPES = //
                     Set.of(Limit.class, Order.class,
                            Sort.class, Sort[].class,
@@ -351,6 +417,25 @@ public class Data_1_1 implements DataVersionCompatibility {
             if (anno instanceof Or)
                 return true;
         return false;
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<? extends Annotation>> lifeCycleAnnoTypes(boolean stateful) {
+        return stateful ? LIFECYCLE_ANNOS_STATEFUL : LIFECYCLE_ANNOS_STATELESS;
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<? extends Annotation>> operationAnnoTypes(boolean stateful) {
+        return stateful ? OP_ANNOS_STATEFUL : OP_ANNOS_STATELESS;
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<?>> resourceAccessorTypes(boolean stateful) {
+        return stateful ? RESOURCE_ACCESSOR_CLASSES_STATEFUL //
+                        : RESOURCE_ACCESSOR_CLASSES_STATELESS;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/bnd.bnd
+++ b/dev/io.openliberty.data.internal.persistence/bnd.bnd
@@ -81,7 +81,7 @@ instrument.classesExcludes: io/openliberty/data/internal/persistence/resources/*
 	io.openliberty.jakarta.cdi.4.0,\
 	io.openliberty.jakarta.data.1.0,\
 	io.openliberty.jakarta.interceptor.2.1,\
-	io.openliberty.jakarta.persistence.3.1,\
+	io.openliberty.jakarta.persistence.3.2,\
 	io.openliberty.jakarta.transaction.2.0,\
 	io.openliberty.jakarta.validation.3.0,\
 	com.ibm.ws.jdbc

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1216,7 +1216,7 @@ public class QueryInfo {
                           method.getName(),
                           repositoryInterface.getName(),
                           entityInfo.entityClass.getName(),
-                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES);
+                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
             else
                 throw exc(OptimisticLockingFailureException.class,
                           "CWWKD1052.multi.opt.lock.exc",
@@ -1225,7 +1225,7 @@ public class QueryInfo {
                           numExpected - updateCount,
                           numExpected,
                           entityInfo.entityClass.getName(),
-                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES);
+                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
 
         Object returnValue = toReturnValue(updateCount, method.getReturnType());
 
@@ -1333,7 +1333,7 @@ public class QueryInfo {
                           repositoryInterface.getName(),
                           e.getClass().getName(),
                           entityProps,
-                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES);
+                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
             }
         } else if (numDeleted > 1) {
             // ought to be unreachable
@@ -1625,10 +1625,9 @@ public class QueryInfo {
                    "CWWKD1011.unknown.method.pattern",
                    method.getName(),
                    repositoryInterface.getName(),
-                   List.of("Delete", "Find", "Insert",
-                           "Query", "Save", "Update"),
-                   List.of("Connection", "DataSource", "EntityManager"),
-                   List.of("count", "delete", "exists", "find"),
+                   Util.operationAnnoNames(producer),
+                   Util.resourceAccessorTypeNames(producer),
+                   Util.methodNamePrefixes(producer),
                    entityInfo.getExampleMethodNames());
     }
 
@@ -2250,7 +2249,7 @@ public class QueryInfo {
                       repositoryInterface.getName(),
                       e.getClass().getName(),
                       entityProps,
-                      Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES);
+                      Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
         }
 
         Object returnValue = em.merge(toEntity(e));
@@ -3451,7 +3450,7 @@ public class QueryInfo {
                     lowerName = lowerName.replace("_", "");
                     attributeName = entityInfo.attributeNames.get(lowerName);
                     if (attributeName == null && failIfNotFound) {
-                        if (Util.hasOperationAnno(method))
+                        if (Util.hasOperationAnno(method, producer))
                             throw exc(MappingException.class,
                                       "CWWKD1010.unknown.entity.attr",
                                       name,
@@ -3466,7 +3465,7 @@ public class QueryInfo {
                                       entityInfo.getType().getName(),
                                       method.getName(),
                                       repositoryInterface.getName(),
-                                      Util.OP_ANNOS,
+                                      Util.operationAnnoNames(producer),
                                       entityInfo.attributeTypes.keySet());
                     }
                 }
@@ -5254,7 +5253,7 @@ public class QueryInfo {
                               method.getName(),
                               repositoryInterface.getName(),
                               entityName,
-                              List.of("Insert", "Save", "Update", "Delete"),
+                              Util.lifeCycleAnnoNames(producer),
                               ql);
             }
         } else {
@@ -5703,7 +5702,7 @@ public class QueryInfo {
                           method.getName(),
                           repositoryInterface.getName(),
                           entityInfo.entityClass.getName(),
-                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES);
+                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
             else
                 throw exc(OptimisticLockingFailureException.class,
                           "CWWKD1052.multi.opt.lock.exc",
@@ -5712,7 +5711,7 @@ public class QueryInfo {
                           numExpected - updateCount,
                           numExpected,
                           entityInfo.entityClass.getName(),
-                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES);
+                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
 
         Object returnValue = toReturnValue(updateCount, method.getReturnType());
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -366,10 +366,9 @@ public class Util {
         Set<Class<? extends Annotation>> annoClasses = producer.provider().compat //
                         .operationAnnoTypes(producer.stateful());
 
-        StringBuilder b = new StringBuilder('[');
-        for (Class<?> annoClass : annoClasses)
-            b.append(b.isEmpty() ? "" : ", ").append(annoClass.getSimpleName());
-        return b.append(']').toString();
+        return annoClasses.stream()
+                           .map(c -> c.getSimpleName)
+                           .collect(Collectors.joining(", ", "[", "]"));
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -287,6 +287,7 @@ public class Util {
 
     /**
      * List of names of repository method life cycle annotations.
+     * Enclosed in brackets and delimited by comma.
      *
      * @param producer producer of the repository bean, from which it can be
      *                     determined if the repository is stateful or stateless.
@@ -296,10 +297,9 @@ public class Util {
         Set<Class<? extends Annotation>> annoClasses = producer.provider().compat //
                         .lifeCycleAnnoTypes(producer.stateful());
 
-        StringBuilder b = new StringBuilder();
-        for (Class<?> annoClass : annoClasses)
-            b.append(b.isEmpty() ? "" : ", ").append(annoClass.getSimpleName());
-        return b.toString();
+        return annoClasses.stream()
+                   .map(c -> c.getSimpleName)
+                   .collect(Collectors.joining(", ", "[", "]"));
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Year;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,12 +42,11 @@ import java.util.function.Function;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.util.UUID;
 
+import io.openliberty.data.internal.persistence.cdi.RepositoryProducer;
+import io.openliberty.data.internal.version.DataVersionCompatibility;
 import jakarta.data.Order;
 import jakarta.data.Sort;
-import jakarta.data.repository.Delete;
-import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
-import jakarta.data.repository.Query;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 import jakarta.persistence.AttributeConverter;
@@ -67,13 +67,27 @@ public class Util {
     public static final String EOLN = String.format("%n");
 
     /**
-     * Type of life cycle methods (by annotation name) that are capable of
-     * returning entities.
+     * Types of life cycle methods (by annotation name) that are capable of
+     * returning entities for stateless repositories.
      */
-    static final List<String> LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES = //
+    static final List<String> LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS = //
                     List.of(Insert.class.getSimpleName(),
                             Save.class.getSimpleName(),
                             Update.class.getSimpleName());
+
+    /**
+     * List of valid prefixes for Query by Method Name methods of a stateful
+     * repository.
+     */
+    private static final Set<String> METHOD_NAME_PREFIXES_STATEFUL = //
+                    Set.of("count", "exists", "find");
+
+    /**
+     * List of valid prefixes for Query by Method Name methods of a stateless
+     * repository.
+     */
+    private static final Set<String> METHOD_NAME_PREFIXES_STATELESS = //
+                    Set.of("count", "delete", "exists", "find");
 
     /**
      * Commonly used result types that are not entities.
@@ -86,11 +100,6 @@ public class Util {
     static final Set<Class<?>> PRIMITIVE_NUMERIC_TYPES = //
                     Set.of(long.class, int.class, short.class, byte.class,
                            double.class, float.class);
-
-    /**
-     * List of Jakarta Data operation annotations for use in NLS messages.
-     */
-    static final String OP_ANNOS = "Delete, Find, Insert, Query, Save, Update";
 
     /**
      * Return types for deleteBy that distinguish delete-only from find-and-delete.
@@ -133,7 +142,8 @@ public class Util {
                     List.of(Instant.class.getSimpleName(),
                             LocalDate.class.getSimpleName(),
                             LocalDateTime.class.getSimpleName(),
-                            LocalTime.class.getSimpleName());
+                            LocalTime.class.getSimpleName(),
+                            Year.class.getSimpleName());
 
     /**
      * These types are never supported for entity attributes.
@@ -227,21 +237,20 @@ public class Util {
      * that performs and operation, such as Query, Find, or Save. This method is
      * for use by error reporting only, so it does not need to be very efficient.
      *
-     * @param method repository method.
+     * @param method   repository method.
+     * @param producer producer of the repository bean instance.
      * @return if the repository method has an annotation indicating an operation.
      */
     @Trivial
-    static final boolean hasOperationAnno(Method method) {
-        Set<Class<? extends Annotation>> operationAnnos = //
-                        Set.of(Delete.class,
-                               Insert.class,
-                               Find.class,
-                               Query.class,
-                               Save.class,
-                               Update.class);
+    static final boolean hasOperationAnno(Method method,
+                                          RepositoryProducer<?> producer) {
+        DataVersionCompatibility compat = producer.provider().compat;
+        Set<Class<? extends Annotation>> statefulAnnos = compat.operationAnnoTypes(true);
+        Set<Class<? extends Annotation>> statelessAnnos = compat.operationAnnoTypes(false);
 
         for (Annotation anno : method.getAnnotations())
-            if (operationAnnos.contains(anno.annotationType()))
+            if (statefulAnnos.contains(anno.annotationType()) ||
+                statelessAnnos.contains(anno.annotationType()))
                 return true;
 
         return false;
@@ -274,6 +283,23 @@ public class Util {
         NON_ENTITY_RESULT_TYPES.add(BigInteger.class);
         NON_ENTITY_RESULT_TYPES.add(Object.class);
         NON_ENTITY_RESULT_TYPES.add(String.class);
+    }
+
+    /**
+     * List of names of repository method life cycle annotations.
+     *
+     * @param producer producer of the repository bean, from which it can be
+     *                     determined if the repository is stateful or stateless.
+     */
+    @Trivial
+    static String lifeCycleAnnoNames(RepositoryProducer<?> producer) {
+        Set<Class<? extends Annotation>> annoClasses = producer.provider().compat //
+                        .lifeCycleAnnoTypes(producer.stateful());
+
+        StringBuilder b = new StringBuilder();
+        for (Class<?> annoClass : annoClasses)
+            b.append(b.isEmpty() ? "" : ", ").append(annoClass.getSimpleName());
+        return b.toString();
     }
 
     /**
@@ -310,6 +336,11 @@ public class Util {
         return validReturnTypes;
     }
 
+    static Set<String> methodNamePrefixes(RepositoryProducer<?> producer) {
+        return producer.stateful() ? METHOD_NAME_PREFIXES_STATEFUL //
+                        : METHOD_NAME_PREFIXES_STATELESS;
+    }
+
     /**
      * Returns a String containing the names of classes delimited by commas.
      *
@@ -321,6 +352,24 @@ public class Util {
         for (Class<?> c : classes)
             b.append(b.isEmpty() ? "" : ", ").append(c.getName());
         return b.toString();
+    }
+
+    /**
+     * List of names of repository method annotations that represent operations.
+     * Enclosed in brackets and delimited by comma.
+     *
+     * @param producer producer of the repository bean, from which it can be
+     *                     determined if the repository is stateful or stateless.
+     */
+    @Trivial
+    static String operationAnnoNames(RepositoryProducer<?> producer) {
+        Set<Class<? extends Annotation>> annoClasses = producer.provider().compat //
+                        .operationAnnoTypes(producer.stateful());
+
+        StringBuilder b = new StringBuilder('[');
+        for (Class<?> annoClass : annoClasses)
+            b.append(b.isEmpty() ? "" : ", ").append(annoClass.getSimpleName());
+        return b.append(']').toString();
     }
 
     /**
@@ -387,6 +436,24 @@ public class Util {
                                cause.getClass().getName() + ']');
             }
         }
+    }
+
+    /**
+     * List of class names of valid return types for resource accessor mtehods.
+     * Enclosed in brackets and delimited by comma.
+     *
+     * @param producer producer of the repository bean, from which it can be
+     *                     determined if the repository is stateful or stateless.
+     */
+    @Trivial
+    static String resourceAccessorTypeNames(RepositoryProducer<?> producer) {
+        Set<Class<?>> types = producer.provider().compat //
+                        .resourceAccessorTypes(producer.stateful());
+
+        StringBuilder b = new StringBuilder('[');
+        for (Class<?> type : types)
+            b.append(b.isEmpty() ? "" : ", ").append(type.getSimpleName());
+        return b.append(']').toString();
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -449,10 +449,9 @@ public class Util {
         Set<Class<?>> types = producer.provider().compat //
                         .resourceAccessorTypes(producer.stateful());
 
-        StringBuilder b = new StringBuilder('[');
-        for (Class<?> type : types)
-            b.append(b.isEmpty() ? "" : ", ").append(type.getSimpleName());
-        return b.append(']').toString();
+        return types.stream()
+                    .map(c -> c.getSimpleName)
+                    .collect(Collectors.joining(", ", "[", "]"));
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.util.UUID;
@@ -297,8 +298,8 @@ public class Util {
         Set<Class<? extends Annotation>> annoClasses = producer.provider().compat //
                         .lifeCycleAnnoTypes(producer.stateful());
 
-        return annoClasses.stream()
-                   .map(c -> c.getSimpleName)
+        return annoClasses.stream() //
+                   .map(Class::getSimpleName) //
                    .collect(Collectors.joining(", ", "[", "]"));
     }
 
@@ -366,8 +367,8 @@ public class Util {
         Set<Class<? extends Annotation>> annoClasses = producer.provider().compat //
                         .operationAnnoTypes(producer.stateful());
 
-        return annoClasses.stream()
-                           .map(c -> c.getSimpleName)
+        return annoClasses.stream() //
+                           .map(Class::getSimpleName) //
                            .collect(Collectors.joining(", ", "[", "]"));
     }
 
@@ -449,8 +450,8 @@ public class Util {
         Set<Class<?>> types = producer.provider().compat //
                         .resourceAccessorTypes(producer.stateful());
 
-        return types.stream()
-                    .map(c -> c.getSimpleName)
+        return types.stream() //
+                    .map(Class::getSimpleName) //
                     .collect(Collectors.joining(", ", "[", "]"));
     }
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -401,6 +401,16 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
     }
 
     /**
+     * Returns the Jakarta Data provider.
+     *
+     * @return the Jakarta Data provider.
+     */
+    @Trivial
+    public DataProvider provider() {
+        return provider;
+    }
+
+    /**
      * Assigns the FutureEMBuilder for this repository producer.
      *
      * @param futureEMBuilder future for an EntityManagerBuilder.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -136,8 +136,9 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
 
     /**
      * Indicates if the repository is stateful (true) or stateless (false).
+     * Default: false
      */
-    private boolean stateful;
+    private boolean stateful = false;
 
     /**
      * Construct an instance of RepositoryProducer.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -75,32 +75,93 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
      */
     private static final long INIT_TIMEOUT_SEC = TimeUnit.MINUTES.toSeconds(5);
 
+    /**
+     * Qualifiers for repository bean instances.
+     */
     private static final Set<Annotation> QUALIFIERS = //
                     Set.of(Any.Literal.INSTANCE, Default.Literal.INSTANCE);
 
+    /**
+     * CDI bean manager.
+     */
     private final BeanManager beanMgr;
+
+    /**
+     * A set of the repository interface type.
+     */
     private final Set<Type> beanTypes;
-    private final FutureEMBuilder futureEMBuilder;
+
+    /**
+     * Future for the EntityManagerBuilder.
+     */
+    private FutureEMBuilder futureEMBuilder;
+
+    /**
+     * CDI extension for the Jakarta Data provider.
+     */
     private final DataExtension extension;
+
+    /**
+     * Map of intercepted instance to bean instance. Applies when a repository
+     * interface has methods with interceptor annotations, such as
+     * Asynchronous or Transactional.
+     */
     private final Map<R, R> intercepted = new ConcurrentHashMap<>();
-    private final Class<?> primaryEntityClass;
+
+    /**
+     * Primary entity class, if any, for the repository.
+     */
+    private Class<?> primaryEntityClass;
+
+    /**
+     * Jakarta Data provider.
+     */
     private final DataProvider provider;
-    private final Map<Class<?>, List<QueryInfo>> queriesPerEntityClass;
+
+    /**
+     * Information about each repository method, grouped by entity class.
+     */
+    final Map<Class<?>, List<QueryInfo>> queriesPerEntityClass;
+
+    /**
+     * Handler for the most recently created repository bean instance.
+     */
     private final AtomicReference<RepositoryImpl<?>> repositoryImplRef = //
-                    new AtomicReference<>(); // most recently created instance
+                    new AtomicReference<>();
+
+    /**
+     * The repository interface.
+     */
     private final Class<?> repositoryInterface;
 
-    RepositoryProducer(Class<?> repositoryInterface, BeanManager beanMgr, DataProvider provider, DataExtension extension,
-                       FutureEMBuilder futureEMBuilder, Class<?> primaryEntityClass, Map<Class<?>, List<QueryInfo>> queriesPerEntityClass) {
+    /**
+     * Indicates if the repository is stateful (true) or stateless (false).
+     */
+    private boolean stateful;
+
+    /**
+     * Construct an instance of RepositoryProducer.
+     * The instance is not usable until setFutureEMBuilder and setPrimaryEntityClass
+     * are invoked on it.
+     *
+     * @param repositoryInterface   the repository interface.
+     * @param beanMgr               the CDI bean manager.
+     * @param provider              Jakarta Data provider.
+     * @param extension             CDI extension for the Jakarta Data provider.
+     * @param queriesPerEntityClass information about each repository query,
+     *                                  grouped by entity class.
+     */
+    RepositoryProducer(Class<?> repositoryInterface,
+                       BeanManager beanMgr,
+                       DataProvider provider,
+                       DataExtension extension,
+                       Map<Class<?>, List<QueryInfo>> queriesPerEntityClass) {
         this.beanMgr = beanMgr;
         this.beanTypes = Set.of(repositoryInterface);
         this.extension = extension;
-        this.futureEMBuilder = futureEMBuilder;
-        this.primaryEntityClass = primaryEntityClass;
         this.provider = provider;
         this.queriesPerEntityClass = queriesPerEntityClass;
         this.repositoryInterface = repositoryInterface;
-        provider.producerCreated(futureEMBuilder.jeeName.getApplication(), this);
     }
 
     @Override
@@ -216,6 +277,7 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
 
         writer.println(indent + "RepositoryProducer@" + Integer.toHexString(hashCode()));
         writer.println(indent + "  repository: " + repositoryInterface.getName());
+        writer.println(indent + "  stateful? " + stateful);
         writer.println(indent + "  primary entity: " +
                        (primaryEntityClass == null ? null : primaryEntityClass.getName()));
         writer.println(indent + "  intercepted: " + intercepted);
@@ -243,7 +305,8 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
         });
 
         writer.println();
-        futureEMBuilder.introspect(writer, "  " + indent);
+        if (futureEMBuilder != null)
+            futureEMBuilder.introspect(writer, "  " + indent);
 
         return queryInfos;
     }
@@ -335,6 +398,55 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
                     throw new DataException(x);
             }
         }
+    }
+
+    /**
+     * Assigns the FutureEMBuilder for this repository producer.
+     *
+     * @param futureEMBuilder future for an EntityManagerBuilder.
+     */
+    @Trivial
+    void setFutureEMBuilder(FutureEMBuilder futureEMBuilder) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "setFutureEMBuilder", futureEMBuilder);
+
+        this.futureEMBuilder = futureEMBuilder;
+
+        provider.producerCreated(futureEMBuilder.jeeName.getApplication(), this);
+    }
+
+    /**
+     * Assigns the primary entity class, if any, for this repository.
+     *
+     * @param primaryEntityClass primary entity class. Null if none.
+     */
+    @Trivial
+    void setPrimaryEntityClass(Class<?> primaryEntityClass) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "setPrimaryEntityClass", primaryEntityClass);
+
+        this.primaryEntityClass = primaryEntityClass;
+    }
+
+    /**
+     * Indicates that the repository is stateful.
+     */
+    @Trivial
+    void setStateful() {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "setStateful");
+
+        stateful = true;
+    }
+
+    /**
+     * Returns whether the repository is stateful (true) or stateless (false).
+     *
+     * @return true if the repository is stateful; false if stateless.
+     */
+    @Trivial
+    public final boolean stateful() {
+        return stateful;
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -132,6 +132,34 @@ public interface DataVersionCompatibility {
     boolean hasOrAnnotation(Annotation[] annos);
 
     /**
+     * Returns the repository method annotations that represent life cycle
+     * operations (such as Delete and Insert) for either a stateful or
+     * stateless repository, depending on the parameter.
+     *
+     * @param stateful true for a stateful repository; false for stateless.
+     * @return the annotation classes.
+     */
+    Set<Class<? extends Annotation>> lifeCycleAnnoTypes(boolean stateful);
+
+    /**
+     * Returns the repository method annotations that represent operations
+     * (such as Find and Delete, but not OrderBy) for either a stateful or
+     * stateless repository, depending on the parameter.
+     *
+     * @param stateful true for a stateful repository; false for stateless.
+     * @return the annotation classes.
+     */
+    Set<Class<? extends Annotation>> operationAnnoTypes(boolean stateful);
+
+    /**
+     * List of valid return types for resource accessor methods.
+     *
+     * @param stateful true for a stateful repository; false for stateless.
+     * @return valid return types.
+     */
+    Set<Class<?>> resourceAccessorTypes(boolean stateful);
+
+    /**
      * Returns the names of special parameter types that are valid for repository
      * find operations.
      *


### PR DESCRIPTION
Be able to identify whether a repository is stateful or stateless based on methods, make the information available, and use it to determine how various lists are output to the user such that messages correspond more closely to what is valid for their repository.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
