### PR TITLE
Allow JCA message during server stop in EJB timer FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -79,6 +79,14 @@ public class PersistentTimerTestHelper {
         // persistent.internal.InvokerTask run starts for a persistent timer during server shutdown,
         // but transaction service has already been shutdown.
         ignoreList.add("J2CA0027E");
+
+        // J2CA0056I: The Connection Manager received a fatal connection error from the Resource Adapter for
+        //            resource dataSource[DefaultDataSource]. The exception is: state STATE_TRAN_WRAPPER_INUSE
+        //            java.sql.SQLNonTransientException: No current connection. DSRA0010E: SQL State = 08003, Error Code = 40,000:ERROR 08003: No current connection.
+        //
+        // persistent.internal.InvokerTask run starts for a persistent timer during server shutdown,
+        // but transaction service has already been shutdown. Error occurs attempting to rollback.
+        ignoreList.add("J2CA0056I.*STATE_TRAN_WRAPPER_INUSE");
 
         // CWWKC1501W: Persistent executor [EJBPersistentTimerExecutor] rolled back task [task id]
         //             (!EJBTimerP![j2eename]) due to failure javax.ejb.EJBException: Timeout method


### PR DESCRIPTION
- timers running during server stop may receive message related to transactions and database access going down
- tolerate J2CA0056I


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".