### PR TITLE
installKernel - check envmap

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
@@ -19,7 +19,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.Authenticator;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
@@ -324,6 +323,9 @@ public class ArtifactDownloaderUtils {
      * @throws MalformedURLException
      */
     public static void setProxyAuthenticator(Map<String, Object> envMap) throws MalformedURLException {
+        if (envMap == null) {
+            return;
+        }
         if (envMap.get("https.proxyUser") != null) {
             Authenticator.setDefault(new SystemPropertiesProxyAuthenticator((String) envMap.get("https.proxyUser"), (String) envMap.get("https.proxyPassword")));
         } else if (envMap.get("http.proxyUser") != null) {


### PR DESCRIPTION
https://github.com/OpenLiberty/ci.maven/issues/1910
When downloading the public key from the LMP/LGP side, environment map needs to be checked. 

Before:
`[ERROR] Failed to execute goal io.openliberty.tools:liberty-maven-plugin:3.11.4:install-feature (install-feature) on project sample-app: Execution install-feature of goal io.openliberty.tools:liberty-maven-plugin:3.11.4:install-feature failed: Cannot invoke "java.util.Map.get(Object)" because "envMap" is null ->`

After:
`[ERROR] Failed to execute goal io.openliberty.tools:liberty-maven-plugin:3.11.4-SNAPSHOT:install-feature (install-feature) on project liberty-maven-plugin-demo1: Error installing features for server test: CWWKF1400E: The format of the localhost:8080 http_proxy environment variable is invalid. Ensure that the http_proxy variable is in the http_proxy=http://<proxy-host>:<proxy-port> format. -> [Help 1]`

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

