### PR TITLE
add support in fattest.simplicity.LibertyClient to run FIPS 140-3 on JDK >= 11

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -675,9 +675,9 @@ public class LibertyClient {
         if (isFIPS140_3EnabledAndSupported()) {
             Log.info(c, "startClientWithArgs", "The JDK version: " + javaInfo.majorVersion() + " and vendor: " + JavaInfo.Vendor.IBM);
 
-            if (javaInfo.majorVersion() == 17){
+            if (javaInfo.majorVersion() >= 11){
                 Log.info(c, "startClientWithArgs", "FIPS 140-3 global build properties is set for Client " + getClientName()
-                                                   + " with IBM Java 17, adding required JVM arguments to run with FIPS 140-3 enabled");
+                                                   + " with IBM Java " + javaInfo.majorVersion() + ", adding required JVM arguments to run with FIPS 140-3 enabled");
                                                    
                 JVM_ARGS += " -Dsemeru.fips=true";
                 JVM_ARGS += " -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Custom";
@@ -3974,21 +3974,21 @@ public class LibertyClient {
     public boolean isFIPS140_3EnabledAndSupported() {
         String methodName = "isFIPS140_3EnabledAndSupported";
         boolean isIBMJVM8 = (javaInfo.majorVersion() == 8) && (javaInfo.VENDOR == Vendor.IBM);
-        boolean isIBMJVM17 = (javaInfo.majorVersion() == 17) && (javaInfo.VENDOR == Vendor.IBM);
+        boolean isIBMJVMGreaterOrEqualTo11 = (javaInfo.majorVersion() >= 11) && (javaInfo.VENDOR == Vendor.IBM);
         if (GLOBAL_CLIENT_FIPS_140_3) {
             Log.info(c, methodName, "Liberty client is running JDK version: " + javaInfo.majorVersion() + " and vendor: " + javaInfo.VENDOR);
             if (isIBMJVM8) {
                 Log.info(c, methodName, "global build properties FIPS_140_3 is set for client " + getClientName() +
                                         " and IBM java 8 is available to run with FIPS 140-3 enabled.");
-            } else if (isIBMJVM17) {
+            } else if (isIBMJVMGreaterOrEqualTo11) {
                 Log.info(c, methodName, "global build properties FIPS_140_3 is set for client " + getClientName() +
-                                        " and IBM java 17 is available to run with FIPS 140-3 enabled.");
+                                        " and IBM java " + javaInfo.majorVersion() + " is available to run with FIPS 140-3 enabled.");
             } else {
-                Log.info(c, methodName, "The global build properties FIPS_140_3 is set for client " + getClientName() +
-                                        ",  but no IBM java 8 or java 17 on liberty client to run with FIPS 140-3 enabled.");
+                throw new RuntimeException("The global build properties FIPS_140_3 is set for client " + getClientName() +
+                                           ",  but no IBM java on liberty client to run with FIPS 140-3 enabled.");
             }
         }
-        return GLOBAL_CLIENT_FIPS_140_3 && (isIBMJVM8 || isIBMJVM17);
+        return GLOBAL_CLIENT_FIPS_140_3 && (isIBMJVM8 || isIBMJVMGreaterOrEqualTo11);
     }
 
     //FIPS 140-3


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

