### PR TITLE
Consumer group for each channel to avoid rebalance

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaAcknowledgementTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -26,8 +26,8 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractKafkaTestServlet;
-import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
 import com.ibm.ws.microprofile.reactive.messaging.fat.repeats.ReactiveMessagingActions;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.PlaintextTests;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -54,10 +54,10 @@ public class KafkaAcknowledgementTest {
         PropertiesAsset appConfig = new PropertiesAsset()
                         .addProperty(AbstractKafkaTestServlet.KAFKA_BOOTSTRAP_PROPERTY, PlaintextTests.kafkaContainer.getBootstrapServers())
                         .include(ConnectorProperties.simpleIncomingChannel(PlaintextTests.connectionProperties(), KafkaReceptionBean.CHANNEL_NAME,
-                                                                           KafkaAcknowledgementTestServlet.APP_GROUPID))
+                                                                           KafkaReceptionBean.GROUP_ID))
                         .include(ConnectorProperties.simpleOutgoingChannel(PlaintextTests.connectionProperties(), KafkaDeliveryBean.CHANNEL_NAME))
                         .include(ConnectorProperties.simpleIncomingChannel(PlaintextTests.connectionProperties(), KafkaPostProcessReceptionBean.POST_PROCESS_CHANNEL,
-                                                                           KafkaAcknowledgementTestServlet.APP_GROUPID));
+                                                                           KafkaPostProcessReceptionBean.GROUP_ID));
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
                         .addAsLibraries(kafkaClientLibs())

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaPostProcessReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaPostProcessReceptionBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 public class KafkaPostProcessReceptionBean {
 
     public static final String POST_PROCESS_CHANNEL = "kafka-ack-post-process";
+    public static final String GROUP_ID = "kafka-ack-post-process-group";
 
     @Incoming(POST_PROCESS_CHANNEL)
     public void process(String message) {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaReceptionBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -27,6 +27,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractRe
 public class KafkaReceptionBean extends AbstractReceptionBean<String> {
 
     public final static String CHANNEL_NAME = "reception-test-input";
+    public final static String GROUP_ID = "reception-test-input-group";
 
     @Incoming(CHANNEL_NAME)
     @Acknowledgment(Strategy.MANUAL)


### PR DESCRIPTION
When a new consumer connects, Kafka always does a rebalance even if the new consumer listens on a completely different set of topics than the existing one.

The KakfaAcknowlegementTest does not expect a rebalance, so to reduce the chance of getting one, give each channel its own consumer group.

For RTC 298788

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

