### PR TITLE
avoid duplicate processing when multiple EJBs are in a module

### DIFF
--- a/dev/io.openliberty.jakarta.data.1.1/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ Bundle-Description: Copied Jakarta Data API classes and some proposed or experim
 Export-Package: \
   jakarta.data;version="1.0.0",\
   jakarta.data.exceptions;version="1.0.0",\
+  jakarta.data.expression;version="1.0.0",\
   jakarta.data.metamodel;version="1.0.0",\
   jakarta.data.metamodel.impl;version="1.0.0",\
   jakarta.data.page;version="1.0.0",\

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/ComparableExpression.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/ComparableExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.expression;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+public interface ComparableExpression<T, V extends Comparable<?>> //
+                extends Expression<T, V> {
 
+    // TODO methods
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/Expression.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/Expression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.expression;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+public interface Expression<T, V> {
 
+    // TODO methods
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/NavigableExpression.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/NavigableExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.expression;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+public interface NavigableExpression<T, U> {
 
+    // TODO methods
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/NumericExpression.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/NumericExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.expression;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+public interface NumericExpression<T, N extends Number & Comparable<N>> //
+                extends ComparableExpression<T, N> {
 
+    // TODO methods
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/TemporalExpression.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/TemporalExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,16 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
+package jakarta.data.expression;
 
-import jakarta.data.metamodel.TextAttribute;
+import java.time.temporal.Temporal;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+public interface TemporalExpression//
+/*           */ <T, V extends Temporal & Comparable<? extends Temporal>> //
+                extends ComparableExpression<T, V> {
 
+    // TODO methods
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/TextExpression.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/TextExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.expression;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+public interface TextExpression<T> extends ComparableExpression<T, String> {
 
+    // TODO methods
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/Attribute.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/Attribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,14 @@ package jakarta.data.metamodel;
  * Method signatures are copied from Jakarta Data.
  */
 public interface Attribute<T> {
+
+    default Class<?> attributeType() {
+        throw new UnsupportedOperationException();
+    }
+
+    default Class<T> declaringType() {
+        throw new UnsupportedOperationException();
+    }
 
     String name();
 

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/BasicAttribute.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/BasicAttribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,34 +12,21 @@
  *******************************************************************************/
 package jakarta.data.metamodel;
 
-import jakarta.data.Sort;
-import jakarta.data.expression.TextExpression;
+import jakarta.data.expression.Expression;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-public interface TextAttribute<T> extends ComparableAttribute<T, String>, TextExpression<T> {
+public interface BasicAttribute<T, V> extends Attribute<T>, Expression<T, V> {
 
-    default Sort<T> ascIgnoreCase() {
-        return Sort.ascIgnoreCase(name());
-    }
-
-    @Override
-    default Class<String> attributeType() {
-        return String.class;
-    }
-
-    default Sort<T> descIgnoreCase() {
-        return Sort.descIgnoreCase(name());
-    }
-
-    static <T> TextAttribute<T> of(Class<T> entityClass,
-                                   String name) {
+    static <T, V> BasicAttribute<T, V> of(Class<T> entityClass,
+                                          String name,
+                                          Class<V> attributeType) {
         if (entityClass == null ||
-            name == null)
+            name == null ||
+            attributeType == null)
             throw new NullPointerException();
 
-        return new TextAttributeRecord<>(entityClass, name);
+        return new BasicAttributeRecord<>(entityClass, name, attributeType);
     }
-
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/BasicAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/BasicAttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,19 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.metamodel;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+record BasicAttributeRecord<T, V>(
+                Class<T> declaringType,
+                String name,
+                Class<V> attributeType)
+                implements BasicAttribute<T, V> {
 
+    @Override
+    public String toString() {
+        return declaringType.getSimpleName().toLowerCase() + '.' + name;
+    }
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/ComparableAttribute.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/ComparableAttribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,34 +12,27 @@
  *******************************************************************************/
 package jakarta.data.metamodel;
 
-import jakarta.data.Sort;
-import jakarta.data.expression.TextExpression;
+import jakarta.data.expression.ComparableExpression;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-public interface TextAttribute<T> extends ComparableAttribute<T, String>, TextExpression<T> {
+public interface ComparableAttribute<T, V extends Comparable<?>> //
+                extends //
+                BasicAttribute<T, V>, //
+                SortableAttribute<T>, //
+                ComparableExpression<T, V> {
 
-    default Sort<T> ascIgnoreCase() {
-        return Sort.ascIgnoreCase(name());
-    }
+    static <T, V extends Comparable<?>> ComparableAttribute<T, V> //
+                    of(Class<T> entityClass,
+                       String name,
+                       Class<V> attributeType) {
 
-    @Override
-    default Class<String> attributeType() {
-        return String.class;
-    }
-
-    default Sort<T> descIgnoreCase() {
-        return Sort.descIgnoreCase(name());
-    }
-
-    static <T> TextAttribute<T> of(Class<T> entityClass,
-                                   String name) {
         if (entityClass == null ||
-            name == null)
+            name == null ||
+            attributeType == null)
             throw new NullPointerException();
 
-        return new TextAttributeRecord<>(entityClass, name);
+        return new ComparableAttributeRecord<>(entityClass, name, attributeType);
     }
-
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/ComparableAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/ComparableAttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,19 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.metamodel;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+record ComparableAttributeRecord<T, V extends Comparable<?>>(
+                Class<T> declaringType,
+                String name,
+                Class<V> attributeType)
+                implements ComparableAttribute<T, V> {
 
+    @Override
+    public String toString() {
+        return declaringType.getSimpleName().toLowerCase() + '.' + name;
+    }
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/NavigableAttribute.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/NavigableAttribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,34 +12,26 @@
  *******************************************************************************/
 package jakarta.data.metamodel;
 
-import jakarta.data.Sort;
-import jakarta.data.expression.TextExpression;
+import jakarta.data.expression.NavigableExpression;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-public interface TextAttribute<T> extends ComparableAttribute<T, String>, TextExpression<T> {
-
-    default Sort<T> ascIgnoreCase() {
-        return Sort.ascIgnoreCase(name());
-    }
+public interface NavigableAttribute<T, U> //
+                extends Attribute<T>, NavigableExpression<T, U> {
 
     @Override
-    default Class<String> attributeType() {
-        return String.class;
-    }
+    Class<U> attributeType();
 
-    default Sort<T> descIgnoreCase() {
-        return Sort.descIgnoreCase(name());
-    }
+    static <T, U> NavigableAttribute<T, U> of(Class<T> entityClass,
+                                              String name,
+                                              Class<U> attributeType) {
 
-    static <T> TextAttribute<T> of(Class<T> entityClass,
-                                   String name) {
         if (entityClass == null ||
-            name == null)
+            name == null ||
+            attributeType == null)
             throw new NullPointerException();
 
-        return new TextAttributeRecord<>(entityClass, name);
+        return new NavigableAttributeRecord<>(entityClass, name, attributeType);
     }
-
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/NavigableAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/NavigableAttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,19 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.metamodel;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+record NavigableAttributeRecord<T, U>(
+                Class<T> declaringType,
+                String name,
+                Class<U> attributeType)
+                implements NavigableAttribute<T, U> {
 
+    @Override
+    public String toString() {
+        return declaringType.getSimpleName().toLowerCase() + '.' + name;
+    }
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/NumericAttribute.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/NumericAttribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,34 +12,22 @@
  *******************************************************************************/
 package jakarta.data.metamodel;
 
-import jakarta.data.Sort;
-import jakarta.data.expression.TextExpression;
+import jakarta.data.expression.NumericExpression;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-public interface TextAttribute<T> extends ComparableAttribute<T, String>, TextExpression<T> {
+public interface NumericAttribute<T, N extends Number & Comparable<N>> //
+                extends ComparableAttribute<T, N>, NumericExpression<T, N> {
 
-    default Sort<T> ascIgnoreCase() {
-        return Sort.ascIgnoreCase(name());
-    }
+    static <T, N extends Number & Comparable<N>> NumericAttribute<T, N> //
+                    of(Class<T> entityClass, String name, Class<N> attributeType) {
 
-    @Override
-    default Class<String> attributeType() {
-        return String.class;
-    }
-
-    default Sort<T> descIgnoreCase() {
-        return Sort.descIgnoreCase(name());
-    }
-
-    static <T> TextAttribute<T> of(Class<T> entityClass,
-                                   String name) {
         if (entityClass == null ||
-            name == null)
+            name == null ||
+            attributeType == null)
             throw new NullPointerException();
 
-        return new TextAttributeRecord<>(entityClass, name);
+        return new NumericAttributeRecord<>(entityClass, name, attributeType);
     }
-
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/NumericAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/NumericAttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,19 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.metamodel;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+record NumericAttributeRecord<T, V extends Number & Comparable<V>>(
+                Class<T> declaringType,
+                String name,
+                Class<V> attributeType)
+                implements NumericAttribute<T, V> {
 
+    @Override
+    public String toString() {
+        return declaringType.getSimpleName().toLowerCase() + '.' + name;
+    }
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/SortableAttribute.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/SortableAttribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,22 @@ import jakarta.data.Sort;
  */
 public interface SortableAttribute<T> extends Attribute<T> {
 
-    Sort<T> asc();
+    default Sort<T> asc() {
+        return Sort.asc(name());
+    }
 
-    Sort<T> desc();
+    default Sort<T> desc() {
+        return Sort.desc(name());
+    }
+
+    static <T, V> SortableAttribute<T> of(Class<T> entityClass,
+                                          String name,
+                                          Class<V> attributeType) {
+        if (entityClass == null ||
+            name == null ||
+            attributeType == null)
+            throw new NullPointerException();
+
+        return new SortableAttributeRecord<>(entityClass, name, attributeType);
+    }
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/SortableAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/SortableAttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,19 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.metamodel;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+record SortableAttributeRecord<T>(
+                Class<T> declaringType,
+                String name,
+                Class<?> attributeType)
+                implements SortableAttribute<T> {
 
+    @Override
+    public String toString() {
+        return declaringType.getSimpleName().toLowerCase() + '.' + name;
+    }
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/TextAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/TextAttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,16 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.TextAttribute;
+package jakarta.data.metamodel;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
+record TextAttributeRecord<T>(Class<T> declaringType, String name)
+                implements TextAttribute<T> {
 
+    @Override
+    public String toString() {
+        return declaringType.getSimpleName().toLowerCase() + '.' + name;
+    }
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/impl/AttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/impl/AttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,5 +17,6 @@ import jakarta.data.metamodel.Attribute;
 /**
  * Method signatures are copied from Jakarta Data.
  */
+@Deprecated(since = "1.1")
 public record AttributeRecord<T>(String name) implements Attribute<T> {
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/impl/SortableAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/impl/SortableAttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,21 +12,12 @@
  *******************************************************************************/
 package jakarta.data.metamodel.impl;
 
-import jakarta.data.Sort;
 import jakarta.data.metamodel.SortableAttribute;
 
 /**
  * Method signatures are copied from Jakarta Data.
  */
+@Deprecated(since = "1.1")
 public record SortableAttributeRecord<T>(String name) implements SortableAttribute<T> {
 
-    @Override
-    public Sort<T> asc() {
-        return Sort.asc(name);
-    }
-
-    @Override
-    public Sort<T> desc() {
-        return Sort.desc(name);
-    }
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/PageRequest.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/PageRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -64,6 +64,8 @@ public interface PageRequest {
     public Mode mode();
 
     public long page();
+
+    public PageRequest page(long pageNum);
 
     public boolean requestTotal();
 

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/Pagination.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/Pagination.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -49,6 +49,11 @@ record Pagination(long page,
     }
 
     @Override
+    public PageRequest page(long pageNum) {
+        return new Pagination(pageNum, size, mode, type, requestTotal);
+    }
+
+    @Override
     public Pagination size(int maxPageSize) {
         return new Pagination(page, maxPageSize, mode, type, requestTotal);
     }
@@ -76,4 +81,5 @@ record Pagination(long page,
     public PageRequest withTotal() {
         return new Pagination(page, size, mode, type, true);
     }
+
 }


### PR DESCRIPTION
Better handles processing of entities for Jakarta Data repositories in modules that have multiple EJBs.  Prior to this PR, the processing would be attempted for as many times as there are EJBs in the module.  This PR now ensures it only happens once.
Also, this PR refreshes Jakarta Data interfaces in the page and metamodel packages to latest.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

