### PR TITLE
Issue reported for MEMBER OF failing on ElementCollection of Embeddable

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1432,14 +1432,14 @@ public class DataJPATestServlet extends FATServlet {
                 throw x;
         }
 
-        // TODO report EclipseLink bug that occurs on the following
+        // TODO enable once issue #32204 is fixed in EclipseLink
         if (false)
             assertIterableEquals(List.of(345003450L, 678006780L),
                                  taxpayers.findByBankAccountsContains(AccountId.of(26122300, 410224))
                                                  .map(t -> t.ssn)
                                                  .collect(Collectors.toList()));
 
-        // TODO also fails with EclipseLink error
+        // TODO enable once issue #31558 is fixed in EclipseLink
         if (false)
             assertIterableEquals(List.of(789007890L),
                                  taxpayers.findByBankAccountsNotEmpty()


### PR DESCRIPTION
Document tracking numbers for 2 more EclispseLink bugs after investigating.
This will allow us to quickly identify what tests to attempt to re-enable after the bugs are fixed in order to confirm it.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".