### PR TITLE
Skip suggested feature test on Java 8

### DIFF
--- a/dev/com.ibm.ws.classloading_classpath_fat/fat/src/io/openliberty/classloading/classpath/fat/ParentLastLibraryFeatureTests.java
+++ b/dev/com.ibm.ws.classloading_classpath_fat/fat/src/io/openliberty/classloading/classpath/fat/ParentLastLibraryFeatureTests.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -38,6 +39,7 @@ import io.openliberty.classloading.parentlast.test.app.ParentLastTestServlet;
  *
  */
 @RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel=11)
 public class ParentLastLibraryFeatureTests extends FATServletClient {
 
     @Server(PARENT_LAST_TEST_SERVER)


### PR DESCRIPTION
The suggested feature message is never logged on Java 8


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

