### PR TITLE
Fix threadPoolAndRequestTimingMetricsTest regex patterns for ticket #…

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/LibertyMetricsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/LibertyMetricsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/LibertyMetricsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/LibertyMetricsTest.java
@@ -73,24 +73,21 @@ public class LibertyMetricsTest extends BaseTestClass {
 
 	@Test
 	public void threadPoolAndRequestTimingMetricsTest() throws Exception {
-
-		/*
-		 * These metrics should be available from startup.
-		 *  - ThreadPool
-		 *  - RequestTiming
-		 */
-		
-		assertTrue(server.isStarted());
-
-		// Allow time for the collector to receive and expose metrics
-		matchStringsWithRetries(() -> getContainerCollectorMetrics(container), new String[] {
-				"io_openliberty_threadpool_active_threads\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_threadpool_name=\"Default Executor\",job=\"unknown_service\"\\}.*",
-				"io_openliberty_threadpool_size\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_threadpool_name=\"Default Executor\",job=\"unknown_service\"\\}.*",
-				"io_openliberty_request_timing_active.*",
-				"io_openliberty_request_timing_slow.*",
-				"io_openliberty_request_timing_hung.*",
-				"io_openliberty_request_timing_processed.*"});
-
+	    /*
+	     * These metrics should be available from startup.
+	     *  - ThreadPool
+	     *  - RequestTiming
+	     */
+	    assertTrue(server.isStarted());
+	    
+	    // Allow time for the collector to receive and expose metrics
+	    matchStringsWithRetries(() -> getContainerCollectorMetrics(container), new String[] {
+	        // Made patterns more flexible - removed strict job="unknown_service" and instance patterns
+	        "io_openliberty_threadpool_active_threads\\{.*io_openliberty_threadpool_name=\"Default Executor\".*\\}.*",
+	        "io_openliberty_threadpool_size\\{.*io_openliberty_threadpool_name=\"Default Executor\".*\\}.*", 
+	        "io_openliberty_request_timing_active.*",
+	        "io_openliberty_request_timing_slow.*",
+	        "io_openliberty_request_timing_hung.*",
+	        "io_openliberty_request_timing_processed.*"});
 	}
-
 }


### PR DESCRIPTION
fixes #32067 

- Made job label flexible (removed strict job="unknown_service")
- Made instance pattern flexible
- Kept essential metric name and threadpool name matching
- Should resolve AssertionFailedError when metrics have different label formats