### PR TITLE
remove unneeded checkpoint guard

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.logging.internal.common/src/io/openliberty/microprofile/telemetry20/logging/internal/OpenTelemetryLogHandler.java
+++ b/dev/io.openliberty.microprofile.telemetry.logging.internal.common/src/io/openliberty/microprofile/telemetry20/logging/internal/OpenTelemetryLogHandler.java
@@ -40,8 +40,6 @@ import com.ibm.wsspi.collector.manager.CollectorManager;
 import com.ibm.wsspi.collector.manager.Handler;
 import com.ibm.wsspi.collector.manager.SynchronousHandler;
 
-import org.osgi.service.component.annotations.Reference;
-
 import io.openliberty.checkpoint.spi.CheckpointPhase;
 import io.openliberty.microprofile.telemetry.internal.common.AgentDetection;
 import io.openliberty.microprofile.telemetry.internal.common.constants.OpenTelemetryConstants;
@@ -186,18 +184,7 @@ public class OpenTelemetryLogHandler implements SynchronousHandler, OpenTelemtry
     public void synchronousWrite(Object event) {
         OpenTelemetryInfo otelInstance = null;
 
-        if (!CheckpointPhase.getPhase().restored()) {
-            // restored() true if checkpoint has been restored or was never active.
-            // so with the negation we enter this block if checkpoint is active and
-            // we have not yet restored.
-
-            // In that situation OpenTelemetry always returns a no-op OpenTelemetryInfo
-            // but we don't want to start poking around the internals before they're set
-            // up in the post-restore phase.
-
-            // in short, this block is no-op.
-
-        } else if (OpenTelemetryAccessor.isRuntimeEnabled()) {
+        if (OpenTelemetryAccessor.isRuntimeEnabled()) {
             // Runtime OpenTelemetry instance
             otelInstance = this.runtimeOtelInfo;
             synchronousWriteInternal(event, otelInstance);


### PR DESCRIPTION
A follow up to https://github.com/OpenLiberty/open-liberty/pull/31870, specifically this comment https://github.com/OpenLiberty/open-liberty/pull/31870#discussion_r2154905355

This removes an if statement to avoid running when checkpoint is active before the restore, but that is already enforced by an annotation. 