### PR TITLE
Openapi map preserve order

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -386,7 +387,7 @@ public class MergeProcessorImpl implements MergeProcessor {
                 return null;
             }
 
-            HashMap<String, T> newMap = new HashMap<>();
+            Map<String, T> newMap = new LinkedHashMap<>(); //We must preserve the order of path items as the order is human visible.
             for (Entry<String, T> entry : componentMap.entrySet()) {
                 String key = entry.getKey();
                 newMap.put(documentNameProcessor.createUniqueName(nameType, key, entry.getValue()), entry.getValue());
@@ -499,7 +500,7 @@ public class MergeProcessorImpl implements MergeProcessor {
                 removeContextRoot(server, contextRoot);
             }
 
-            Map<String, PathItem> newPathItems = new HashMap<>();
+            Map<String, PathItem> newPathItems = new LinkedHashMap<>(); //We must preserve the order of path items as the order is human visible.
             for (Entry<String, PathItem> entry : pathItems.entrySet()) {
                 PathItem pathItem = entry.getValue();
 

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
@@ -387,7 +387,7 @@ public class MergeProcessorImpl implements MergeProcessor {
                 return null;
             }
 
-            Map<String, T> newMap = new LinkedHashMap<>(); //We must preserve the order of path items as the order is human visible.
+            Map<String, T> newMap = new LinkedHashMap<>(); //We must preserve the order of components as the order is human visible.
             for (Entry<String, T> entry : componentMap.entrySet()) {
                 String key = entry.getKey();
                 newMap.put(documentNameProcessor.createUniqueName(nameType, key, entry.getValue()), entry.getValue());

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/ModelCopy.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/ModelCopy.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,7 +13,7 @@
 package io.openliberty.microprofile.openapi20.internal.merge;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -66,8 +66,9 @@ public class ModelCopy {
 
     @Trivial
     private static Map<Object, Object> copyMap(Map<?, ?> copyFrom) {
-        Map<Object, Object> copyTo = new HashMap<>();
+        Map<Object, Object> copyTo = new LinkedHashMap<>();
         for (Entry<?, ?> entry : copyFrom.entrySet()) {
+            System.out.println("GREP copying map entry " + entry.getKey().toString() + " : " + entry.getValue().toString());
             copyTo.put(entry.getKey(), doCopy(entry.getValue()));
         }
         return copyTo;

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/ModelCopy.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/ModelCopy.java
@@ -68,7 +68,6 @@ public class ModelCopy {
     private static Map<Object, Object> copyMap(Map<?, ?> copyFrom) {
         Map<Object, Object> copyTo = new LinkedHashMap<>();
         for (Entry<?, ?> entry : copyFrom.entrySet()) {
-            System.out.println("GREP copying map entry " + entry.getKey().toString() + " : " + entry.getValue().toString());
             copyTo.put(entry.getKey(), doCopy(entry.getValue()));
         }
         return copyTo;

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
@@ -687,12 +687,12 @@ public class MergeConfigServerXMLTest {
         // check that documentation includes all paths in the right order
         String doc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
         JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc).get("paths");
-        String openAPIText = openapiNode.toPrettyString().replaceAll("\\R", " ");
-
-        Pattern p = Pattern.compile(".*foo1.*foo2.*foo3.*bar1.*bar2.*bar3.*");
-        Matcher m = p.matcher(openAPIText);
-
-        Assert.assertTrue("Could not find the regex " + p.toString() + " in " + openAPIText, m.matches());
+        
+        List<String> pathNames = new ArrayList<>();
+        openapiNode.path("paths").fieldNames().forEachRemaining(pathNames::add);
+        
+        assertThat("Path names not found in expected order in " + doc,
+                   pathNames, contains("foo1", "foo2", "foo3", "bar1", "bar2", "bar3"));
     }
 
     private void setMergeConfig(List<String> included, List<String> excluded, MpOpenAPIInfoElement info) throws Exception {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
@@ -665,6 +665,7 @@ public class MergeConfigServerXMLTest {
 
     //This test creates an openAPI doc with a map containing values from two apps, and checks they preserve their ordering
     @Test
+
     public void testMergePreservesMapOrdering() throws Exception {
         setMergeConfig(list("test2", "test3"), null, null);
 
@@ -688,7 +689,7 @@ public class MergeConfigServerXMLTest {
         JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc).get("paths");
         String openAPIText = openapiNode.toPrettyString().replaceAll("\\R", " ");
 
-        Pattern p = Pattern.compile(".*foo.*foo2.*foo3.*bar.*bar2.*bar3.*");
+        Pattern p = Pattern.compile(".*foo1.*foo2.*foo3.*bar1.*bar2.*bar3.*");
         Matcher m = p.matcher(openAPIText);
 
         Assert.assertTrue("Could not find the regex " + p.toString() + " in " + openAPIText, m.matches());

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
@@ -12,6 +12,7 @@ package io.openliberty.microprofile.openapi20.fat.deployments;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static io.openliberty.microprofile.openapi20.fat.utils.OpenAPITestUtil.assertEqualIgnoringPropertyOrder;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -20,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.jboss.shrinkwrap.api.Archive;
@@ -30,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -687,10 +685,10 @@ public class MergeConfigServerXMLTest {
         // check that documentation includes all paths in the right order
         String doc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
         JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc).get("paths");
-        
+
         List<String> pathNames = new ArrayList<>();
         openapiNode.path("paths").fieldNames().forEachRemaining(pathNames::add);
-        
+
         assertThat("Path names not found in expected order in " + doc,
                    pathNames, contains("foo1", "foo2", "foo3", "bar1", "bar2", "bar3"));
     }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/MergeConfigServerXMLTest.java
@@ -687,10 +687,10 @@ public class MergeConfigServerXMLTest {
         JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc).get("paths");
 
         List<String> pathNames = new ArrayList<>();
-        openapiNode.path("paths").fieldNames().forEachRemaining(pathNames::add);
+        openapiNode.fieldNames().forEachRemaining(pathNames::add);
 
         assertThat("Path names not found in expected order in " + doc,
-                   pathNames, contains("foo1", "foo2", "foo3", "bar1", "bar2", "bar3"));
+                   pathNames, contains("/test2/foo1", "/test2/foo2", "/test2/foo3", "/test3/bar1", "/test3/bar2", "/test3/bar3"));
     }
 
     private void setMergeConfig(List<String> included, List<String> excluded, MpOpenAPIInfoElement info) throws Exception {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-bar.json
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-bar.json
@@ -12,7 +12,7 @@
 		}
 	},
 	"paths": {
-        "/bar": {
+        "/bar1": {
             "get": {
                 "summary": "openapi.json - Get test data",
                 "responses": {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-bar.json
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-bar.json
@@ -5,60 +5,60 @@
 		"version": "1.0.0",
 		"description": "Test REST API in Liberty with tabs in json",
 		"termsOfService": "http://example.com/terms/",
-		"contact":{
-		   "name": "Open API support team",
-		   "email": "oapisupport@example.com",
-		   "url": "http://www.example.com/support"
+		"contact": {
+			"name": "Open API support team",
+			"email": "oapisupport@example.com",
+			"url": "http://www.example.com/support"
 		}
 	},
 	"paths": {
-        "/bar1": {
-            "get": {
-                "summary": "openapi.json - Get test data",
-                "responses": {
-                    "200": {
-                        "description": "Test data retrieved",
-                        "schema": {
-                            "$ref": "#/components/schemas/TestData"
-                        }
-                    },
-                    "404": {
-                        "description": "Test data not found"
-                    }
-                }
-            }
+		"/bar1": {
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
 		},
 		"/bar2": {
-            "get": {
-                "summary": "openapi.json - Get test data",
-                "responses": {
-                    "200": {
-                        "description": "Test data retrieved",
-                        "schema": {
-                            "$ref": "#/components/schemas/TestData"
-                        }
-                    },
-                    "404": {
-                        "description": "Test data not found"
-                    }
-                }
-            }
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
 		},
 		"/bar3": {
-            "get": {
-                "summary": "openapi.json - Get test data",
-                "responses": {
-                    "200": {
-                        "description": "Test data retrieved",
-                        "schema": {
-                            "$ref": "#/components/schemas/TestData"
-                        }
-                    },
-                    "404": {
-                        "description": "Test data not found"
-                    }
-                }
-            }
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
 		}
-    }
+	}
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-bar.json
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-bar.json
@@ -1,0 +1,64 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"title": "Test REST API",
+		"version": "1.0.0",
+		"description": "Test REST API in Liberty with tabs in json",
+		"termsOfService": "http://example.com/terms/",
+		"contact":{
+		   "name": "Open API support team",
+		   "email": "oapisupport@example.com",
+		   "url": "http://www.example.com/support"
+		}
+	},
+	"paths": {
+        "/bar": {
+            "get": {
+                "summary": "openapi.json - Get test data",
+                "responses": {
+                    "200": {
+                        "description": "Test data retrieved",
+                        "schema": {
+                            "$ref": "#/components/schemas/TestData"
+                        }
+                    },
+                    "404": {
+                        "description": "Test data not found"
+                    }
+                }
+            }
+		},
+		"/bar2": {
+            "get": {
+                "summary": "openapi.json - Get test data",
+                "responses": {
+                    "200": {
+                        "description": "Test data retrieved",
+                        "schema": {
+                            "$ref": "#/components/schemas/TestData"
+                        }
+                    },
+                    "404": {
+                        "description": "Test data not found"
+                    }
+                }
+            }
+		},
+		"/bar3": {
+            "get": {
+                "summary": "openapi.json - Get test data",
+                "responses": {
+                    "200": {
+                        "description": "Test data retrieved",
+                        "schema": {
+                            "$ref": "#/components/schemas/TestData"
+                        }
+                    },
+                    "404": {
+                        "description": "Test data not found"
+                    }
+                }
+            }
+		}
+    }
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-foo.json
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-foo.json
@@ -5,60 +5,60 @@
 		"version": "1.0.0",
 		"description": "Test REST API in Liberty with tabs in json",
 		"termsOfService": "http://example.com/terms/",
-		"contact":{
-		   "name": "Open API support team",
-		   "email": "oapisupport@example.com",
-		   "url": "http://www.example.com/support"
+		"contact": {
+			"name": "Open API support team",
+			"email": "oapisupport@example.com",
+			"url": "http://www.example.com/support"
 		}
 	},
 	"paths": {
-        "/foo1": {
-            "get": {
-                "summary": "openapi.json - Get test data",
-                "responses": {
-                    "200": {
-                        "description": "Test data retrieved",
-                        "schema": {
-                            "$ref": "#/components/schemas/TestData"
-                        }
-                    },
-                    "404": {
-                        "description": "Test data not found"
-                    }
-                }
-            }
+		"/foo1": {
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
 		},
 		"/foo2": {
-            "get": {
-                "summary": "openapi.json - Get test data",
-                "responses": {
-                    "200": {
-                        "description": "Test data retrieved",
-                        "schema": {
-                            "$ref": "#/components/schemas/TestData"
-                        }
-                    },
-                    "404": {
-                        "description": "Test data not found"
-                    }
-                }
-            }
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
 		},
 		"/foo3": {
-            "get": {
-                "summary": "openapi.json - Get test data",
-                "responses": {
-                    "200": {
-                        "description": "Test data retrieved",
-                        "schema": {
-                            "$ref": "#/components/schemas/TestData"
-                        }
-                    },
-                    "404": {
-                        "description": "Test data not found"
-                    }
-                }
-            }
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
 		}
-    }
+	}
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-foo.json
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-foo.json
@@ -12,7 +12,7 @@
 		}
 	},
 	"paths": {
-        "/foo": {
+        "/foo1": {
             "get": {
                 "summary": "openapi.json - Get test data",
                 "responses": {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-foo.json
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/test1/static-file-foo.json
@@ -1,0 +1,64 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"title": "Test REST API",
+		"version": "1.0.0",
+		"description": "Test REST API in Liberty with tabs in json",
+		"termsOfService": "http://example.com/terms/",
+		"contact":{
+		   "name": "Open API support team",
+		   "email": "oapisupport@example.com",
+		   "url": "http://www.example.com/support"
+		}
+	},
+	"paths": {
+        "/foo": {
+            "get": {
+                "summary": "openapi.json - Get test data",
+                "responses": {
+                    "200": {
+                        "description": "Test data retrieved",
+                        "schema": {
+                            "$ref": "#/components/schemas/TestData"
+                        }
+                    },
+                    "404": {
+                        "description": "Test data not found"
+                    }
+                }
+            }
+		},
+		"/foo2": {
+            "get": {
+                "summary": "openapi.json - Get test data",
+                "responses": {
+                    "200": {
+                        "description": "Test data retrieved",
+                        "schema": {
+                            "$ref": "#/components/schemas/TestData"
+                        }
+                    },
+                    "404": {
+                        "description": "Test data not found"
+                    }
+                }
+            }
+		},
+		"/foo3": {
+            "get": {
+                "summary": "openapi.json - Get test data",
+                "responses": {
+                    "200": {
+                        "description": "Test data retrieved",
+                        "schema": {
+                            "$ref": "#/components/schemas/TestData"
+                        }
+                    },
+                    "404": {
+                        "description": "Test data not found"
+                    }
+                }
+            }
+		}
+    }
+}


### PR DESCRIPTION
Ensure that map elements in an OpenAPI document preserve their order during merge so they're displayed to the user in the right order.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #32197