### PR TITLE
Do not pass the TrOSGiLogForwarder class to the TraceComponent ctor

### DIFF
--- a/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/Tr.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/Tr.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 IBM Corporation and others.
+ * Copyright (c) 2010, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -27,6 +27,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;
+import com.ibm.ws.logging.ResourceBundleSupport;
 import com.ibm.ws.logging.internal.TraceNLSResolver;
 import com.ibm.ws.logging.internal.TraceSpecification;
 import com.ibm.ws.logging.internal.TraceSpecification.TraceElement;
@@ -875,7 +876,7 @@ public class Tr {
         ResourceBundle rb;
         String msg;
         try {
-            rb = TraceNLSResolver.getInstance().getResourceBundle(tc.getTraceClass(), tc.getResourceBundleName(), locales);
+            rb = TraceNLSResolver.getInstance().getResourceBundle(ResourceBundleSupport.getTraceClassForResourceBundle(tc), tc.getResourceBundleName(), locales);
             msg = rb.getString(msgKey);
         } catch (Exception ex) {
             // no FFDC required

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/ResourceBundleSupport.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/ResourceBundleSupport.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.logging;
+
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * A mix-in interface to be used to support providing a Class to get a ClassLoader when trying to 
+ * resolve a ResourceBundle.  This interface is important when a null Class object is passed to
+ * the TraceComponent constructor.  See OSGiTraceComponent class in TrOSGiLogForwarder for where
+ * this interface is primarily implemented.
+ */
+public interface ResourceBundleSupport {
+
+    Class<?> getClassForResourceBundle();
+
+    static Class<?> getTraceClassForResourceBundle(TraceComponent tc) {
+        Class<?> resolveClass = tc.getTraceClass();
+        // If getTraceClass() returns null, check to see if the TraceComponent is subclassed and
+        // implements ResourceBundleSupport, call the method on that interface to get the Class
+        // to be used to resolve the ResourceBundle.
+        if (resolveClass == null && tc instanceof ResourceBundleSupport) {
+            resolveClass = ((ResourceBundleSupport) tc).getClassForResourceBundle();
+        }
+        return resolveClass;
+    }
+}

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/WsLogRecord.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/WsLogRecord.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2024 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,6 +25,7 @@ import com.ibm.ejs.ras.TraceNLS;
 import com.ibm.websphere.logging.hpel.LogRecordContext;
 import com.ibm.websphere.ras.DataFormatHelper;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.logging.ResourceBundleSupport;
 import com.ibm.wsspi.logging.LogRecordExt;
 
 /**
@@ -524,7 +525,7 @@ public class WsLogRecord extends LogRecord implements java.io.Serializable, LogR
 
         retMe.setLoggerName(tc.getName());
         retMe.setParameters(msgParms);
-        retMe.setTraceClass(tc.getTraceClass());
+        retMe.setTraceClass(ResourceBundleSupport.getTraceClassForResourceBundle(tc));
         retMe.setResourceBundleName(tc.getResourceBundleName());
         
         // Only Messages/trace logged through BaseTraceService (Tr), call this method to construct the WsLogRecord object.

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/WsLogger.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/WsLogger.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2024 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -31,6 +31,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.TraceStateChangeListener;
 import com.ibm.ws.kernel.boot.logging.WsLogManager;
+import com.ibm.ws.logging.ResourceBundleSupport;
 
 /**
  * WebSphere extension of a Java Logger object. This uses the deprecated RAS
@@ -247,7 +248,7 @@ public class WsLogger extends Logger implements TraceStateChangeListener {
 
         LogRecordContext.getExtensions(logRecord.getExtensions());        
         
-        logRecord.setTraceClass(ivTC.getTraceClass());
+        logRecord.setTraceClass(ResourceBundleSupport.getTraceClassForResourceBundle(ivTC));
 
         // populate runtime data
         // Note: this is WAS version, UOW, process ID, etc


### PR DESCRIPTION
- Passing the same class to TraceComponent for each OSGi Bundle ends up causing that class to be transformed over and over again.  We don't want TrOSGiLogForwarder to be transformed anyway, so just don't pass it to the TraceComponent constructor.
- The previous logic caused the JIT to have to re-compile the class over and over again causing startup performance issues when OSGi tracing was enabled using a trace specification like `LogService=all`
- The resolving of the resource bundle also relies on the Class passed in, so created a new mixin interface to be used in the case that null is passed in for the Class in the TraceComponent constructor

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
