### PR TITLE
Reduce trace noise for classloading

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -314,7 +314,11 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
             return new ByteResourceInformation(container, this, className, this::getActualBytes, hook);
         }
 
+        @Trivial
         private byte[] getActualBytes() {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "CCL: EntryUniversalResource.getActualBytes for " + resourceName);
+            }
             try {
                 try {
                     InputStream is = this.entry.adapt(InputStream.class);
@@ -828,6 +832,7 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
             }
         }
 
+        @Trivial
         private void processContainer(Container c, Map<Integer, List<UniversalContainer>> map, int chop) {
             for (Entry e : c) {
                 try {
@@ -853,6 +858,7 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
         }
 
         @Override
+        @Trivial
         synchronized public void updatePackageMap(Map<Integer, List<UniversalContainer>> map) {
             if (tc.isDebugEnabled())
                 Tr.debug(tc, "CCL: updating map for adaptable container with path " + this.container.getPath());
@@ -952,7 +958,11 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
             return new ByteResourceInformation(container, this, className, this::getActualBytes, hook);
         }
 
+        @Trivial
         byte[] getActualBytes() {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "CCL: ArtifactEntryUniversalResource.getActualBytes for " + resourceName);
+            }
             try {
                 InputStream is = this.entry.getInputStream();
                 return ContainerClassLoader.getBytes(is, (int) entry.getSize());
@@ -1329,6 +1339,7 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
             addUniversalContainers(new ArtifactContainerUniversalContainer(container, hook));
         }
 
+        @Trivial
         private List<UniversalContainer> getUniversalContainersForPath(String path, List<UniversalContainer> classpath) {
             //if we have outstanding requests, then we should just use the classpath, else
             //we risk not seeing content on the classpath that we should see.
@@ -1696,6 +1707,7 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
          *
          * @return The byte[]
          */
+        @Trivial
         public byte[] getBytes() {
             return this.bytes;
         }
@@ -1717,10 +1729,12 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
             return fromClassCache;
         }
 
+        @Trivial
         public byte[] getActualBytes() throws IOException {
             return actualBytes.get();
         }
 
+        @Trivial
         public void storeInClassCache(Class<?> clazz, byte[] definedBytes ) {
             if (fromClassCache || hook == null) {
                 return;
@@ -2120,6 +2134,7 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
         }
     }
 
+    @Trivial
     Collection<Collection<URL>> getClassPath() {
         return smartClassPath.getClassPath();
     }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ThreadContextClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ThreadContextClassLoader.java
@@ -245,6 +245,7 @@ public class ThreadContextClassLoader extends UnifiedClassLoader implements Keye
     // must be defined with the app loader so they have proper visibility to their
     // super classes.
     @Override
+    @Trivial
     public Class<?> publicDefineClass(String name, byte[] b, ProtectionDomain protectionDomain) {
         if (appLoader instanceof SpringLoader) {
             return ((SpringLoader) appLoader).publicDefineClass(name, b, protectionDomain);


### PR DESCRIPTION
Avoid printing the class byte array over and over. Reduce noise from processing package map.


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

