### PR TITLE
Disable chain certificate tests in SAML SSO bucket when FIPS 140-3 is enabled

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.HttpMethod;
@@ -35,6 +36,8 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.JakartaEE10Action;
 import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule;
 import componenttest.topology.impl.LibertyServerWrapper;
 
 /**
@@ -60,6 +63,9 @@ public class BasicSAMLTests extends SAMLCommonTest {
     private static final Class<?> thisClass = BasicSAMLTests.class;
 
     private static final String MSG_CWWKO0219I_SSL_PORT_READY = "CWWKO0219I:.*ssl.*";
+
+    @Rule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.security.saml.sso-2.0_fat");
 
     // example of updating Partner and Federation
     //	SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -1021,6 +1027,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
      *
      * @throws Exception
      */
+    @SkipJavaSemeruWithFipsEnabledRule
     @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException" })
     @Mode(TestMode.LITE)
     @Test
@@ -1066,6 +1073,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
      *
      * @throws Exception
      */
+    @SkipJavaSemeruWithFipsEnabledRule
     @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException" })
     @Test
     public void basicSAMLTests_chainedCert_noMetaData_rootInKeyStore() throws Exception {

--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
@@ -1027,6 +1027,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
      *
      * @throws Exception
      */
+    // TODO: Test is disabled from running when FIPS 140-3 is enabled, convert chained certificate to use SHA256withRSA signature algorithm
     @SkipJavaSemeruWithFipsEnabledRule
     @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException" })
     @Mode(TestMode.LITE)
@@ -1073,6 +1074,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
      *
      * @throws Exception
      */
+    // TODO: Test is disabled from running when FIPS 140-3 is enabled, convert chained certificate to use SHA256withRSA signature algorithm
     @SkipJavaSemeruWithFipsEnabledRule
     @AllowedFFDC(value = { "com.ibm.ws.security.saml.error.SamlException" })
     @Test


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

----

- Disable chain certificate tests in SAML SSO bucket when FIPS 140-3 is enabled.
- Tests may be re-enabled if the chained certificate can be converted to use SHA256withRSA