### PR TITLE
update fips custom profile - mp telemetry monitor fat

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+# Allowing for open-source org.objectweb.asm
+# But To Do: Investigation on the open source with component owner 
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.objectweb.asm.commons.SerialVersionUIDAdder}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]


### PR DESCRIPTION
Fix FAT test failure with FIPS 140-3 enabled and Java 17 Semeru by updating custom profile in java.security to avoid FIPS compliant error.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).