### PR TITLE
add fips 140-3 support for WebServiceCacheProcessor sha-256

### DIFF
--- a/dev/com.ibm.ws.dynacache.web/src/com/ibm/ws/cache/servlet/WebServicesCacheProcessor.java
+++ b/dev/com.ibm.ws.dynacache.web/src/com/ibm/ws/cache/servlet/WebServicesCacheProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2022 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,7 @@ public class WebServicesCacheProcessor extends FragmentCacheProcessor {
    // id constants for type=BODY
    public static final String HASH = "Hash";
    public static final String LITERAL = "Literal";
+   private static final String HASH_TYPE = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256 : CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA;
 
    SAXParserFactory factory = null;
    SAXParser parser = null;
@@ -219,7 +220,7 @@ public class WebServicesCacheProcessor extends FragmentCacheProcessor {
                // else if(c.id.equalsIgnoreCase(HASH)){
                else { //default is hash value.
                   if (md == null)
-                     md = MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA);
+                     md = MessageDigest.getInstance(HASH_TYPE);
                   byte[] reqHash = md.digest(reqContent);
                   return Base64Coder.encode(reqHash);
                }


### PR DESCRIPTION
FipsPB: https://libh-proxy1.fyre.ibm.com/cognitive/pipelineAnalysis.html?pipelineId=4a9608f9-2367-41c6-9377-4af48dc97096

<img width="1100" height="42" alt="Screenshot 2025-07-14 at 9 47 15 AM" src="https://github.com/user-attachments/assets/8640cb3b-4663-476a-a2b9-067158c1934d" />
