### PR TITLE
Fixed ClassCastException during server start, when traceFileName=stdout and timedLogRollover is set.

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -242,6 +242,9 @@ public class BaseTraceService implements TrService {
     /** The maximum FFDC file age before deletion. */
     private volatile long maxFfdcAge = -1;
 
+    /** The trace file name */
+    private volatile String traceFileName = "trace.log";
+
     /** Early msgs issued before MessageRouter is started. */
     protected volatile Queue<RoutedMessage> earlierMessages = new SimpleRotatingSoftQueue<RoutedMessage>(new RoutedMessage[100]);
     protected volatile Queue<RoutedMessage> earlierTraces = new SimpleRotatingSoftQueue<RoutedMessage>(new RoutedMessage[200]);
@@ -1433,9 +1436,9 @@ public class BaseTraceService implements TrService {
             //null and empty rolloverStartTime are the same
             if (rolloverStartTime == null)
                 rolloverStartTime = "";
-            // If neither of the rollover attributes change, return without rescheduling
-            // Also, if the traceFileName is set to "stdout", then we must reschedule the rollover by omitting the trace.log file.
-            if (this.rolloverStartTime.equals(rolloverStartTime) && this.rolloverInterval == rolloverInterval && !traceFileName.equals("stdout")) {
+            // If neither of the rollover attributes change, return without rescheduling.
+            // Also, if the traceFileName attribute value did NOT change, return without rescheduling
+            if (this.rolloverStartTime.equals(rolloverStartTime) && this.rolloverInterval == rolloverInterval && this.traceFileName.equals(traceFileName)) {
                 return;
             } else {
                 timedLogRollover_Timer.cancel();
@@ -1480,6 +1483,7 @@ public class BaseTraceService implements TrService {
 
         this.rolloverStartTime = rolloverStartTime;
         this.rolloverInterval = rolloverInterval;
+        this.traceFileName = traceFileName; // Preserve the previous traceFileName, in order to check if the attribute changed.
 
         //parse startTimeField
         String[] hourMinPair = rolloverStartTime.split(":");

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -1425,16 +1425,17 @@ public class BaseTraceService implements TrService {
     private void scheduleTimeBasedLogRollover(LogProviderConfigImpl config) {
         String rolloverStartTime = config.getRolloverStartTime();
         long rolloverInterval = config.getRolloverInterval();
-        String fileName = config.getTraceFileName();
+        String traceFileName = config.getTraceFileName();
 
-        //if the rollover has already been scheduled, cancel it
-        //this is either a reschedule, or a unschedule
+        // If the rollover has already been scheduled, cancel it
+        // This is either a reschedule, or a unschedule
         if (this.isLogRolloverScheduled) {
             //null and empty rolloverStartTime are the same
             if (rolloverStartTime == null)
                 rolloverStartTime = "";
-            //if neither of the rollover attributes change, return without rescheduling
-            if (this.rolloverStartTime.equals(rolloverStartTime) && this.rolloverInterval == rolloverInterval) {
+            // If neither of the rollover attributes change, return without rescheduling
+            // Also, if the traceFileName is set to "stdout", then we must reschedule the rollover by omitting the trace.log file.
+            if (this.rolloverStartTime.equals(rolloverStartTime) && this.rolloverInterval == rolloverInterval && !traceFileName.equals("stdout")) {
                 return;
             } else {
                 timedLogRollover_Timer.cancel();
@@ -1519,7 +1520,7 @@ public class BaseTraceService implements TrService {
         //schedule rollover
         timedLogRollover_Timer = new Timer(true);
         TimedLogRoller tlr;
-        if (fileName.equals("stdout")) {
+        if (traceFileName.equals("stdout")) {
             // If traceFileName is configured to stdout, that means there will be no trace.log to rollover,
             // omit the trace.log, when scheduling the rollover.
             tlr = new TimedLogRoller(messagesLog);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #31954

- Added a condition when scheduling the timedLogRollover, to only schedule it for messages.log, if the traceFileName=stdout, in bootstrap.properties or server.xml.
- Fixed edge case for dynamic traceFileName updates and timedLogRollover.
