### PR TITLE
Fix EE 10 archive images

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -528,7 +528,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&webProfile10Features
-        packageServerConflict = "com.ibm.websphere.appserver.sessionStore,com.ibm.websphere.appserver.jdbc,io.openliberty.microProfile,io.openliberty.mpConfig,io.openliberty.mpFaultTolerance,io.openliberty.mpOpenAPI,io.openliberty.mpRestClient,io.openliberty.mpMetrics,io.openliberty.mpTelemetry,io.openliberty.org.eclipse.microprofile.config,io.openliberty.org.eclipse.microprofile.faulttolerance,io.openliberty.org.eclipse.microprofile.openapi,io.openliberty.org.eclipse.microprofile.rest.client,io.openliberty.org.eclipse.microprofile.metrics,io.openliberty.mpCompatible,io.openliberty.internal.mpVersion"
+        packageServerConflict = "com.ibm.websphere.appserver.sessionStore,com.ibm.websphere.appserver.jdbc,io.openliberty.microProfile,io.openliberty.mpConfig,io.openliberty.mpFaultTolerance,io.openliberty.mpOpenAPI,io.openliberty.mpRestClient,io.openliberty.mpMetrics,io.openliberty.mpTelemetry,io.openliberty.org.eclipse.microprofile.config,io.openliberty.org.eclipse.microprofile.faulttolerance,io.openliberty.org.eclipse.microprofile.openapi,io.openliberty.org.eclipse.microprofile.rest.client,io.openliberty.org.eclipse.microprofile.metrics,io.openliberty.mpCompatible,io.openliberty.internal.mpVersion,io.openliberty.mpHealth.4.0.ee.10.0.mp"
         outputTo new File(packageDir, "webProfile10")
         doLast {
             copy {
@@ -547,7 +547,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&jakartaee10Features
-        packageServerConflict = "com.ibm.websphere.appserver.sessionStore,com.ibm.websphere.appserver.jdbc,io.openliberty.microProfile,io.openliberty.mpConfig,io.openliberty.mpFaultTolerance,io.openliberty.mpOpenAPI,io.openliberty.mpRestClient,io.openliberty.mpMetrics,io.openliberty.mpTelemetry,io.openliberty.org.eclipse.microprofile.config,io.openliberty.org.eclipse.microprofile.faulttolerance,io.openliberty.org.eclipse.microprofile.openapi,io.openliberty.org.eclipse.microprofile.rest.client,io.openliberty.org.eclipse.microprofile.metrics,io.openliberty.mpCompatible,io.openliberty.internal.mpVersion"
+        packageServerConflict = "com.ibm.websphere.appserver.sessionStore,com.ibm.websphere.appserver.jdbc,io.openliberty.microProfile,io.openliberty.mpConfig,io.openliberty.mpFaultTolerance,io.openliberty.mpOpenAPI,io.openliberty.mpRestClient,io.openliberty.mpMetrics,io.openliberty.mpTelemetry,io.openliberty.org.eclipse.microprofile.config,io.openliberty.org.eclipse.microprofile.faulttolerance,io.openliberty.org.eclipse.microprofile.openapi,io.openliberty.org.eclipse.microprofile.rest.client,io.openliberty.org.eclipse.microprofile.metrics,io.openliberty.mpCompatible,io.openliberty.internal.mpVersion,io.openliberty.mpHealth.4.0.ee.10.0.mp"
         outputTo new File(packageDir, "jakartaee10")
         doLast {
             copy {

--- a/dev/build.image/profiles/webProfile10/features.xml
+++ b/dev/build.image/profiles/webProfile10/features.xml
@@ -13,6 +13,7 @@
 <feature>microProfile-6.0</feature>
 <feature>microProfile-6.1</feature>
 <feature>microProfile-7.0</feature>
+<feature>microProfile-7.1</feature>
 <feature>appAuthentication</feature>
 <feature>appSecurity</feature>
 <feature>beanValidation</feature>

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-6.0/io.openliberty.microProfile-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-6.0/io.openliberty.microProfile-6.0.feature
@@ -20,7 +20,8 @@ Subsystem-Name: MicroProfile 6.0
   io.openliberty.mpJwt-2.1, \
   io.openliberty.mpMetrics-5.0, \
   io.openliberty.mpRestClient-3.0, \
-  io.openliberty.mpTelemetry-1.0
+  io.openliberty.mpTelemetry-1.0, \
+  io.openliberty.mpHealth.4.0.ee.10.0.mp-6.0
 kind=ga
 edition=core
 WLP-InstantOn-Enabled: true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-6.1/io.openliberty.microProfile-6.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-6.1/io.openliberty.microProfile-6.1.feature
@@ -20,7 +20,8 @@ Subsystem-Name: MicroProfile 6.1
   io.openliberty.mpJwt-2.1, \
   io.openliberty.mpMetrics-5.1, \
   io.openliberty.mpRestClient-3.0, \
-  io.openliberty.mpTelemetry-1.1; ibm.tolerates:= "2.0"
+  io.openliberty.mpTelemetry-1.1; ibm.tolerates:= "2.0", \
+  io.openliberty.mpHealth.4.0.ee.10.0.mp-6.1
 kind=ga
 edition=core
 WLP-InstantOn-Enabled: true


### PR DESCRIPTION
- The `io.openliberty.mpHealth.4.0.ee.10.0.mp-6.1` feature was not getting put into the EE 10 archive installs
- Add `io.openliberty.mpHealth.4.0.ee.10.0.mp-6.0` to the `microProfile-6.0` feature file and `io.openliberty.mpHealth.4.0.ee.10.0.mp-6.1` to the `microProfile-6.1` feature file so that they are forced to be loaded during packaging of the archive files
- Update the server conflict list to include `io.openliberty.mpHealth.4.0.ee.10.0.mp` so that both are allowed to be in the archive files
- Discovered that in #31692, the update to webprofile10 archive zip to include microProfile-7.1 was missed so adding it as well in this PR

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
