### PR TITLE
Test to check getSingleResultOrNull 

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/Book.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/Book.java
@@ -17,8 +17,12 @@ import jakarta.persistence.Id;
 @Entity
 public class Book {
     @Id
-    private Long id;
-    private String title;
-    private LocalDate publicationDate;
-
+    public Long id;
+    public String title;
+    
+    public Book() {}
+    public Book(Long id, String title) {
+        this.id = id;
+        this.title = title;     
+    }
 }

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -739,6 +739,15 @@ public class JakartaPersistenceServlet extends FATServlet {
             throw e;
         }
         assertEquals("Jakarta Persistence 3.2", resultFound.title);
+
+        try {
+            resultNotFound = em.createQuery("SELECT b FROM Book b WHERE b.id = ?1", Book.class)
+                        .setParameter(1, 2L) // This ID does not exist
+                        .getSingleResultOrNull();
+         } catch (Exception e){
+            throw e;
+        }
+        assertNull(resultNotFound);
     }
 
     /**

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -25,6 +25,7 @@ import org.junit.Ignore;
 
 import componenttest.app.FATServlet;
 import io.openliberty.jpa.persistence.tests.models.AsciiCharacter;
+import io.openliberty.jpa.persistence.tests.models.Book;
 import io.openliberty.jpa.persistence.tests.models.Event;
 import io.openliberty.jpa.persistence.tests.models.Organization;
 import io.openliberty.jpa.persistence.tests.models.Participant;
@@ -716,6 +717,28 @@ public class JakartaPersistenceServlet extends FATServlet {
         }
 
         assertEquals(123_450_000, result.timestamp.getNano());
+    }
+
+    @Test
+    public void testGetSingleResultOrNull() throws Exception {
+        deleteAllEntities(Book.class);
+
+        Book bookJPA = new Book(1L, "Jakarta Persistence 3.2");
+
+        tx.begin();
+        em.persist(bookJPA);
+        tx.commit();
+
+        Book resultFound, resultNotFound;
+
+        try {
+            resultFound = em.createQuery("SELECT b FROM Book b WHERE b.id = ?1", Book.class)
+                        .setParameter(1, 1L)
+                        .getSingleResultOrNull();
+         } catch (Exception e){
+            throw e;
+        }
+        assertEquals("Jakarta Persistence 3.2", resultFound.title);
     }
 
     /**


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This PR adds test to servlet introduced in PR #31583 to check the working of getSingleResultOrNull method specified in Jakarta Persistence 3.2 specification.
