### PR TITLE
Fix the jca bvt tests

### DIFF
--- a/dev/com.ibm.ws.jca_fat_bvt/publish/servers/com.ibm.ws.jca.fat.bvt/server.xml
+++ b/dev/com.ibm.ws.jca_fat_bvt/publish/servers/com.ibm.ws.jca.fat.bvt/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2011,2022 IBM Corporation and others.
+    Copyright (c) 2011,2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@
     <variable name="onError" value="FAIL"/>
 
     <connectionFactory id="cf1" jndiName="eis/cf1">
-      <containerAuthData user="CNTRUSER" password="{aes}APsFRXLhJp7FYchi1uAsgi+eFzVg87omLpRnYxeBEKiM"/>    
+      <containerAuthData user="CNTRUSER" password="{aes}ARB8AqwcDz6FKge0YPLTzcl3fg1dMahVWbPHFozb47LJywphgiQS/3C0lQdULcMU20T46wE85y6auKcR4kE0pbX82wkXitMJwtN9o3jUjxK+3vOxGP5rF32zf78j/ow3Wql1r9Cz0Ab5TA=="/>    
       <properties.RAR1 sslSocketFactory="mySSLConfig" tableName="cf1tbl" userName="CF1USER"/>
     </connectionFactory>
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
Fixed the password for the jca bvt server.xml files
Changed the AES 128 password in the server.xml to AES 256 to make it FIPS compliant.
################################################################################################
