### PR TITLE
Use less common port to avoid intermittent build breaks in `SoReuseAddrTest`

### DIFF
--- a/dev/io.openliberty.transport.http_fat/publish/servers/SoReuseAddr/server.xml
+++ b/dev/io.openliberty.transport.http_fat/publish/servers/SoReuseAddr/server.xml
@@ -13,8 +13,8 @@
 
     <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
-                  httpPort="${bvt.prop.HTTP_default}"
-                  httpsPort="${bvt.prop.HTTP_default.secure}">
+                  httpPort="${bvt.prop.HTTP_septenary}"
+                  httpsPort="${bvt.prop.HTTP_septenary.secure}">
         <tcpOptions portOpenRetries="60" soReuseAddr="false"/>
     </httpEndpoint>
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #32164