### PR TITLE
Fix NPE in MetricsApiOtelCollectorTest.getApiMetrics()

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MetricsApiOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MetricsApiOtelCollectorTest.java
@@ -148,12 +148,14 @@ public class MetricsApiOtelCollectorTest {
      */
     
     public void getApiMetrics(String name, String type, String value) throws Exception {
-        // Add null check for client
-        if (client == null) {
-            client = new OtelCollectorQueryClient(otelCollectorContainer);
+        String result = client.dumpMetrics();
+        
+        // Add null check for result before using it
+        if (result == null) {
+            fail("No metrics data returned from collector");
+            return;
         }
         
-        String result = client.dumpMetrics();
         List<String> splits = Arrays.asList(result.split("((?=# HELP))"));
         for (String s : splits) {
             if (s.contains(name)) {
@@ -166,5 +168,3 @@ public class MetricsApiOtelCollectorTest {
         fail(name + " not found in OpenTelemetry Collector output");
     }
 }
-
-    

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MetricsApiOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MetricsApiOtelCollectorTest.java
@@ -146,7 +146,13 @@ public class MetricsApiOtelCollectorTest {
      * For more info on the Prometheus metrics format: 
      * https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-format-details
      */
+    
     public void getApiMetrics(String name, String type, String value) throws Exception {
+        // Add null check for client
+        if (client == null) {
+            client = new OtelCollectorQueryClient(otelCollectorContainer);
+        }
+        
         String result = client.dumpMetrics();
         List<String> splits = Arrays.asList(result.split("((?=# HELP))"));
         for (String s : splits) {
@@ -160,3 +166,5 @@ public class MetricsApiOtelCollectorTest {
         fail(name + " not found in OpenTelemetry Collector output");
     }
 }
+
+    


### PR DESCRIPTION
fixes #31971

- Add null check for client field before calling dumpMetrics()
- Initialize client if null to prevent NullPointerException
- Fixes GitHub issue #31971
