### PR TITLE
Add xmlWSClient-4.0 feature to support xmlWS in appClient with EE 11

### DIFF
--- a/dev/build.featureStart.base/src/com/ibm/ws/test/featurestart/features/FeatureFilter.java
+++ b/dev/build.featureStart.base/src/com/ibm/ws/test/featurestart/features/FeatureFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -67,7 +67,7 @@ public class FeatureFilter {
             // location variable.
             return "Required variable 'wmqJmsClient.rar.location' is not set";
 
-        } else if (shortName.indexOf("-") == -1 ) {
+        } else if (shortName.indexOf("-") == -1) {
             // Versionless features cannot run by themselves
             // Requires other features to be configured for it to resolve
             return "Cannot start by itself";
@@ -107,10 +107,11 @@ public class FeatureFilter {
     }
 
     /**
-     * Tell if a feature is a client-only feature.  Currently,
+     * Tell if a feature is a client-only feature. Currently,
      * features which have names which contain 'eeClient' or 'securityClient'
-     * are client-only features.  Those are 'jakartaeeClient' and
-     * 'securityClient'.
+     * are client-only features. Those are 'jakartaeeClient', 'javaeeClient' and
+     * 'securityClient'.  With EE 11 also added in xmlWSClient now that XML
+     * Web Services is not longer required by the platform.
      *
      * Previously, the test was against 'client', but that was incorrect.
      *
@@ -119,8 +120,8 @@ public class FeatureFilter {
      */
     public static boolean isClient(String shortName) {
         String upperShortName = shortName.toUpperCase();
-        return ( upperShortName.contains("EECLIENT") ||
-                 upperShortName.contains("SECURITYCLIENT") );
+        return (upperShortName.contains("EECLIENT") ||
+                upperShortName.contains("SECURITYCLIENT") ||
+                upperShortName.contains("XMLWSCLIENT"));
     }
 }
-

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaxwsClientSecurity-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaxwsClientSecurity-2.2.feature
@@ -4,7 +4,7 @@ visibility=private
 IBM-App-ForceRestart: uninstall, \
  install
 IBM-Process-Types: client
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.jaxwsClient-2.2)(osgi.identity=io.openliberty.xmlWSClient-3.0)(osgi.identity=io.openliberty.xmlWSClient-4.0)))", \
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.jaxwsClient-2.2)(osgi.identity=io.openliberty.xmlWSClient.internal-3.0)(osgi.identity=io.openliberty.xmlWSClient.internal-4.0)))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.appSecurityClient-1.0))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.jaxws.clientcontainer.security

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlWSClient.internal-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlWSClient.internal-3.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.xmlWSClient-3.0
+symbolicName=io.openliberty.xmlWSClient.internal-3.0
 Subsystem-Name: Internal JAX-WS Client Container Features
 WLP-Activation-Type: parallel
 singleton=true

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlWSClient.internal-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlWSClient.internal-4.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.xmlWSClient-4.0
+symbolicName=io.openliberty.xmlWSClient.internal-4.0
 Subsystem-Name: Internal JAX-WS Client Container Features
 WLP-Activation-Type: parallel
 singleton=true

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-10.0/io.openliberty.jakartaeeClient-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-10.0/io.openliberty.jakartaeeClient-10.0.feature
@@ -106,7 +106,7 @@ Subsystem-Name: Jakarta EE 10.0 Application Client
   io.openliberty.managedBeans-2.0, \
   com.ibm.websphere.appserver.eeCompatible-10.0, \
   io.openliberty.appclient.appClient-2.0, \
-  io.openliberty.xmlWSClient-4.0, \
+  io.openliberty.xmlWSClient.internal-4.0, \
   com.ibm.websphere.appserver.transaction-2.0, \
   io.openliberty.jsonp-2.1
 -jars=io.openliberty.ejbcontainer; location:=dev/api/ibm/

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-11.0/io.openliberty.jakartaeeClient-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-11.0/io.openliberty.jakartaeeClient-11.0.feature
@@ -61,17 +61,6 @@ IBM-API-Package: \
   org.omg.SendingContext; type="spec", \
   org.omg.SendingContext.CodeBasePackage; type="spec", \
   org.omg.TimeBase; type="spec", \
-  jakarta.jws; type="spec", \
-  jakarta.jws.soap; type="spec", \
-  jakarta.xml.soap; type="spec", \
-  jakarta.xml.ws; type="spec", \
-  jakarta.xml.ws.handler; type="spec", \
-  jakarta.xml.ws.handler.soap; type="spec", \
-  jakarta.xml.ws.http; type="spec", \
-  jakarta.xml.ws.soap; type="spec", \
-  jakarta.xml.ws.spi; type="spec", \
-  jakarta.xml.ws.spi.http; type="spec", \
-  jakarta.xml.ws.wsaddressing; type="spec", \
   jakarta.annotation; type="spec", \
   jakarta.annotation.security; type="spec", \
   jakarta.annotation.sql; type="spec", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-9.1/io.openliberty.jakartaeeClient-9.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-9.1/io.openliberty.jakartaeeClient-9.1.feature
@@ -108,7 +108,7 @@ Subsystem-Name: Jakarta EE 9.1 Application Client
   io.openliberty.managedBeans-2.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0, \
   io.openliberty.appclient.appClient-2.0, \
-  io.openliberty.xmlWSClient-3.0, \
+  io.openliberty.xmlWSClient.internal-3.0, \
   com.ibm.websphere.appserver.transaction-2.0, \
   io.openliberty.jsonp-2.0
 -jars=io.openliberty.ejbcontainer; location:=dev/api/ibm/

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/io.openliberty.xmlWSClient-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/io.openliberty.xmlWSClient-4.0.feature
@@ -1,0 +1,44 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.xmlWSClient-4.0
+visibility=public
+Subsystem-Name: Jakarta XML Web Services 4.0 Client
+WLP-Activation-Type: parallel
+singleton=true
+IBM-App-ForceRestart: uninstall, \
+ install
+IBM-API-Package: \
+  jakarta.jws; type="spec", \
+  jakarta.jws.soap; type="spec", \
+  jakarta.xml.soap; type="spec", \
+  jakarta.xml.ws; type="spec", \
+  jakarta.xml.ws.handler; type="spec", \
+  jakarta.xml.ws.handler.soap; type="spec", \
+  jakarta.xml.ws.http; type="spec", \
+  jakarta.xml.ws.soap; type="spec", \
+  jakarta.xml.ws.spi; type="spec", \
+  jakarta.xml.ws.spi.http; type="spec", \
+  jakarta.xml.ws.wsaddressing; type="spec", \
+  jakarta.annotation; type="spec", \
+  jakarta.annotation.security; type="spec", \
+  jakarta.annotation.sql; type="spec"
+IBM-SPI-Package: \
+  com.ibm.wsspi.adaptable.module, \
+  com.ibm.ws.adaptable.module.structure, \
+  com.ibm.wsspi.adaptable.module.adapters, \
+  com.ibm.wsspi.artifact, \
+  com.ibm.wsspi.artifact.factory, \
+  com.ibm.wsspi.artifact.factory.contributor, \
+  com.ibm.wsspi.artifact.overlay, \
+  com.ibm.wsspi.artifact.equinox.module, \
+  com.ibm.wsspi.anno.classsource, \
+  com.ibm.wsspi.anno.info, \
+  com.ibm.wsspi.anno.service, \
+  com.ibm.wsspi.anno.targets, \
+  com.ibm.wsspi.anno.util, \
+  com.ibm.ws.anno.classsource.specification
+IBM-ShortName: xmlWSClient-4.0
+IBM-Process-Types: client
+-features=\
+  io.openliberty.xmlWSClient.internal-4.0
+kind=beta
+edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_cs.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_cs.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_de.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_de.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_es.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_es.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_fr.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_fr.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_hu.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_hu.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_it.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_it.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_ja.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_ja.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_ko.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_ko.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_pl.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_pl.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_pt_BR.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_pt_BR.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_ro.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_ro.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_ru.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_ru.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_zh.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_zh.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_zh_TW.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWSClient-4.0/resources/l10n/io.openliberty.xmlWSClient-4.0_zh_TW.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+description=This feature enables support for Jakarta XML Web Services 4.0 for a Jakarta EE application client.

--- a/dev/com.ibm.ws.jaxws.clientcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.clientcontainer_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2023 IBM Corporation and others.
+# Copyright (c) 2019, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -42,7 +42,10 @@ tested.features: \
   servlet-6.0, \
   appsecurity-5.0, \
   jsonp-2.1, \
-  cdi-4.0
+  cdi-4.0, \
+  appSecurity-6.0, \
+  pages-4.0, \
+  cdi-4.1
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.jaxws.clientcontainer_fat/fat/src/com/ibm/ws/jaxws/clientcontainer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxws.clientcontainer_fat/fat/src/com/ibm/ws/jaxws/clientcontainer/fat/FATSuite.java
@@ -1,16 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jaxws.clientcontainer.fat;
+
+import java.util.Arrays;
+import java.util.HashSet;
 
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -34,6 +37,7 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().fullFATOnly())
                     .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                    .andWith(FeatureReplacementAction.EE10_FEATURES());
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                    .andWith(FeatureReplacementAction.EE11_FEATURES().alwaysAddFeatures(new HashSet<>(Arrays.asList("xmlBinding-4.0", "xmlWSClient-4.0"))));
 
 }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -52,8 +52,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.eclipse.equinox.region.RegionDigraph;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.BundleException;
 import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleException;
 import org.osgi.framework.BundleListener;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
@@ -186,7 +186,11 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
 
     private static Version JAVA_MAJOR_VERSION = new Version(JavaInfo.majorVersion(), 0, 0);
 
-    final static Collection<String> ALLOWED_ON_ALL_FEATURES = Arrays.asList("com.ibm.websphere.appserver.timedexit-1.0", "com.ibm.websphere.appserver.osgiConsole-1.0");
+    final static Collection<String> ALLOWED_ON_ALL_FEATURES = Arrays.asList(
+                                                                            "com.ibm.websphere.appserver.timedexit-1.0",
+                                                                            "com.ibm.websphere.appserver.osgiConsole-1.0",
+                                                                            "io.openliberty.xmlBinding-4.0" // Removed from platform in EE 11.  Can be specified on server or client now.
+    );
     final static Collection<String> ALL_ALLOWED_ON_CLIENT_FEATURES;
     static {
         Collection<String> temp = new ArrayList<String>();
@@ -247,7 +251,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
 
         Set<String> getPlatformsWithLowerCaseName() {
             Set<String> lcnPlatforms = new HashSet<String>();
-            if(platforms == null){
+            if (platforms == null) {
                 return lcnPlatforms;
             }
             for (String platform : platforms) {
@@ -351,7 +355,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
         private volatile Collection<ProvisioningFeatureDefinition> kernelFeatures;
 
         private final FeatureManager featureManager;
-       
+
         private final ProvisioningMode initialMode;
 
         KernelFeaturesHolder(FeatureManager featureManager, ProvisioningMode initialMode) {
@@ -979,8 +983,8 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             Tr.debug(tc, "all installed features " + postInstalledFeatures);
         }
 
-        if(result != null){
-            if(!result.getResolvedPlatforms().isEmpty()){
+        if (result != null) {
+            if (!result.getResolvedPlatforms().isEmpty()) {
                 Tr.info(tc, "RESOLVED_PLATFORM", result.getResolvedPlatforms());
             }
 
@@ -989,19 +993,19 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             List<String> resolvedVersionless = new ArrayList<>();
             List<String> resolvedVersioned = new ArrayList<>();
             for (Map.Entry<String, String> versionlessResolved : result.getVersionlessFeatures().entrySet()) {
-                if(versionlessResolved.getValue() == null){
+                if (versionlessResolved.getValue() == null) {
                     continue;
                 }
                 ProvisioningFeatureDefinition versionless = featureRepository.getFeature(versionlessResolved.getKey());
                 ProvisioningFeatureDefinition versioned = featureRepository.getFeature(versionlessResolved.getValue());
-                if((postInstalledFeatures.contains(versionless.getFeatureName()) || postInstalledFeatures.contains(versionless.getSymbolicName()))
-                    && (postInstalledFeatures.contains(versioned.getFeatureName()) || postInstalledFeatures.contains(versioned.getSymbolicName()))){
-                    
+                if ((postInstalledFeatures.contains(versionless.getFeatureName()) || postInstalledFeatures.contains(versionless.getSymbolicName()))
+                    && (postInstalledFeatures.contains(versioned.getFeatureName()) || postInstalledFeatures.contains(versioned.getSymbolicName()))) {
+
                     resolvedVersionless.add(versionless.getFeatureName());
                     resolvedVersioned.add(versioned.getFeatureName());
                 }
             }
-            if(!resolvedVersionless.isEmpty()){
+            if (!resolvedVersionless.isEmpty()) {
                 Tr.info(tc, "VERSIONLESS_FEATURE_RESOLVED_TO_FEATURE", resolvedVersionless, resolvedVersioned);
             }
         }
@@ -1342,7 +1346,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
                 // If we don't want to include auto features, then check each feature before adding it.
                 if (!includeAutoFeatures) {
                     if (fd instanceof ProvisioningFeatureDefinition) {
-                        if (!((ProvisioningFeatureDefinition) fd).isAutoFeature())
+                        if (!fd.isAutoFeature())
                             publicFeatures.add(fd.getFeatureName());
                     } else {
                         // If we're not an instance of ProvisioningFeatureDefinition then add the feature to the list.
@@ -1493,27 +1497,27 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             }
 
             @Override
-            public Map<String, String> getVersionlessFeatures(){
+            public Map<String, String> getVersionlessFeatures() {
                 return Collections.emptyMap();
             }
 
             @Override
-            public Set<String> getResolvedPlatforms(){
+            public Set<String> getResolvedPlatforms() {
                 return Collections.emptySet();
             }
 
             @Override
-            public Set<String> getMissingPlatforms(){
+            public Set<String> getMissingPlatforms() {
                 return Collections.emptySet();
             }
 
             @Override
-            public Map<String, Set<String>> getDuplicatePlatforms(){
+            public Map<String, Set<String>> getDuplicatePlatforms() {
                 return Collections.emptyMap();
             }
 
             @Override
-            public Map<String, Set<String>> getNoPlatformVersionless(){
+            public Map<String, Set<String>> getNoPlatformVersionless() {
                 return Collections.emptyMap();
             }
         };
@@ -1530,10 +1534,10 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
      */
     @FFDCIgnore(Throwable.class)
     protected Result updateFeatures(WsLocationAdmin locService,
-                                     Provisioner provisioner,
-                                     Set<String> preInstalledFeatures,
-                                     FeatureChange featureChange,
-                                     long sequenceNumber) {
+                                    Provisioner provisioner,
+                                    Set<String> preInstalledFeatures,
+                                    FeatureChange featureChange,
+                                    long sequenceNumber) {
         // NOTE RE: FFDCIgnore above-- The catch block for Throwable below, stores
         // the exception in an InstallStatus object and calls FFDC at a more appropriate time.
         BundleList newBundleList = null;
@@ -1598,7 +1602,8 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
                         bundleCache.addAllNoReplace(newBundleList);
 
                         // Update installedFeatures with the features that were successfully added
-                        featureRepository.setResolvedFeatures(goodFeatures, newConfiguredFeatures, reportedConfigurationErrors, newConfiguredPlatforms, platformEnvironmentVariable);
+                        featureRepository.setResolvedFeatures(goodFeatures, newConfiguredFeatures, reportedConfigurationErrors, newConfiguredPlatforms,
+                                                              platformEnvironmentVariable);
                     }
                 }
             }
@@ -1757,10 +1762,10 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
     private boolean areConfiguredFeaturesGood(Set<String> newConfiguredFeatures, Set<String> newConfiguredPlatforms) {
         if (!!!featureRepository.isDirty()
             && !!!featureRepository.hasConfigurationError()
-            && featureRepository.getConfiguredFeatures().equals(newConfiguredFeatures)){
-            if(featureRepository.getPlatforms().equals(newConfiguredPlatforms) 
+            && featureRepository.getConfiguredFeatures().equals(newConfiguredFeatures)) {
+            if (featureRepository.getPlatforms().equals(newConfiguredPlatforms)
                 && equals(featureRepository.getPlatformEnvVar(), platformEnvironmentVariable)) {
-                    
+
                 // check that all installed features are still installed
                 for (String resolvedFeature : featureRepository.getResolvedFeatures()) {
                     if (featureRepository.getFeature(resolvedFeature) == null) {
@@ -2010,36 +2015,34 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             }
         }
 
-        if(!result.getDuplicatePlatforms().isEmpty()){
-            for(Map.Entry<String, Set<String>> duplicatePlatforms : result.getDuplicatePlatforms().entrySet()){
+        if (!result.getDuplicatePlatforms().isEmpty()) {
+            for (Map.Entry<String, Set<String>> duplicatePlatforms : result.getDuplicatePlatforms().entrySet()) {
                 Tr.error(tc, "DUPLICATE_PLATFORMS", duplicatePlatforms.getValue());
             }
         }
 
-        if(!result.getMissingPlatforms().isEmpty()){
+        if (!result.getMissingPlatforms().isEmpty()) {
             reportedErrors = true;
             Set<String> remainingMissingPlatforms = new HashSet<String>();
-            if(platformEnvironmentVariable != null){
-                for(String plat : result.getMissingPlatforms()){
-                    if(platformEnvironmentVariable.contains(plat)){
+            if (platformEnvironmentVariable != null) {
+                for (String plat : result.getMissingPlatforms()) {
+                    if (platformEnvironmentVariable.contains(plat)) {
                         Tr.error(tc, "UNKNOWN_PLATFORM_VALUE_ENV_VAR", plat);
-                    }
-                    else{
+                    } else {
                         remainingMissingPlatforms.add(plat);
                     }
                 }
-            }
-            else{
+            } else {
                 remainingMissingPlatforms.addAll(result.getMissingPlatforms());
             }
-            if(!remainingMissingPlatforms.isEmpty()){
-                for(String missingPlat : remainingMissingPlatforms){
+            if (!remainingMissingPlatforms.isEmpty()) {
+                for (String missingPlat : remainingMissingPlatforms) {
                     Tr.error(tc, "UNKNOWN_PLATFORM_ELEMENT", missingPlat);
                 }
             }
         }
 
-        if(!result.getNoPlatformVersionless().isEmpty()){
+        if (!result.getNoPlatformVersionless().isEmpty()) {
             for (Map.Entry<String, Set<String>> noPlatformVersionless : result.getNoPlatformVersionless().entrySet()) {
                 Tr.error(tc, "NO_RESOLVED_PLATFORM", noPlatformVersionless.getValue());
             }
@@ -2049,7 +2052,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             String versionlessResolved = versionlessResolvedEntry.getKey();
             String versionedResolved = versionlessResolvedEntry.getValue();
 
-            if(versionedResolved != null){
+            if (versionedResolved != null) {
                 continue; // Sucessfully resolved.  Nothing to check.
             }
 
@@ -2061,7 +2064,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             ProvisioningFeatureDefinition compatibility = null;
             for (String platform : platforms) {
                 compatibility = featureRepository.getCompatibilityFeature(platform);
-                if(compatibility != null){
+                if (compatibility != null) {
                     break;
                 }
             }
@@ -2070,21 +2073,21 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             }
 
             String compatibilityBaseName = featureRepository.getFeatureBaseName(compatibility.getFeatureName());
-            for(String resolvedPlat : result.getResolvedPlatforms()){
+            for (String resolvedPlat : result.getResolvedPlatforms()) {
                 ProvisioningFeatureDefinition compatibilityFeature = featureRepository.getCompatibilityFeature(resolvedPlat);
-                if(compatibilityFeature == null){
-                    continue; 
+                if (compatibilityFeature == null) {
+                    continue;
                 }
                 String resolvedBaseName = featureRepository.getFeatureBaseName(compatibilityFeature.getFeatureName());
 
-                if(compatibilityBaseName.equals(resolvedBaseName)){
-                    if(!platforms.contains(resolvedPlat)){
+                if (compatibilityBaseName.equals(resolvedBaseName)) {
+                    if (!platforms.contains(resolvedPlat)) {
                         Tr.error(tc, "INCOMPATIBLE_VERSIONLESS_FEATURE_WITH_PLATFORM", getFeatureName(versionlessResolved), resolvedPlat);
                         break;
                     }
                 }
             }
-       }
+        }
 
         List<Entry<String, Collection<Chain>>> sortedConflicts = new ArrayList<Entry<String, Collection<Chain>>>(result.getConflicts().entrySet());
         sortedConflicts.sort(new ConflictComparator()); // order by importance
@@ -2386,7 +2389,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
     }
 
     private String getPreferredEePlatform(String symbolicName, String compatibleFeatureBase) {
-        if(symbolicName.startsWith(compatibleFeatureBase)){
+        if (symbolicName.startsWith(compatibleFeatureBase)) {
             return getEeCompatiblePlatform(symbolicName, false); // include ee version
         }
         ProvisioningFeatureDefinition fdefinition = featureRepository.getFeature(symbolicName);

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -91,7 +91,9 @@ public class FeatureDefinitionUtils {
                                                                                            "io.openliberty.jakartaeeClient-9.1",
                                                                                            "io.openliberty.jakartaeeClient-10.0",
                                                                                            "io.openliberty.jakartaeeClient-11.0",
-                                                                                           "com.ibm.websphere.appserver.appSecurityClient-1.0");
+                                                                                           "com.ibm.websphere.appserver.appSecurityClient-1.0",
+                                                                                           "io.openliberty.xmlWSClient-4.0" // Removed from the platform in EE 11
+    );
 
     public static final String NL = "\r\n";
     static final String SPLIT_CHAR = ";";

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE10Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE10Action.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -100,7 +100,8 @@ public class JakartaEE10Action extends JakartaEEAction {
                                                   "servlet-6.0",
                                                   "websocket-2.1",
                                                   "xmlBinding-4.0",
-                                                  "xmlWS-4.0"
+                                                  "xmlWS-4.0",
+                                                  "xmlWSClient-4.0"
     };
 
     public static final Set<String> EE10_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE10_FEATURES_ARRAY)));

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE11Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE11Action.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -101,7 +101,8 @@ public class JakartaEE11Action extends JakartaEEAction {
                                                   "servlet-6.1",
                                                   "websocket-2.2",
                                                   "xmlBinding-4.0",
-                                                  "xmlWS-4.0"
+                                                  "xmlWS-4.0",
+                                                  "xmlWSClient-4.0"
     };
 
     private static final String[] EE11_ONLY_FEATURES_ARRAY_LOWERCASE = {

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10Features.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10Features.java
@@ -299,6 +299,7 @@ public class EE10Features {
         // remove client features
         features.remove("jakartaeeClient-10.0");
         features.remove("appSecurityClient-1.0");
+        features.remove("xmlWSClient-4.0");
 
         // remove acmeCA-2.0 since it requires additional resources and configuration
         features.remove("acmeCA-2.0");

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11Features.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11Features.java
@@ -308,6 +308,7 @@ public class EE11Features {
         // remove client features
         features.remove("jakartaeeClient-11.0");
         features.remove("appSecurityClient-1.0");
+        features.remove("xmlWSClient-4.0");
 
         // remove acmeCA-2.0 since it requires additional resources and configuration
         features.remove("acmeCA-2.0");


### PR DESCRIPTION
- Add repeat for EE 11 features in com.ibm.ws.jaxws.clientcontainer_fat FAT suite
- Allow xmlBinding-4.0 to be specified as a client or server feature so it can be used in an application client container
- Add xmlWSClient-4.0 feature to be used in the application client container when using EE 11 app client features
- Remove XML WS and SOAP APIs from the IBM API list for  `jakartaeeclient-11.0` feature
- Update fattest.simplicity to have a list of client only feature base names so we don't add xmlWSClient-4.0 to the server configurations
- Update io.openliberty.jakartaee prefixed fat buckets to handle the new xmlWSClient-4.0 feature to not add it to the server.xml since it is a client feature
- Update baseFeature start tests to not do anything with xmlWSClient-4.0 feature since it is a client feature and cannot run in a server process

for #25092 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
