### PR TITLE
Disable Reactive Messaging SASL Plain tests for FIPS

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/LibertyLoginModuleTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/LibertyLoginModuleTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.secure.fat.suite.SaslPlainTests;
 import componenttest.annotation.MaximumJavaLevel;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -50,6 +51,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 @RunWith(FATRunner.class)
 @MaximumJavaLevel(javaLevel = 22)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class LibertyLoginModuleTest {
 
     private static final String APP_NAME = "kafkaLoginModuleTest";
@@ -62,6 +64,9 @@ public class LibertyLoginModuleTest {
 
     @ClassRule
     public static RepeatTests r = ReactiveMessagingActions.repeatDefault(SERVER_NAME);
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/invalid/LibertyLoginModuleInvalidTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/invalid/LibertyLoginModuleInvalidTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Map;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -50,6 +51,7 @@ import componenttest.topology.impl.LibertyServer;
  * Test the login module with an incorrectly encoded password
  */
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class LibertyLoginModuleInvalidTest {
 
     private static final String APP_NAME = "kafkaLoginModuleInvalidTest";
@@ -65,6 +67,9 @@ public class LibertyLoginModuleInvalidTest {
 
     @ClassRule
     public static RepeatTests r = ReactiveMessagingActions.repeatDefault(SERVER_NAME);
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/none/LibertyLoginModuleNoEncTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/none/LibertyLoginModuleNoEncTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.secure.fat.suite.SaslPlainTests;
 import componenttest.annotation.MaximumJavaLevel;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -47,6 +48,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 @MaximumJavaLevel(javaLevel = 22)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class LibertyLoginModuleNoEncTest {
 
     private static final String APP_NAME = "kafkaLoginModuleNoEncTest";
@@ -59,6 +61,9 @@ public class LibertyLoginModuleNoEncTest {
 
     @ClassRule
     public static RepeatTests r = ReactiveMessagingActions.repeatDefault(SERVER_NAME);
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/special_chars/LibertyLoginModuleSpecialCharsTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.secure.fat.suite.SaslPlainTests;
 import componenttest.annotation.MaximumJavaLevel;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -47,6 +48,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 @MaximumJavaLevel(javaLevel = 22)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class LibertyLoginModuleSpecialCharsTest {
 
     private static final String APP_NAME = "kafkaLoginModuleSpecialCharsTest";
@@ -59,6 +61,9 @@ public class LibertyLoginModuleSpecialCharsTest {
 
     @ClassRule
     public static RepeatTests r = ReactiveMessagingActions.repeatDefault(SERVER_NAME);
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/xor/LibertyLoginModuleXorTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/liberty_login/xor/LibertyLoginModuleXorTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.secure.fat.suite.SaslPlainTests;
 import componenttest.annotation.MaximumJavaLevel;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -51,6 +52,7 @@ import componenttest.topology.impl.LibertyServer;
 @RunWith(FATRunner.class)
 @MaximumJavaLevel(javaLevel = 22)
 @Mode(TestMode.FULL)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class LibertyLoginModuleXorTest {
 
     private static final String APP_NAME = "kafkaLoginModuleXorTest";
@@ -63,6 +65,9 @@ public class LibertyLoginModuleXorTest {
 
     @ClassRule
     public static RepeatTests r = ReactiveMessagingActions.repeatDefault(SERVER_NAME);
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/sasl_plain/KafkaSaslPlainTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.secure_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/kafka/secure/fat/sasl_plain/KafkaSaslPlainTest.java
@@ -18,6 +18,7 @@ import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaU
 
 import com.ibm.ws.microprofile.reactive.messaging.kafka.secure.fat.suite.SaslPlainTests;
 import componenttest.annotation.MaximumJavaLevel;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -47,6 +48,7 @@ import componenttest.topology.impl.LibertyServer;
  */
 @RunWith(FATRunner.class)
 @MaximumJavaLevel(javaLevel = 22)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class KafkaSaslPlainTest {
 
     private static final String APP_NAME = "kafkaSaslTest";
@@ -59,6 +61,9 @@ public class KafkaSaslPlainTest {
 
     @ClassRule
     public static RepeatTests r = ReactiveMessagingActions.repeatDefault(SERVER_NAME);
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled(SERVER_NAME);
 
     @BeforeClass
     public static void setup() throws Exception {


### PR DESCRIPTION
Due to limitations of configuration and SASL PLAIN communications, disable tests that use PLAIN when running server in FIPS Mode.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
