### PR TITLE
mpOpenAPI: Fix servers for proxy on same port

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/ProxySupportServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/ProxySupportServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -24,5 +24,7 @@
   </featureManager>
 
   <keyStore id="defaultKeyStore" password="password" />
+  
+  <httpEndpoint id="defaultHttpEndpoint" httpPort="-1" httpsPort="-1"/> <!-- ports will be overwritten by test -->
 
 </server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
-  [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fix the automatic population of the `servers` section of the OpenAPI document in the case where:
- the request is proxied
- the proxy and the liberty server use the same port number
- the proxy and the liberty server do not use the same protocol (e.g. proxy is doing https termination so the proxy uses https while the liberty server uses http)

Fixes #32046