### PR TITLE
Re-enable BoundedBuffer as the queue used for ExecutorService

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ConcurrentPriorityBlockingQueue.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ConcurrentPriorityBlockingQueue.java
@@ -343,12 +343,13 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
             if (currentTailNext == end) {
                 // if we win the race to update the tail's next, the new item is added to the queue
                 if (currentTail.next.compareAndSet(end, newTail)) {
+                    // increase the queue size
+                    size.release();
+
                     // don't update the tail each time.  update the tail on a later insert into the queue
                     if (currentTail != startingTail) {
                         tail.compareAndSet(startingTail, newTail);
                     }
-                    // increase the queue size
-                    size.release();
                     return true;
                 }
 

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ProcessorAwareQueue.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ProcessorAwareQueue.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.threading.internal;
+
+/**
+ * A mix-in interface to allow for ExecutorService Queue implementations to
+ * remove themselves from CPUInfo if it is registered as a AvailableProcessorsListener
+ */
+public interface ProcessorAwareQueue {
+
+    /**
+     * If registered as a AvailableProcessorsListener with CpuInfo, call
+     * CpuInfo to unregister.
+     */
+    public void removeFromAvailableProcessors();
+}


### PR DESCRIPTION
- Some scenarios were regressed with the ConcurrentPriorityBlockingQueue and there will need to be some updates made.  While those are being worked on, will put the BoundedBuffer back as the Queue of choice for the ExecutorService.
- This PR disables the functions that were added in #31621 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
