### PR TITLE
Update x5t algorithm to SHA-256 variant for FIPS compliance

### DIFF
--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -80,8 +80,12 @@ Export-Package: \
 	com.ibm.ws.security.test.common;version=latest,\
 	com.ibm.json4j;version=latest,\
 	io.openliberty.org.apache.commons.logging;version=latest,\
-	com.ibm.ws.logging;version=latest,\
 	com.ibm.ws.container.service.compat;version=latest,\
 	com.ibm.ws.org.slf4j.api;version=latest,\
-	com.ibm.websphere.security;version=latest
+	com.ibm.websphere.security;version=latest,\
+	com.ibm.ws.logging;version=latest, \
+  	org.mockito:mockito-core;version=4.11.0, \
+  	org.mockito:mockito-inline;version=4.11.0, \
+  	net.bytebuddy:byte-buddy;version=1.16.1, \
+  	net.bytebuddy:byte-buddy-agent;version=1.16.1
 	

--- a/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/auth/PrivateKeyJwtAuthMethod.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/src/io/openliberty/security/oidcclientcore/token/auth/PrivateKeyJwtAuthMethod.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.common.crypto.CryptoUtils;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.security.common.ssl.SecuritySSLUtils;
 import com.ibm.ws.ssl.KeyStoreService;
@@ -167,7 +168,7 @@ public class PrivateKeyJwtAuthMethod extends TokenEndpointAuthMethod {
     private void setHeaderValues(JsonWebSignature jws) throws Exception {
         jws.setAlgorithmHeaderValue(clientAssertionSigningAlgorithm);
         jws.setHeader("typ", "JWT");
-        jws.setHeader("x5t", getX5tForPublicKey());
+        jws.setHeader(CryptoUtils.isFips140_3EnabledWithBetaGuard() ? "x5t#S256" : "x5t", getX5tForPublicKey());
     }
 
     String getX5tForPublicKey() throws Exception {
@@ -176,7 +177,7 @@ public class PrivateKeyJwtAuthMethod extends TokenEndpointAuthMethod {
         if (x509Cert == null) {
             x509Cert = getX509CertificateFromSslRef();
         }
-        return X509Util.x5t(x509Cert);
+        return CryptoUtils.isFips140_3EnabledWithBetaGuard() ? X509Util.x5tS256(x509Cert) : X509Util.x5t(x509Cert);
     }
 
     @FFDCIgnore(Exception.class)

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/auth/PrivateKeyJwtAuthMethodTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/auth/PrivateKeyJwtAuthMethodTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 IBM Corporation and others.
+ * Copyright (c) 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,10 +32,13 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ssl.JSSEHelper;
 import com.ibm.websphere.ssl.SSLConfigChangeListener;
+import com.ibm.ws.common.crypto.CryptoUtils;
 import com.ibm.ws.security.common.ssl.SecuritySSLUtils;
 import com.ibm.ws.security.test.common.CommonTestClass;
 import com.ibm.ws.ssl.KeyStoreService;
@@ -94,7 +97,7 @@ public class PrivateKeyJwtAuthMethodTest extends CommonTestClass {
         authMethod = new PrivateKeyJwtAuthMethod(configurationId, clientId, tokenEndpointUrl, clientAssertionSigningAlgorithm, null, sslRef, keyAliasName) {
             @Override
             String getX5tForPublicKey() throws Exception {
-                return "x5t#S256_" + testName.getMethodName();            
+                return "x5t_" + testName.getMethodName();
             }
         };
         authMethod.setKeyStoreService(keyStoreService);
@@ -149,6 +152,30 @@ public class PrivateKeyJwtAuthMethodTest extends CommonTestClass {
     }
 
     @Test
+    public void test_getPrivateKeyJwtParameters_withFips140_3() throws Exception {
+        try (MockedStatic<CryptoUtils> cryptoUtilsMock = setupMockFips140_3()) {
+
+            authMethod = new PrivateKeyJwtAuthMethod(configurationId, clientId, tokenEndpointUrl, clientAssertionSigningAlgorithm, null, sslRef, keyAliasName) {
+                @Override
+                String getX5tForPublicKey() throws Exception {
+                    return "x5t#S256_" + testName.getMethodName();
+                }
+            };
+            authMethod.setKeyStoreService(keyStoreService);
+            PrivateKey privateKey = keyPair.getPrivate();
+            getPrivateKeyFromKeystoreExpectations(privateKey);
+
+            HashMap<String, String> parameters = authMethod.getPrivateKeyJwtParameters();
+            assertEquals(TokenConstants.CLIENT_ASSERTION_TYPE + " paramter value did not match expected value.", TokenConstants.CLIENT_ASSERTION_TYPE_JWT_BEARER,
+                        parameters.get(TokenConstants.CLIENT_ASSERTION_TYPE));
+            assertTrue("Parameters did not include the required " + TokenConstants.CLIENT_ASSERTION + " parameter. Parameters were: " + parameters,
+                    parameters.containsKey(TokenConstants.CLIENT_ASSERTION));
+            String jwt = parameters.get(TokenConstants.CLIENT_ASSERTION);
+            verifyPrivateKeyJwt(jwt);
+        }
+    }
+
+    @Test
     public void test_createPrivateKeyJwt_missingKey() throws Exception {
         getPrivateKeyFromKeystoreExpectations(null);
         try {
@@ -168,6 +195,27 @@ public class PrivateKeyJwtAuthMethodTest extends CommonTestClass {
 
         verifyPrivateKeyJwt(jwt);
     }
+
+    @Test
+    public void test_createPrivateKeyJwt_withFips140_3() throws Exception {
+        try (MockedStatic<CryptoUtils> cryptoUtilsMock = setupMockFips140_3()) {
+
+            authMethod = new PrivateKeyJwtAuthMethod(configurationId, clientId, tokenEndpointUrl, clientAssertionSigningAlgorithm, null, sslRef, keyAliasName) {
+                @Override
+                String getX5tForPublicKey() throws Exception {
+                    return "x5t#S256_" + testName.getMethodName();
+                }
+            };
+            authMethod.setKeyStoreService(keyStoreService);
+
+            PrivateKey privateKey = keyPair.getPrivate();
+            getPrivateKeyFromKeystoreExpectations(privateKey);
+
+            String jwt = authMethod.createPrivateKeyJwt();
+            
+            verifyPrivateKeyJwt(jwt);
+    }
+}
 
     @SuppressWarnings("unchecked")
     @Test
@@ -224,7 +272,11 @@ public class PrivateKeyJwtAuthMethodTest extends CommonTestClass {
         JsonWebSignature jws = (JsonWebSignature) JsonWebSignature.fromCompactSerialization(jwt);
         assertEquals("JWT's alg header did not match expected value.", clientAssertionSigningAlgorithm, jws.getAlgorithmHeaderValue());
         assertEquals("JWT's typ header did not match expected value.", "JWT", jws.getHeader("typ"));
-        assertEquals("JWT's x5t#S256 header did not match expected value.", "x5t#S256_" + testName.getMethodName(), jws.getHeader("x5t#S256"));
+        if (CryptoUtils.isFips140_3EnabledWithBetaGuard()){
+            assertEquals("JWT's x5t#S256 header did not match expected value.", "x5t#S256_" + testName.getMethodName(), jws.getHeader("x5t#S256"));
+        } else {
+            assertEquals("JWT's x5t header did not match expected value.", "x5t_" + testName.getMethodName(), jws.getHeader("x5t"));
+        }
         String rawPayload = jws.getUnverifiedPayload();
         JSONObject jsonPayload = JSONObject.parse(rawPayload);
         // Verify required claims
@@ -239,4 +291,9 @@ public class PrivateKeyJwtAuthMethodTest extends CommonTestClass {
         assertNotNull("Expected JWT to include a jti claim, but it did not.", jsonPayload.get("jti"));
     }
 
+    private MockedStatic<CryptoUtils> setupMockFips140_3() {
+        MockedStatic<CryptoUtils> cryptoUtilsMock = Mockito.mockStatic(CryptoUtils.class);
+        cryptoUtilsMock.when(CryptoUtils::isFips140_3EnabledWithBetaGuard).thenReturn(true);
+        return cryptoUtilsMock;
+    }
 }

--- a/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/auth/PrivateKeyJwtAuthMethodTest.java
+++ b/dev/io.openliberty.security.oidcclientcore.internal/test/io/openliberty/security/oidcclientcore/token/auth/PrivateKeyJwtAuthMethodTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -94,7 +94,7 @@ public class PrivateKeyJwtAuthMethodTest extends CommonTestClass {
         authMethod = new PrivateKeyJwtAuthMethod(configurationId, clientId, tokenEndpointUrl, clientAssertionSigningAlgorithm, null, sslRef, keyAliasName) {
             @Override
             String getX5tForPublicKey() throws Exception {
-                return "x5t_" + testName.getMethodName();
+                return "x5t#S256_" + testName.getMethodName();            
             }
         };
         authMethod.setKeyStoreService(keyStoreService);
@@ -224,8 +224,7 @@ public class PrivateKeyJwtAuthMethodTest extends CommonTestClass {
         JsonWebSignature jws = (JsonWebSignature) JsonWebSignature.fromCompactSerialization(jwt);
         assertEquals("JWT's alg header did not match expected value.", clientAssertionSigningAlgorithm, jws.getAlgorithmHeaderValue());
         assertEquals("JWT's typ header did not match expected value.", "JWT", jws.getHeader("typ"));
-        assertEquals("JWT's x5t header did not match expected value.", "x5t_" + testName.getMethodName(), jws.getHeader("x5t"));
-
+        assertEquals("JWT's x5t#S256 header did not match expected value.", "x5t#S256_" + testName.getMethodName(), jws.getHeader("x5t#S256"));
         String rawPayload = jws.getUnverifiedPayload();
         JSONObject jsonPayload = JSONObject.parse(rawPayload);
         // Verify required claims


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

----

- Updated to use Jose4j `x5tS256()` (SHA-256) method to generate thumbprint of X509 certificate when FIPS 140-3 is enabled.
   - Updated the JWT header to be conditionally set to x5t#S256 or x5t based on whether FIPS 140-3 is used.
   - When FIPS is not enabled, the implementation continues to use `x5t()` (SHA-1).
- Added new unit tests to validate the x5t#S256 behavior when FIPS 140-3 is enabled.
