### PR TITLE
Changes due to eclipselink b09

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -116,8 +116,7 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
                             isForward ? queryInfo.jpqlAfterCursor : //
                                             queryInfo.jpqlBeforeCursor;
 
-            @SuppressWarnings("unchecked")
-            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, queryInfo.entityInfo.entityClass);
+            jakarta.persistence.Query query = em.createQuery(jpql);
             queryInfo.setParameters(query, args);
 
             if (cursor.isPresent())
@@ -126,7 +125,9 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
             query.setFirstResult(firstResult);
             query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1)); // extra position is for knowing whether to expect another page
 
-            results = query.getResultList();
+            @SuppressWarnings("unchecked")
+            List<T> resultList = query.getResultList();
+            results = resultList;
 
             // Cursor-based pagination in the previous page direction is implemented
             // by reversing the ORDER BY to obtain the previous page. A side-effect

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -98,15 +98,16 @@ public class PageImpl<T> implements Page<T> {
 
         EntityManager em = queryInfo.entityInfo.builder.createEntityManager();
         try {
-            @SuppressWarnings("unchecked")
-            TypedQuery<T> query = (TypedQuery<T>) em.createQuery(queryInfo.jpql, queryInfo.entityInfo.entityClass);
+            jakarta.persistence.Query query = em.createQuery(queryInfo.jpql);
             queryInfo.setParameters(query, args);
 
             int maxPageSize = pageRequest.size();
             query.setFirstResult(queryInfo.computeOffset(pageRequest));
             query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1));
 
-            results = query.getResultList();
+            @SuppressWarnings("unchecked")
+            List<T> resultList = query.getResultList();
+            results = resultList;
         } catch (Exception x) {
             throw RepositoryImpl.failure(x, queryInfo.entityInfo.builder);
         } finally {

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1439,7 +1439,8 @@ public class DataJPATestServlet extends FATServlet {
                                                  .map(t -> t.ssn)
                                                  .collect(Collectors.toList()));
 
-        // TODO enable once issue #31558 is fixed in EclipseLink
+        // TODO enable once issue #31558 and
+        // TODO subsequently #32263 is fixed in EclipseLink
         if (false)
             assertIterableEquals(List.of(789007890L),
                                  taxpayers.findByBankAccountsNotEmpty()
@@ -4777,17 +4778,18 @@ public class DataJPATestServlet extends FATServlet {
                                              .map(Arrays::toString)
                                              .collect(Collectors.toList()));
 
-        // page of array attribute 
-         
-        /*To-do Enable once #32246 is fixed.
-         * 
+        // page of array attribute
+
+        /*
+         * TODO Enable once #32246 is fixed.
+         *
          * assertIterableEquals(List.of(Arrays.toString(wabashaZipCodes), Arrays.toString(winonaZipCodes)),
          * counties.findZipCodesByNameStartsWith("W", PageRequest.ofSize(10))
          * .stream()
          * .map(Arrays::toString)
          * .collect(Collectors.toList()));
          */
-        
+
         // optional iterator of array attribute
         Iterator<int[]> it = counties.findZipCodesByPopulationLessThanEqual(50000);
         assertIterableEquals(List.of(Arrays.toString(fillmoreZipCodes), Arrays.toString(wabashaZipCodes), Arrays.toString(winonaZipCodes)),

--- a/dev/io.openliberty.jakarta.data.1.1/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.1/bnd.bnd
@@ -32,6 +32,7 @@ Export-Package: \
   jakarta.data.page;version="1.0.0",\
   jakarta.data.page.impl;version="1.0.0",\
   jakarta.data.repository;version="1.0.0",\
+  jakarta.data.restrict;version="1.0.0",\
   jakarta.data.spi;version="1.0.0",\
   jakarta.data.spi.expression.literal;version="1.0.0"
 

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/TemporalAttribute.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/TemporalAttribute.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.metamodel;
+
+import java.time.temporal.Temporal;
+import java.util.Objects;
+
+import jakarta.data.expression.TemporalExpression;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public interface TemporalAttribute<T, V extends Temporal & Comparable<? extends Temporal>> //
+                extends //
+                ComparableAttribute<T, V>, //
+                TemporalExpression<T, V> {
+
+    static <T, V extends Temporal & Comparable<? extends Temporal>> //
+    TemporalAttribute<T, V> of(Class<T> entityClass,
+                               String name,
+                               Class<V> attributeType) {
+
+        Objects.requireNonNull(entityClass, "entityClass");
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(attributeType, "attributeType");
+
+        return new TemporalAttributeRecord<>(entityClass, name, attributeType);
+    }
+}

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/TemporalAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/TemporalAttributeRecord.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.metamodel;
+
+import java.time.temporal.Temporal;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+record TemporalAttributeRecord<T, V extends Temporal & Comparable<? extends Temporal>>(
+                Class<T> declaringType,
+                String name,
+                Class<V> attributeType)
+                implements TemporalAttribute<T, V> {
+
+    @Override
+    public String toString() {
+        return declaringType.getSimpleName().toLowerCase() + '.' + name;
+    }
+}

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/BasicRestriction.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/BasicRestriction.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.restrict;
+
+import jakarta.data.constraint.Constraint;
+import jakarta.data.expression.Expression;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public interface BasicRestriction<T, V> extends Restriction<T> {
+
+    Constraint<V> constraint();
+
+    Expression<T, V> expression();
+
+    static <T, V> Restriction<T> of(Expression<T, V> expression,
+                                    Constraint<V> constraint) {
+
+        return new BasicRestrictionRecord<>(expression, constraint);
+    }
+}

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/BasicRestrictionRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/BasicRestrictionRecord.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.restrict;
+
+import java.util.Objects;
+
+import jakarta.data.constraint.Constraint;
+import jakarta.data.expression.Expression;
+import jakarta.data.metamodel.Attribute;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+record BasicRestrictionRecord<T, V>(Expression<T, V> expression,
+                Constraint<V> constraint)
+                implements BasicRestriction<T, V> {
+
+    BasicRestrictionRecord {
+        Objects.requireNonNull(expression, "expression");
+        Objects.requireNonNull(constraint, "constraint");
+    }
+
+    @Override
+    public Restriction<T> negate() {
+        return BasicRestriction.of(expression, constraint.negate());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder();
+
+        if (expression instanceof Attribute<?> attribute)
+            b.append(attribute.name());
+        else
+            b.append(expression.toString());
+
+        b.append(' ');
+        b.append(constraint);
+
+        return b.toString();
+    }
+}

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/CompositeRestriction.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/CompositeRestriction.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.restrict;
+
+import java.util.List;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public interface CompositeRestriction<T> extends Restriction<T> {
+
+    enum Type {
+        ALL,
+        ANY;
+
+        String asQueryLanguage() {
+            return this == ALL ? "AND" : "OR";
+        }
+    }
+
+    boolean isNegated();
+
+    List<Restriction<? super T>> restrictions();
+
+    Type type();
+}

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/CompositeRestrictionRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/CompositeRestrictionRecord.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.restrict;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+record CompositeRestrictionRecord<T>(
+                Type type,
+                List<Restriction<? super T>> restrictions,
+                boolean isNegated)
+                implements CompositeRestriction<T> {
+
+    private static final int SINGLE_RESTRICTION_LENGTH_ESTIMATE = 100;
+
+    CompositeRestrictionRecord {
+
+        Objects.requireNonNull(restrictions, "restrictions");
+
+        if (restrictions.isEmpty())
+            throw new IllegalArgumentException("restrictions");
+
+        restrictions.forEach(r -> Objects.requireNonNull(r, "restriction"));
+    }
+
+    CompositeRestrictionRecord(Type type,
+                               List<Restriction<? super T>> restrictions) {
+
+        this(type, restrictions, false);
+    }
+
+    @Override
+    public CompositeRestriction<T> negate() {
+
+        return new CompositeRestrictionRecord<>(type, restrictions, !isNegated);
+    }
+
+    @Override
+    public String toString() {
+
+        String op = type.asQueryLanguage();
+        int len = 6 + restrictions.size() * SINGLE_RESTRICTION_LENGTH_ESTIMATE;
+        StringBuilder builder = new StringBuilder(len);
+        if (isNegated)
+            builder.append("NOT (");
+
+        boolean first = true;
+        for (Restriction<? super T> restriction : restrictions) {
+            if (first)
+                first = false;
+            else
+                builder.append(' ').append(op).append(' ');
+
+            builder.append('(').append(restriction).append(')');
+        }
+
+        if (isNegated)
+            builder.append(')');
+
+        return builder.toString();
+    }
+}

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/Restrict.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/Restrict.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.restrict;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public class Restrict {
+
+    private Restrict() {
+    }
+
+    public static <T> Restriction<T> //
+                    all(List<? extends Restriction<? super T>> restrictions) {
+
+        return new CompositeRestrictionRecord<T>( //
+                        CompositeRestriction.Type.ALL, //
+                        List.copyOf(restrictions));
+    }
+
+    @SafeVarargs
+    public static <T> Restriction<T> all(Restriction<? super T>... restrictions) {
+
+        return new CompositeRestrictionRecord<T>( //
+                        CompositeRestriction.Type.ALL, //
+                        List.of(restrictions));
+    }
+
+    public static <T> Restriction<T> //
+                    any(List<? extends Restriction<? super T>> restrictions) {
+
+        return new CompositeRestrictionRecord<T>( //
+                        CompositeRestriction.Type.ANY, //
+                        List.copyOf(restrictions));
+    }
+
+    @SafeVarargs
+    public static <T> Restriction<T> any(Restriction<? super T>... restrictions) {
+
+        return new CompositeRestrictionRecord<T>( //
+                        CompositeRestriction.Type.ANY, //
+                        List.of(restrictions));
+    }
+
+    public static <T> Restriction<T> not(Restriction<T> restriction) {
+
+        Objects.requireNonNull(restriction, "restriction");
+
+        return restriction.negate();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Restriction<T> unrestricted() {
+
+        return (Restriction<T>) Unrestricted.INSTANCE;
+    }
+
+}

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/Restriction.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/Restriction.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.restrict;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+public interface Restriction<T> {
+
+    Restriction<T> negate();
+}

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/Unmatchable.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/Unmatchable.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.restrict;
+
+import java.util.List;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+class Unmatchable<T> implements CompositeRestriction<T> {
+    static final Unmatchable<?> INSTANCE = new Unmatchable<>();
+
+    // prevent instantiation by others
+    private Unmatchable() {
+    }
+
+    @Override
+    public boolean isNegated() {
+        return false;
+    }
+
+    @Override
+    public CompositeRestriction<T> negate() {
+        @SuppressWarnings("unchecked")
+        CompositeRestriction<T> r = (CompositeRestriction<T>) Unrestricted.INSTANCE;
+        return r;
+    }
+
+    @Override
+    public List<Restriction<? super T>> restrictions() {
+        return List.of();
+    }
+
+    @Override
+    public String toString() {
+        return "UNMATCHABLE";
+    }
+
+    @Override
+    public Type type() {
+        return Type.ANY;
+    }
+
+}

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/Unrestricted.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/restrict/Unrestricted.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jakarta.data.restrict;
+
+import java.util.List;
+
+/**
+ * Method signatures are copied from Jakarta Data.
+ */
+class Unrestricted<T> implements CompositeRestriction<T> {
+    static final Unrestricted<?> INSTANCE = new Unrestricted<>();
+
+    private Unrestricted() {
+    }
+
+    @Override
+    public boolean isNegated() {
+        return false;
+    }
+
+    @Override
+    public CompositeRestriction<T> negate() {
+        @SuppressWarnings("unchecked")
+        CompositeRestriction<T> r = (CompositeRestriction<T>) Unmatchable.INSTANCE;
+        return r;
+    }
+
+    @Override
+    public List<Restriction<? super T>> restrictions() {
+        return List.of();
+    }
+
+    @Override
+    public String toString() {
+        return "UNRESTRICTED";
+    }
+
+    @Override
+    public Type type() {
+        return Type.ALL;
+    }
+
+}


### PR DESCRIPTION
This PR includes some changes to omit the entity type when making a query where the result type is uncertain because it might be the entity type, a subset, or a single entity attribute.  This became necessary after EclipseLink 5 beta 09 became more restrictive.  Also, this adds a reference to a new EclipseLink issue that was found after tests were able to get further along.  And it refreshes to the latest API for the restrict package and a few classes from metamodel that were missed previously.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
