### PR TITLE
Allow users to pass Ant properties to the command that runs FATs

### DIFF
--- a/.ci-orchestrator/steps/fats/fatCommon.properties
+++ b/.ci-orchestrator/steps/fats/fatCommon.properties
@@ -1,4 +1,6 @@
-command=ant -f build-test.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
+# Allows users to pass Ant properties to the command that runs FATs across all the platforms (distributed, z/OS, etc).
+extra.fat.ant.options=
+command=ant -f build-test.xml localrun ${extra.fat.ant.options} -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
 ebcPlan=See Shortlist
 # The branch of CRIU installed in CRIU-supported environments for Checkpoint testing; only used in standard FAT steps (i.e. it is ignored for z/OS). 
 ebcExtraProps=criu_branch=0.50.1-release

--- a/.ci-orchestrator/steps/fats/zOSFATs.yml
+++ b/.ci-orchestrator/steps/fats/zOSFATs.yml
@@ -19,7 +19,7 @@
     # Pattern causes us to only execute the z/OS FATs.
     fatPatternToMatch: .*_zfat
     runZosTests: true
-    command: ant -f build-ztest.xml localrun -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
+    command: ant -f build-ztest.xml localrun ${extra.fat.ant.options} -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib.antClasspath
     runner_threshold: 13
     runner_minimum_total: 4
     runner_max_total: 4

--- a/.ci-orchestrator/steps/fats/zOSUnittests.yml
+++ b/.ci-orchestrator/steps/fats/zOSUnittests.yml
@@ -19,7 +19,7 @@
     # Pattern causes us to only execute the z/OS unittests.
     fatPatternToMatch: .*_ztest
     runZosTests: true
-    command: ant -f build-zunittest.xml unittest -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib/ecj-4.3.1.jar -lib ../ant_build/lib.antClasspath -lib ../prereq.published/lib -lib ../ant_build/lib/biz.aQute.bnd-3.3.0.jar -lib ../ant_build/lib/jsoup-1.7.2.jar
+    command: ant -f build-zunittest.xml unittest ${extra.fat.ant.options} -propertyfile ../../../buildandbucket.properties -DhaltOnFailure=false -lib ../ant_build/lib/ecj-4.3.1.jar -lib ../ant_build/lib.antClasspath -lib ../prereq.published/lib -lib ../ant_build/lib/biz.aQute.bnd-3.3.0.jar -lib ../ant_build/lib/jsoup-1.7.2.jar
     runner_threshold: 5
     runner_minimum_total: 2
     runner_max_total: 2


### PR DESCRIPTION
- Adds the property `extra.fat.ant.options` to all the FAT steps. This solves the problem of needing to pass Ant options like `-Dglobal.jvm.args="-Dcom.ibm.ws.beta.edition=true"` to the ant call that executes on the Jenkins test runner and needs to allow setting it for all platforms, z/OS included. The FATs are launched via the `command` property, and since that differs between distributed and z/OS platforms, then we need to insert extra options that the user provides into the command (and default to empty string if none are provided).