### PR TITLE
Netty getRequestURL double slash 

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
@@ -390,7 +390,7 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
         String host = context.getLocalAddr().getCanonicalHostName();
         int port = context.getLocalPort();
 
-        return new StringBuffer(getScheme() + "://" + host + ":" + port + "/" + getRequestURI());
+        return new StringBuffer(getScheme() + "://" + host + ":" + port + getRequestURI());
 
     }
 


### PR DESCRIPTION
CICS testing uncovered double slash in the getRequestURL result.   This causes some CICS tests to fail.