### PR TITLE
allow sha-1 on for derbyMonitor

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,14 @@
+# SHA-1 is required for WebSocket Upgrade requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.derby.iapi.services.monitor.Monitor}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/semeruFips140_3CustomProfile.properties
@@ -1,4 +1,3 @@
-# The use of the SHA-1 algorithm in org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl.boot appears to serve only as a way to prime the MessageDigest engine and is not used for actual password hashing. However, its presence is still problematic, as SHA-1 is not FIPS-compliant.
 # Issue to track: https://github.com/OpenLiberty/open-liberty/issues/31937
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3

--- a/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore/semeruFips140_3CustomProfile.properties
@@ -1,4 +1,5 @@
-# SHA-1 is required for WebSocket Upgrade requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept
+# The use of the SHA-1 algorithm in org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl.boot appears to serve only as a way to prime the MessageDigest engine and is not used for actual password hashing. However, its presence is still problematic, as SHA-1 is not FIPS-compliant.
+# Issue to track: https://github.com/OpenLiberty/open-liberty/issues/31937
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \

--- a/dev/com.ibm.ws.rest.handler.validator_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,14 @@
+# SHA-1 is required for WebSocket Upgrade requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.derby.iapi.services.monitor.Monitor}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.rest.handler.validator_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/semeruFips140_3CustomProfile.properties
@@ -1,4 +1,3 @@
-# The use of the SHA-1 algorithm in org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl.boot appears to serve only as a way to prime the MessageDigest engine and is not used for actual password hashing. However, its presence is still problematic, as SHA-1 is not FIPS-compliant.
 # Issue to track: https://github.com/OpenLiberty/open-liberty/issues/31937
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3

--- a/dev/com.ibm.ws.rest.handler.validator_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/semeruFips140_3CustomProfile.properties
@@ -1,4 +1,5 @@
-# SHA-1 is required for WebSocket Upgrade requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept
+# The use of the SHA-1 algorithm in org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl.boot appears to serve only as a way to prime the MessageDigest engine and is not used for actual password hashing. However, its presence is still problematic, as SHA-1 is not FIPS-compliant.
+# Issue to track: https://github.com/OpenLiberty/open-liberty/issues/31937
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \

--- a/dev/com.ibm.ws.session.cache_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.session.cache_fat/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,14 @@
+# SHA-1 is required for WebSocket Upgrade requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.derby.iapi.services.monitor.Monitor}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.session.cache_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.session.cache_fat/semeruFips140_3CustomProfile.properties
@@ -1,4 +1,3 @@
-# The use of the SHA-1 algorithm in org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl.boot appears to serve only as a way to prime the MessageDigest engine and is not used for actual password hashing. However, its presence is still problematic, as SHA-1 is not FIPS-compliant.
 # Issue to track: https://github.com/OpenLiberty/open-liberty/issues/31937
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3

--- a/dev/com.ibm.ws.session.cache_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.session.cache_fat/semeruFips140_3CustomProfile.properties
@@ -1,4 +1,5 @@
-# SHA-1 is required for WebSocket Upgrade requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept
+# The use of the SHA-1 algorithm in org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl.boot appears to serve only as a way to prime the MessageDigest engine and is not used for actual password hashing. However, its presence is still problematic, as SHA-1 is not FIPS-compliant.
+# Issue to track: https://github.com/OpenLiberty/open-liberty/issues/31937
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,14 @@
+# SHA-1 is required for WebSocket Upgrade requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.derby.iapi.services.monitor.Monitor}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/semeruFips140_3CustomProfile.properties
@@ -1,4 +1,3 @@
-# The use of the SHA-1 algorithm in org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl.boot appears to serve only as a way to prime the MessageDigest engine and is not used for actual password hashing. However, its presence is still problematic, as SHA-1 is not FIPS-compliant.
 # Issue to track: https://github.com/OpenLiberty/open-liberty/issues/31937
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/semeruFips140_3CustomProfile.properties
@@ -1,4 +1,5 @@
-# SHA-1 is required for WebSocket Upgrade requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept
+# The use of the SHA-1 algorithm in org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl.boot appears to serve only as a way to prime the MessageDigest engine and is not used for actual password hashing. However, its presence is still problematic, as SHA-1 is not FIPS-compliant.
+# Issue to track: https://github.com/OpenLiberty/open-liberty/issues/31937
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \

--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/semeruFips140_3CustomProfile.properties
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,14 @@
+# SHA-1 is required for WebSocket Upgrade requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.derby.iapi.services.monitor.Monitor}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/semeruFips140_3CustomProfile.properties
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/semeruFips140_3CustomProfile.properties
@@ -1,4 +1,3 @@
-# The use of the SHA-1 algorithm in org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl.boot appears to serve only as a way to prime the MessageDigest engine and is not used for actual password hashing. However, its presence is still problematic, as SHA-1 is not FIPS-compliant.
 # Issue to track: https://github.com/OpenLiberty/open-liberty/issues/31937
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3

--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/semeruFips140_3CustomProfile.properties
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/semeruFips140_3CustomProfile.properties
@@ -1,4 +1,5 @@
-# SHA-1 is required for WebSocket Upgrade requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Accept
+# The use of the SHA-1 algorithm in org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl.boot appears to serve only as a way to prime the MessageDigest engine and is not used for actual password hashing. However, its presence is still problematic, as SHA-1 is not FIPS-compliant.
+# Issue to track: https://github.com/OpenLiberty/open-liberty/issues/31937
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \


### PR DESCRIPTION
FipsPB: https://libh-proxy1.fyre.ibm.com/cognitive/pipelineAnalysis.html?pipelineId=c27430f3-529c-46cb-aa8a-b4d7e4d2e975&tab=Request%2BProperties

the 4 failing buckets are all WS-CD-Open buckets, I forgot to update the build-test.xml to pick up the semeruFips... properties file. the OL buckets passed, so I'm hoping to merge this PR, the CL PR is here: https://github.ibm.com/websphere/WS-CD-Open/pull/34640