### PR TITLE
Add information on latest EclipseLink bug

### DIFF
--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/ejb/StartupSingletonEJB.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/ejb/StartupSingletonEJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,8 +21,6 @@ import jakarta.inject.Inject;
 @Singleton
 public class StartupSingletonEJB {
 
-    //TODO Renable when  javax.naming.NameNotFoundException is fixed
-    //FutureEMBuilder: InitialContext.doLookup(dataStore)
     @Inject
     EJBModuleDSDRepo repo;
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -4934,23 +4934,21 @@ public class DataJPATestServlet extends FATServlet {
 
         boolean updated;
         try {
-            // TODO Uncomment the following 3 lines of code to reproduce this EclipseLink error:
-            // jakarta.persistence.PersistenceException: Exception [EclipseLink-4002] ...
-            // Call: UPDATE WLPBusiness SET LATITUDE = ?, NAME = ? WHERE (ID = ?)
-            // ...
-            // Caused by: java.sql.SQLDataException: An attempt was made to get a data value of type 'DECIMAL' from a data value of type 'test.jakarta.data.jpa.web.Location'.
-            //   ...
-            //   at org.apache.derby.iapi.jdbc.BrokeredPreparedStatement.setObject(Unknown Source)
-            //   at com.ibm.ws.rsadapter.jdbc.WSJdbcPreparedStatement.setObject(WSJdbcPreparedStatement.java:1687)
-            //   at org.eclipse.persistence.internal.databaseaccess.DatabasePlatform.setParameterValueInDatabaseCall(DatabasePlatform.java:2462)
-            //   at org.eclipse.persistence.platform.database.DerbyPlatform.setParameterValueInDatabaseCall(DerbyPlatform.java:985)
-            //   at org.eclipse.persistence.internal.databaseaccess.DatabaseCall.prepareStatement(DatabaseCall.java:799)
-            //   at org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor.basicExecuteCall(DatabaseAccessor.java:630)
+            // TODO enable once #32185 is fixed in EclipseLink
+            // jakarta.persistence.PersistenceException:
+            // Exception [EclipseLink-26] (Eclipse Persistence Services -
+            // 5.0.0-B08.v202505280949-dfc411d38767f696ce9f2741de051aef050cbeba):
+            // org.eclipse.persistence.exceptions.DescriptorException
+            // Exception Description: Trying to get value for instance variable [street]
+            //   of type [test.jakarta.data.jpa.web.Street] from the object
+            //   [test.jakarta.data.jpa.web.Location]. The specified object is not an
+            //   instance of the class or interface declaring the underlying field.
+            // Internal Exception: java.lang.IllegalArgumentException:
+            //   Can not get test.jakarta.data.jpa.web.Street field
+            //   test.jakarta.data.jpa.web.Address.street on test.jakarta.data.jpa.web.Location
             //Address newAddress = new Address("Rochester", "MN", 55901, 3605, new Street("US 52", "N"));
             //Location newLocation = new Location(newAddress, 44.05881f, -92.50556f);
             //assertEquals(true, businesses.updateWithJPQL(newLocation, "IBM", ibm.id));
-
-            // Jakarta Data was able to avoid the above error by generating a query to set each attribute individually,
 
             ibm.location.latitude = 44.05881f;
             ibm.location.longitude = -92.50556f;


### PR DESCRIPTION
Update comments on an EclipseLink bug and include the tracking issue number.
An error shown in comments is no longer occurring, but EclipseLink now fails with a different error. This PR updates the comments for the latest error and includes the tracking issue there so that we will know what to re-enable once they fix it.

Also, I cleaned up two other lines of comments that were erroneously still claiming that some lines of a test were disabled.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
