### PR TITLE
required keyword is incorrect; use isRequired

### DIFF
--- a/.ci-orchestrator/checks.yml
+++ b/.ci-orchestrator/checks.yml
@@ -10,7 +10,7 @@ triggers:
   groups: ["LibertyDev"]
   propertyDefinitions:
     - name: githubPRNumber
-      required: true
+      isRequired: true
       description: "PR number to perform delivery requirement verification against e.g. 30188"
 
 steps:


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

"required" keyword in the YML configuration for the affected pipeline isn't correct; use "isRequired".
