### PR TITLE
RuntimeException: Server stop failed with RC 1.

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
@@ -79,7 +79,7 @@ public class SessionCacheOneServerTest extends FATServletClient {
     public static void tearDown() throws Exception {
         executor.shutdownNow();
         Log.info(SessionCacheOneServerTest.class, "tearDown", "Wait for active tasks to stop...");
-        TimeUnit.SECONDS.sleep(5);
+        TimeUnit.SECONDS.sleep(30);
         server.stopServer();
 
         if (isZOS()) {


### PR DESCRIPTION
Server stop failed with RC 1 due to slow response.
 
Stopping server com.ibm.ws.session.cache.fat.infinispan.server. 
The command stop failed because of a communication error with the server. 
Server com.ibm.ws.session.cache.fat.infinispan.server stop failed. Check server logs for details. Stderr:

java.lang.RuntimeException: Server stop failed with RC 1.
Stdout:

Stopping server com.ibm.ws.session.cache.fat.infinispan.server.
The command stop failed because of a communication error with the server.
Server com.ibm.ws.session.cache.fat.infinispan.server stop failed. Check server logs for details.

Stderr:

at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3304)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3169)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3163)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3139)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3048)
at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3023)
at com.ibm.ws.session.cache.fat.infinispan.SessionCacheOneServerTest.tearDown(SessionCacheOneServerTest.java:83)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:149)
at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:401)
at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:203) 