### PR TITLE
Add FIPS 140-3 custom profile to OIDC client FAT suite

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientSignatureAlgTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientSignatureAlgTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,6 +34,8 @@ import com.meterware.httpunit.WebConversation;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule;
 
 /**
  * This is the test class that will run tests to verify the correct behavior with
@@ -66,6 +69,9 @@ public class OidcClientSignatureAlgTests extends CommonTest {
     protected static String hostName = "localhost";
     public static final String MSG_USER_NOT_IN_REG = "CWWKS1106A";
     protected static SignatureEncryptionUserinfoUtils signingUtils = new SignatureEncryptionUserinfoUtils();
+
+    @Rule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.security.openidconnect.client-1.0_fat.opWithStub");
 
     @SuppressWarnings("serial")
     @BeforeClass
@@ -490,10 +496,12 @@ public class OidcClientSignatureAlgTests extends CommonTest {
 
     /**
      * Test shows that the RP can not consume a JWT signed with sigAlg RS256, but a different key
+     * Skip test on FIPS 140-3 because it requires RSA keys to be at least 2048 bit
      *
      * @throws Exception
      */
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void OidcClientSignatureAlgTests_SignTokenRS256_RPVerifyRS256_keyMismatch() throws Exception {
 
         genericSigAlgTest("short_" + Constants.SIGALG_RS256, Constants.SIGALG_RS256);
@@ -502,10 +510,12 @@ public class OidcClientSignatureAlgTests extends CommonTest {
 
     /**
      * Test shows that the RP can not consume a JWT signed with sigAlg RS384, but a different key
+     * Skip test on FIPS 140-3 because it requires RSA keys to be at least 2048 bit
      *
      * @throws Exception
      */
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void OidcClientSignatureAlgTests_SignTokenRS384_RPVerifyRS384_keyMismatch() throws Exception {
 
         genericSigAlgTest("short_" + Constants.SIGALG_RS384, Constants.SIGALG_RS384);
@@ -514,10 +524,12 @@ public class OidcClientSignatureAlgTests extends CommonTest {
 
     /**
      * Test shows that the RP can not consume a JWT signed with sigAlg RS512, but a different key
+     * Skip test on FIPS 140-3 because it requires RSA keys to be at least 2048 bit
      *
      * @throws Exception
      */
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void OidcClientSignatureAlgTests_SignTokenRS512_RPVerifyRS512_keyMismatch() throws Exception {
 
         genericSigAlgTest("short_" + Constants.SIGALG_RS512, Constants.SIGALG_RS512);

--- a/dev/com.ibm.ws.security.oidc.client_fat.2/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,19 @@
+# Allowing for org.jose4j
+# TODO: Revisit usage of RSA and SHA-1 (RSA-OAEP/RSA-OAEP-256) after ECDH-ES update
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.jose4j.jwa.AlgorithmFactory}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.jose4j.jwe.CipherUtil}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.jose4j.jwe.WrappingKeyManagementAlgorithm}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, RSA, *, FullClassName:org.jose4j.jwa.AlgorithmFactory}, \
+    {Cipher, RSA, *, FullClassName:org.jose4j.jwe.CipherUtil}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

- Added FIPS 140-3 custom profile to enable usage of RSA-OAEP and RSA-OAEP-256 when FIPS 140-3 is enabled.
  - Usage of the above algorithms should be revisited when ECDH-ES algorithm is enabled.
- Disabled tests using a signing key size of 1024 bits from running when FIPS is enabled.
  - A signing key size of 1024 bits is not supported in FIPS, at minimum the key size must be 2048 bits.

