### PR TITLE
Fix up the build paths for Eclipse

### DIFF
--- a/dev/com.ibm.ws.springboot.fat20.concurrency.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.fat20.concurrency.app/bnd.bnd
@@ -39,4 +39,5 @@ src: \
   org.springframework:spring-jdbc;${springVersion20}, \
   org.springframework:spring-tx;${springVersion20}, \
   org.springframework:spring-web;${springVersion20}, \
-  org.slf4j:slf4j-api;version=1.7.36
+  org.slf4j:slf4j-api;version=1.7.36, \
+  com.ibm.websphere.javaee.servlet.3.1

--- a/dev/com.ibm.ws.springboot.fat20.data.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.fat20.data.app/bnd.bnd
@@ -43,6 +43,7 @@ src: \
   org.springframework:spring-web;${springVersion20}, \
   org.slf4j:slf4j-api;version=1.7.36, \
   com.ibm.websphere.javaee.persistence.2.2;version=latest,\
+  com.ibm.websphere.javaee.servlet.3.1,\
   org.springframework.data:spring-data-commons;version=2.7.6,\
   org.springframework.data:spring-data-jpa;version=2.7.6
   

--- a/dev/com.ibm.ws.springboot.fat20.jms.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.fat20.jms.app/bnd.bnd
@@ -42,4 +42,5 @@ src: \
   org.springframework:spring-tx;${springVersion20}, \
   org.springframework:spring-web;${springVersion20}, \
   org.slf4j:slf4j-api;version=1.7.36, \
-  com.ibm.websphere.javaee.jms.2.0;version=latest
+  com.ibm.websphere.javaee.jms.2.0;version=latest, \
+  com.ibm.websphere.javaee.servlet.3.1

--- a/dev/com.ibm.ws.springboot.fat20.transactions.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.fat20.transactions.app/bnd.bnd
@@ -40,4 +40,5 @@ src: \
   org.springframework:spring-jdbc;${springVersion20}, \
   org.springframework:spring-tx;${springVersion20}, \
   org.springframework:spring-web;${springVersion20}, \
-  org.slf4j:slf4j-api;version=1.7.36
+  org.slf4j:slf4j-api;version=1.7.36, \
+  com.ibm.websphere.javaee.servlet.3.1

--- a/dev/com.ibm.ws.springboot.fat20.validation.app/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.fat20.validation.app/bnd.bnd
@@ -39,5 +39,5 @@ src: \
   org.springframework:spring-core;${springVersion20}, \
   org.springframework:spring-web;${springVersion20}, \
   org.slf4j:slf4j-api;version=1.7.36, \
+  com.ibm.websphere.javaee.servlet.3.1, \
   com.ibm.websphere.javaee.validation.2.0;version=latest
-  

--- a/dev/io.openliberty.springboot.fat30.data.app/bnd.bnd
+++ b/dev/io.openliberty.springboot.fat30.data.app/bnd.bnd
@@ -46,6 +46,7 @@ src: \
   org.springframework:spring-web;${springVersion30}, \
   org.slf4j:slf4j-api;version=1.7.36, \
   io.openliberty.jakarta.persistence.3.1;version=latest,\
+  io.openliberty.jakarta.servlet.6.0;version=latest, \
   org.springframework.data:spring-data-commons;version=3.3.0,\
   org.springframework.data:spring-data-jpa;version=3.3.0
   

--- a/dev/io.openliberty.springboot.fat30.validation.app/bnd.bnd
+++ b/dev/io.openliberty.springboot.fat30.validation.app/bnd.bnd
@@ -42,5 +42,6 @@ src: \
   org.springframework:spring-core;${springVersion30}, \
   org.springframework:spring-web;${springVersion30}, \
   org.slf4j:slf4j-api;version=1.7.36, \
+  io.openliberty.jakarta.servlet.6.0;version=latest, \
   io.openliberty.jakarta.validation.3.0;version=latest
   

--- a/dev/io.openliberty.springboot.fat30.websocket.app/bnd.bnd
+++ b/dev/io.openliberty.springboot.fat30.websocket.app/bnd.bnd
@@ -36,5 +36,6 @@ src: \
   org.springframework:spring-context;${springVersion30}, \
   org.springframework:spring-web;${springVersion30}, \
   org.springframework:spring-websocket;${springVersion30}, \
+  io.openliberty.jakarta.servlet.6.0;version=latest, \
   io.openliberty.jakarta.websocket.client.2.1;version=latest, \
   io.openliberty.jakarta.websocket.2.1;version=latest


### PR DESCRIPTION
Importing some projects into Eclipse results in errors about indirect references to javax.servlet.ServletContext or jakarta.servlet.ServletContext Resolve by adding the appropriate servlet API to the bnd.bnd.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
