### PR TITLE
Null value supplied as Limit, Sort, and Sort array

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -5009,27 +5009,26 @@ public class QueryInfo {
             for (int s = 0; s < sortPositions.length; s++) {
                 int p = sortPositions[s];
                 if (Order.class.equals(paramTypes[p]) ||
-                    Sort.class.equals(paramTypes[p]))
+                    Sort.class.equals(paramTypes[p]) ||
+                    Sort[].class.equals(paramTypes[p])) {
+                    String paramTypeName = Sort[].class.equals(paramTypes[p]) //
+                                    ? (Sort.class.getName() + "[]") //
+                                    : paramTypes[p].getName();
                     if (args[p] == null)
                         // BasicRepository.findAll(PageRequest, Order) requires
                         // NullPointerException when Order is null.
                         throw exc(NullPointerException.class,
                                   "CWWKD1087.null.param",
-                                  paramTypes[p].getName(),
+                                  paramTypeName,
                                   method.getName(),
                                   repositoryInterface.getName());
                     else
                         throw exc(IllegalArgumentException.class,
                                   "CWWKD1088.empty.sorts",
-                                  paramTypes[p].getName(),
+                                  paramTypeName,
                                   method.getName(),
                                   repositoryInterface.getName());
-                else if (Sort[].class.equals(paramTypes[p]))
-                    throw exc(IllegalArgumentException.class,
-                              "CWWKD1088.empty.sorts",
-                              Sort.class.getName() + "[]",
-                              method.getName(),
-                              repositoryInterface.getName());
+                }
             }
         }
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -1558,6 +1558,26 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Supply a null Limit results in NullPointerException.
+     */
+    @Test
+    public void testNullLimit() {
+        try {
+            List<Voter> found = voters
+                            .findBySsnLessThanEqualOrderBySsnDesc(999999999, null);
+            fail("Repository method with a null Limit must raise" +
+                 " NullPointerException. Instead: " + found);
+        } catch (NullPointerException x) {
+            if (x.getMessage() != null &&
+                x.getMessage().startsWith("CWWKD1087E") &&
+                x.getMessage().contains(Limit.class.getName()))
+                ; // expected
+            else
+                throw x;
+        }
+    }
+
+    /**
      * BasicRepository.findAll(PageRequest, null) must raise NullPointerException.
      */
     @Test
@@ -1589,6 +1609,47 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() != null &&
                 x.getMessage().startsWith("CWWKD1087E") &&
                 x.getMessage().contains(PageRequest.class.getName()))
+                ; // expected
+            else
+                throw x;
+        }
+    }
+
+    /**
+     * Attempt to supply a NULL Sort parameter.
+     */
+    @Test
+    public void testNullSortArgument() {
+        Page<Voter> page;
+        try {
+            page = voters.selectByName("Vincent",
+                                       PageRequest.ofSize(9),
+                                       null);
+            fail("Obtained a page sorted by NULL: " + page);
+        } catch (NullPointerException x) {
+            if (x.getMessage() != null &&
+                x.getMessage().startsWith("CWWKD1087E") &&
+                x.getMessage().contains(Sort.class.getName()))
+                ; // expected
+            else
+                throw x;
+        }
+    }
+
+    /**
+     * Attempt to supply a NULL varargs Sort parameter.
+     */
+    @Test
+    public void testNullSortArray() {
+        Page<Voter> page;
+        try {
+            page = voters.selectAll(PageRequest.ofSize(3),
+                                    (Sort[]) null);
+            fail("Obtained a page sorted by NULL: " + page);
+        } catch (NullPointerException x) {
+            if (x.getMessage() != null &&
+                x.getMessage().startsWith("CWWKD1087E") &&
+                x.getMessage().contains(Sort.class.getName() + "[]"))
                 ; // expected
             else
                 throw x;


### PR DESCRIPTION
Ensure that NullPointerException is raised when a Null value is supplied as a Limit, Sort, or Sort[] special parameter to a repository method.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
