### PR TITLE
Skip tests with postgresql password - exmple.testcontainers fat

### DIFF
--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/BasicTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/BasicTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -26,9 +26,16 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import web.generic.ContainersTestServlet;
 
+import org.junit.ClassRule;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
+
+
 /**
  * Example test class showing how to use a predefined TestCotnainer
+ * Note: The annotation @SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule is used only when the build environment is eanbled with FIPS,
+ * which indicates the test is excluded as out of scope for our internal FIPS compliant testing due to sample usage.
  */
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 @RunWith(FATRunner.class)
 public class BasicTest extends FATServletClient {
 
@@ -39,6 +46,9 @@ public class BasicTest extends FATServletClient {
     public static LibertyServer server;
 
     static PostgreSQLContainer<?> container = FATSuite.container;
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("build.example.testcontainers");
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ContainersTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ContainersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -31,9 +31,14 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import web.generic.ContainersTestServlet;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
+
 /**
  * Example test class showing how to setup a GenericContainer
+ * Note: The annotation @SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule is used only when the build environment is eanbled with FIPS,
+ * which indicates the test is excluded as out of scope for FIPS compliant testing due to sample usage.
  */
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 @RunWith(FATRunner.class)
 public class ContainersTest extends FATServletClient {
 
@@ -80,6 +85,9 @@ public class ContainersTest extends FATServletClient {
                                     .withRegEx(".*database system is ready to accept connections.*\\s")
                                     .withTimes(2)
                                     .withStartupTimeout(Duration.ofSeconds(60)));
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("build.example.testcontainers");    
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/DockerfileTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/DockerfileTest.java
@@ -35,9 +35,15 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.topology.impl.LibertyServer;
 import web.generic.ContainersTestServlet;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
+
+
 /**
  * Example test class showing how to setup a testcontainer that uses a custom dockerfile.
+ * Note: The annotation @SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule is used only when the build environment is eanbled with FIPS,
+ * which indicates the test is excluded as out of scope for FIPS compliant testing due to sample usage.
  */
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 @Mode(FULL)
 @RunWith(FATRunner.class)
 public class DockerfileTest {
@@ -83,6 +89,9 @@ public class DockerfileTest {
                                     .withRegEx(".*database system is ready to accept connections.*\\s")
                                     .withTimes(2)
                                     .withStartupTimeout(Duration.ofSeconds(60)));
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("build.example.testcontainers");
 
     @BeforeClass
     public static void setUp() throws Exception {


### PR DESCRIPTION
Fix FAT test failure with FIPS 140-3 enabled and Java 17 Semeru by skipping tests with postgresql password to avoid FIPS compliant error.

Note: the change now is for testing only; it's still under discussion for best solution.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).

