### PR TITLE
Enforce ordering of FIPS jvm.options file

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -8188,7 +8188,8 @@ public class LibertyServer implements LogMonitorClient {
         if (isFIPS140_3EnabledAndSupported(info) || isFIPS140_2EnabledAndSupported(info)) {
             this.configureLTPAKeys(info);
             Map<String, String> jvm_opts = this.getJvmOptionsAsMap();
-            Map<String, String> combined = new HashMap(jvm_opts);
+            // Use LinkedHashMap to ensure entry ordering to not break --add-module entries
+            Map<String, String> combined = new LinkedHashMap(jvm_opts);
             combined.putAll(this.getFipsJvmOptions(info, true));
             if (!combined.isEmpty() && !combined.equals(jvm_opts)) {
                 this.setJvmOptions(combined);


### PR DESCRIPTION
When the FIPS JVM options are combined with an existing jvm.options file, it is possible for it to break the JVM options file if the existing entry has a --add-exports or -add-modules entry as the module entry is on a new line and the HashMap is inconsistent in what is returned from `getEntrySet()`.

Example base jvm.options file contents
```
# Allow access to sun.tools.attach.HotSpotVirtualMachine for Java Dump
--add-exports
jdk.attach/sun.tools.attach=ALL-UNNAMED
```

Can become with FIPS enabled (beta currently required)
```
--add-exports
-Dcom.ibm.ws.beta.edition=true
jdk.attach/sun.tools.attach=ALL-UNNAMED
-Dglobal.fips_140-3=true
-Dsemeru.fips=true
-Djava.security.properties=/root/WS-CD-Open/dev/com.ibm.ws.collective.controller_fat/autoFVT/semeruFips140_3CustomProfile.properties
-Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Custom
```
This stops the server from starting as the export line does not parse

Changing to LinkedHashMap
```
--add-exports
jdk.attach/sun.tools.attach=ALL-UNNAMED
-Dcom.ibm.ws.beta.edition=true
-Dglobal.fips_140-3=true
-Dsemeru.fips=true
-Djava.security.properties=/root/WS-CD-Open/dev/com.ibm.ws.collective.controller_fat/autoFVT/semeruFips140_3CustomProfile.properties
-Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Custom
```

From JavaDoc for LinkedHashMap:
`This implementation spares its clients from the unspecified, generally chaotic ordering provided by HashMap (and Hashtable)`


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
