### PR TITLE
Fix up NullPointerException that can happen if trace is enabled

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderRef.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ClassLoaderRef.java
@@ -155,8 +155,12 @@ public class ClassLoaderRef extends LibertyLoader implements SpringLoader {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(super.toString());
-        sb.append(": Application ClassLoader ");
-        sb.append(classLoaderWeakRef.get());
+        // classLoaderWeakRef can be null if toString() is called by trace during 
+        // super constructor
+        if (classLoaderWeakRef != null) {
+            sb.append(": Application ClassLoader ");
+            sb.append(classLoaderWeakRef.get());
+        }
         return sb.toString();
     }
 

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/LibertyLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/LibertyLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,10 +19,13 @@ import java.util.Enumeration;
 
 import org.osgi.framework.Bundle;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 import com.ibm.ws.classloading.LibertyClassLoader;
 import com.ibm.ws.kernel.boot.classloader.NameBasedClassLoaderLock;
 import com.ibm.ws.kernel.boot.utils.KeyBasedLockStore;
 
+@Trivial
 public abstract class LibertyLoader extends SecureClassLoader implements NoClassNotFoundLoader, LibertyClassLoader, DeclaredApiAccess {
     static {
         ClassLoader.registerAsParallelCapable();

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.access.internal_fat/.project
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.access.internal_fat/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>io.openliberty.microprofile.telemetry.2.0.logging.acesss.internal_fat</name>
+	<name>io.openliberty.microprofile.telemetry.2.0.logging.access.internal_fat</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
- If toString() is called on ClassLoaderRef during construction time before classLoaderWeakRef in the parent class, an NPE can result and can result in the JDK seg faulting due to a problem in Java
- Update to not get an NPE if toString() is called at the wrong time
- Update the parent of ClassLoaderRef to be marked `@Trivial`
- Small update to .project file to have the project name match the directory name.

The NPE happening is caused by my changes in #31850.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
