### PR TITLE
Intermixed repository method parameters

### DIFF
--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 import io.openliberty.data.internal.version.DataVersionCompatibility;
+import io.openliberty.data.internal.version.QueryType;
 import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
@@ -180,6 +181,20 @@ public class Data_1_0 implements DataVersionCompatibility {
         // absent any other constraints or annotations.
         constraints[p] = By.class;
         return qpNext + 1;
+    }
+
+    @Override
+    @Trivial
+    public boolean isSpecialParamValid(Class<?> paramType,
+                                       QueryType queryType) {
+        return switch (queryType) {
+            case FIND -> true;
+            case FIND_AND_DELETE -> !PageRequest.class.equals(paramType);
+            case COUNT, EXISTS -> Order.class.equals(paramType) ||
+                                  Sort.class.equals(paramType) ||
+                                  Sort[].class.equals(paramType);
+            default -> false;
+        };
     }
 
     @Override

--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -30,6 +30,7 @@ import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.page.PageRequest;
+import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
@@ -106,36 +107,21 @@ public class Data_1_0 implements DataVersionCompatibility {
                     Set.of(Limit.class, Order.class, PageRequest.class,
                            Sort.class, Sort[].class);
 
+    /**
+     * Appends the equality constraint.
+     */
     @Override
     @Trivial
-    public StringBuilder appendCondition(StringBuilder q, int qp,
-                                         Method method, int p,
-                                         String o_, String attrName,
-                                         boolean isCollection, Annotation[] annos) {
+    public StringBuilder appendConstraint(StringBuilder q,
+                                          String o_,
+                                          String attrName,
+                                          Object constraint,
+                                          int qp,
+                                          boolean isCollection,
+                                          Annotation[] annos) {
         if (attrName.charAt(attrName.length() - 1) != ')')
             q.append(o_);
         return q.append(attrName).append("=?").append(qp);
-    }
-
-    @Override
-    @Trivial
-    public StringBuilder appendConditionsForIdClass(StringBuilder q, int qp,
-                                                    Method method, int p,
-                                                    String o_, String[] idClassAttrNames,
-                                                    Annotation[] annos) {
-        q.append('(');
-
-        int count = 0;
-        for (String name : idClassAttrNames) {
-            if (count != 0)
-                q.append(" AND ");
-
-            q.append(o_).append(name).append("=?").append(count++ + qp);
-        }
-
-        q.append(')');
-
-        return q;
     }
 
     @Override
@@ -182,6 +168,22 @@ public class Data_1_0 implements DataVersionCompatibility {
 
     @Override
     @Trivial
+    public int inspectMethodParam(int p,
+                                  Class<?> paramType,
+                                  Annotation[] paramAnnos,
+                                  String[] attrNames,
+                                  Object[] constraints, // TODO 1.1: Class<?>[]
+                                  char[] updateOps,
+                                  int qpNext) {
+        // In Data 1.0, all constraints are the equality condition
+        // By.class serves as a marker for this because that is how it behaves
+        // absent any other constraints or annotations.
+        constraints[p] = By.class;
+        return qpNext + 1;
+    }
+
+    @Override
+    @Trivial
     public Set<Class<? extends Annotation>> lifeCycleAnnoTypes(boolean stateful) {
         return stateful ? LIFECYCLE_ANNOS_STATEFUL : LIFECYCLE_ANNOS_STATELESS;
     }
@@ -190,6 +192,12 @@ public class Data_1_0 implements DataVersionCompatibility {
     @Trivial
     public Set<Class<? extends Annotation>> operationAnnoTypes(boolean stateful) {
         return stateful ? OP_ANNOS_STATEFUL : OP_ANNOS_STATELESS;
+    }
+
+    @Override
+    @Trivial
+    public String paramAnnosForUpdate() {
+        return By.class.getName();
     }
 
     @Override

--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 import io.openliberty.data.internal.version.DataVersionCompatibility;
+import io.openliberty.data.internal.version.QueryType;
 import io.openliberty.data.repository.Count;
 import io.openliberty.data.repository.Exists;
 import io.openliberty.data.repository.Is;
@@ -422,6 +423,22 @@ public class Data_1_1 implements DataVersionCompatibility {
         }
 
         return qpNext;
+    }
+
+    @Override
+    @Trivial
+    public boolean isSpecialParamValid(Class<?> paramType,
+                                       QueryType queryType) {
+        return switch (queryType) {
+            case FIND -> true;
+            case FIND_AND_DELETE -> !PageRequest.class.equals(paramType);
+            case COUNT, EXISTS -> Order.class.equals(paramType) ||
+                // TODO 1.1 Restriction.class.equals(paramType) ||
+                                  Sort.class.equals(paramType) ||
+                                  Sort[].class.equals(paramType);
+            case QM_DELETE, QM_UPDATE -> false; // TODO 1.1 Restriction.class.equals(paramType)
+            default -> false;
+        };
     }
 
     @Override

--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -50,8 +50,8 @@ import io.openliberty.data.repository.update.SubtractFrom;
 import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
-import jakarta.data.exceptions.MappingException;
 import jakarta.data.page.PageRequest;
+import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
@@ -156,27 +156,28 @@ public class Data_1_1 implements DataVersionCompatibility {
 
     @Override
     @Trivial
-    public StringBuilder appendCondition(StringBuilder q, int qp,
-                                         Method method, int p,
-                                         String o_, String attrName,
-                                         boolean isCollection, Annotation[] annos) {
+    public StringBuilder appendConstraint(StringBuilder q,
+                                          String o_,
+                                          String attrName,
+                                          Object constraint,
+                                          int qp,
+                                          boolean isCollection,
+                                          Annotation[] annos) {
         StringBuilder attributeExpr = new StringBuilder();
 
-        Is.Op comparison = Is.Op.Equal;
+        Is.Op comparison = (Is.Op) constraint;
         List<Annotation> functionAnnos = new ArrayList<>();
         for (int a = annos.length - 1; a >= 0; a--) {
-            if (annos[a] instanceof Is) {
-                comparison = ((Is) annos[a]).value();
-            } else {
-                String annoPackage = annos[a].annotationType().getPackageName();
-                if (FUNCTION_ANNO_PACKAGE.equals(annoPackage)) {
-                    functionAnnos.add(annos[a]);
-                    String functionType = annos[a] instanceof Extract ? ((Extract) annos[a]).value().name() //
-                                    : annos[a] instanceof Rounded ? ((Rounded) annos[a]).value().name() //
-                                                    : annos[a].annotationType().getSimpleName();
-                    String functionCall = FUNCTION_CALLS.get(functionType);
-                    attributeExpr.append(functionCall);
-                }
+            String annoPackage = annos[a].annotationType().getPackageName();
+            if (FUNCTION_ANNO_PACKAGE.equals(annoPackage)) {
+                functionAnnos.add(annos[a]);
+                String functionType = annos[a] instanceof Extract //
+                                ? ((Extract) annos[a]).value().name() //
+                                : annos[a] instanceof Rounded //
+                                                ? ((Rounded) annos[a]).value().name() //
+                                                : annos[a].annotationType().getSimpleName();
+                String functionCall = FUNCTION_CALLS.get(functionType);
+                attributeExpr.append(functionCall);
             }
         }
 
@@ -206,7 +207,7 @@ public class Data_1_1 implements DataVersionCompatibility {
             if (ignoreCase ||
                 baseOp != Is.Op.Equal) // TODO also have an operation for collection containing?
                 throw new UnsupportedOperationException("The " + comparison.name() +
-                                                        " comparison that is applied to entity attribute " +
+                                                        " constraint that is applied to entity attribute " +
                                                         attrName +
                                                         " is not supported for collection attributes."); // TODO NLS (future)
 
@@ -272,57 +273,6 @@ public class Data_1_1 implements DataVersionCompatibility {
             default:
                 throw new UnsupportedOperationException(comparison.name());
         }
-
-        return q;
-    }
-
-    @Override
-    @Trivial
-    public StringBuilder appendConditionsForIdClass(StringBuilder q, int qp,
-                                                    Method method, int p,
-                                                    String o_, String[] idClassAttrNames,
-                                                    Annotation[] annos) {
-        boolean ignoreCase = false;
-        for (int a = annos.length - 1; a >= 0; a--) {
-            if (annos[a] instanceof Is) {
-                Is.Op comparison = ((Is) annos[a]).value();
-                if (comparison.base() != Is.Op.Equal)
-                    throw new MappingException("The " + annos[a] +
-                                               " annotation cannot be applied to a parameter of the " +
-                                               method.getName() + " method of the " +
-                                               method.getDeclaringClass().getName() +
-                                               " repository because the parameter type is an IdClass."); // TODO NLS
-                ignoreCase = comparison.ignoreCase();
-                if (comparison.isNegative())
-                    q.append(" NOT ");
-            } else {
-                String annoPackage = annos[a].annotationType().getPackageName();
-                if (FUNCTION_ANNO_PACKAGE.equals(annoPackage))
-                    throw new MappingException("The " + annos[a].annotationType().getSimpleName() +
-                                               " annotation cannot be applied to a parameter of the " +
-                                               method.getName() + " method of the " +
-                                               method.getDeclaringClass().getName() +
-                                               " repository because the parameter type is an IdClass."); // TODO NLS
-            }
-        }
-
-        q.append('(');
-
-        int count = 0;
-        for (String name : idClassAttrNames) {
-            if (count != 0)
-                q.append(" AND ");
-
-            if (ignoreCase)
-                q.append("LOWER(").append(o_).append(name).append(')');
-            else
-                q.append(o_).append(name);
-
-            q.append('=');
-            appendParam(q, ignoreCase, count++ + qp);
-        }
-
-        q.append(')');
 
         return q;
     }
@@ -420,6 +370,61 @@ public class Data_1_1 implements DataVersionCompatibility {
     }
 
     @Override
+    public int inspectMethodParam(int p,
+                                  Class<?> paramType,
+                                  Annotation[] paramAnnos,
+                                  String[] attrNames,
+                                  Object[] constraints, // TODO 1.1: Class<?>[]
+                                  char[] updateOps,
+                                  int qpNext) {
+        int qpOriginal = qpNext;
+
+        for (Annotation anno : paramAnnos)
+            if (anno instanceof Is) {
+                constraints[p] = ((Is) anno).value();
+                qpNext++;
+            } else if (anno instanceof Assign) {
+                attrNames[p] = ((Assign) anno).value();
+                updateOps[p] = '=';
+                qpNext++;
+            } else if (anno instanceof Add) {
+                attrNames[p] = ((Add) anno).value();
+                updateOps[p] = '+';
+                qpNext++;
+            } else if (anno instanceof Multiply) {
+                attrNames[p] = ((Multiply) anno).value();
+                updateOps[p] = '*';
+                qpNext++;
+            } else if (anno instanceof Divide) {
+                attrNames[p] = ((Divide) anno).value();
+                updateOps[p] = '/';
+                qpNext++;
+            } else if (anno instanceof SubtractFrom) {
+                attrNames[p] = ((SubtractFrom) anno).value();
+                updateOps[p] = '-';
+                qpNext++;
+            }
+
+        if (qpNext == qpOriginal) { // no annotation indicating a constraint or update
+            if (false) { // TODO 1.1 check if paramType is a Constraint
+                // qpNext increment will vary by Constraint subtype
+                // TODO 1.1: if Constraint.class and generated upfront,
+                // qpNext = PARAM_CONSTRAINT_DEFERRED;
+            } else {
+                constraints[p] = Is.Op.Equal;
+                qpNext++;
+            }
+        } else if (qpNext - qpOriginal > 1) {
+            // TODO possibly allow a redundant Constraint that matches the Is annotation.
+            qpNext = PARAM_ANNOS_CONFLICT;
+        } else if (false) { // TODO 1.1 check if paramType is a Constraint
+            qpNext = PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT;
+        }
+
+        return qpNext;
+    }
+
+    @Override
     @Trivial
     public Set<Class<? extends Annotation>> lifeCycleAnnoTypes(boolean stateful) {
         return stateful ? LIFECYCLE_ANNOS_STATEFUL : LIFECYCLE_ANNOS_STATELESS;
@@ -429,6 +434,18 @@ public class Data_1_1 implements DataVersionCompatibility {
     @Trivial
     public Set<Class<? extends Annotation>> operationAnnoTypes(boolean stateful) {
         return stateful ? OP_ANNOS_STATEFUL : OP_ANNOS_STATELESS;
+    }
+
+    @Override
+    @Trivial
+    public String paramAnnosForUpdate() {
+        // TODO 1.1
+        return By.class.getSimpleName() + ", " +
+               Add.class.getSimpleName() + ", " +
+               Assign.class.getSimpleName() + ", " +
+               Divide.class.getSimpleName() + ", " +
+               Multiply.class.getSimpleName() + ", " +
+               SubtractFrom.class.getSimpleName();
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -178,7 +178,8 @@ CWWKD1013.cde.missing.param.anno.useraction=Update the repository method such \
 CWWKD1014.upd.missing.param.anno=CWWKD1014E: The {0} method of the {1} repository \
  is not a valid lifecycle Update method because the method has {2} parameters. \
  Repository methods that are annotated with a lifecycle annotation must have \
- exactly 1 parameter, which must be the entity or an array or List of the entity. \
+ exactly 1 parameter, which must be the entity, an array of the entity, or a \
+ List of the entity. \
  The {0} method is also not a valid parameter-based update operation because \
  method parameter {3} does not have an annotation ({4}) that indicates the entity \
  attribute name. Alternatively, enable the -parameters compile option and give the \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -124,7 +124,8 @@ CWWKD1009.lifecycle.param.err=CWWKD1009E: The {0} method of the {1} repository \
 CWWKD1009.lifecycle.param.err.explanation=Lifecycle methods must have a single \
  entity parameter.
 CWWKD1009.lifecycle.param.err.useraction=Update the repository method to have a \
- single parameter that is an entity or an array or List of the entity.
+ single parameter that is an entity, an array of the entity, or a List of the \
+ entity.
 
 CWWKD1010.unknown.entity.attr=CWWKD1010E: An entity attribute named {0} is \
  not found on the {1} entity class for the {2} method of the {3} repository \
@@ -187,8 +188,8 @@ CWWKD1014.upd.missing.param.anno.explanation=Parameters of repository update \
  must have a single entity parameter.
 CWWKD1014.upd.missing.param.anno.useraction=Update the repository method such that \
  all parameters correspond to entity attributes. Alternatively, update the \
- repository method to have a single parameter that is an entity or an array or \
- List of the entity.
+ repository method to have a single parameter that is an entity, an array of the \
+ entity, or a List of the entity.
 
 CWWKD1015.null.entity.param=CWWKD1015E: The {0} method of the {1} repository \
  interface cannot accept a null entity.
@@ -1175,7 +1176,7 @@ CWWKD1116.resource.unavailable.useraction=Verify the configuration of resources 
 
 CWWKD1117.anno.constraint.conflict=CWWKD1117E: Parameter {0} of the {1} method \
  of the {2} repository interface cannot be annotated with the annotations: {3}. \
- One or more of the annotations is incompatible with the {4} type of the \
+ One or more of the annotations are incompatible with the {4} type of the \
  repository method parameter.
 CWWKD1117.anno.constraint.conflict.explanation=Constraint and its subtypes \
  cannot be combined with parameter annotations other than the By annotation.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -296,15 +296,7 @@ CWWKD1026.ignore.case.not.text.useraction=Ensure the sort criteria is applied \
  to the correct entity attribute and remove the instruction to ignore case if the \
  entity attribute does not represent text.
 
-CWWKD1027.anno.missing.attr.name=CWWKD1027E: Parameter {0} of the {1} method of \
- the {2} repository interface is annotated with an {3} annotation that does not \
- specify an entity attribute name as its value. The annotation must either specify \
- the entity attribute name as its value, or the -parameters compile option must be \
- enabled and the parameter must have the same name as the entity attribute.
-CWWKD1027.anno.missing.attr.name.explanation=Parameters of repository update \
- methods must correspond to entity attributes.
-CWWKD1027.anno.missing.attr.name.useraction=Update the repository method to \
- indicate the entity attribute to which the parameter pertains.
+# TODO CWWKD1027 removed prior to GA of data-1.0 and can be reused
 
 CWWKD1028.first.exceeds.max=CWWKD1028E: The {0} method of the {1} repository \
  interface requests the first {2} results, which exceeds the maximum allowed \
@@ -1177,3 +1169,20 @@ CWWKD1116.resource.unavailable.explanation=A resource that the repositories \
  require did not become available.
 CWWKD1116.resource.unavailable.useraction=Verify the configuration of resources \
  that the repositories use.
+
+CWWKD1117.anno.constraint.conflict=CWWKD1117E: Parameter {0} of the {1} method \
+ of the {2} repository interface cannot be annotated with the annotations: {3}. \
+ One or more of the annotations is incompatible with the {4} type of the \
+ repository method parameter.
+CWWKD1117.anno.constraint.conflict.explanation=Constraint and its subtypes \
+ cannot be combined with parameter annotations other than the By annotation.
+CWWKD1117.anno.constraint.conflict.useraction=Remove the conflicting annotation \
+ or specify the entity attribute type instead of a Constraint type.
+
+CWWKD1118.param.anno.conflict=CWWKD1118E: Parameter {0} of the {1} method \
+ of the {2} repository interface cannot be annotated with the annotations: {3}. \
+ Two or more of the annotations conflict with each other.
+CWWKD1118.param.anno.conflict.explanation=The combination of parameter \
+ annotations is not valid.
+CWWKD1118.param.anno.conflict.useraction=Remove one or more of the conflicting \
+ annotations from the repository method parameter.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -124,7 +124,7 @@ CWWKD1009.lifecycle.param.err=CWWKD1009E: The {0} method of the {1} repository \
 CWWKD1009.lifecycle.param.err.explanation=Lifecycle methods must have a single \
  entity parameter.
 CWWKD1009.lifecycle.param.err.useraction=Update the repository method to have a \
- single parameter that is an entity or an array of List of the entity.
+ single parameter that is an entity or an array or List of the entity.
 
 CWWKD1010.unknown.entity.attr=CWWKD1010E: An entity attribute named {0} is \
  not found on the {1} entity class for the {2} method of the {3} repository \
@@ -174,18 +174,21 @@ CWWKD1013.cde.missing.param.anno.explanation=Parameters of repository count, \
 CWWKD1013.cde.missing.param.anno.useraction=Update the repository method such \
  that all parameters correspond to entity attributes.
 
-CWWKD1014.upd.missing.param.anno=CWWKD1014E: Parameter {0} of the {1} method of \
- the {2} repository interface does not match an entity attribute. Parameters that \
- do not match an entity attribute must have one of the parameter annotations: {3}. \
- To define a condition for the restriction of query results, the parameter must \
- be annotated with the By annotation and the By annotation value must be \
- assigned to be the entity attribute name. Alternatively, enable the \
- -parameters compile option and give the parameter the same name as the entity \
- attribute.
+CWWKD1014.upd.missing.param.anno=CWWKD1014E: The {0} method of the {1} repository \
+ is not a valid lifecycle Update method because the method has {2} parameters. \
+ Repository methods that are annotated with a lifecycle annotation must have \
+ exactly 1 parameter, which must be the entity or an array or List of the entity. \
+ The {0} method is also not a valid parameter-based update operation because \
+ method parameter {3} does not have an annotation ({4}) that indicates the entity \
+ attribute name. Alternatively, enable the -parameters compile option and give the \
+ parameter the same name as the entity attribute.
 CWWKD1014.upd.missing.param.anno.explanation=Parameters of repository update \
- methods must correspond to entity attributes.
+ methods must correspond to entity attributes. Alternatively, lifecycle methods \
+ must have a single entity parameter.
 CWWKD1014.upd.missing.param.anno.useraction=Update the repository method such that \
- all parameters correspond to entity attributes.
+ all parameters correspond to entity attributes. Alternatively, update the \
+ repository method to have a single parameter that is an entity or an array or \
+ List of the entity.
 
 CWWKD1015.null.entity.param=CWWKD1015E: The {0} method of the {1} repository \
  interface cannot accept a null entity.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -17,6 +17,17 @@ import static io.openliberty.data.internal.persistence.Condition.Not;
 import static io.openliberty.data.internal.persistence.Util.SORT_PARAM_TYPES;
 import static io.openliberty.data.internal.persistence.Util.lifeCycleReturnTypes;
 import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
+import static io.openliberty.data.internal.version.QueryType.COUNT;
+import static io.openliberty.data.internal.version.QueryType.EXISTS;
+import static io.openliberty.data.internal.version.QueryType.FIND;
+import static io.openliberty.data.internal.version.QueryType.FIND_AND_DELETE;
+import static io.openliberty.data.internal.version.QueryType.INSERT;
+import static io.openliberty.data.internal.version.QueryType.LC_DELETE;
+import static io.openliberty.data.internal.version.QueryType.LC_UPDATE;
+import static io.openliberty.data.internal.version.QueryType.LC_UPDATE_RET_ENTITY;
+import static io.openliberty.data.internal.version.QueryType.QM_DELETE;
+import static io.openliberty.data.internal.version.QueryType.QM_UPDATE;
+import static io.openliberty.data.internal.version.QueryType.SAVE;
 import static jakarta.data.repository.By.ID;
 
 import java.io.PrintWriter;
@@ -58,6 +69,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.data.internal.persistence.cdi.RepositoryProducer;
 import io.openliberty.data.internal.version.DataVersionCompatibility;
+import io.openliberty.data.internal.version.QueryType;
 import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
@@ -87,27 +99,6 @@ import jakarta.persistence.TypedQuery;
  */
 public class QueryInfo {
     private static final TraceComponent tc = Tr.register(QueryInfo.class);
-
-    public static enum Type {
-        COUNT(false), // query method count
-        EXISTS(false), // query method exists
-        FIND(false), // query method find/@Find/@Query(SELECT/FROM/WHERE)
-        FIND_AND_DELETE(true), // query method delete/@Delete with entity result
-        INSERT(true), // life cycle @Insert
-        LC_DELETE(true), // life cycle @Delete
-        LC_UPDATE(true), // life cycle @Update
-        LC_UPDATE_RET_ENTITY(true), // life cycle @Update with entity result
-        QM_DELETE(true), // query method delete/@Delete/@Query(DELETE)
-        QM_UPDATE(true), // query method update/@Update/@Query(UPDATE)
-        RESOURCE_ACCESS(false), // resource accessor method
-        SAVE(true); // life cycle @Save
-
-        final boolean requiresTransaction;
-
-        private Type(boolean requiresTransaction) {
-            this.requiresTransaction = requiresTransaction;
-        }
-    }
 
     /**
      * Placeholder that indicates the entity class needs to be determined
@@ -293,7 +284,7 @@ public class QueryInfo {
     /**
      * Categorization of query type.
      */
-    Type type;
+    QueryType type;
 
     /**
      * Indicates whether or not to validate method parameters, if Jakarta Validation is available.
@@ -418,7 +409,7 @@ public class QueryInfo {
     public QueryInfo(RepositoryProducer<?> repositoryProducer,
                      Class<?> repositoryInterface,
                      Method method,
-                     Type type) {
+                     QueryType type) {
         this.method = method;
         this.entityParamType = null;
         this.multiType = null;
@@ -1553,21 +1544,22 @@ public class QueryInfo {
     }
 
     /**
-     * Constructs the MappingException for the error where a repository method
-     * parameter lacks an annotation that identifies the corresponding entity
-     * attribute name.
+     * Constructs the MappingException or UnsupportedOoperationException for
+     * the error where a repository method parameter lacks an annotation that
+     * identifies the corresponding entity attribute name.
      *
-     * @return UnsupportedOperationException.
+     * @param p position (1-based) of the repository method parameter.
+     * @return MappingException or UnsupportedOperationException.
      */
     @Trivial
-    private MappingException excMissingParamAnno(int p) {
+    private RuntimeException excMissingParamAnno(int p) {
         DataVersionCompatibility compat = producer.provider().compat;
 
         switch (type) {
             case FIND:
             case FIND_AND_DELETE:
                 validateParameterPositions();
-                String specParams = type == Type.FIND //
+                String specParams = type == FIND //
                                 ? compat.specialParamsForFind() //
                                 : compat.specialParamsForFindAndDelete();
                 throw exc(MappingException.class,
@@ -1585,11 +1577,12 @@ public class QueryInfo {
                           method.getName(),
                           repositoryInterface.getName());
             case QM_UPDATE:
-                throw exc(MappingException.class,
+                throw exc(UnsupportedOperationException.class,
                           "CWWKD1014.upd.missing.param.anno",
-                          p,
                           method.getName(),
                           repositoryInterface.getName(),
+                          method.getParameterCount(),
+                          p,
                           compat.paramAnnosForUpdate());
             default: // should be unreachable
                 throw new IllegalStateException(type.name());
@@ -1937,7 +1930,7 @@ public class QueryInfo {
             jakarta.persistence.Query query = em.createQuery(jpql);
             setParameters(query, args);
 
-            if (type == Type.FIND_AND_DELETE)
+            if (type == FIND_AND_DELETE)
                 query.setLockMode(LockModeType.PESSIMISTIC_WRITE);
 
             int startAt = limit != null //
@@ -1987,7 +1980,7 @@ public class QueryInfo {
                     }
                 }
 
-                if (type == Type.FIND_AND_DELETE)
+                if (type == FIND_AND_DELETE)
                     delete(results, em);
 
                 if (results.isEmpty() && isOptional) {
@@ -2015,7 +2008,7 @@ public class QueryInfo {
                             break;
                         }
                     if (firstNonNullResult == null
-                        || type == Type.FIND_AND_DELETE
+                        || type == FIND_AND_DELETE
                         || returnArrayType != Object.class &&
                            returnArrayType.isInstance(firstNonNullResult)
                         || returnArrayType.isPrimitive() &&
@@ -2674,10 +2667,10 @@ public class QueryInfo {
                         .append("DELETE FROM ").append(entityInfo.name).append(' ').append(o);
 
         if (method.getParameterCount() == 0) {
-            type = Type.QM_DELETE;
+            type = QM_DELETE;
             hasWhere = false;
         } else {
-            setType(Delete.class, Type.LC_DELETE);
+            setType(Delete.class, LC_DELETE);
             hasWhere = true;
 
             q.append(" WHERE (");
@@ -2760,7 +2753,8 @@ public class QueryInfo {
      * Allowed special parameter types vary by method annotation.
      *
      * @param q          JPQL query to which to append a WHERE clause.
-     *                       Or null to create a new JPQL query.
+     *                       Or null in the case of Find/Update methods
+     *                       to create a new JPQL query.
      * @param methodAnno Count, Delete, Exists, Find, or Update. Never null.
      * @param countPages indicates whether or not to count pages.
      *                       Only applies for find queries.
@@ -2780,8 +2774,6 @@ public class QueryInfo {
         String o_ = entityVar_;
         DataVersionCompatibility compat = entityInfo.builder.provider.compat;
 
-        boolean isFindOrDelete = methodAnno instanceof Find ||
-                                 methodAnno instanceof Delete;
         Boolean isNamePresent = null; // unknown
         Parameter[] params = null;
 
@@ -2791,12 +2783,12 @@ public class QueryInfo {
         while (numAttributeParams > 0 &&
                specParamTypes.contains(paramTypes[numAttributeParams - 1])) {
             numAttributeParams--;
-            if (!isFindOrDelete) // special parameter is not allowed
+            if (!compat.isSpecialParamValid(paramTypes[numAttributeParams], type))
                 throw exc(UnsupportedOperationException.class,
                           "CWWKD1020.invalid.param.type",
                           method.getName(),
                           repositoryInterface.getName(),
-                          paramTypes[numAttributeParams - 1].getSimpleName(),
+                          paramTypes[numAttributeParams].getSimpleName(),
                           methodAnno.annotationType().getSimpleName());
         }
 
@@ -2844,13 +2836,14 @@ public class QueryInfo {
             // Determine the entity attribute name, first from @By or an assignment
             // annotation.
             String name = attrNames[p];
-            if (name == null || name.length() == 0) {
+            if (name == null) {
                 for (Annotation anno : annosForAllParams[p])
                     if (anno instanceof By)
                         name = ((By) anno).value();
             }
             // Otherwise determine the entity attribute name from the parameter name,
-            if (name == null || name.length() == 0) {
+            if (name == null ||
+                name.length() == 0 && attrNames[p] != null) { // TODO 1.2 allow the empty string on assign annos?
                 if (isNamePresent == null) {
                     params = method.getParameters();
                     isNamePresent = params[p].isNamePresent();
@@ -2863,86 +2856,80 @@ public class QueryInfo {
             attrNames[p] = getAttributeName(name, true);
         }
 
-        if (q == null)
-            // Write new JPQL, starting with UPDATE or SELECT
-            if (methodAnno instanceof Update) {
-                type = Type.QM_UPDATE;
-                q = new StringBuilder(250).append("UPDATE ") //
-                                .append(entityInfo.name).append(' ').append(o) //
-                                .append(" SET");
+        // Write new JPQL, starting with SELECT or UPDATE
+        if (q == null && type == FIND) { // SELECT
+            q = generateSelectClause() //
+                            .append(" FROM ") //
+                            .append(entityInfo.name).append(' ').append(o);
+        } else if (q == null) { // UPDATE
+            q = new StringBuilder(250).append("UPDATE ") //
+                            .append(entityInfo.name).append(' ').append(o) //
+                            .append(" SET");
 
-                boolean first = true;
-                // p is the repository method parameter position (0-based)
-                for (int p = 0; p < numAttributeParams; p++) {
-                    char op = updateOps[p];
-                    if (op != Character.MIN_VALUE) {
-                        if (op != '=' &&
-                            entityInfo.idClassAttributeAccessors != null &&
-                            paramTypes[p].equals(entityInfo.idType)) {
-                            // IdClass values cannot support operations other than
-                            // assignment.
-                            // Unreachable in version 1.0 and uncertain what
-                            // will be added to the spec. Deferring NLS message
-                            // until then.
-                            throw new MappingException("One or more of the " +
-                                                       Arrays.toString(annosForAllParams[p]) +
-                                                       " annotations specifes an operation" +
-                                                       " that cannot be used on parameter " +
-                                                       (p + 1) + " of the " + method.getName() +
-                                                       " method of the " +
-                                                       repositoryInterface.getName() +
-                                                       " repository when the Id is an IdClass.");
-                        } else {
-                            String name = attrNames[p];
+            boolean first = true;
+            // p is the repository method parameter position (0-based)
+            for (int p = 0; p < numAttributeParams; p++) {
+                char op = updateOps[p];
+                if (op != Character.MIN_VALUE) {
+                    if (op != '=' &&
+                        entityInfo.idClassAttributeAccessors != null &&
+                        paramTypes[p].equals(entityInfo.idType)) {
+                        // TODO 1.1
+                        // IdClass values cannot support operations other than
+                        // assignment.
+                        // Unreachable in version 1.0 and uncertain what
+                        // will be added to the spec. Deferring NLS message
+                        // until then.
+                        throw new MappingException("One or more of the " +
+                                                   Arrays.toString(annosForAllParams[p]) +
+                                                   " annotations specifes an operation" +
+                                                   " that cannot be used on parameter " +
+                                                   (p + 1) + " of the " + method.getName() +
+                                                   " method of the " +
+                                                   repositoryInterface.getName() +
+                                                   " repository when the Id is an IdClass.");
+                    } else {
+                        String name = attrNames[p];
 
-                            q.append(first ? " " : ", ");
-                            appendAttributeName(name, q);
-                            q.append("=");
-                            first = false;
+                        q.append(first ? " " : ", ");
+                        appendAttributeName(name, q);
+                        q.append("=");
+                        first = false;
 
-                            boolean withFunction = false;
-                            switch (op) {
-                                case '=':
-                                    break;
-                                case '+':
-                                    Class<?> attrType = entityInfo.attributeTypes.get(name);
-                                    withFunction = CharSequence.class.isAssignableFrom(attrType);
-                                    if (withFunction)
-                                        q.append("CONCAT(").append(o_).append(name).append(',');
-                                    else
-                                        q.append(o_).append(name).append('+');
-                                    break;
-                                default:
-                                    q.append(o_).append(name).append(op);
-                            }
-
-                            jpqlParamCount++;
-                            q.append('?').append(qpStarts[p]);
-
-                            if (withFunction)
-                                q.append(')');
+                        boolean withFunction = false;
+                        switch (op) {
+                            case '=':
+                                break;
+                            case '+':
+                                Class<?> attrType = entityInfo.attributeTypes.get(name);
+                                withFunction = CharSequence.class.isAssignableFrom(attrType);
+                                if (withFunction)
+                                    q.append("CONCAT(").append(o_).append(name).append(',');
+                                else
+                                    q.append(o_).append(name).append('+');
+                                break;
+                            default:
+                                q.append(o_).append(name).append(op);
                         }
+
+                        jpqlParamCount++;
+                        q.append('?').append(qpStarts[p]);
+
+                        if (withFunction)
+                            q.append(')');
                     }
                 }
-
-                if (first)
-                    // No parameters are annotated to indicate update.
-                    // Raise an error that considers this an invalid life cycle
-                    // operation attempt. In the future, we could raise an error
-                    // that also mentions the possibility of invalid parameter-based
-                    // update operation.
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1009.lifecycle.param.err",
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              method.getParameterCount(),
-                              Update.class.getSimpleName());
-            } else {
-                type = Type.FIND;
-                q = generateSelectClause() //
-                                .append(" FROM ") //
-                                .append(entityInfo.name).append(' ').append(o);
             }
+
+            if (first)
+                // No parameters are annotated to indicate update.
+                throw exc(UnsupportedOperationException.class,
+                          "CWWKD1009.lifecycle.param.err",
+                          method.getName(),
+                          repositoryInterface.getName(),
+                          method.getParameterCount(),
+                          Update.class.getSimpleName());
+        }
 
         int startIndexForWhereClause = q.length();
 
@@ -2978,11 +2965,10 @@ public class QueryInfo {
         if (hasWhere)
             q.append(')');
 
-        if (countPages && type == Type.FIND)
+        if (countPages && type == FIND)
             generateCount(numAttributeParams == 0 ? null : q.substring(startIndexForWhereClause));
 
-        if (type == Type.FIND ||
-            type == Type.FIND_AND_DELETE)
+        if (type == FIND || type == FIND_AND_DELETE)
             initDynamicSortPositions(paramTypes);
 
         if (trace && tc.isEntryEnabled())
@@ -3004,7 +2990,7 @@ public class QueryInfo {
         String[] cols, selections = entityInfo.builder.provider.compat.getSelections(method);
         if (selections.length == 0) {
             cols = null;
-        } else if (type == Type.FIND_AND_DELETE) {
+        } else if (type == FIND_AND_DELETE) {
             // Unreachable in version 1.0 and uncertain what will be added to
             // the spec regarding selections. Deferring NLS message until then.
             throw new UnsupportedOperationException //
@@ -3028,7 +3014,7 @@ public class QueryInfo {
         if (singleType.isPrimitive())
             singleType = Util.wrapperClassIfPrimitive(singleType);
 
-        if (type == Type.FIND_AND_DELETE &&
+        if (type == FIND_AND_DELETE &&
             !(singleType.isAssignableFrom(Util.wrapperClassIfPrimitive(entityInfo.idType)) ||
               singleType.isAssignableFrom(entityInfo.getType()))) {
             throw exc(MappingException.class,
@@ -3302,7 +3288,7 @@ public class QueryInfo {
 
         if (entityInfo.attributeNamesForEntityUpdate != null &&
             Util.UPDATE_COUNT_TYPES.contains(singleType)) {
-            setType(Update.class, Type.LC_UPDATE);
+            setType(Update.class, LC_UPDATE);
 
             q = new StringBuilder(100) //
                             .append("UPDATE ").append(entityInfo.name) //
@@ -3322,7 +3308,7 @@ public class QueryInfo {
             // Update that returns an entity. And also used when an entity
             // has relation attributes that require using em.merge.
             // Perform a find operation first so that em.merge can be used.
-            setType(Update.class, Type.LC_UPDATE_RET_ENTITY);
+            setType(Update.class, LC_UPDATE_RET_ENTITY);
 
             q = new StringBuilder(100) //
                             .append("SELECT ").append(o) //
@@ -3728,9 +3714,9 @@ public class QueryInfo {
                                   repository.primaryEntityInfoFuture,
                                   compat);
             } else if (save != null) { // @Save annotation
-                setType(Save.class, Type.SAVE);
+                setType(Save.class, SAVE);
             } else if (insert != null) { // @Insert annotation
-                setType(Insert.class, Type.INSERT);
+                setType(Insert.class, INSERT);
             } else if (entityParamType != null) {
                 if (update != null) { // @Update annotation
                     q = generateUpdateEntity();
@@ -3753,7 +3739,7 @@ public class QueryInfo {
                     q = initQueryByMethodName(countPages);
                 }
 
-                if (type == Type.FIND_AND_DELETE
+                if (type == FIND_AND_DELETE
                     && multiType != null
                     && Stream.class.isAssignableFrom(multiType)) {
                     throw exc(UnsupportedOperationException.class,
@@ -3769,7 +3755,7 @@ public class QueryInfo {
             // The @OrderBy annotation from Jakarta Data provides sort criteria statically
             if (orderBy.length > 0) {
                 // disallow on incompatible operations
-                if (type != Type.FIND && type != Type.FIND_AND_DELETE)
+                if (type != FIND && type != FIND_AND_DELETE)
                     throw exc(UnsupportedOperationException.class,
                               "CWWKD1096.orderby.incompat",
                               method.getName(),
@@ -3803,7 +3789,7 @@ public class QueryInfo {
 
             // Default to ascending by ID when the repository method that uses
             // pagination does not provide a way to indicate sort criteria.
-            if (type == Type.FIND &&
+            if (type == FIND &&
                 query == null && // do not change the user's Query value
                 sortPositions.length == 0 &&
                 (sorts == null || sorts.isEmpty()) &&
@@ -3905,7 +3891,7 @@ public class QueryInfo {
             if (startAt + 12 < length
                 && ql.regionMatches(true, startAt + 1, "ELETE", 0, 5)
                 && Character.isWhitespace(ql.charAt(startAt + 6))) {
-                type = Type.QM_DELETE;
+                type = QM_DELETE;
                 jpql = ql;
                 startAt += 7; // start of FROM
                 for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
@@ -3971,7 +3957,7 @@ public class QueryInfo {
             if (startAt + 13 < length
                 && ql.regionMatches(true, startAt + 1, "PDATE", 0, 5)
                 && Character.isWhitespace(ql.charAt(startAt + 6))) {
-                type = Type.QM_UPDATE;
+                type = QM_UPDATE;
                 jpql = ql;
                 startAt += 7; // start of EntityName
                 for (; startAt < length && Character.isWhitespace(ql.charAt(startAt)); startAt++);
@@ -4145,7 +4131,7 @@ public class QueryInfo {
             else if (order0 >= 0 && orderLen == 0)
                 orderLen = length - order0;
 
-            type = Type.FIND;
+            type = FIND;
             entityVar = "this";
             entityVar_ = "";
             hasWhere = whereLen > 0;
@@ -4441,7 +4427,7 @@ public class QueryInfo {
             if (orderBy >= 0)
                 parseOrderBy(orderBy, q);
 
-            type = Type.FIND;
+            type = FIND;
         } else if (methodName.startsWith("delete") || methodName.startsWith("remove")) {
             int orderBy = -1;
             boolean isFindAndDelete = isFindAndDelete();
@@ -4452,11 +4438,11 @@ public class QueryInfo {
                 } else if (by > 0) {
                     orderBy = methodName.indexOf("OrderBy", by + 2);
                 }
-                type = Type.FIND_AND_DELETE;
+                type = FIND_AND_DELETE;
                 q = generateSelectClause().append(" FROM ").append(entityInfo.name).append(' ').append(o);
                 jpqlDelete = generateDeleteById();
             } else { // DELETE
-                type = Type.QM_DELETE;
+                type = QM_DELETE;
                 q = new StringBuilder(150).append("DELETE FROM ").append(entityInfo.name).append(' ').append(o);
             }
 
@@ -4467,23 +4453,23 @@ public class QueryInfo {
             if (orderBy > 0)
                 parseOrderBy(orderBy, q);
 
-            type = type == null ? Type.QM_DELETE : type;
+            type = type == null ? QM_DELETE : type;
         } else if (methodName.startsWith("update")) {
             int c = by < 0 ? 6 : (by + 2);
             q = generateUpdateClause(methodName, c);
-            type = Type.QM_UPDATE;
+            type = QM_UPDATE;
         } else if (methodName.startsWith("count")) {
             q = new StringBuilder(150).append("SELECT COUNT(").append(o).append(") FROM ").append(entityInfo.name).append(' ').append(o);
             if (by > 0 && methodName.length() > by + 2)
                 generateWhereClause(methodName, by + 2, methodName.length(), q);
-            type = Type.COUNT;
+            type = COUNT;
         } else if (methodName.startsWith("exists")) {
             q = new StringBuilder(200) //
                             .append("SELECT ID(").append(o).append(") FROM ") //
                             .append(entityInfo.name).append(' ').append(o);
             if (by > 0 && methodName.length() > by + 2)
                 generateWhereClause(methodName, by + 2, methodName.length(), q);
-            type = Type.EXISTS;
+            type = EXISTS;
             validateReturnForExists();
         } else {
             throw excUnsupportedMethod();
@@ -4516,26 +4502,30 @@ public class QueryInfo {
         String o = entityVar;
         StringBuilder q = null;
 
-        if (methodTypeAnno instanceof Find || methodTypeAnno instanceof Update) {
+        if (methodTypeAnno instanceof Find) {
+            type = FIND;
+            q = generateParamBasedQuery(null, methodTypeAnno, countPages);
+        } else if (methodTypeAnno instanceof Update) {
+            type = QM_UPDATE;
             q = generateParamBasedQuery(null, methodTypeAnno, countPages);
         } else if (methodTypeAnno instanceof Delete) {
             if (isFindAndDelete()) {
-                type = Type.FIND_AND_DELETE;
+                type = FIND_AND_DELETE;
                 q = generateSelectClause().append(" FROM ").append(entityInfo.name).append(' ').append(o);
                 jpqlDelete = generateDeleteById();
             } else { // DELETE
-                type = Type.QM_DELETE;
+                type = QM_DELETE;
                 q = new StringBuilder(150).append("DELETE FROM ").append(entityInfo.name).append(' ').append(o);
             }
             if (method.getParameterCount() > 0)
                 generateParamBasedQuery(q, methodTypeAnno, countPages);
         } else if ("Count".equals(methodTypeAnno.annotationType().getSimpleName())) {
-            type = Type.COUNT;
+            type = COUNT;
             q = new StringBuilder(150).append("SELECT COUNT(").append(o).append(") FROM ").append(entityInfo.name).append(' ').append(o);
             if (method.getParameterCount() > 0)
                 generateParamBasedQuery(q, methodTypeAnno, countPages);
         } else if ("Exists".equals(methodTypeAnno.annotationType().getSimpleName())) {
-            type = Type.EXISTS;
+            type = EXISTS;
             validateReturnForExists();
             q = new StringBuilder(200) //
                             .append("SELECT ID(").append(o).append(") FROM ") //
@@ -5474,7 +5464,8 @@ public class QueryInfo {
      * @param annoClass     Insert, Update, Save, or Delete annotation class.
      * @param operationType corresponding operation type.
      */
-    private void setType(Class<? extends Annotation> annoClass, Type operationType) {
+    private void setType(Class<? extends Annotation> annoClass,
+                         QueryType operationType) {
         type = operationType;
         if (entityParamType == null) {
             int paramCount = method.getParameterCount();
@@ -5682,7 +5673,7 @@ public class QueryInfo {
                       method.getGenericReturnType().getTypeName(),
                       method.getName(),
                       repositoryInterface.getName(),
-                      type == Type.QM_DELETE ? "Delete" : "Update");
+                      type == QM_DELETE ? "Delete" : "Update");
         return result;
     }
 
@@ -5883,9 +5874,9 @@ public class QueryInfo {
         int methodParamCount = method.getParameterCount();
         if (jpql != null &&
             methodParamCount < jpqlParamCount &&
-            type != Type.LC_DELETE &&
-            type != Type.LC_UPDATE &&
-            type != Type.LC_UPDATE_RET_ENTITY)
+            type != LC_DELETE &&
+            type != LC_UPDATE &&
+            type != LC_UPDATE_RET_ENTITY)
             throw exc(UnsupportedOperationException.class,
                       "CWWKD1021.insufficient.params",
                       method.getName(),
@@ -5896,10 +5887,10 @@ public class QueryInfo {
 
         if (jpql != null &&
             jpqlParamCount < methodParamCount &&
-            type != Type.FIND &&
-            type != Type.FIND_AND_DELETE) {
+            type != FIND &&
+            type != FIND_AND_DELETE) {
 
-            if (type == Type.QM_DELETE) {
+            if (type == QM_DELETE) {
                 Class<?>[] paramTypes = method.getParameterTypes();
                 for (int i = jpqlParamCount; i < methodParamCount; i++)
                     if (Util.SORT_PARAM_TYPES.contains(paramTypes[i]) ||
@@ -5920,7 +5911,7 @@ public class QueryInfo {
                       jpql);
         }
 
-        if (type == Type.FIND &&
+        if (type == FIND &&
             CursoredPage.class.equals(multiType)) {
 
             if (!singleType.equals(entityInfo.getType()))

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -49,6 +49,7 @@ import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.QueryInfo;
 import io.openliberty.data.internal.persistence.Util;
+import io.openliberty.data.internal.version.QueryType;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.EmptyResultException;
 import jakarta.data.exceptions.EntityExistsException;
@@ -219,7 +220,7 @@ public class DataExtension implements Extension {
                                 producer, //
                                 repositoryInterface, //
                                 method, //
-                                QueryInfo.Type.RESOURCE_ACCESS);
+                                QueryType.RESOURCE_ACCESS);
 
                 List<QueryInfo> queries = queriesPerEntity.get(Void.class);
                 if (queries == null)

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -173,6 +173,17 @@ public interface DataVersionCompatibility {
                            int qpNext);
 
     /**
+     * Determines if the special parameter type is valid for the type of
+     * repository method.
+     *
+     * @param paramType type of special parameter.
+     * @param queryType type of repository method.
+     * @return true if valid. False if not valid.
+     */
+    boolean isSpecialParamValid(Class<?> paramType,
+                                QueryType queryType);
+
+    /**
      * Returns the repository method annotations that represent life cycle
      * operations (such as Delete and Insert) for either a stateful or
      * stateless repository, depending on the parameter.

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -29,41 +29,43 @@ public interface DataVersionCompatibility {
     final String[] NO_SELECTIONS = new String[0];
 
     /**
-     * Append a condition such as o.myAttribute < ?1 to the JPQL query.
+     * Error condition returned by inspectMethodParam indicating that an annotation
+     * of the method parameter conflicts with the constraint type of the method
+     * parameter.
+     */
+    final int PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT = -1;
+
+    /**
+     * Error condition returned by inspectMethodParam indicating that two or more
+     * annotations on the method parameter conflict with each other.
+     */
+    final int PARAM_ANNOS_CONFLICT = -2;
+
+    /**
+     * Return code for inspectMethodParam that indicates that the Constraint subtype
+     * is not determined until method invocation.
+     */
+    final int PARAM_CONSTRAINT_DEFERRED = -3;
+
+    /**
+     * Append a constraint such as o.myAttribute < ?1 to the JPQL query.
      *
      * @param q            JPQL query to which to append.
-     * @param qp           query parameter position (1-based).
-     * @param method       the repository method.
-     * @param p            method parameter position (0-based).
      * @param o_           entity identifier variable.
      * @param attrName     entity attribute name.
+     * @param constraint   type of constraint to apply to the entity attribute.
+     * @param qp           query parameter position (1-based).
      * @param isCollection whether the entity attribute is a collection.
      * @param annos        method parameter annotations.
      * @return the updated JPQL query.
      */
-    StringBuilder appendCondition(StringBuilder q, int qp,
-                                  Method method, int p,
-                                  String o_, String attrName,
-                                  boolean isCollection, Annotation[] annos);
-
-    /**
-     * Append conditions for an IdClass attribute such as
-     * (o.idClassAttr1 = ?1 AND o.idClassAttr2 = ?2)
-     * to the JPQL query.
-     *
-     * @param q                JPQL query to which to append.
-     * @param qp               query parameter position (1-based).
-     * @param method           the repository method.
-     * @param p                method parameter position (0-based).
-     * @param o_               entity identifier variable.
-     * @param idClassAttrNames entity attribute names for the IdClass.
-     * @param annos            method parameter annotations.
-     * @return the updated JPQL query.
-     */
-    StringBuilder appendConditionsForIdClass(StringBuilder q, int qp,
-                                             Method method, int p,
-                                             String o_, String[] idClassAttrNames,
-                                             Annotation[] annos);
+    StringBuilder appendConstraint(StringBuilder q,
+                                   String o_,
+                                   String attrName,
+                                   Object constraint, // TODO 1.1 Class<?>
+                                   int qp,
+                                   boolean isCollection,
+                                   Annotation[] annos);
 
     /**
      * Indicates whether the enabled version of Jakarta Data is at the requested
@@ -132,6 +134,45 @@ public interface DataVersionCompatibility {
     boolean hasOrAnnotation(Annotation[] annos);
 
     /**
+     * Inspects the type and annotations of a method parameter to a parameter-based
+     * Find/Delete/Update method to determine its meaning. Based on the meaning,
+     * updates one or more of (attrNames, constraints, updateOps) at position p.
+     *
+     * @param p           repository method parameter index (0-based).
+     * @param paramType   class of the repository method parameter at index p.
+     *                        When generating the query upfront, this comes from
+     *                        the repository method signature. When generating the
+     *                        query at invocation time and a Constraint subtype is
+     *                        supplied, this is the class of the supplied instance.
+     *                        The latter should be done in response to receiving a
+     *                        PARAM_CONSTRAINT_DEFERRED return code during the
+     *                        attempt at upfront query generation.
+     * @param paramAnnos  annotations on the repository method parameter at index p.
+     * @param attrNames   the implementer can update this at position p to supply
+     *                        the entity attribute name from the value of an
+     *                        assignment annotation.
+     * @param constraints the implementer can update this at position p to supply
+     *                        the constraint type indicated by the Is annotation or
+     *                        a constraint type method parameter.
+     * @param updateOps   the implementer can update this at position p to supply
+     *                        the update operation indicated by an assignment
+     *                        annotation.
+     * @param qpNext      the next JQPL query parameter index to use (1-based)
+     *                        for the current repository method parameter.
+     * @return the next JPQL query parameter index to use (1-based) for the
+     *         subsequent repository method parameter. Otherwise returns an
+     *         error code: PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT or
+     *         PARAM_ANNOS_CONFLICT or PARAM_CONSTRAINT_DEFERRED.
+     */
+    int inspectMethodParam(int p,
+                           Class<?> paramType,
+                           Annotation[] paramAnnos,
+                           String[] attrNames,
+                           Object[] constraints, // TODO 1.1: Class<?>[]
+                           char[] updateOps,
+                           int qpNext);
+
+    /**
      * Returns the repository method annotations that represent life cycle
      * operations (such as Delete and Insert) for either a stateful or
      * stateless repository, depending on the parameter.
@@ -150,6 +191,14 @@ public interface DataVersionCompatibility {
      * @return the annotation classes.
      */
     Set<Class<? extends Annotation>> operationAnnoTypes(boolean stateful);
+
+    /**
+     * Returns the names of annotations that are valid on the parameters of a
+     * parameter-based update method.
+     *
+     * @return the annotation names.
+     */
+    String paramAnnosForUpdate();
 
     /**
      * List of valid return types for resource accessor methods.

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/QueryType.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/QueryType.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.data.internal.version;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+/**
+ * Type of repository method query.
+ */
+@Trivial
+public enum QueryType {
+    // query method count
+    COUNT(!Require.TX, !Require.RETURN_HIDDEN),
+
+    // query method exists
+    EXISTS(!Require.TX, !Require.RETURN_HIDDEN),
+
+    // query method find/@Find/@Query(SELECT/FROM/WHERE)
+    FIND(!Require.TX, Require.RETURN_HIDDEN),
+
+    // query method delete/@Delete with entity result
+    FIND_AND_DELETE(Require.TX, Require.RETURN_HIDDEN),
+
+    // life cycle @Insert
+    INSERT(Require.TX, Require.RETURN_HIDDEN),
+
+    // life cycle @Delete
+    LC_DELETE(Require.TX, !Require.RETURN_HIDDEN),
+
+    // life cycle @Update
+    LC_UPDATE(Require.TX, !Require.RETURN_HIDDEN),
+
+    // life cycle @Update with entity result
+    LC_UPDATE_RET_ENTITY(Require.TX, Require.RETURN_HIDDEN),
+
+    // query method delete/@Delete/@Query(DELETE)
+    QM_DELETE(Require.TX, !Require.RETURN_HIDDEN),
+
+    // query method update/@Update/@Query(UPDATE)
+    QM_UPDATE(Require.TX, !Require.RETURN_HIDDEN),
+
+    // resource accessor method
+    RESOURCE_ACCESS(!Require.TX, !Require.RETURN_HIDDEN),
+
+    // life cycle @Save
+    SAVE(Require.TX, Require.RETURN_HIDDEN);
+
+    /**
+     * Indicates if a return value from this type of method must be hidden from
+     * trace and logs.
+     */
+    public final boolean hideReturnValue;
+
+    /**
+     * Indicate if the operation must be run within a transaction.
+     */
+    public final boolean requiresTransaction;
+
+    /**
+     * Internal constructor for enumeration values.
+     *
+     * @param requiresTransaction require a transaction for the operation.
+     * @param hideReturnValue     suppress logging/tracing of the method's return
+     *                                value by default
+     */
+    private QueryType(boolean requiresTransaction,
+                      boolean hideReturnValue) {
+        this.hideReturnValue = hideReturnValue;
+        this.requiresTransaction = requiresTransaction;
+    }
+
+    /**
+     * Constants used internally by the enumeration.
+     * The constants cannot be declared directly on the enumeration because the
+     * enumerated values need access to them and cannot access fields that are
+     * declared later in the file.
+     */
+    private static final class Require {
+        static final boolean RETURN_HIDDEN = true;
+        static final boolean TX = true;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -56,7 +56,6 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1009E.*addNothing", // Insert method without parameters
                                    "CWWKD1009E.*addSome", // Insert method with multiple parameters
                                    "CWWKD1009E.*changeNothing", // Update method without parameters
-                                   "CWWKD1009E.*changeBoth", // Update method with multiple entity parameters
                                    "CWWKD1009E.*storeNothing", // Save method without parameters
                                    "CWWKD1009E.*storeInDatabase", // Save method with multiple parameters
                                    "CWWKD1010E.*nameAndZipCode", // Record return type with invalid attribute name
@@ -64,6 +63,7 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1010E.*sortedByEndOfAddress", // OrderBy with invalid function
                                    "CWWKD1010E.*sortedByZipCode", // OrderBy with invalid attribute name
                                    "CWWKD1011E.*findByIgnoreCaseContains", // missing entity attribute name
+                                   "CWWKD1014E.*changeBoth", // Update method with multiple entity parameters
                                    "CWWKD1015E.*addPollingLocation", // insert null entity
                                    "CWWKD1015E.*addOrUpdatePollingLocation", // save null entity
                                    "CWWKD1017E.*livesAt", // multiple Limit parameters
@@ -72,7 +72,10 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1018E.*occupying", // intermixed Limit and PageRequest
                                    "CWWKD1019E.*livingAt", // mix of named/positional parameters
                                    "CWWKD1019E.*residingAt", // unused parameters
-                                   "CWWKD1022E.*discardPage", // Delete operation with a PageRequest
+                                   "CWWKD1020E.*discardLimited", // Limit parameter on Delete method
+                                   "CWWKD1020E.*discardOrdered", // Order parameter on Delete method
+                                   "CWWKD1020E.*discardPage", // Delete operation with a PageRequest
+                                   "CWWKD1020E.*discardSorted", // Sort parameter on Delete method
                                    "CWWKD1024E.*findByAddressContainsOrderByAsc", // missing entity attribute name
                                    "CWWKD1024E.*inPrecinct", // @By with empty string value
                                    "CWWKD1024E.*inTownship", // @OrderBy with empty string value
@@ -106,9 +109,6 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1093E.*selectByBirthday", // VERSION(THIS) used when there is no version
                                    "CWWKD1094E.*register", // incompatible return type
                                    "CWWKD1096E.*discardInOrder", // OrderBy annotation without return type
-                                   "CWWKD1097E.*discardLimited", // Limit parameter on Delete method
-                                   "CWWKD1097E.*discardOrdered", // Order parameter on Delete method
-                                   "CWWKD1097E.*discardSorted", // Sort parameter on Delete method
                                    "CWWKD1098E.*findFirst5ByAddress", // Order ahead of query params
                                    "CWWKD1098E.*occupantsOf", // PageRequest/Order ahead of query params
                                    "CWWKD1098E.*withNameLongerThan", // Limit ahead of query params

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -569,7 +569,7 @@ public class DataErrPathsTestServlet extends FATServlet {
                  + " a PageRequest.");
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null ||
-                !x.getMessage().startsWith("CWWKD1022E:") ||
+                !x.getMessage().startsWith("CWWKD1020E:") ||
                 !x.getMessage().contains("discardPage"))
                 throw x;
         }
@@ -588,7 +588,7 @@ public class DataErrPathsTestServlet extends FATServlet {
                  " deletes entities but does not return them");
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null ||
-                !x.getMessage().startsWith("CWWKD1097E:") ||
+                !x.getMessage().startsWith("CWWKD1020E:") ||
                 !x.getMessage().contains("discardLimited"))
                 throw x;
         }
@@ -636,7 +636,7 @@ public class DataErrPathsTestServlet extends FATServlet {
                  " deletes entities but does not return them");
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null ||
-                !x.getMessage().startsWith("CWWKD1097E:") ||
+                !x.getMessage().startsWith("CWWKD1020E:") ||
                 !x.getMessage().contains("discardOrdered"))
                 throw x;
         }
@@ -655,7 +655,7 @@ public class DataErrPathsTestServlet extends FATServlet {
                  " deletes entities and returns an update count: " + count);
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null ||
-                !x.getMessage().startsWith("CWWKD1097E:") ||
+                !x.getMessage().startsWith("CWWKD1020E:") ||
                 !x.getMessage().contains("discardSorted"))
                 throw x;
         }
@@ -1371,7 +1371,7 @@ public class DataErrPathsTestServlet extends FATServlet {
                  " multiple parameters. Result: " + list);
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null ||
-                !x.getMessage().startsWith("CWWKD1009E") ||
+                !x.getMessage().startsWith("CWWKD1014E") ||
                 !x.getMessage().contains("changeBoth"))
                 throw x;
         }

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Shipments.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Shipments.java
@@ -80,6 +80,13 @@ public interface Shipments {
     @Delete
     int statusBasedRemoval(@By("status") String s);
 
+    // The assignment is intentionally between the other two query parameters
+    // to cover a scenario of intermixing them.
+    @Update
+    boolean switchDestination(String status,
+                              @Assign("destination") String newDestination,
+                              long id);
+
     @Update
     boolean updateLocation(long id,
                            String location,

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Towns.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Towns.java
@@ -105,6 +105,13 @@ public interface Towns {
                 @Assign("areaCodes") Set<Integer> newAreaCodes,
                 @Assign("population") int newPopulation);
 
+    // The assignment is intentionally between the other two query parameters
+    // to cover a scenario of intermixing them.
+    @Update
+    boolean setPopulation(@By(ID) TownId id,
+                          @Assign("population") int newPopulation,
+                          @By("population") int oldPopulation);
+
     @Find
     @OrderBy(value = ID, descending = true)
     CursoredPage<Town> sizedWithin(@By("population") @Is(GreaterThanEqual) int minPopulation,


### PR DESCRIPTION
Rewrite how parameter-based repository methods are processed to allow for intermixing of parameters related to the WHERE and UPDATE clauses.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
