### PR TITLE
allow springboot static init for sha-1 and md5 for fips, skip jms web app test for fips

### DIFF
--- a/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/AbstractSpringTests.java
+++ b/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/AbstractSpringTests.java
@@ -46,6 +46,7 @@ import com.ibm.websphere.simplicity.config.VirtualHost;
 import com.ibm.websphere.simplicity.config.WebApplication;
 
 import componenttest.containers.TestContainerSuite;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -53,6 +54,9 @@ public abstract class AbstractSpringTests extends TestContainerSuite {
 
     @Rule
     public TestName testName = new TestName();
+
+    @Rule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("SpringBootTests");
 
     static enum AppConfigType {
         DROPINS_SPRING,

--- a/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsSpringBootAppTests20.java
+++ b/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsSpringBootAppTests20.java
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule;
 
 @RunWith(FATRunner.class)
 public class JmsSpringBootAppTests20 extends JmsAbstractTests {
@@ -34,6 +35,7 @@ public class JmsSpringBootAppTests20 extends JmsAbstractTests {
 
     @ExpectedFFDC("org.springframework.web.util.NestedServletException")
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void testJmsSpringBootApplicationWithTransaction() throws Exception {
         testJmsWithTransaction();
     }

--- a/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsWebAppTests20.java
+++ b/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsWebAppTests20.java
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule;
 
 @RunWith(FATRunner.class)
 public class JmsWebAppTests20 extends JmsAbstractTests {
@@ -39,6 +40,7 @@ public class JmsWebAppTests20 extends JmsAbstractTests {
 
     @ExpectedFFDC("org.springframework.web.util.NestedServletException")
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void testJmsWebApplicationWithTransaction() throws Exception {
         testJmsWithTransaction();
     }

--- a/dev/com.ibm.ws.springboot.fat20_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.springboot.fat20_fat/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.springframework.security.crypto.factory.PasswordEncoderFactories}, \
+    {MessageDigest, MD5, *, FullClassName:org.springframework.security.crypto.factory.PasswordEncoderFactories}, \
+    {MessageDigest, SHA-1, *, FullClassName:com.ibm.ws.wsoc.util.Utils}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/AbstractSpringTests.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/AbstractSpringTests.java
@@ -47,10 +47,14 @@ import com.ibm.websphere.simplicity.config.VirtualHost;
 import com.ibm.websphere.simplicity.config.WebApplication;
 
 import componenttest.containers.TestContainerSuite;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 public abstract class AbstractSpringTests extends TestContainerSuite {
+
+    @Rule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("SpringBootTests");
 
     // All current FAT application names.
     public static final String SPRING_BOOT_30_APP_ACTUATOR = "io.openliberty.springboot.fat30.actuator.app-0.0.1-SNAPSHOT.jar";

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsSpringBootAppTests30.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsSpringBootAppTests30.java
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
@@ -36,6 +37,7 @@ public class JmsSpringBootAppTests30 extends JmsAbstractTests {
 
     @ExpectedFFDC("jakarta.servlet.ServletException")
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void testJmsSpringBootApplicationWithTransaction() throws Exception {
         testJmsWithTransaction();
     }

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsWebAppTests30.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsWebAppTests30.java
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
@@ -41,6 +42,7 @@ public class JmsWebAppTests30 extends JmsAbstractTests {
 
     @ExpectedFFDC("jakarta.servlet.ServletException")
     @Test
+    @SkipJavaSemeruWithFipsEnabledRule
     public void testJmsWebApplicationWithTransaction() throws Exception {
         testJmsWithTransaction();
     }

--- a/dev/io.openliberty.springboot.fat30_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/io.openliberty.springboot.fat30_fat/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.springframework.security.crypto.factory.PasswordEncoderFactories}, \
+    {MessageDigest, MD5, *, FullClassName:org.springframework.security.crypto.factory.PasswordEncoderFactories}, \
+    {MessageDigest, SHA-1, *, FullClassName:com.ibm.ws.wsoc.util.Utils}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]


### PR DESCRIPTION
FipsPB: https://libh-proxy1.fyre.ibm.com/cognitive/pipelineAnalysis.html?pipelineId=47b19c41-3c71-4fd8-97e5-372c96f6947b

<img width="963" height="156" alt="Screenshot 2025-07-15 at 11 13 14 PM" src="https://github.com/user-attachments/assets/e858094c-6d28-4a72-8ec0-f66c2d19e137" />
