### PR TITLE
Fix trace.log from being created when traceFileName=stdout in server.xml

### DIFF
--- a/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/TrConfigurator.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/TrConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2014 IBM Corporation and others.
+ * Copyright (c) 2010, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/TrConfigurator.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/websphere/ras/TrConfigurator.java
@@ -129,6 +129,10 @@ public class TrConfigurator {
                     setupSafeLevelsIndex();
                 }
             }
+            
+            // Propagate updates to the delegates, to ensure all logging configuration attributes 
+            // are updated from server.xml.
+            getDelegate().update(config);
 
             TraceSpecification newTs = setTraceSpec(config.getTraceString());
 
@@ -139,9 +143,6 @@ public class TrConfigurator {
             // we've updated the defaults from server.xml (we can set this a million times.. 
             // first pass through is the key.. 
             defaultUpdated = true;
-
-            // Propagate updates to the delegate
-            getDelegate().update(config);
         }
 
         // issue warning if trace has been enabled and there's no instrumentation agent


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/open-liberty/issues/31949
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- When the server starts up, the traceLog writer gets initialized with the default values for the logging attribute configuration with `traceFileName=trace.log` or based on what is configured in bootstrap.properties, then in `TrConfigurator.update()` we set the configured traceSpecification which triggers the trace.log file to be created, then the `BaseTraceService.update()` call is made, which updates the logging configurations with `traceFileName=stdout` in server.xml, this is too late in the flow, as the trace.log file is already created. 
- Moved the `BaseTraceService.update()` call before the traceSpecification is set, to ensure all the correct logging configurations are set beforehand.