### PR TITLE
Updating custom properties for BCL and Jcache tests

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
@@ -1,3 +1,5 @@
+# Allowing for org.apache.xml.security.encryption.XMLCipher
+# But To Do: Investigation on the open source with component owner
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
@@ -3,12 +3,13 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, MD5, *, FullClassName:org.wildfly.security.sasl.digest.AbstractDigestMechanism}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
     {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
-    {Mac, HmacMD5, *, FullClassName:org.wildfly.security.sasl.digest.AbstractDigestMechanism}, \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
@@ -10,6 +10,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
@@ -11,4 +11,5 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
@@ -10,4 +10,5 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/semeruFips140_3CustomProfile.properties
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/semeruFips140_3CustomProfile.properties
@@ -1,3 +1,5 @@
+# Allowing for org.apache.xml.security.encryption.XMLCipher
+# But To Do: Investigation on the open source with component owner
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/semeruFips140_3CustomProfile.properties
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/semeruFips140_3CustomProfile.properties
@@ -5,6 +5,7 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, MD5, *, FullClassName:org.wildfly.security.sasl.digest.AbstractDigestMechanism}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
     {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/semeruFips140_3CustomProfile.properties
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/semeruFips140_3CustomProfile.properties
@@ -5,7 +5,6 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, MD5, *, FullClassName:org.wildfly.security.sasl.digest.AbstractDigestMechanism}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
     {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \

--- a/dev/io.openliberty.jcache.internal_fat.infinispan/semeruFips140_3CustomProfile.properties
+++ b/dev/io.openliberty.jcache.internal_fat.infinispan/semeruFips140_3CustomProfile.properties
@@ -1,3 +1,5 @@
+# Allowing for org.wildfly.security.sasl.digest.AbstractDigestMechanism
+# But To Do: Investigation on the open source with component owner
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

- Updated the custom properties file to make, BCL.saml.1, fips compliant
- Updated  the custom properties for jcache infinispan to make more of the tests, pass and avoid:

```
Caused by: java.security.NoSuchAlgorithmException: Algorithm HmacMD5 not available

 at java.base/javax.crypto.Mac.getInstance(Mac.java:190)

 at org.wildfly.security.sasl.digest.AbstractDigestMechanism.getHmac(AbstractDigestMechanism.java:479)
```
- Updated jcache hazelcast's properties file for tracking open source components in the comments.

################################################################################################
