### PR TITLE
Postgres transaction fat fixed

### DIFF
--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuth/bootstrap.properties
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuth/bootstrap.properties
@@ -11,5 +11,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 derby.connection.requireAuthentication=true
-derby.user.dbuser=dbpass
+derby.user.dbuser=dbpassword
 com.ibm.ws.logging.trace.specification=org.apache.felix*=all:Transaction=all:com.ibm.ws.app.manager.*=all

--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuth/server.xml
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuth/server.xml
@@ -44,10 +44,10 @@
       <properties.derby.embedded  createDatabase="create" databaseName="${shared.resource.dir}/data/transactionFATCloud"/>
     </dataSource>
     
-    <authData id="auth0" user="dby" password="dbnot"/> 
-    <authData id="auth1" user="dbuser" password="dbpass" fat.modify="true"/>
-    <authData id="auth2" user="dby" password="dbnot"/>
-    <authData id="auth3" user="dbuser" password="dbpass" fat.modify="true"/>
+    <authData id="auth0" user="dby" password="dbnotpassword"/> 
+    <authData id="auth1" user="dbuser" password="dbpassword" fat.modify="true"/>
+    <authData id="auth2" user="dby" password="dbnotpassword"/>
+    <authData id="auth3" user="dbuser" password="dbpassword" fat.modify="true"/>
      
     <application location="containerAuth.war">
         <classloader commonLibraryRef="AnonymousJDBCLib"/>

--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthBadUser/bootstrap.properties
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthBadUser/bootstrap.properties
@@ -11,5 +11,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 derby.connection.requireAuthentication=true
-derby.user.dbuser=dbpass
+derby.user.dbuser=dbpassword
 com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthBadUser/server.xml
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthBadUser/server.xml
@@ -44,8 +44,8 @@
       <properties.derby.embedded  createDatabase="create" databaseName="${shared.resource.dir}/data/transactionFATCloud"/>
     </dataSource>
   
-    <authData id="auth1" user="dbuser" password="dbpass" fat.modify="true"/>
-    <authData id="auth99" user="bad" password="badpass" fat.modify="false"/>
+    <authData id="auth1" user="dbuser" password="dbpassword" fat.modify="true"/>
+    <authData id="auth99" user="bad" password="badpassword" fat.modify="false"/>
   
     <application location="containerAuth.war">
         <classloader commonLibraryRef="AnonymousJDBCLib"/>

--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthEmbed/bootstrap.properties
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthEmbed/bootstrap.properties
@@ -11,5 +11,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 derby.connection.requireAuthentication=true
-derby.user.dbuser=dbpass
+derby.user.dbuser=dbpassword
 com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthEmbed/server.xml
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthEmbed/server.xml
@@ -43,10 +43,10 @@
       <properties.derby.embedded  createDatabase="create" databaseName="${shared.resource.dir}/data/transactionFATCloud"/>
     </dataSource>
   
-    <authData id="auth0" user="dby" password="dbnot"/> 
-    <authData id="auth1" user="dbuser" password="dbpass" fat.modify="true"/>
-    <authData id="auth2" user="dby" password="dbnot"/>
-    <authData id="auth3" user="dbuser" password="dbpass" fat.modify="true"/>
+    <authData id="auth0" user="dby" password="dbnotpassword"/> 
+    <authData id="auth1" user="dbuser" password="dbpassword" fat.modify="true"/>
+    <authData id="auth2" user="dby" password="dbnotpassword"/>
+    <authData id="auth3" user="dbuser" password="dbpassword" fat.modify="true"/>
   
     <application location="containerAuth.war">
         <classloader commonLibraryRef="AnonymousJDBCLib"/>

--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthEmbedBadUser/bootstrap.properties
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthEmbedBadUser/bootstrap.properties
@@ -11,5 +11,5 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
 derby.connection.requireAuthentication=true
-derby.user.dbuser=dbpass
+derby.user.dbuser=dbpassword
 com.ibm.ws.logging.trace.specification=Transaction=all

--- a/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthEmbedBadUser/server.xml
+++ b/dev/io.openliberty.transaction.containerAuth_fat.derby/publish/servers/containerAuthEmbedBadUser/server.xml
@@ -42,8 +42,8 @@
       <properties.derby.embedded  createDatabase="create" databaseName="${shared.resource.dir}/data/transactionFATCloud"/>
     </dataSource>
   
-    <authData id="auth1" user="dbuser" password="dbpass" fat.modify="true"/>
-    <authData id="auth99" user="bad" password="badpass" fat.modify="false"/>
+    <authData id="auth1" user="dbuser" password="dbpassword" fat.modify="true"/>
+    <authData id="auth99" user="bad" password="badpassword" fat.modify="false"/>
   
     <application location="containerAuth.war">
         <classloader commonLibraryRef="AnonymousJDBCLib"/>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

I was seeing the following issue in io.openliberty.transaction.containerAuth_fat.postgresql, which was causing a bunch of failures. It was strange because the password used is `private static final String POSTGRES_PASS = "superSecret"`; which shouldn't cause issues. io.openliberty.transaction.containerAuth_fat.derby tests were being used in this fat. Those tests used some passwords with length < 10 which caused the failure below. 

Works now with the following fix:
```
Tests - 24	
Failures - 0	
Errors - 0	
Success rate - 100.00%	 
Time - 1024.436
```

```
VMDUMP055I Processing dump event "throw", detail "java/security/spec/InvalidKeySpecException", exception "Password must be 10 characters or higher when using the OpenJCEPlusFIPS provider." at 2025/07/13 12:52:15 - please wait.
Thread=Equinox start level thread - Equinox Container: dba1397a-fd7d-4d7f-b348-1231a08cdd30 (00007F43CC00F7E0) Status=Running
	at com/ibm/crypto/plus/provider/PBKDF2KeyImpl.<init>(Lcom/ibm/crypto/plus/provider/OpenJCEPlusProvider;Ljavax/crypto/spec/PBEKeySpec;Ljava/lang/String;)V (PBKDF2KeyImpl.java:112)
	at com/ibm/crypto/plus/provider/PBKDF2Core.engineGenerateSecret(Ljava/security/spec/KeySpec;)Ljavax/crypto/SecretKey; (PBKDF2Core.java:55)
	at javax/crypto/SecretKeyFactory.generateSecret(Ljava/security/spec/KeySpec;)Ljavax/crypto/SecretKey; (SecretKeyFactory.java:340)
	at org/postgresql/shaded/com/ongres/scram/common/util/CryptoUtil.hi(Ljavax/crypto/SecretKeyFactory;I[C[BI)[B (CryptoUtil.java:120)
	at org/postgresql/shaded/com/ongres/scram/common/ScramMechanisms.saltedPassword(Lorg/postgresql/shaded/com/ongres/scram/common/stringprep/StringPreparation;Ljava/lang/String;[BI)[B (ScramMechanisms.java:154)
	at org/postgresql/shaded/com/ongres/scram/common/ScramFunctions.saltedPassword(Lorg/postgresql/shaded/com/ongres/scram/common/ScramMechanism;Lorg/postgresql/shaded/com/ongres/scram/common/stringprep/StringPreparation;Ljava/lang/String;[BI)[B (ScramFunctions.java:59)
	at org/postgresql/shaded/com/ongres/scram/client/ScramSession$ClientFinalProcessor.<init>(Lorg/postgresql/shaded/com/ongres/scram/client/ScramSession;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V (ScramSession.java:196)
	at org/postgresql/shaded/com/ongres/scram/client/ScramSession$ClientFinalProcessor.<init>(Lorg/postgresql/shaded/com/ongres/scram/client/ScramSession;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILorg/postgresql/shaded/com/ongres/scram/client/ScramSession$1;)V (ScramSession.java:163)
	at org/postgresql/shaded/com/ongres/scram/client/ScramSession$ServerFirstProcessor.clientFinalProcessor(Ljava/lang/String;)Lorg/postgresql/shaded/com/ongres/scram/client/ScramSession$ClientFinalProcessor; (ScramSession.java:130)
	at org/postgresql/jre7/sasl/ScramAuthenticator.processServerFirstMessage(I)V (ScramAuthenticator.java:147)
	at org/postgresql/core/v3/ConnectionFactoryImpl.doAuthentication(Lorg/postgresql/core/PGStream;Ljava/lang/String;Ljava/lang/String;Ljava/util/Properties;)V (ConnectionFactoryImpl.java:868)
	at org/postgresql/core/v3/ConnectionFactoryImpl.tryConnect(Ljava/util/Properties;Ljavax/net/SocketFactory;Lorg/postgresql/util/HostSpec;Lorg/postgresql/jdbc/SslMode;Lorg/postgresql/jdbc/GSSEncMode;)Lorg/postgresql/core/PGStream; (ConnectionFactoryImpl.java:207)
	at 
```
################################################################################################
