### PR TITLE
Added the properties file for the infinispan session container

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/semeruFips140_3CustomProfile.properties
@@ -3,7 +3,7 @@
 # org.eclipse.persistence.internal.libraries.asm.commons.SerialVersionUIDAdder: https://github.com/OpenLiberty/open-liberty/issues/31867
 # org.apache.yoko.rmi.impl.ValueDescriptor: https://github.com/OpenLiberty/open-liberty/issues/31845
 # java.rmi/sun.rmi.server.Util: https://github.com/OpenLiberty/open-liberty/issues/31859
-# Allowing for com.sun.security.sasl.Provider to fix issues in the SASL Plain Factory
+# Allowing for the com.sun.security.sasl.Provider provider to fix issues in the SASL Plain Factory
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/semeruFips140_3CustomProfile.properties
@@ -1,0 +1,27 @@
+# com.ibm.ws.wsoc.util.Utils: https://github.com/OpenLiberty/open-liberty/issues/31931
+# org.objectweb.asm.commons.SerialVersionUIDAdder: https://github.com/OpenLiberty/open-liberty/issues/31847
+# org.eclipse.persistence.internal.libraries.asm.commons.SerialVersionUIDAdder: https://github.com/OpenLiberty/open-liberty/issues/31867
+# org.apache.yoko.rmi.impl.ValueDescriptor: https://github.com/OpenLiberty/open-liberty/issues/31845
+# java.rmi/sun.rmi.server.Util: https://github.com/OpenLiberty/open-liberty/issues/31859
+# Allowing for com.sun.security.sasl.Provider to fix issues in the SASL Plain Factory
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
+    {KeyStore, PKCS12, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
+    {MessageDigest, SHA-1, *, FullClassName:com.ibm.ws.wsoc.util.Utils}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.objectweb.asm.commons.SerialVersionUIDAdder}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.eclipse.persistence.internal.libraries.asm.commons.SerialVersionUIDAdder}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.yoko.rmi.impl.ValueDescriptor}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.rmi/sun.rmi.server.Util}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl}, \
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [ \
+    {AlgorithmParameters, PBES2, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = com.sun.security.sasl.Provider [ \
+  {SaslServerFactory, PLAIN, *, FullClassName:com.sun.security.sasl.PlainServerFactory}, \
+  {SaslClientFactory, PLAIN, *, FullClassName:com.sun.security.sasl.PlainClientFactory}]

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/semeruFips140_3CustomProfile.properties
@@ -4,6 +4,8 @@
 # org.apache.yoko.rmi.impl.ValueDescriptor: https://github.com/OpenLiberty/open-liberty/issues/31845
 # java.rmi/sun.rmi.server.Util: https://github.com/OpenLiberty/open-liberty/issues/31859
 # Allowing for the com.sun.security.sasl.Provider provider to fix issues in the SASL Plain Factory
+# Allowing for open-source org.apache.derby
+# But To Do: Investigation on the derby jdbc client with component owner
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \


### PR DESCRIPTION
To fix issues with the SASL client factory, I added in:
`RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = com.sun.security.sasl.Provider [ \
  {SaslServerFactory, PLAIN, *, FullClassName:com.sun.security.sasl.PlainServerFactory}, \
  {SaslClientFactory, PLAIN, *, FullClassName:com.sun.security.sasl.PlainClientFactory}]`

To fix derby issues:
`{MessageDigest, SHA-1, *, FullClassName:org.apache.derby.impl.jdbc.authentication.BasicAuthenticationServiceImpl}, \`

Issues:

> [WARNING ] Failed to initialize a channel. Closing: [id: 0xcf7ba6cb]
SaslClientFactory implementation now found
JVMDUMP055I Processing dump event "throw", detail "java/lang/IllegalStateException", exception "SaslClientFactory implementation now found" at 2025/07/16 10:53:06 - please wait.
Thread=HotRod-client-async-pool-1-4 (00007FEA94014D80) Status=Running
	at org/infinispan/client/hotrod/impl/transport/netty/ChannelInitializer.getSaslClientFactory(Lorg/infinispan/client/hotrod/configuration/AuthenticationConfiguration;)Ljavax/security/sasl/SaslClientFactory; (ChannelInitializer.java:195)
	at org/infinispan/client/hotrod/impl/transport/netty/ChannelInitializer.initAuthentication(Lio/netty/channel/Channel;Lorg/infinispan/client/hotrod/configuration/AuthenticationConfiguration;)V (ChannelInitializer.java:155)
	at org/infinispan/client/hotrod/impl/transport/netty/ChannelInitializer.initChannel(Lio/netty/channel/Channel;)V (ChannelInitializer.java:84)
	at io/netty/channel/ChannelInitializer.initChannel(Lio/netty/channel/ChannelHandlerContext;)Z (ChannelInitializer.java:129)
	at io/netty/channel/ChannelInitializer.handlerAdded(Lio/netty/channel/ChannelHandlerContext;)V (ChannelInitializer.java:112)
	at io/netty/channel/AbstractChannelHandlerContext.callHandlerAdded()V (AbstractChannelHandlerContext.java:964)
	at io/netty/channel/DefaultChannelPipeline.callHandlerAdded0(Lio/netty/channel/AbstractChannelHandlerContext;)V (DefaultChannelPipeline.java:613)
	at io/netty/channel/DefaultChannelPipeline.access$100(Lio/netty/channel/DefaultChannelPipeline;Lio/netty/channel/AbstractChannelHandlerContext;)V (DefaultChannelPipeline.java:46)
	at io/netty/channel/DefaultChannelPipeline$PendingHandlerAddedTask.execute()V (DefaultChannelPipeline.java:1475)
	at io/netty/channel/DefaultChannelPipeline.callHandlerAddedForAllHandlers()V (DefaultChannelPipeline.java:1127)
	at io/netty/channel/DefaultChannelPipeline.invokeHandlerAddedIfNeeded()V (DefaultChannelPipeline.java:654)
	at io/netty/channel/AbstractChannel$AbstractUnsafe.register0(Lio/netty/channel/ChannelPromise;)V (AbstractChannel.java:503)
	at io/netty/channel/AbstractChannel$AbstractUnsafe.access$200(Lio/netty/channel/AbstractChannel$AbstractUnsafe;Lio/netty/channel/ChannelPromise;)V (AbstractChannel.java:416)
	at io/netty/channel/AbstractChannel$AbstractUnsafe$1.run()V (AbstractChannel.java:475)
	at io/netty/util/concurrent/AbstractEventExecutor.safeExecute(Ljava/lang/Runnable;)V (AbstractEventExecutor.java:163)
	at io/netty/util/concurrent/SingleThreadEventExecutor.runAllTasks(J)Z (SingleThreadEventExecutor.java:510)
	at io/netty/channel/nio/NioEventLoop.run()V (NioEventLoop.java:518)
	at io/netty/util/concurrent/SingleThreadEventExecutor$6.run()V (SingleThreadEventExecutor.java:1044)
	at io/netty/util/internal/ThreadExecutorMap$2.run()V (ThreadExecutorMap.java:74)
	at java/util/concurrent/ThreadPoolExecutor.runWorker(Ljava/util/concurrent/ThreadPoolExecutor$Worker;)V (ThreadPoolExecutor.java:1136) (Compiled Code)
	at java/util/concurrent/ThreadPoolExecutor$Worker.run()V (ThreadPoolExecutor.java:635)
	at java/lang/Thread.run()V (Thread.java:853)