### PR TITLE
Cleanup bnd.bnd for routing archiveExpander

### DIFF
--- a/dev/com.ibm.ws.filetransfer.routing.archiveExpander/bnd.bnd
+++ b/dev/com.ibm.ws.filetransfer.routing.archiveExpander/bnd.bnd
@@ -31,24 +31,11 @@ Import-Package: \
  !org.apache.commons.io.file, *
 
 -includeresource: \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/channels/FileChannels*, \
  @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/**/*.class, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/input/NullInputStream*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/NullOutputStream*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/NullWriter*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/QueueOutputStream*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/ThresholdingOutputStream*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/ByteArrayOutputStream*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/AbstractByteArrayOutputStream*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/StringBuilderWriter*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/AppendableWriter*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/input/BoundedInputStream*, \
  @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/Charsets*, \
  @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/IOUtils*, \
  @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/CloseableURLConnection*, \
  @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/StandardLineSeparator*, \
- @${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/function/IOTriFunction*, \
  @${repo;com.ibm.ws.org.apache.commons.compress}!/org/apache/commons/compress/archivers/ArchiveEntry*, \
  @${repo;com.ibm.ws.org.apache.commons.compress}!/org/apache/commons/compress/archivers/ArchiveInputStream*, \
  @${repo;com.ibm.ws.org.apache.commons.compress}!/org/apache/commons/compress/compressors/bzip2/BZip2CompressorInputStream*, \


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Clean up `com.ibm.ws.filetransfer.routing.archiveExpander/bnd.bnd`