### PR TITLE
Adding the CSP headers in the response headers for the default Liberty welcome page

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -127,6 +127,9 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
     private boolean WebConnCanClose = true;
     private final String h2InitError = "com.ibm.ws.transport.http.http2InitError";
 
+    // OLGH31942 Adding CSP headers for the default welcome page
+    private static final String CONTENT_SECURITY_POLICY = "default-src 'self'; script-src 'self' 'unsafe-inline' https://openliberty.io https://public.dhe.ibm.com; style-src 'self' 'unsafe-inline';";
+
     private final AtomicBoolean decrementNeeded = new AtomicBoolean(false);
 
     private final AtomicBoolean closeCompleted = new AtomicBoolean(false);
@@ -576,6 +579,7 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
         try {
             if (exists(inputStream)) {
                 String theURI = this.isc.getRequest().getRequestURI();
+                this.response.setHeader(HttpHeaderKeys.HDR_CONTENT_SECURITY_POLICY.getName(), CONTENT_SECURITY_POLICY); //OLGH31942 Adding CSP headers for the default welcome page
                 // for OK responses that are not index.html, set the cache-control header to a year
                 // If someone assigns a web-app for the root context, whatever is in that application
                 // should get picked up instead of our welcome page w/o having to clear the cache

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2023 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -230,6 +230,9 @@ public class HttpHeaderKeys extends HeaderKeys {
     public static final HttpHeaderKeys HDR_AUTHORIZATION_ENCODING = new HttpHeaderKeys("Authorization-Encoding");
 
     public static final HttpHeaderKeys HDR_ORIGIN = new HttpHeaderKeys("Origin");
+
+    /** Enumerated object for the HTTP header key CONTENT-SECURITY-POLICY */
+    public static final HttpHeaderKeys HDR_CONTENT_SECURITY_POLICY = new HttpHeaderKeys("Content-Security-Policy");
 
     /** Max value of header keys that will be kept in key storage */
     public static final int ORD_MAX = 1024;

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/FATSuite.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/FATSuite.java
@@ -30,7 +30,8 @@ import io.openliberty.transport.http_fat.accesslists.AccessListsTests;
                 SoReuseAddrTest.class,
                 TcpOptionsDefaultTests.class,
                 ContentTypeResponseHeaderTests.class,
-                AccessLogRolloverTest.class
+                AccessLogRolloverTest.class,
+                LibertyWelcomePageResponseHeaderTests.class
 })
 
 public class FATSuite {

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/LibertyWelcomePageResponseHeaderTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/LibertyWelcomePageResponseHeaderTests.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.transport.http_fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Test to verify Content-Security-Protocol header is added in the response
+ * headers on the liberty default welcome page
+ */
+@RunWith(FATRunner.class)
+public class LibertyWelcomePageResponseHeaderTests {
+    private static final Class<?> c = LibertyWelcomePageResponseHeaderTests.class;
+    private static final Logger LOG = Logger.getLogger(c.getName());
+
+    @Server("ContentSecurityProtocolHeader")
+    public static LibertyServer server;
+
+    /**
+     *
+     * 
+     * @throws Exception
+     */
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Start the server and wait for it to be ready
+        server.startServer();
+        // ensure server has started.
+        server.waitForStringInLog("CWWKF0011I:.*");
+    }
+
+    /**
+     * shut down the test server
+     * 
+     * @throws Exception
+     */
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * Test that checks if the liberty default welcome page returns the
+     * Content-Security-Protocol header in the
+     * response
+     */
+    @Test
+    public void testCSPHeadersOnDefaultWelcomePage() throws Exception {
+        String contentSecurityProtocolHeader = getCSPResposeHeaders();
+        assertNotNull("Content-Security-Protocol header was not set", contentSecurityProtocolHeader);
+        String csp = "default-src 'self'; script-src 'self' 'unsafe-inline' https://openliberty.io https://public.dhe.ibm.com; style-src 'self' 'unsafe-inline';";
+        assertEquals("Correct Content-Security-Protocol header was not found", csp,
+                contentSecurityProtocolHeader.trim());
+
+        Log.info(c, "testCSPHeadersOnDefaultWelcomePage",
+                "Successfully verified Content-Security-Policy header on the default welcome page: "
+                        + contentSecurityProtocolHeader);
+    }
+
+    /**
+     * Helper method to get the Content-Security-Protocol header from a response
+     * 
+     * @return The Content-Security-Policy header value
+     * @throws Exception If an error occurs
+     */
+    private String getCSPResposeHeaders() throws Exception {
+        HttpURLConnection con = getConnection();
+        con.setRequestMethod("GET");
+
+        int responseCode = con.getResponseCode();
+
+        assertEquals("Did not get the expected 200 OK response code from the Welcome Page", HttpURLConnection.HTTP_OK,
+                responseCode);
+
+        String contentSecurityProtocolHeader = con.getHeaderField("Content-Security-Policy");
+
+        Log.info(c, "getCSPResposeHeaders", "CSP Header: " + contentSecurityProtocolHeader);
+
+        return contentSecurityProtocolHeader;
+    }
+
+    /**
+     * Creates an HttpURLConnection to the specified path
+     * 
+     * @return An HttpURLConnection
+     * @throws IOException If an error occurs
+     */
+    private HttpURLConnection getConnection() throws IOException {
+        URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/");
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        return con;
+    }
+
+}

--- a/dev/io.openliberty.transport.http_fat/publish/servers/ContentSecurityProtocolHeader/bootstrap.properties
+++ b/dev/io.openliberty.transport.http_fat/publish/servers/ContentSecurityProtocolHeader/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/io.openliberty.transport.http_fat/publish/servers/ContentSecurityProtocolHeader/server.xml
+++ b/dev/io.openliberty.transport.http_fat/publish/servers/ContentSecurityProtocolHeader/server.xml
@@ -1,0 +1,18 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server description="Test content-type in response headers.">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+    </featureManager>
+
+</server>


### PR DESCRIPTION

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #31942

