### PR TITLE
Fix NPE in BaseTestClass validatePrometheusHTTPMetric methods

### DIFF
--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
@@ -391,8 +391,7 @@ public abstract class BaseTestClass {
         Log.info(c, "validatePrometheusHTTPMetricCount", "Trying to match: " + matchString);
         
         if (vendorMetricsOutput == null) {
-            //Log.info(c, "validatePrometheusHTTPMetricCount", "vendorMetricsOutput is null - metrics endpoint may not be responding");
-        	Log.info(c, "validatePrometheusHTTPMetricSum", "vendorMetricsOutput is null - metrics endpoint may not be responding");
+        	Log.info(c, "validatePrometheusHTTPMetricCount", "vendorMetricsOutput is null - metrics endpoint may not be responding");
         	return false;
         }
         
@@ -452,7 +451,7 @@ public abstract class BaseTestClass {
         Log.info(c, "validatePrometheusHTTPMetricSum", "Trying to match: " + matchString);
         
         if (vendorMetricsOutput == null) {
-            Log.info(c, "validatePrometheusHTTPMetricCount", "vendorMetricsOutput is null - metrics endpoint may not be responding");
+            Log.info(c, "validatePrometheusHTTPMetricSum", "vendorMetricsOutput is null - metrics endpoint may not be responding");
             return false;
         }
         

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
@@ -389,6 +389,13 @@ public abstract class BaseTestClass {
         matchString += expectedCount;
 
         Log.info(c, "validatePrometheusHTTPMetricCount", "Trying to match: " + matchString);
+        
+        if (vendorMetricsOutput == null) {
+            //Log.info(c, "validatePrometheusHTTPMetricCount", "vendorMetricsOutput is null - metrics endpoint may not be responding");
+        	Log.info(c, "validatePrometheusHTTPMetricSum", "vendorMetricsOutput is null - metrics endpoint may not be responding");
+        	return false;
+        }
+        
         try (Scanner sc = new Scanner(vendorMetricsOutput)) {
             while (sc.hasNextLine()) {
                 String line = sc.nextLine();
@@ -443,6 +450,12 @@ public abstract class BaseTestClass {
         matchString += expectedSum;
 
         Log.info(c, "validatePrometheusHTTPMetricSum", "Trying to match: " + matchString);
+        
+        if (vendorMetricsOutput == null) {
+            Log.info(c, "validatePrometheusHTTPMetricCount", "vendorMetricsOutput is null - metrics endpoint may not be responding");
+            return false;
+        }
+        
         try (Scanner sc = new Scanner(vendorMetricsOutput)) {
             while (sc.hasNextLine()) {
                 String line = sc.nextLine();


### PR DESCRIPTION
Fixes #31739

- Add null checks for vendorMetricsOutput parameter in validatePrometheusHTTPMetricCount and validatePrometheusHTTPMetricSum methods
- Prevents NullPointerException when metrics endpoint returns null response
- Returns false and logs informative message when metrics endpoint is unavailable