### PR TITLE
if resolved features contains missing features don't stop resolution

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -1110,7 +1110,7 @@ public class FeatureResolverImpl implements FeatureResolver {
         Set<String> result = processCurrentPermutation(rootFeatures, preResolved, selectionContext);
 
         // if the first pass resulted in no conflicts return the results (optimistic)
-        if (selectionContext.getResult().getConflicts().isEmpty()) {
+        if (selectionContext.getResult().getConflicts().isEmpty() && selectionContext.getResult().getMissing().isEmpty()) {
             selectionContext.selectCurrentPermutation();
             return result;
         }
@@ -1121,7 +1121,7 @@ public class FeatureResolverImpl implements FeatureResolver {
         // addition conflict.  That implies that a better solution may be available.
         // As long as there are more conflicts than the number of initial root conflicts
         // and there is a different permutation to try do another pass
-        while (selectionContext.currentHasMoreThanInitialBlockedCount() && selectionContext.popPermutation()) {
+        while ((selectionContext.currentHasMoreThanInitialBlockedCount() || selectionContext.currentHasMissing()) && selectionContext.popPermutation()) {
             result = processCurrentPermutation(rootFeatures, preResolved, selectionContext);
         }
 
@@ -1533,6 +1533,10 @@ public class FeatureResolverImpl implements FeatureResolver {
             return getBlockedCount() > _initialBlockedCount.get();
         }
 
+        boolean currentHasMissing() {
+            return !_current._result._missing.isEmpty();
+        }
+
         void setInitialRootBlockedCount() {
             // only set this once
             _initialBlockedCount.compareAndSet(-1, getBlockedCount());
@@ -1554,7 +1558,8 @@ public class FeatureResolverImpl implements FeatureResolver {
         void checkForBestSolution() {
             // check if the current best (store as the last permutation) has more conflicts
             // than the current solution.
-            if (_permutations.getLast()._result.getConflicts().size() > _current._result.getConflicts().size()) {
+            if (_permutations.getLast()._result.getConflicts().size() > _current._result.getConflicts().size() || 
+                (_permutations.getLast()._result.getConflicts().size() == _current._result.getConflicts().size() && _permutations.getLast()._result.getMissing().size() > _current._result.getMissing().size())) {
                 // Replace the current best (stored as the last permutation)
                 _permutations.pollLast();
                 _permutations.addLast(_current);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

A draft PR for #32216 
In order to make the feature resolver keep attempting to resolve features after finding missing features there are two things that need to change. First there needs to be a checker for if the result contains missing features at the point we are done trying to resolve one combination of features and if we do contain missing features then don't exit the loop. Secondly the mechanism that keeps track of the best possible solution needs to be aware of missing features in the solution, otherwise a solution with 2 missing features and a solution with 0 would be the same.