### PR TITLE
IllegalStateException after stop server calls

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -356,7 +356,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
         run("testSetAttribute&attribute=testModifyFileset&value=1", session);
         run("testCacheContains&attribute=testModifyFileset&value=1", session);
 
-        server.stopServer("CWWKL0012W.*bogus", "SRVE8059E", "CWWKE0701E.*CacheException", "SESN0307E", "SESN0309E");
+        server.stopServer("CWWKL0012W.*bogus", "SRVE8059E", "CWWKE0701E.*CacheException", "SESN0307E", "SESN0309E", "SESN0306E");
     }
 
     /**


### PR DESCRIPTION

Session invalidator was launched after the LibertyServer.stopServer() call:

[7/18/25, 20:23:43:707 PDT] 00000072 id=00000000 com.ibm.ws.logging.internal.impl.IncidentImpl                I FFDC1015I: An FFDC Incident has been created: "java.lang.IllegalStateException: Cache operations can not be performed. The cache closed com.ibm.ws.session.store.cache.CacheHashMap 390" at ffdc_25.07.18_20.23.42.0.log
[7/18/25, 20:23:43:707 PDT] 00000072 id=00000000 com.ibm.ws.session.store.cache.CacheHashMap                  E SESN0306E: An exception occurred when invalidating a session in the cache. The exception is: java.lang.IllegalStateException: Cache operations can not be performed. The cache closed
	at com.hazelcast.cache.impl.AbstractClusterWideIterator.ensureOpen(AbstractClusterWideIterator.java:192)
	at com.hazelcast.cache.impl.AbstractClusterWideIterator.hasNext(AbstractClusterWideIterator.java:110)
	at com.ibm.ws.session.store.cache.CacheHashMap.doInvalidations(CacheHashMap.java:296)
	at com.ibm.ws.session.store.cache.CacheHashMap.performInvalidation(CacheHashMap.java:1061)
	at com.ibm.ws.session.store.common.BackedStore.runInvalidation(BackedStore.java:132)
	at com.ibm.ws.session.SessionInvalidatorWithThreadPool$InvalidationTask.run(SessionInvalidatorWithThreadPool.java:69)

testModifyFileset:java.lang.Exception: 2025-07-18-20:23:59:098 Errors/warnings were found in server sessionCacheServer logs:
<br>[7/18/25, 20:23:43:707 PDT] 00000072 com.ibm.ws.session.store.cache.CacheHashMap                  E SESN0306E: An exception occurred when invalidating a session in the cache. The exception is: java.lang.IllegalStateException: Cache operations can not be performed. The cache closed
    at componenttest.topology.impl.LibertyServer.checkLogsForErrorsAndWarnings(LibertyServer.java:3511)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3332)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3169)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3163)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3139)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3048)
    at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:3023)
    at com.ibm.ws.session.cache.config.fat.SessionCacheErrorPathsTest.testModifyFileset(SessionCacheErrorPathsTest.java:359)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:236)
    at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:401)
    at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:203)
    at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:149)