### PR TITLE
DHE Server check job missing required parameter

### DIFF
--- a/.ci-orchestrator/checks.yml
+++ b/.ci-orchestrator/checks.yml
@@ -38,6 +38,8 @@ steps:
   workType: Jenkins
   projectName: dheServerCheck
   timeoutInMinutes: 120
+  properties:
+    githubPRApi: "https://api.github.com/repos/OpenLiberty/open-liberty/pulls/${githubPRNumber}"
 
 - stepName: Code Checklist Creation
   workType: Jenkins


### PR DESCRIPTION
The "DHE Server Artifacts Check" jobs in manually triggered "Open Liberty Delivery Requirements Verification" pipelines are failing with the following:

```[Pipeline] sh
+ ./getPRFileChanges.sh -u -f ./files.json
Invoking -f/files
cat: headers.txt: No such file or directory
jq: error: Could not open file ./temp: No such file or directory
rm: cannot remove './temp': No such file or directory
```

Example: https://libh-proxy1.fyre.ibm.com/cognitive-dev/pipelineAnalysis.html?pipelineId=cdee2d2b-081a-4300-9dcb-fca0e11073a7

This is due to that particular job missing a required property in the pipeline's configuration file; the others have it.