### PR TITLE
Fixup build path for tests in Eclipse

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -3002,6 +3002,11 @@
       <version>8.2.0.v20160908</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jnosql.communication</groupId>
+      <artifactId>jnosql-communication-semistructured</artifactId>
+      <version>1.1.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jnosql.mapping</groupId>
       <artifactId>jnosql-mapping-semistructured</artifactId>
       <version>1.1.4</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -596,6 +596,7 @@ org.eclipse.jetty:jetty-util:9.2.2.v20140723
 org.eclipse.jetty:jetty-util:9.4.39.v20210325
 org.eclipse.jetty:jetty-util:9.4.7.RC0
 org.eclipse.jetty:jetty-websocket:8.2.0.v20160908
+org.eclipse.jnosql.communication:jnosql-communication-semistructured:1.1.4
 org.eclipse.jnosql.mapping:jnosql-mapping-semistructured:1.1.4
 org.eclipse.microprofile.config:microprofile-config-api:1.1
 org.eclipse.microprofile.config:microprofile-config-api:1.2.1

--- a/dev/io.openliberty.data.internal_fat_nosql/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_nosql/bnd.bnd
@@ -36,4 +36,5 @@ fat.test.container.images: public.ecr.aws/docker/library/mongo:6.0.6
 	io.openliberty.jakarta.transaction.2.0,\
 	io.openliberty.org.eclipse.microprofile.config.3.0,\
 	io.openliberty.org.testcontainers;version=latest,\
+	org.eclipse.jnosql.communication:jnosql-communication-semistructured;version=1.1.4,\
 	org.eclipse.jnosql.mapping:jnosql-mapping-semistructured;version=1.1.4


### PR DESCRIPTION
Resolve the following error in Eclipse by updating the build path:
- Cannot find the class file for org.eclipse.jnosql.communication.semistructured.CriteriaCondition.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".