### PR TITLE
sessionGetTimeoutCacheCheck test get null session

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -862,6 +862,12 @@ public class SessionCacheTestServlet extends FATServlet {
         }
         String key = request.getParameter("key");
         String expected = request.getParameter("expectedValue");
+        if (session == null) {
+            // Retry getSession() as request.getSession(true) can not be null in the production world
+            System.out.println("Sleep 5 seconds due to session return null");
+            TimeUnit.SECONDS.sleep(5);
+            session = request.getSession(createSession);
+        }        
         String sessionId = session.getId();
 
         // poll for entry to be invalidated from cache


### PR DESCRIPTION
testCacheInvalidationLocalCacheTwoServer_EE11_FEATURES_CacheManager:junit.framework.AssertionFailedError: 2025-06-17-10:31:07:367 Servlet call was not successful: ERROR: Caught exception attempting to call test method sessionGetTimeoutCacheCheck on servlet session.cache.infinispan.web.SessionCacheTestServlet
java.lang.NullPointerException: Cannot invoke "jakarta.servlet.http.HttpSession.getId()" because "session" is null
    at session.cache.infinispan.web.SessionCacheTestServlet.sessionGetTimeoutCacheCheck(SessionCacheTestServlet.java:865)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at componenttest.app.FATServlet.doGet(FATServlet.java:76)
    at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:633)
    at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:723)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1266)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:754)