### PR TITLE
fix com.ibm.ws.security.oidc.server_fat.jaxrs.config.noOP when fips 140-3 is enabled

### DIFF
--- a/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.commonTest/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/noOP/NoOPSignatureRSServerTests.java
+++ b/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.commonTest/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/noOP/NoOPSignatureRSServerTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,6 +34,8 @@ import com.ibm.ws.security.oauth_oidc.fat.commonTest.TestSettings;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule;
 
 /**
  * Class for RS signature algorithm tests
@@ -52,6 +55,9 @@ public class NoOPSignatureRSServerTests extends MangleJWTTestTools {
 
     private static final JwtTokenActions actions = new JwtTokenActions();
     public static final JwtTokenBuilderUtils tokenBuilderHelpers = new JwtTokenBuilderUtils();
+
+    @Rule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled(OPServerName);
 
     @BeforeClass
     public static void setupBeforeTest() throws Exception {
@@ -505,10 +511,12 @@ public class NoOPSignatureRSServerTests extends MangleJWTTestTools {
 
     /**
      * Test shows that the RS can not consume a JWT signed with sigAlg RS256, but a different key
+     * Skip test on FIPS 140-3 because it requires RSA keys to be at least 2048 bit
      *
      * @throws Exception
      */
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void OidcClientSignatureAlgTests_SignTokenRS256_RSVerifyRS256_keyMismatch() throws Exception {
 
         genericSigAlgTest("short_" + Constants.SIGALG_RS256, Constants.SIGALG_RS256);
@@ -517,10 +525,12 @@ public class NoOPSignatureRSServerTests extends MangleJWTTestTools {
 
     /**
      * Test shows that the RS can not consume a JWT signed with sigAlg RS384, but a different key
+     * Skip test on FIPS 140-3 because it requires RSA keys to be at least 2048 bit
      *
      * @throws Exception
      */
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void OidcClientSignatureAlgTests_SignTokenRS384_RSVerifyRS384_keyMismatch() throws Exception {
 
         genericSigAlgTest("short_" + Constants.SIGALG_RS384, Constants.SIGALG_RS384);
@@ -529,10 +539,12 @@ public class NoOPSignatureRSServerTests extends MangleJWTTestTools {
 
     /**
      * Test shows that the RS can not consume a JWT signed with sigAlg RS512, but a different key
+     * Skip test on FIPS 140-3 because it requires RSA keys to be at least 2048 bit
      *
      * @throws Exception
      */
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void OidcClientSignatureAlgTests_SignTokenRS512_RSVerifyRS512_keyMismatch() throws Exception {
 
         genericSigAlgTest("short_" + Constants.SIGALG_RS512, Constants.SIGALG_RS512);

--- a/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.noOP/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.noOP/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,22 @@
+# Allowing open source org.jose4j
+#
+# TODO:
+# Come back and see if any of these tests can use ECDH instead of RSA
+# Or if not, then see if it makes more sense to disable the test instead of adding to the FIPS profile
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {MessageDigest, SHA-1, *, FullClassName:org.jose4j.jwa.AlgorithmFactory}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.jose4j.jwe.CipherUtil}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.jose4j.jwe.WrappingKeyManagementAlgorithm}, \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:org.jose4j.jwa.AlgorithmFactory}, \
+    {Cipher, RSA, *, FullClassName:org.jose4j.jwe.CipherUtil}, \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]


### PR DESCRIPTION
- skip rs256 tests that use <2048-bit keys on fips
    - fips requires rsa keys to be at least 2048-bit, so let's disable these tests that are specifically testing using a 1024-bit rsa key
- allow rsa-oaep in oidc.server_fat.jaxrs.config.noOP on fips
    - we'll need to come back and see if any of these tests can use ecdh instead of rsa-oaep. or if not, then see if it makes more sense to disable the test instead of adding to the fips profile