### PR TITLE
skip tests tck.ssl - mp rest client fat tck

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
@@ -1,0 +1,42 @@
+<!--Copyright (c) 2019, 2025 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License 2.0 which accompanies this distribution, 
+    and is available at 
+        http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0 
+    Contributors: 
+        IBM Corporation - initial API and implementation
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-rest.client-1.3-tck" verbose="2"
+    configfailurepolicy="continue">
+    <test name="tck-package-org.eclipse.microprofile.rest.client.tck">
+        <packages>
+            <package name="org.eclipse.microprofile.rest.client.tck.*"></package>
+        </packages>
+        <classes>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
+            <methods>
+                <exclude name="shouldSucceedMutualSslWithValidSslContext" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+        </classes>
+    </test>
+</suite>

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
@@ -16,6 +16,11 @@
         <packages>
             <package name="org.eclipse.microprofile.rest.client.tck.*"></package>
         </packages>
+        <!-- ******Begin of Fips-related excludes****** 
+             The keystore using old PBE algorithm is no longer supported with FIPS 140-3, 
+             the related tests from *.tck.ssl.* are temporarily excluded until the issue is fixed, 
+             which is currently tracked under https://github.com/microprofile/microprofile-rest-client/issues/399. 
+        -->
         <classes>
           <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
             <methods>
@@ -38,5 +43,6 @@
             </methods>
           </class>
         </classes>
+        <!-- ******End of Fips-related excludes****** -->
     </test>
 </suite>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,13 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import componenttest.topology.impl.LibertyServerFactory;
+import com.ibm.websphere.simplicity.log.Log;
+
 /**
  * This is a test class that runs a whole Maven TCK as one test FAT test.
  * There is a detailed output on specific
@@ -35,11 +42,31 @@ public class RestClientTckPackageTest {
 
     private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
 
-    @Server("FATServer")
-    public static LibertyServer server;
+    public static LibertyServer server = LibertyServerFactory.getLibertyServer("FATServer");
+
+    // Define fipsEnabled
+    private static final boolean fipsEnabled;
+
+    static {
+        boolean isFipsEnabled = false;
+        try {
+            isFipsEnabled = server.isFIPS140_3EnabledAndSupported();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        fipsEnabled = isFipsEnabled;
+    }
 
     @BeforeClass
     public static void setUp() throws Exception {
+        Log.info(RestClientTckPackageTest.class, "setup", "fipsEnabled: " + fipsEnabled);
+        if (fipsEnabled) {
+            Path cwd = Paths.get(".");
+            Log.info(RestClientTckPackageTest.class, "setup", "cwd = " + cwd.toAbsolutePath());
+            Path fipsFile = Paths.get("publish/tckRunner/tck/tck-suite.xml-fips");
+            Path tckSuiteFile = Paths.get("publish/tckRunner/tck/tck-suite.xml");
+            Files.copy(fipsFile, tckSuiteFile, StandardCopyOption.REPLACE_EXISTING);
+        }   
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
@@ -1,0 +1,42 @@
+<!--Copyright (c) 2020, 2025 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License 2.0 which accompanies this distribution, 
+    and is available at 
+        http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0 
+    Contributors: 
+        IBM Corporation - initial API and implementation
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-rest.client-1.3-tck" verbose="2"
+    configfailurepolicy="continue">
+    <test name="tck-package-org.eclipse.microprofile.rest.client.tck">
+        <packages>
+            <package name="org.eclipse.microprofile.rest.client.tck.*"></package>
+        </packages>
+        <classes>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
+            <methods>
+                <exclude name="shouldSucceedMutualSslWithValidSslContext" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+        </classes>
+    </test>
+</suite>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
@@ -16,6 +16,11 @@
         <packages>
             <package name="org.eclipse.microprofile.rest.client.tck.*"></package>
         </packages>
+        <!-- ******Begin of Fips-related excludes****** 
+             The keystore using old PBE algorithm is no longer supported with FIPS 140-3, 
+             the related tests from *.tck.ssl.* are temporarily excluded until the issue is fixed, 
+             which is currently tracked under https://github.com/microprofile/microprofile-rest-client/issues/399. 
+        -->
         <classes>
           <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
             <methods>
@@ -38,5 +43,6 @@
             </methods>
           </class>
         </classes>
+        <!-- ******End of Fips-related excludes****** -->
     </test>
 </suite>

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,8 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
 
+import componenttest.topology.impl.LibertyServerFactory;
+
 /**
  * This is a test class that runs a whole Maven TCK as one test FAT test.
  * There is a detailed output on specific
@@ -41,22 +43,41 @@ public class RestClientTckPackageTest {
 
     private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
 
-    @Server("FATServer")
-    public static LibertyServer server;
+    public static LibertyServer server = LibertyServerFactory.getLibertyServer("FATServer");
+
+    // Define fipsEnabled
+    private static final boolean fipsEnabled;
+
+    static {
+        boolean isFipsEnabled = false;
+        try {
+            isFipsEnabled = server.isFIPS140_3EnabledAndSupported();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        fipsEnabled = isFipsEnabled;
+    }
 
     @BeforeClass
     public static void setup() throws Exception {
         String javaVersion = System.getProperty("java.version");
         Log.info(RestClientTckPackageTest.class, "setup", "javaVersion: " + javaVersion);
+        Log.info(RestClientTckPackageTest.class, "setup", "fipsEnabled: " + fipsEnabled);
         System.out.println("java.version = " + javaVersion);
         if (javaVersion.startsWith("1.8")) {
-            Path cwd = Paths.get(".");
-            Log.info(RestClientTckPackageTest.class, "setup", "cwd = " + cwd.toAbsolutePath());
-            Path java8File = Paths.get("publish/tckRunner/tck/tck-suite.xml-java8");
-            Path tckSuiteFile = Paths.get("publish/tckRunner/tck/tck-suite.xml");
-            Files.copy(java8File, tckSuiteFile, StandardCopyOption.REPLACE_EXISTING);
+            useTCKSuite("java8");
+        } else if (fipsEnabled) {
+            useTCKSuite("fips");  
         }
         server.startServer();
+    }
+
+    private static void useTCKSuite(String id) throws Exception {
+        Path cwd = Paths.get(".");
+        Log.info(RestClientTckPackageTest.class, "setup", "cwd = " + cwd.toAbsolutePath());
+        Path java8File = Paths.get("publish/tckRunner/tck/tck-suite.xml-" + id);
+        Path tckSuiteFile = Paths.get("publish/tckRunner/tck/tck-suite.xml");
+        Files.copy(java8File, tckSuiteFile, StandardCopyOption.REPLACE_EXISTING);
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
@@ -17,36 +17,42 @@
             <package name="org.eclipse.microprofile.rest.client.tck.*"/>
         </packages>
         <classes>
-        <class name="org.eclipse.microprofile.rest.client.tck.sse.BasicReactiveStreamsTest">
-            <methods>
+          <class name="org.eclipse.microprofile.rest.client.tck.sse.BasicReactiveStreamsTest">
+             <methods>
                 <exclude name=".*" />
-            </methods>
-        </class>
-        <class name="org.eclipse.microprofile.rest.client.tck.sse.ReactiveStreamsPublisherTckTest">
-            <methods>
+             </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.sse.ReactiveStreamsPublisherTckTest">
+             <methods>
                 <exclude name=".*" />
-            </methods>
-        </class>
-        <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
-            <methods>
+             </methods>
+          </class>
+          <!-- ******Begin of Fips-related excludes****** 
+               The keystore using old PBE algorithm is no longer supported with FIPS 140-3, 
+               the related tests from *.tck.ssl.* are temporarily excluded until the issue is fixed, 
+               which is currently tracked under https://github.com/microprofile/microprofile-rest-client/issues/399. 
+          -->
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
+             <methods>
                 <exclude name="shouldSucceedMutualSslWithValidSslContext" />
-            </methods>
+             </methods>
           </class>
           <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest">
-            <methods>
+             <methods>
                 <exclude name=".*" />
-            </methods>
+             </methods>
           </class>
           <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest">
-            <methods>
+             <methods>
                 <exclude name=".*" />
-            </methods>
+             </methods>
           </class>
           <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest">
-            <methods>
+             <methods>
                 <exclude name=".*" />
-            </methods>
+             </methods>
           </class>
-    </classes>
+          <!-- ******End of Fips-related excludes****** -->
+        </classes>
     </test>
 </suite>

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
@@ -1,0 +1,52 @@
+<!--Copyright (c) 2020, 2025 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License 2.0 which accompanies this distribution, 
+    and is available at 
+        http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0 
+    Contributors: 
+        IBM Corporation - initial API and implementation
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-rest.client-2.0-tck" verbose="2"
+    configfailurepolicy="continue">
+    <test name="tck-package-org.eclipse.microprofile.rest.client.tck">
+        <packages>
+            <package name="org.eclipse.microprofile.rest.client.tck.*"/>
+        </packages>
+        <classes>
+        <class name="org.eclipse.microprofile.rest.client.tck.sse.BasicReactiveStreamsTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+        </class>
+        <class name="org.eclipse.microprofile.rest.client.tck.sse.ReactiveStreamsPublisherTckTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+        </class>
+        <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
+            <methods>
+                <exclude name="shouldSucceedMutualSslWithValidSslContext" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+    </classes>
+    </test>
+</suite>

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
@@ -1,0 +1,52 @@
+<!--Copyright (c) 2021, 2025 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License 2.0 which accompanies this distribution, 
+    and is available at 
+        http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0 
+    Contributors: 
+        IBM Corporation - initial API and implementation
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-rest.client-3.0-tck" verbose="2"
+    configfailurepolicy="continue">
+    <test name="tck-package-org.eclipse.microprofile.rest.client.tck">
+        <packages>
+            <package name="org.eclipse.microprofile.rest.client.tck.*"/>
+        </packages>
+        <classes>
+        <class name="org.eclipse.microprofile.rest.client.tck.sse.BasicReactiveStreamsTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+        </class>
+        <class name="org.eclipse.microprofile.rest.client.tck.sse.ReactiveStreamsPublisherTckTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+        </class>
+        <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
+            <methods>
+                <exclude name="shouldSucceedMutualSslWithValidSslContext" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+        </classes>
+    </test>
+</suite>

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
@@ -17,17 +17,22 @@
             <package name="org.eclipse.microprofile.rest.client.tck.*"/>
         </packages>
         <classes>
-        <class name="org.eclipse.microprofile.rest.client.tck.sse.BasicReactiveStreamsTest">
+          <class name="org.eclipse.microprofile.rest.client.tck.sse.BasicReactiveStreamsTest">
             <methods>
                 <exclude name=".*" />
             </methods>
-        </class>
-        <class name="org.eclipse.microprofile.rest.client.tck.sse.ReactiveStreamsPublisherTckTest">
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.sse.ReactiveStreamsPublisherTckTest">
             <methods>
                 <exclude name=".*" />
             </methods>
-        </class>
-        <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
+          </class>
+          <!-- ******Begin of Fips-related excludes****** 
+               The keystore using old PBE algorithm is no longer supported with FIPS 140-3, 
+               the related tests from *.tck.ssl.* are temporarily excluded until the issue is fixed, 
+               which is currently tracked under https://github.com/microprofile/microprofile-rest-client/issues/399.
+          -->
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
             <methods>
                 <exclude name="shouldSucceedMutualSslWithValidSslContext" />
             </methods>
@@ -47,6 +52,7 @@
                 <exclude name=".*" />
             </methods>
           </class>
+          <!-- ******End of Fips-related excludes****** -->
         </classes>
     </test>
 </suite>

--- a/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
+++ b/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
@@ -1,0 +1,42 @@
+<!--Copyright (c) 2024, 2205 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License 2.0 which accompanies this distribution, 
+    and is available at 
+        http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0 
+    Contributors: 
+        IBM Corporation - initial API and implementation
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-rest.client-4.0-tck" verbose="2"
+    configfailurepolicy="continue">
+    <test name="tck-package-org.eclipse.microprofile.rest.client.tck">
+        <packages>
+            <package name="org.eclipse.microprofile.rest.client.tck.*"/>
+        </packages>
+        <classes>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
+            <methods>
+                <exclude name="shouldSucceedMutualSslWithValidSslContext" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslHostnameVerifierTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslMutualTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+          <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslTrustStoreTest">
+            <methods>
+                <exclude name=".*" />
+            </methods>
+          </class>
+        </classes>
+    </test>
+</suite>

--- a/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
+++ b/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-fips
@@ -1,4 +1,4 @@
-<!--Copyright (c) 2024, 2205 IBM Corporation and others. All rights reserved.
+<!--Copyright (c) 2024, 2025 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -16,6 +16,11 @@
         <packages>
             <package name="org.eclipse.microprofile.rest.client.tck.*"/>
         </packages>
+        <!-- ******Begin of Fips-related excludes****** 
+             The keystore using old PBE algorithm is no longer supported with FIPS 140-3,
+             the related tests from *.tck.ssl.* are temporarily excluded until the issue is fixed,
+             which is currently tracked under https://github.com/microprofile/microprofile-rest-client/issues/399.
+        -->
         <classes>
           <class name="org.eclipse.microprofile.rest.client.tck.ssl.SslContextTest">
             <methods>
@@ -38,5 +43,6 @@
             </methods>
           </class>
         </classes>
+        <!-- ******End of Fips-related excludes****** -->
     </test>
 </suite>


### PR DESCRIPTION
Fix FAT TCK test failure with FIPS 140-3 enabled and Java17 Semeru by updating `tck-suite.xml` to exclude the affected tests and `RestClientTckPackageTest.java` to set fips flag for the exclusion to avoid FIPS compliant error in respect to keystores.

The updated fat:
- com.ibm.ws.microprofile.rest.client13_fat_tck
- com.ibm.ws.microprofile.rest.client14_fat_tck
- io.openliberty.microprofile.rest.client.2.0.internal_fat_tck
- io.openliberty.microprofile.rest.client.3.0.internal_fat_tck
- io.openliberty.microprofile.rest.client.4.0.internal_fat_tck


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).

