### PR TITLE
Caught NullPointerException at testStringBufferAppendWithoutSetAttribute

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -898,9 +898,17 @@ public class SessionCacheTestServlet extends FATServlet {
      */
     public void testStringBufferAppendWithoutSetAttribute(HttpServletRequest request, HttpServletResponse response) throws Exception {
         String key = request.getParameter("key");
-        HttpSession session = request.getSession(true);
-        StringBuffer value = (StringBuffer) session.getAttribute(key);
-        value.append("Appended");
+        HttpSession session = request.getSession(true);     
+        if (session == null) {
+            // Retry getSession() as request.getSession(true) can not be null
+            System.out.println("Retry getSession() as request.getSession(true) can not be null, most likely due to slow machines.");
+            TimeUnit.SECONDS.sleep(5);
+            session = request.getSession(true);           
+        }        
+        if (session != null) {
+            StringBuffer value = (StringBuffer) session.getAttribute(key);
+            value.append("Appended");
+        }
     }
 
     public void testTimeoutExtensionA(HttpServletRequest request, HttpServletResponse response) throws Exception {


### PR DESCRIPTION

testModifyWithoutPut_CacheManager:junit.framework.AssertionFailedError: 2025-06-15-16:50:03:770 Servlet call was not successful: ERROR: Caught exception attempting to call test method testStringBufferAppendWithoutSetAttribute on servlet session.cache.infinispan.web.SessionCacheTestServlet
java.lang.NullPointerException
    at session.cache.infinispan.web.SessionCacheTestServlet.testStringBufferAppendWithoutSetAttribute(SessionCacheTestServlet.java:903)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at componenttest.app.FATServlet.doGet(FATServlet.java:76)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:686)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:791)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1266)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:754)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:451)
    at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1362)
    at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1078)
    at com.ibm.ws.webcontainer.servlet.CacheServletWrapper.handleRequest(CacheServletWrapper.java:77)
    at com.ibm.ws.webcontainer40.servlet.CacheServletWrapper40.handleRequest(CacheServletWrapper40.java:87)
    at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:978)
    at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:293)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1284)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:500)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:459)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:569)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:503)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:363)
    at com.ibm.ws.http.channel.internal.inbound.HttpICLReadCallback.complete(HttpICLReadCallback.java:72)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:516)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:586)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:970)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1059)
    at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:298)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:835)

    at com.ibm.ws.session.cache.fat.infinispan.FATSuite.run(FATSuite.java:68)
    at com.ibm.ws.session.cache.fat.infinispan.SessionCacheApp.invokeServlet(SessionCacheApp.java:40)
    at com.ibm.ws.session.cache.fat.infinispan.SessionCacheTwoServerTest.testModifyWithoutPut(SessionCacheTwoServerTest.java:255)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:236)
    at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:149)
    at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:401)
    at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:203)