### PR TITLE
Update RestEasy MP Rest Client code to no longer leak memory

### DIFF
--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/build.gradle
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,26 +13,36 @@
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 configurations {
-  wiremockAndJetty
+  wiremock
+  jetty
   httpcore
 }
 
-configurations.wiremockAndJetty {
+configurations.wiremock {
+  transitive = false
+}
+
+configurations.jetty {
   transitive = false
 }
 
 dependencies {
-  wiremockAndJetty 'com.github.tomakehurst:wiremock-standalone:2.14.0',
-    'org.eclipse.jetty:jetty-http:9.4.31.v20200723',
+  wiremock 'com.github.tomakehurst:wiremock-standalone:2.14.0'
+  jetty 'org.eclipse.jetty:jetty-http:9.4.31.v20200723',
     'org.eclipse.jetty:jetty-io:9.4.31.v20200723',
     'org.eclipse.jetty:jetty-server:9.4.31.v20200723',
     'org.eclipse.jetty:jetty-util:9.4.31.v20200723'
   httpcore 'org.apache.httpcomponents:httpcore:4.4.11'
 }
 
-task addWiremockAndJetty(type: Copy) {
-  from configurations.wiremockAndJetty
+task addJetty(type: Copy) {
+  from configurations.jetty
   into "${buildDir}/autoFVT/publish/servers/FATServer/"
+}
+
+task addWiremock(type: Copy) {
+  from configurations.wiremock
+  into "${buildDir}/autoFVT/publish/servers/FATServer/lib/global"
 }
 
 task addHttpcore(type: Copy) {
@@ -41,6 +51,7 @@ task addHttpcore(type: Copy) {
 }
 
 addRequiredLibraries {
-  dependsOn addWiremockAndJetty
+  dependsOn addJetty
+  dependsOn addWiremock
   dependsOn addHttpcore
 }

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=60000
--Xmx1024m
+-Xmx512m

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/src/test/resources/log4testng.properties
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/src/test/resources/log4testng.properties
@@ -1,1 +1,1 @@
-log4testng.rootLogger=DEBUG
+log4testng.rootLogger=INFO

--- a/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/build.gradle
+++ b/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,26 +13,36 @@
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 configurations {
-  wiremockAndJetty
+  wiremock
+  jetty
   httpcore
 }
 
-configurations.wiremockAndJetty {
+configurations.wiremock {
+  transitive = false
+}
+
+configurations.jetty {
   transitive = false
 }
 
 dependencies {
-  wiremockAndJetty 'org.wiremock:wiremock-standalone:3.0.1',
-    'org.eclipse.jetty:jetty-http:11.0.21',
+  wiremock 'org.wiremock:wiremock-standalone:3.0.1'
+  jetty 'org.eclipse.jetty:jetty-http:11.0.21',
     'org.eclipse.jetty:jetty-io:11.0.21',
     'org.eclipse.jetty:jetty-server:11.0.21',
     'org.eclipse.jetty:jetty-util:11.0.21'
   httpcore 'org.apache.httpcomponents.core5:httpcore5:5.2'
 }
 
-task addWiremockAndJetty(type: Copy) {
-  from configurations.wiremockAndJetty
+task addJetty(type: Copy) {
+  from configurations.jetty
   into "${buildDir}/autoFVT/publish/servers/FATServer/"
+}
+
+task addWiremock(type: Copy) {
+  from configurations.wiremock
+  into "${buildDir}/autoFVT/publish/servers/FATServer/lib/global"
 }
 
 task addHttpcore(type: Copy) {
@@ -41,7 +51,8 @@ task addHttpcore(type: Copy) {
 }
 
 addRequiredLibraries {
-  dependsOn addWiremockAndJetty
+  dependsOn addJetty
+  dependsOn addWiremock
   dependsOn addHttpcore
 }
 

--- a/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=60000
--Xmx2048m
+-Xmx512m

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 /*
  * JBoss, Home of Professional Open Source.
  *
@@ -247,7 +256,7 @@ public class ProxyInvocationHandler implements InvocationHandler {
         interfaces[0] = resourceInterface;
         final Object proxy = Proxy.newProxyInstance(getClassLoader(resourceInterface), interfaces,
                 new ProxyInvocationHandler(resourceInterface, target, Set.copyOf(providers), client));
-        ClientHeaderProviders.registerForClass(resourceInterface, proxy, beanManager);
+        // ClientHeaderProviders.registerForClass(resourceInterface, proxy, beanManager); // Liberty change since done in LibertyRestClientBuilderImpl
         return proxy;
     }
 

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
@@ -1,0 +1,299 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.microprofile.client;
+
+import java.io.Closeable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Set;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.client.ResponseProcessingException;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.microprofile.client.header.ClientHeaderFillingException;
+import org.jboss.resteasy.microprofile.client.header.ClientHeaderProviders;
+
+public class ProxyInvocationHandler implements InvocationHandler {
+
+    private static final Logger LOGGER = Logger.getLogger(ProxyInvocationHandler.class);
+    public static final Type[] NO_TYPES = {};
+
+    private final Object target;
+
+    private final Set<Object> providerInstances;
+
+    private final ResteasyClient client;
+
+    private final AtomicBoolean closed;
+
+    public ProxyInvocationHandler(final Class<?> restClientInterface,
+            final Object target,
+            final Set<Object> providerInstances,
+            final ResteasyClient client) {
+        this.target = target;
+        this.providerInstances = providerInstances;
+        this.client = client;
+        this.closed = new AtomicBoolean();
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (RestClientProxy.class.equals(method.getDeclaringClass())) {
+            return invokeRestClientProxyMethod(method);
+        }
+        // Autocloseable/Closeable
+        if (method.getName().equals("close") && (args == null || args.length == 0)) {
+            close();
+            return null;
+        }
+        // Check if this proxy is closed or the client itself is closed. The client may be closed if this proxy was a
+        // sub-resource and the resource client itself was closed.
+        if (closed.get() || client.isClosed()) {
+            closed.set(true);
+            throw new IllegalStateException("RestClientProxy is closed");
+        }
+
+        boolean replacementNeeded = false;
+        Object[] argsReplacement = args != null ? new Object[args.length] : null;
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+
+        if (args != null) {
+            for (Object p : providerInstances) {
+                if (p instanceof ParamConverterProvider) {
+
+                    int index = 0;
+                    for (Object arg : args) {
+                        // ParamConverter's are not allowed to be passed null values. If we have a null value do not process
+                        // it through the provider.
+                        if (arg == null) {
+                            continue;
+                        }
+
+                        if (parameterAnnotations[index].length > 0) { // does a parameter converter apply?
+                            ParamConverter<?> converter = ((ParamConverterProvider) p).getConverter(arg.getClass(), null,
+                                    parameterAnnotations[index]);
+                            if (converter != null) {
+                                Type[] genericTypes = getGenericTypes(converter.getClass());
+                                if (genericTypes.length == 1) {
+
+                                    // minimum supported types
+                                    switch (genericTypes[0].getTypeName()) {
+                                        case "java.lang.String":
+                                            @SuppressWarnings("unchecked")
+                                            ParamConverter<String> stringConverter = (ParamConverter<String>) converter;
+                                            argsReplacement[index] = stringConverter.toString((String) arg);
+                                            replacementNeeded = true;
+                                            break;
+                                        case "java.lang.Integer":
+                                            @SuppressWarnings("unchecked")
+                                            ParamConverter<Integer> intConverter = (ParamConverter<Integer>) converter;
+                                            argsReplacement[index] = intConverter.toString((Integer) arg);
+                                            replacementNeeded = true;
+                                            break;
+                                        case "java.lang.Boolean":
+                                            @SuppressWarnings("unchecked")
+                                            ParamConverter<Boolean> boolConverter = (ParamConverter<Boolean>) converter;
+                                            argsReplacement[index] = boolConverter.toString((Boolean) arg);
+                                            replacementNeeded = true;
+                                            break;
+                                        default:
+                                            continue;
+                                    }
+                                }
+                            }
+                        } else {
+                            argsReplacement[index] = arg;
+                        }
+                        index++;
+                    }
+                }
+            }
+        }
+
+        if (replacementNeeded) {
+            args = argsReplacement;
+        }
+
+        try {
+            final Object result = method.invoke(target, args);
+            final Class<?> returnType = method.getReturnType();
+            // Check if this is a sub-resource. A sub-resource must be an interface.
+            if (returnType.isInterface()) {
+                final Annotation[] annotations = method.getDeclaredAnnotations();
+                boolean hasPath = false;
+                boolean hasHttpMethod = false;
+                // Check the annotations. If the method has one of the @HttpMethod annotations, we will just use the
+                // current method. If it only has a @Path, then we need to create a proxy for the return type.
+                for (Annotation annotation : annotations) {
+                    final Class<?> type = annotation.annotationType();
+                    if (type.equals(Path.class)) {
+                        hasPath = true;
+                    } else if (type.getDeclaredAnnotation(HttpMethod.class) != null) {
+                        hasHttpMethod = true;
+                    }
+                }
+                if (!hasHttpMethod && hasPath) {
+                    // Create a proxy of the return type re-using the providers and client, but do not add the required
+                    // interfaces for the sub-resource.
+                    return createProxy(returnType, result, false, providerInstances, client, getBeanManager());
+                }
+            }
+            return result;
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof CompletionException) {
+                cause = cause.getCause();
+            }
+            if (cause instanceof ExceptionMapping.HandlerException) {
+                ((ExceptionMapping.HandlerException) cause).mapException(method);
+                // no applicable exception mapper found or applicable mapper returned null
+                return null;
+            }
+            if (cause instanceof ResponseProcessingException) {
+                ResponseProcessingException rpe = (ResponseProcessingException) cause;
+                cause = rpe.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw cause;
+                }
+            } else {
+                if (cause instanceof ProcessingException &&
+                        cause.getCause() instanceof ClientHeaderFillingException) {
+                    throw cause.getCause().getCause();
+                }
+                if (cause instanceof RuntimeException) {
+                    throw cause;
+                }
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Creates a proxy for the interface. The proxy will implement the interfaces {@link RestClientProxy} and
+     * {@link Closeable}.
+     *
+     * @param resourceInterface the resource interface to create the proxy for
+     * @param target            the target object for the proxy
+     * @param providers         the providers for the client
+     * @param client            the client to use
+     * @param beanManager       the bean manager used to register {@linkplain ClientHeaderProviders client header providers}
+     * @return the new proxy
+     */
+    static Object createProxy(final Class<?> resourceInterface, final Object target, final Set<Object> providers,
+            final ResteasyClient client, final BeanManager beanManager) {
+        return createProxy(resourceInterface, target, true, providers, client, beanManager);
+    }
+
+    /**
+     * Creates a proxy for the interface.
+     * <p>
+     * If {@code addExtendedInterfaces} is set to {@code true}, the proxy will implement the interfaces
+     * {@link RestClientProxy} and {@link Closeable}.
+     * </p>
+     *
+     * @param resourceInterface     the resource interface to create the proxy for
+     * @param target                the target object for the proxy
+     * @param addExtendedInterfaces {@code true} if the proxy should also implement {@link RestClientProxy} and
+     *                              {@link Closeable}
+     * @param providers             the providers for the client
+     * @param client                the client to use
+     * @param beanManager           the bean manager used to register {@linkplain ClientHeaderProviders client header providers}
+     * @return the new proxy
+     */
+    static Object createProxy(final Class<?> resourceInterface, final Object target, final boolean addExtendedInterfaces,
+            final Set<Object> providers, final ResteasyClient client, final BeanManager beanManager) {
+        final Class<?>[] interfaces;
+        if (addExtendedInterfaces) {
+            interfaces = new Class<?>[3];
+            interfaces[1] = RestClientProxy.class;
+            interfaces[2] = Closeable.class;
+        } else {
+            interfaces = new Class[1];
+        }
+        interfaces[0] = resourceInterface;
+        final Object proxy = Proxy.newProxyInstance(getClassLoader(resourceInterface), interfaces,
+                new ProxyInvocationHandler(resourceInterface, target, Set.copyOf(providers), client));
+        ClientHeaderProviders.registerForClass(resourceInterface, proxy, beanManager);
+        return proxy;
+    }
+
+    private Object invokeRestClientProxyMethod(final Method method) {
+        switch (method.getName()) {
+            case "getClient":
+                return client;
+            case "close":
+                close();
+                return null;
+            default:
+                throw new IllegalStateException("Unsupported RestClientProxy method: " + method);
+        }
+    }
+
+    private void close() {
+        if (closed.compareAndSet(false, true)) {
+            client.close();
+        }
+    }
+
+    private Type[] getGenericTypes(Class<?> aClass) {
+        Type[] genericInterfaces = aClass.getGenericInterfaces();
+        Type[] genericTypes = NO_TYPES;
+        for (Type genericInterface : genericInterfaces) {
+            if (genericInterface instanceof ParameterizedType) {
+                genericTypes = ((ParameterizedType) genericInterface).getActualTypeArguments();
+            }
+        }
+        return genericTypes;
+    }
+
+    private static ClassLoader getClassLoader(final Class<?> type) {
+        if (System.getSecurityManager() == null) {
+            return type.getClassLoader();
+        }
+        return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) type::getClassLoader);
+    }
+
+    private static BeanManager getBeanManager() {
+        try {
+            CDI<Object> current = CDI.current();
+            return current != null ? current.getBeanManager() : null;
+        } catch (IllegalStateException e) {
+            LOGGER.debug("CDI container is not available", e);
+            return null;
+        }
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
@@ -7,6 +7,8 @@
  * 
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
+// https://github.com/resteasy/resteasy-microprofile/blob/3.0.0.Final/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/ProxyInvocationHandler.java
+// https://repo.maven.apache.org/maven2/org/jboss/resteasy/microprofile/microprofile-rest-client-base/3.0.0.Final/microprofile-rest-client-base-3.0.0.Final-sources.jar
 /*
  * JBoss, Home of Professional Open Source.
  *

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeaderProviders.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeaderProviders.java
@@ -1,0 +1,167 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.microprofile.client.header;
+
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+import org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl;
+import org.jboss.resteasy.microprofile.client.CdiConstructorInjector;
+
+/**
+ * A storage of {@link ClientHeaderProvider}s
+ */
+public class ClientHeaderProviders {
+    private static final ClientHeadersFactory defaultHeadersFactory = new DefaultClientHeadersFactoryImpl();
+
+    private static final Map<Method, ClientHeaderProvider> providersForMethod = new ConcurrentHashMap<>();
+    private static final Map<Class<?>, ClientHeadersFactory> headerFactoriesForClass = new ConcurrentHashMap<>();
+
+    private static final HeaderFillerFactory fillerFactory;
+
+    /**
+     * Get {@link ClientHeaderProvider} for a given method, if exists
+     *
+     * @param method a method to get the provider for
+     *
+     * @return the provider responsible for setting the headers
+     */
+    public static Optional<ClientHeaderProvider> getProvider(Method method) {
+        return Optional.ofNullable(providersForMethod.get(method));
+    }
+
+    /**
+     * Get {@link ClientHeadersFactory} for a given class, if exists
+     *
+     * @param aClass a class to get the ClientHeadersFactory for
+     *
+     * @return the factory used to adjust the headers
+     */
+    public static Optional<ClientHeadersFactory> getFactory(Class<?> aClass) {
+        return Optional.ofNullable(headerFactoriesForClass.get(aClass));
+    }
+
+    /**
+     * Register, in a static map, {@link ClientHeaderProvider}`s for the given class and all of its methods
+     *
+     * @param clientClass a class to scan for {@link org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam} and
+     *                    {@link RegisterClientHeaders}
+     * @param clientProxy proxy of the clientClass, used to handle the default methods
+     *
+     * @deprecated use {@link #registerForClass(Class, Object, BeanManager)}
+     */
+    @Deprecated
+    public static void registerForClass(Class<?> clientClass, Object clientProxy) {
+        registerForClass(clientClass, clientProxy, null);
+    }
+
+    /**
+     * Register, in a static map, {@link ClientHeaderProvider}`s for the given class and all of its methods
+     *
+     * @param clientClass a class to scan for {@link org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam} and
+     *                    {@link RegisterClientHeaders}
+     * @param clientProxy proxy of the clientClass, used to handle the default methods
+     * @param beanManager the bean manager used to construct CDI beans
+     */
+    public static void registerForClass(Class<?> clientClass, Object clientProxy, BeanManager beanManager) {
+        Stream.of(clientClass.getMethods())
+                .forEach(m -> registerForMethod(m, clientProxy));
+        registerHeaderFactory(clientClass, beanManager);
+    }
+
+    private static void registerHeaderFactory(Class<?> aClass, BeanManager beanManager) {
+        RegisterClientHeaders annotation = aClass.getAnnotation(RegisterClientHeaders.class);
+        if (annotation != null) {
+            Optional<ClientHeadersFactory> clientHeadersFactory = getCustomHeadersFactory(annotation, aClass, beanManager);
+
+            headerFactoriesForClass.put(aClass, clientHeadersFactory.orElse(defaultHeadersFactory));
+        }
+    }
+
+    private static Optional<ClientHeadersFactory> getCustomHeadersFactory(RegisterClientHeaders annotation,
+            Class<?> source, BeanManager beanManager) {
+        Class<? extends ClientHeadersFactory> factoryClass = annotation.value();
+        try {
+            return Optional.of(construct(factoryClass, beanManager));
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new RestClientDefinitionException(
+                    "Failed to instantiate " + factoryClass.getCanonicalName() + ", the client header factory for "
+                            + source.getCanonicalName(),
+                    e);
+        }
+    }
+
+    private static void registerForMethod(Method method, Object clientProxy) {
+        ClientHeaderProvider.forMethod(method, clientProxy, fillerFactory).ifPresent(
+                provider -> providersForMethod.put(method, provider));
+    }
+
+    private static ClientHeadersFactory construct(final Class<? extends ClientHeadersFactory> factory,
+            final BeanManager manager)
+            throws IllegalAccessException, InstantiationException {
+        if (manager != null) {
+            Set<Bean<?>> beans = manager.getBeans(factory);
+            if (!beans.isEmpty()) {
+                final CdiConstructorInjector injector = new CdiConstructorInjector(factory, manager);
+                // The CdiConstructorInjector does not use the unwrapAsync value using false has no effect
+                return factory.cast(injector.construct(false));
+            }
+        }
+        return factory.newInstance();
+    }
+
+    static {
+        final PrivilegedAction<HeaderFillerFactory> action = () -> {
+            ServiceLoader<HeaderFillerFactory> fillerFactories = ServiceLoader.load(HeaderFillerFactory.class);
+            int highestPrio = Integer.MIN_VALUE;
+            HeaderFillerFactory result = null;
+            for (HeaderFillerFactory factory : fillerFactories) {
+                if (factory.getPriority() > highestPrio) {
+                    highestPrio = factory.getPriority();
+                    result = factory;
+                }
+            }
+            return result;
+        };
+        final HeaderFillerFactory result = System.getSecurityManager() == null ? action.run()
+                : AccessController.doPrivileged(action);
+        if (result == null) {
+            throw new IllegalStateException("Unable to find a HeaderFillerFactory implementation");
+        } else {
+            fillerFactory = result;
+        }
+    }
+
+    private ClientHeaderProviders() {
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeaderProviders.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeaderProviders.java
@@ -7,6 +7,8 @@
  * 
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
+// https://github.com/resteasy/resteasy-microprofile/blob/3.0.0.Final/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/header/ClientHeaderProviders.java
+// https://repo.maven.apache.org/maven2/org/jboss/resteasy/microprofile/microprofile-rest-client-base/3.0.0.Final/microprofile-rest-client-base-3.0.0.Final-sources.jar
 /*
  * JBoss, Home of Professional Open Source.
  *

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeaderProviders.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeaderProviders.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 /*
  * JBoss, Home of Professional Open Source.
  *
@@ -44,8 +53,10 @@ import org.jboss.resteasy.microprofile.client.CdiConstructorInjector;
 public class ClientHeaderProviders {
     private static final ClientHeadersFactory defaultHeadersFactory = new DefaultClientHeadersFactoryImpl();
 
-    private static final Map<Method, ClientHeaderProvider> providersForMethod = new ConcurrentHashMap<>();
-    private static final Map<Class<?>, ClientHeadersFactory> headerFactoriesForClass = new ConcurrentHashMap<>();
+    // Liberty change start
+    private final Map<Method, ClientHeaderProvider> providersForMethod = new ConcurrentHashMap<>();
+    private final Map<Class<?>, ClientHeadersFactory> headerFactoriesForClass = new ConcurrentHashMap<>();
+    // Liberty change end
 
     private static final HeaderFillerFactory fillerFactory;
 
@@ -56,7 +67,7 @@ public class ClientHeaderProviders {
      *
      * @return the provider responsible for setting the headers
      */
-    public static Optional<ClientHeaderProvider> getProvider(Method method) {
+    public Optional<ClientHeaderProvider> getProvider(Method method) { // Liberty change
         return Optional.ofNullable(providersForMethod.get(method));
     }
 
@@ -67,7 +78,7 @@ public class ClientHeaderProviders {
      *
      * @return the factory used to adjust the headers
      */
-    public static Optional<ClientHeadersFactory> getFactory(Class<?> aClass) {
+    public Optional<ClientHeadersFactory> getFactory(Class<?> aClass) { // Liberty change
         return Optional.ofNullable(headerFactoriesForClass.get(aClass));
     }
 
@@ -81,7 +92,7 @@ public class ClientHeaderProviders {
      * @deprecated use {@link #registerForClass(Class, Object, BeanManager)}
      */
     @Deprecated
-    public static void registerForClass(Class<?> clientClass, Object clientProxy) {
+    public void registerForClass(Class<?> clientClass, Object clientProxy) { // Liberty change
         registerForClass(clientClass, clientProxy, null);
     }
 
@@ -93,13 +104,13 @@ public class ClientHeaderProviders {
      * @param clientProxy proxy of the clientClass, used to handle the default methods
      * @param beanManager the bean manager used to construct CDI beans
      */
-    public static void registerForClass(Class<?> clientClass, Object clientProxy, BeanManager beanManager) {
+    public void registerForClass(Class<?> clientClass, Object clientProxy, BeanManager beanManager) { // Liberty change
         Stream.of(clientClass.getMethods())
                 .forEach(m -> registerForMethod(m, clientProxy));
         registerHeaderFactory(clientClass, beanManager);
     }
 
-    private static void registerHeaderFactory(Class<?> aClass, BeanManager beanManager) {
+    private void registerHeaderFactory(Class<?> aClass, BeanManager beanManager) { // Liberty change
         RegisterClientHeaders annotation = aClass.getAnnotation(RegisterClientHeaders.class);
         if (annotation != null) {
             Optional<ClientHeadersFactory> clientHeadersFactory = getCustomHeadersFactory(annotation, aClass, beanManager);
@@ -108,7 +119,7 @@ public class ClientHeaderProviders {
         }
     }
 
-    private static Optional<ClientHeadersFactory> getCustomHeadersFactory(RegisterClientHeaders annotation,
+    private Optional<ClientHeadersFactory> getCustomHeadersFactory(RegisterClientHeaders annotation, // Liberty change
             Class<?> source, BeanManager beanManager) {
         Class<? extends ClientHeadersFactory> factoryClass = annotation.value();
         try {
@@ -121,12 +132,12 @@ public class ClientHeaderProviders {
         }
     }
 
-    private static void registerForMethod(Method method, Object clientProxy) {
+    private void registerForMethod(Method method, Object clientProxy) { // Liberty change
         ClientHeaderProvider.forMethod(method, clientProxy, fillerFactory).ifPresent(
                 provider -> providersForMethod.put(method, provider));
     }
 
-    private static ClientHeadersFactory construct(final Class<? extends ClientHeadersFactory> factory,
+    private ClientHeadersFactory construct(final Class<? extends ClientHeadersFactory> factory, // Liberty change
             final BeanManager manager)
             throws IllegalAccessException, InstantiationException {
         if (manager != null) {
@@ -162,6 +173,6 @@ public class ClientHeaderProviders {
         }
     }
 
-    private ClientHeaderProviders() {
+    public ClientHeaderProviders() { // Liberty change
     }
 }

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.resteasy.microprofile.client.header;
+
+import static org.jboss.resteasy.microprofile.client.utils.ListCastUtils.castToListOfStrings;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+import org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl;
+import org.jboss.resteasy.core.Headers;
+import org.jboss.resteasy.microprofile.client.impl.MpClientInvocation;
+import org.jboss.resteasy.microprofile.client.utils.ClientRequestContextUtils;
+
+/**
+ * First the headers from `@ClientHeaderParam` annotations are applied,
+ * they can be overwritten by JAX-RS `@HeaderParam` (coming in the `requestContext`)
+ *
+ * Then, if a `ClientHeadersFactory` is defined, all the headers, together with incoming container headers,
+ * are passed to it and it can overwrite them.
+ */
+@Priority(Integer.MIN_VALUE)
+public class ClientHeadersRequestFilter implements ClientRequestFilter {
+
+    private static final MultivaluedMap<String, String> EMPTY_MAP = new MultivaluedHashMap<>();
+
+    private final MultivaluedMap<String, Object> defaultHeaders;
+
+    /**
+     * Creates a new filter.
+     */
+    public ClientHeadersRequestFilter() {
+        this.defaultHeaders = new Headers<>();
+    }
+
+    /**
+     * Creates a new filter which will add each default header by default to the request headers. Note the values of
+     * the {@code defaultHeaders} will be appended and header values are not replaced.
+     *
+     * @param defaultHeaders the default headers to add
+     */
+    public ClientHeadersRequestFilter(final MultivaluedMap<String, Object> defaultHeaders) {
+        this.defaultHeaders = new Headers<>();
+        this.defaultHeaders.putAll(defaultHeaders);
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        Method method = ClientRequestContextUtils.getMethod(requestContext);
+
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+
+        Optional<ClientHeaderProvider> handler = ClientHeaderProviders.getProvider(method);
+        handler.ifPresent(h -> h.addHeaders(headers));
+
+        Optional<ClientHeadersFactory> factory = ClientHeaderProviders
+                .getFactory(ClientRequestContextUtils.getDeclaringClass(requestContext));
+
+        requestContext.getHeaders().forEach(
+                (key, values) -> headers.put(key, castToListOfStrings(values)));
+
+        @SuppressWarnings("unchecked")
+        MultivaluedMap<String, String> containerHeaders = (MultivaluedMap<String, String>) requestContext
+                .getProperty(MpClientInvocation.CONTAINER_HEADERS);
+        if (containerHeaders == null)
+            containerHeaders = EMPTY_MAP;
+        // stupid final rules
+        MultivaluedMap<String, String> incomingHeaders = containerHeaders;
+
+        if (!factory.isPresent() || factory.get() instanceof DefaultClientHeadersFactoryImpl) {
+            // When using the default factory, pass the proposed outgoing headers onto the request context.
+            // Propagation with the default factory will then overwrite any values if required.
+            headers.forEach((key, values) -> requestContext.getHeaders().put(key, castToListOfObjects(values)));
+        }
+
+        factory.ifPresent(f -> f.update(incomingHeaders, headers)
+                .forEach((key, values) -> requestContext.getHeaders().put(key, castToListOfObjects(values))));
+
+        this.defaultHeaders.forEach((name, values) -> requestContext.getHeaders().addAll(name, values));
+    }
+
+    private static List<Object> castToListOfObjects(List<String> values) {
+        return new ArrayList<>(values);
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 /*
  * JBoss, Home of Professional Open Source.
  *
@@ -52,12 +61,7 @@ public class ClientHeadersRequestFilter implements ClientRequestFilter {
 
     private final MultivaluedMap<String, Object> defaultHeaders;
 
-    /**
-     * Creates a new filter.
-     */
-    public ClientHeadersRequestFilter() {
-        this.defaultHeaders = new Headers<>();
-    }
+    private final ClientHeaderProviders headerProviders; // Liberty change
 
     /**
      * Creates a new filter which will add each default header by default to the request headers. Note the values of
@@ -65,9 +69,10 @@ public class ClientHeadersRequestFilter implements ClientRequestFilter {
      *
      * @param defaultHeaders the default headers to add
      */
-    public ClientHeadersRequestFilter(final MultivaluedMap<String, Object> defaultHeaders) {
+    public ClientHeadersRequestFilter(final MultivaluedMap<String, Object> defaultHeaders, ClientHeaderProviders headerProviders) { // Liberty Change
         this.defaultHeaders = new Headers<>();
         this.defaultHeaders.putAll(defaultHeaders);
+        this.headerProviders = new ClientHeaderProviders(); // Liberty Change
     }
 
     @Override
@@ -76,10 +81,10 @@ public class ClientHeadersRequestFilter implements ClientRequestFilter {
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
 
-        Optional<ClientHeaderProvider> handler = ClientHeaderProviders.getProvider(method);
+        Optional<ClientHeaderProvider> handler = headerProviders.getProvider(method); // Liberty change
         handler.ifPresent(h -> h.addHeaders(headers));
 
-        Optional<ClientHeadersFactory> factory = ClientHeaderProviders
+        Optional<ClientHeadersFactory> factory = headerProviders // Liberty change
                 .getFactory(ClientRequestContextUtils.getDeclaringClass(requestContext));
 
         requestContext.getHeaders().forEach(

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient.4.0/src/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
@@ -7,6 +7,8 @@
  * 
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
+// https://github.com/resteasy/resteasy-microprofile/blob/3.0.0.Final/rest-client-base/src/main/java/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
+// https://repo.maven.apache.org/maven2/org/jboss/resteasy/microprofile/microprofile-rest-client-base/3.0.0.Final/microprofile-rest-client-base-3.0.0.Final-sources.jar
 /*
  * JBoss, Home of Professional Open Source.
  *
@@ -72,7 +74,7 @@ public class ClientHeadersRequestFilter implements ClientRequestFilter {
     public ClientHeadersRequestFilter(final MultivaluedMap<String, Object> defaultHeaders, ClientHeaderProviders headerProviders) { // Liberty Change
         this.defaultHeaders = new Headers<>();
         this.defaultHeaders.putAll(defaultHeaders);
-        this.headerProviders = new ClientHeaderProviders(); // Liberty Change
+        this.headerProviders = headerProviders; // Liberty Change
     }
 
     @Override

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/header/ClientHeaderProviders.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/header/ClientHeaderProviders.java
@@ -1,0 +1,134 @@
+package org.jboss.resteasy.microprofile.client.header;
+
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+import org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl;
+import org.jboss.resteasy.cdi.CdiConstructorInjector;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+
+/**
+ * A storage of {@link ClientHeaderProvider}s
+ */
+public class ClientHeaderProviders {
+    private static final ClientHeadersFactory defaultHeadersFactory = new DefaultClientHeadersFactoryImpl();
+
+    private static Map<Method, ClientHeaderProvider> providersForMethod = new ConcurrentHashMap<>();
+    private static Map<Class<?>, ClientHeadersFactory> headerFactoriesForClass = new ConcurrentHashMap<>();
+
+    private static final HeaderFillerFactory fillerFactory;
+
+    /**
+     * Get {@link ClientHeaderProvider} for a given method, if exists
+     *
+     * @param method a method to get the provider for
+     * @return the provider responsible for setting the headers
+     */
+    public static Optional<ClientHeaderProvider> getProvider(Method method) {
+        return Optional.ofNullable(providersForMethod.get(method));
+    }
+
+    /**
+     * Get {@link ClientHeadersFactory} for a given class, if exists
+     *
+     * @param aClass a class to get the ClientHeadersFactory for
+     * @return the factory used to adjust the headers
+     */
+    public static Optional<ClientHeadersFactory> getFactory(Class<?> aClass) {
+        return Optional.ofNullable(headerFactoriesForClass.get(aClass));
+    }
+
+    /**
+     * Register, in a static map, {@link ClientHeaderProvider}`s for the given class and all of its methods
+     *
+     * @param clientClass a class to scan for {@link org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam} and {@link RegisterClientHeaders}
+     * @param clientProxy proxy of the clientClass, used to handle the default methods
+     *
+     * @deprecated use {@link #registerForClass(Class, Object, BeanManager)}
+     */
+    @Deprecated
+    public static void registerForClass(Class<?> clientClass, Object clientProxy) {
+        registerForClass(clientClass, clientProxy, null);
+    }
+
+    /**
+     * Register, in a static map, {@link ClientHeaderProvider}`s for the given class and all of its methods
+     *
+     * @param clientClass a class to scan for {@link org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam} and {@link RegisterClientHeaders}
+     * @param clientProxy proxy of the clientClass, used to handle the default methods
+     * @param beanManager the bean manager used to construct CDI beans
+     */
+    public static void registerForClass(Class<?> clientClass, Object clientProxy, BeanManager beanManager) {
+        Stream.of(clientClass.getMethods())
+                .forEach(m -> registerForMethod(m, clientProxy));
+        registerHeaderFactory(clientClass, beanManager);
+    }
+
+    private static void registerHeaderFactory(Class<?> aClass, BeanManager beanManager) {
+        RegisterClientHeaders annotation = aClass.getAnnotation(RegisterClientHeaders.class);
+        if (annotation != null) {
+            Optional<ClientHeadersFactory> clientHeadersFactory = getCustomHeadersFactory(annotation, aClass, beanManager);
+
+            headerFactoriesForClass.put(aClass, clientHeadersFactory.orElse(defaultHeadersFactory));
+        }
+    }
+
+    private static Optional<ClientHeadersFactory> getCustomHeadersFactory(RegisterClientHeaders annotation, Class<?> source, BeanManager beanManager) {
+        Class<? extends ClientHeadersFactory> factoryClass = annotation.value();
+        try {
+            return Optional.of(construct(factoryClass, beanManager));
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new RestClientDefinitionException(
+                    "Failed to instantiate " + factoryClass.getCanonicalName() + ", the client header factory for " + source.getCanonicalName(),
+                    e
+            );
+        }
+    }
+
+    private static void registerForMethod(Method method, Object clientProxy) {
+        ClientHeaderProvider.forMethod(method, clientProxy, fillerFactory).ifPresent(
+                provider -> providersForMethod.put(method, provider)
+        );
+    }
+
+    private static ClientHeadersFactory construct(final Class<? extends ClientHeadersFactory> factory, final BeanManager manager) throws IllegalAccessException, InstantiationException {
+        if (manager != null) {
+            Set<Bean<?>> beans = manager.getBeans(factory);
+            if (!beans.isEmpty()) {
+                final CdiConstructorInjector injector = new CdiConstructorInjector(factory, manager);
+                // The CdiConstructorInjector does not use the unwrapAsync value using false has no effect
+                return factory.cast(injector.construct(false));
+            }
+        }
+        return factory.newInstance();
+    }
+
+    static {
+        ServiceLoader<HeaderFillerFactory> fillerFactories = ServiceLoader.load(HeaderFillerFactory.class);
+        int highestPrio = Integer.MIN_VALUE;
+        HeaderFillerFactory result = null;
+        for (HeaderFillerFactory factory : fillerFactories) {
+            if (factory.getPriority() > highestPrio) {
+                highestPrio = factory.getPriority();
+                result = factory;
+            }
+        }
+        if (result == null) {
+            throw new java.lang.IllegalStateException("Unable to find a HeaderFillerFactory implementation");
+        } else {
+            fillerFactory = result;
+        }
+    }
+
+    private ClientHeaderProviders() {
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
@@ -1,0 +1,69 @@
+package org.jboss.resteasy.microprofile.client.header;
+
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+import org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl;
+import org.jboss.resteasy.microprofile.client.impl.MpClientInvocation;
+import org.jboss.resteasy.microprofile.client.utils.ClientRequestContextUtils;
+
+import javax.annotation.Priority;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.jboss.resteasy.microprofile.client.utils.ListCastUtils.castToListOfStrings;
+
+
+/**
+ * First the headers from `@ClientHeaderParam` annotations are applied,
+ * they can be overwritten by JAX-RS `@HeaderParam` (coming in the `requestContext`)
+ *
+ * Then, if a `ClientHeadersFactory` is defined, all the headers, together with incoming container headers,
+ * are passed to it and it can overwrite them.
+ */
+@Priority(Integer.MIN_VALUE)
+public class ClientHeadersRequestFilter implements ClientRequestFilter {
+
+    private static final MultivaluedMap<String, String> EMPTY_MAP = new MultivaluedHashMap<>();
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        Method method = ClientRequestContextUtils.getMethod(requestContext);
+
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+
+        Optional<ClientHeaderProvider> handler = ClientHeaderProviders.getProvider(method);
+        handler.ifPresent(h -> h.addHeaders(headers));
+
+        Optional<ClientHeadersFactory> factory = ClientHeaderProviders.getFactory(ClientRequestContextUtils.getDeclaringClass(requestContext));
+
+        requestContext.getHeaders().forEach(
+                (key, values) -> headers.put(key, castToListOfStrings(values))
+        );
+
+        @SuppressWarnings("unchecked")
+        MultivaluedMap<String,String> containerHeaders = (MultivaluedMap<String, String>) requestContext.getProperty(MpClientInvocation.CONTAINER_HEADERS);
+        if(containerHeaders == null)
+            containerHeaders = EMPTY_MAP;
+        // stupid final rules
+        MultivaluedMap<String,String> incomingHeaders = containerHeaders;
+
+        if (!factory.isPresent() || factory.get() instanceof DefaultClientHeadersFactoryImpl) {
+            // When using the default factory, pass the proposed outgoing headers onto the request context.
+            // Propagation with the default factory will then overwrite any values if required.
+            headers.forEach((key, values) -> requestContext.getHeaders().put(key, castToListOfObjects(values)));
+        }
+
+        factory.ifPresent(f -> f.update(incomingHeaders, headers)
+                .forEach((key, values) -> requestContext.getHeaders().put(key, castToListOfObjects(values)))
+        );
+    }
+
+    private static List<Object> castToListOfObjects(List<String> values) {
+        return new ArrayList<>(values);
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
+++ b/dev/io.openliberty.org.jboss.resteasy.mprestclient/src/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
@@ -1,3 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+// https://github.com/resteasy/resteasy/blob/4.7.2.Final/resteasy-client-microprofile-base/src/main/java/org/jboss/resteasy/microprofile/client/header/ClientHeadersRequestFilter.java
+// https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-client-microprofile-base/4.7.2.Final/resteasy-client-microprofile-base-4.7.2.Final-sources.jar
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jboss.resteasy.microprofile.client.header;
 
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
@@ -30,16 +60,24 @@ public class ClientHeadersRequestFilter implements ClientRequestFilter {
 
     private static final MultivaluedMap<String, String> EMPTY_MAP = new MultivaluedHashMap<>();
 
+    // Liberty change start
+    private final ClientHeaderProviders headerProviders;
+
+    public ClientHeadersRequestFilter(ClientHeaderProviders headerProviders) {
+        this.headerProviders = headerProviders;
+    }
+    // Liberty change end
+
     @Override
     public void filter(ClientRequestContext requestContext) {
         Method method = ClientRequestContextUtils.getMethod(requestContext);
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
 
-        Optional<ClientHeaderProvider> handler = ClientHeaderProviders.getProvider(method);
+        Optional<ClientHeaderProvider> handler = headerProviders.getProvider(method); // Liberty change
         handler.ifPresent(h -> h.addHeaders(headers));
 
-        Optional<ClientHeadersFactory> factory = ClientHeaderProviders.getFactory(ClientRequestContextUtils.getDeclaringClass(requestContext));
+        Optional<ClientHeadersFactory> factory = headerProviders.getFactory(ClientRequestContextUtils.getDeclaringClass(requestContext)); // Liberty change
 
         requestContext.getHeaders().forEach(
                 (key, values) -> headers.put(key, castToListOfStrings(values))


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Change ClientHeaderProviders to no longer have static methods and make the constructor public so that we new up a new instance per client that is built
- Update ClientHeaderRequestFilter to take a ClientHeaderProvider instance in its constructor in order to get the needed information
- Change LibertyRestClientBuilderImpl and RestClientBuilderImpl to do things the new way
- Remove call to ClientHeaderProviders in ProxyInvocationHandler since it is already called by RestClientBuilderImpl
- Update MP RestClient TCK FATs to reduce memory usage
- Update Liberty server heap size to 512M instead of 1G or 2G
- Change to have wiremock be in the global library instead of in the non global one
- Update 3.0 TCK logging settings to disable debug since it adds extra output to System.out causing OutOfMemoryError when processing the test output

Fixes #32092