### PR TITLE
Add Bundle-DocURL and Bundle-Developers for generated pom.xmls

### DIFF
--- a/dev/cnf/build.bnd
+++ b/dev/cnf/build.bnd
@@ -78,6 +78,16 @@ instrument.taskInjection: false
 
 buildEngineName: defaultEngine
 
+Bundle-DocURL: \
+  https://openliberty.io
+
+Bundle-Developers: \
+  contbld; \
+  name=contbld; \
+  email=contbld@uk.ibm.com; \
+  organization=IBM; \
+  organizationUrl=https://openliberty.io
+
 Bundle-License: \
   Eclipse Public License; \
   url=https://www.eclipse.org/legal/epl-2.0/


### PR DESCRIPTION
- Add `Bundle-DocURL` and `Bundle-Developers` into `cnf/build.bnd` to add attributes to generated pom.xmls.