### PR TITLE
Add FIPS 140-3 custom profile to JWT Builder FAT suite

### DIFF
--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwkEndpointValidationUrlTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwkEndpointValidationUrlTests.java
@@ -56,6 +56,8 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
@@ -70,6 +72,9 @@ public class JwkEndpointValidationUrlTests extends CommonSecurityFat {
 
     @Rule
     public static final TestRule conditIgnoreRule = new ConditionalIgnoreRule();
+
+    @Rule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.security.jwt_fat.builder");
 
     public static class skipIfAddressDoesNotResolve extends MySkipRule {
 
@@ -439,6 +444,7 @@ public class JwkEndpointValidationUrlTests extends CommonSecurityFat {
      * @throws Exception
      */
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     @ConditionalIgnoreRule.ConditionalIgnore(condition = skipIfAddressDoesNotResolve.class)
     public void JwkEndpointValidationUrlTests_jwkSigningKeySize_1024() throws Exception {
 

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
@@ -47,6 +47,8 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
@@ -64,6 +66,9 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
 
     @Rule
     public static final TestRule conditIgnoreRule = new ConditionalIgnoreRule();
+
+    @Rule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.security.jwt_fat.builder");
 
     private static final JwtBuilderActions actions = new JwtBuilderActions();
     public static final BuilderTestValidationUtils validationUtils = new BuilderTestValidationUtils();
@@ -1868,6 +1873,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
      * </OL>
      */
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void JwtBuilderAPIConfigTests_jwkEnabled_jwkSigningKeySize_1024() throws Exception {
 
         String builderId = "jwkEnabled_size_1024";

--- a/dev/com.ibm.ws.security.jwt_fat.builder/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,19 @@
+# Allowing for org.jose4j
+# TODO: Revisit usage of RSA and SHA-1 (RSA-OAEP/RSA-OAEP-256) after ECDH-ES update
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.jose4j.jwa.AlgorithmFactory}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.jose4j.jwe.CipherUtil}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.jose4j.jwe.WrappingKeyManagementAlgorithm}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, RSA, *, FullClassName:org.jose4j.jwa.AlgorithmFactory}, \
+    {Cipher, RSA, *, FullClassName:org.jose4j.jwe.CipherUtil}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

----

- Added FIPS 140-3 custom profile to enable usage of RSA-OAEP and RSA-OAEP-256 when FIPS 140-3 is enabled.
  - Usage of the above algorithms should be revisited when ECDH-ES algorithm is enabled.
- Disabled tests using a signing key size of 1024 bits from running when FIPS is enabled.
  - A signing key size of 1024 bits is not supported in FIPS, at minimum the key size must be 2048 bits. 
  - Updating these tests to use 2048-bit keys isn't necessary, as existing tests already cover this scenario and pass with FIPS enabled.
