### PR TITLE
fips 140-3: allow kerberos and oracle driver usage for jdbc krb5 fat

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_krb5/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,26 @@
+# Allowing for JDBC Kerberos
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/com.sun.crypto.provider.HmacSHA1}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, AES, *, ModuleAndFullClassName:openjceplus/com.ibm.crypto.plus.provider.AESCipher}, \
+    {Cipher, AES, *, Package:sun.security.krb5.internal.crypto}, \
+    {Cipher, HmacSHA1, *, Package:sun.security.krb5.internal.crypto}, \
+    {Mac, HmacSHA1, *, Package:sun.security.krb5.internal.crypto}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = com.ibm.crypto.plus.provider.OpenJCEPlus [ \
+  {SecretKeyFactory, PBKDF2WithHmacSHA512, *, FullClassName:oracle.jdbc.driver.OracleDriver}, \
+  {MessageDigest, SHA-1, *, FullClassName:oracle.jdbc.driver.OracleDriver}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.6 = sun.security.jgss.SunProvider [ \
+    {GssApiMechanism, 1.2.840.113554.1.2.2, *} , \
+    {GssApiMechanism, 1.3.6.1.5.5.2, *}]
+    
+


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

This change reduces the failures from 23 to 12 when FIPS 140-3 is enabled