### PR TITLE
Fix SPNEGO bucket in z/OS

### DIFF
--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/spnego/SpnegoOIDCCommonTest.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/spnego/SpnegoOIDCCommonTest.java
@@ -14,6 +14,8 @@ package com.ibm.ws.security.oauth_oidc.fat.commonTest.spnego;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -103,6 +105,12 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
 	protected final static Krb5Helper krb5Helper = new Krb5Helper();
 	protected static KdcHelper kdcHelper = null;
 
+    private static boolean isZOS = System.getProperty("os.name").equals("z/OS");
+
+     // When running on zOS the file format is not properly converted for the krb.conf file currently,
+    // so we will use krb.conf, which is already formatted for zOS.
+    private static final String SERVER_KRB5_CONFIG_FILE = isZOS ? SPNEGOConstants.ZOS_SERVER_KRB5_CONFIG_FILE : SPNEGOConstants.SERVER_KRB5_CONFIG_FILE;
+
 	@Rule
 	public TestName name = new TestName();
 
@@ -134,7 +142,7 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
 	public static String createSpnegoTokenForUser(String user, String password) throws Exception {
 		Log.info(c, "createSpnegoTokenForUser", "^^^^Creating a new SPNEGO token for specific user: " + user +"^^^^");
 		String spnegoToken = testHelper.createSpnegoToken(user, password, TARGET_SERVER,
-				SPNEGOConstants.SERVER_KRB5_CONFIG_FILE, krb5Helper);
+				SERVER_KRB5_CONFIG_FILE, krb5Helper);
 		
 		Log.info(c, "createSpnegoTokenForUser", "^^^^The token that was created looks like this: " + spnegoToken);
 		return spnegoToken;
@@ -190,7 +198,7 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
 
 		try {
 			spnegoTokenForTestClass = testHelper.createSpnegoToken(user, password, TARGET_SERVER,
-					SPNEGOConstants.SERVER_KRB5_CONFIG_FILE, krb5Helper);
+					SERVER_KRB5_CONFIG_FILE, krb5Helper);
 		} catch (Exception e) {
 			String errorMsg = "Exception was caught while trying to create a SPNEGO token. Ensuing tests requiring use of this token might fail. "
 					+ e.getMessage();
@@ -498,10 +506,34 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
 
     protected static void createKrbConf(LibertyServer testServer) throws IOException {
         String thisMethod = "createKrbConf";
-        Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
-        FileOutputStream out = new FileOutputStream(testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
-        out.write(InitClass.KRB5_CONF.getBytes());
-        out.close();
+        Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot()
+                + SERVER_KRB5_CONFIG_FILE);
+        // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
+        // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
+        // Additionally, for this update to work the allowed skew also needs to be
+        // updated on the KDC machine
+        InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
+        if (InitClass.KRB5_CONF.contains("clockskew  = 600")) {
+            Log.info(c, thisMethod, "Replaced clockskew  = 300 with clockskew  = 600");
+        } else {
+            Log.info(c, thisMethod, "Did not find clockskew  = 300 in krb5.conf");
+        }
+        if (isZOS) {
+            try (FileOutputStream out = new FileOutputStream(
+                    testServer.getServerRoot() + SERVER_KRB5_CONFIG_FILE);
+                    OutputStreamWriter osw = new OutputStreamWriter(out, "IBM-1047");
+                    PrintWriter pw = new PrintWriter(osw)) {
+                pw.print(InitClass.KRB5_CONF.getBytes());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+        } else {
+            FileOutputStream out = new FileOutputStream(
+                    testServer.getServerRoot() + SERVER_KRB5_CONFIG_FILE);
+            out.write(InitClass.KRB5_CONF.getBytes());
+            out.close();
+        }
     }
 
 	private static HashMap<String, String> addBootstrapProps(Map<String, String> testProps)

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/spnego/SpnegoOIDCCommonTest.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/spnego/SpnegoOIDCCommonTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/spnego/SpnegoOIDCCommonTest.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/spnego/SpnegoOIDCCommonTest.java
@@ -512,11 +512,11 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
         // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
         // Additionally, for this update to work the allowed skew also needs to be
         // updated on the KDC machine
+        InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
         if (InitClass.KRB5_CONF == null) {
             Log.info(c, thisMethod, "KRB5_CONF is null. This may be because we failed to obtain information from Consul.");
             throw new IOException("KRB5_CONF is null. Cannot create krb.conf file.");
         }
-        InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
         if (InitClass.KRB5_CONF.contains("clockskew  = 600")) {
             Log.info(c, thisMethod, "Replaced clockskew  = 300 with clockskew  = 600");
         } else {

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/spnego/SpnegoOIDCCommonTest.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/spnego/SpnegoOIDCCommonTest.java
@@ -12,6 +12,10 @@
  *******************************************************************************/
 package com.ibm.ws.security.oauth_oidc.fat.commonTest.spnego;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
@@ -107,10 +111,6 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
 
     private static boolean isZOS = System.getProperty("os.name").equals("z/OS");
 
-     // When running on zOS the file format is not properly converted for the krb.conf file currently,
-    // so we will use krb.conf, which is already formatted for zOS.
-    private static final String SERVER_KRB5_CONFIG_FILE = isZOS ? SPNEGOConstants.ZOS_SERVER_KRB5_CONFIG_FILE : SPNEGOConstants.SERVER_KRB5_CONFIG_FILE;
-
 	@Rule
 	public TestName name = new TestName();
 
@@ -142,7 +142,7 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
 	public static String createSpnegoTokenForUser(String user, String password) throws Exception {
 		Log.info(c, "createSpnegoTokenForUser", "^^^^Creating a new SPNEGO token for specific user: " + user +"^^^^");
 		String spnegoToken = testHelper.createSpnegoToken(user, password, TARGET_SERVER,
-				SERVER_KRB5_CONFIG_FILE, krb5Helper);
+				SPNEGOConstants.SERVER_KRB5_CONFIG_FILE, krb5Helper);
 		
 		Log.info(c, "createSpnegoTokenForUser", "^^^^The token that was created looks like this: " + spnegoToken);
 		return spnegoToken;
@@ -198,7 +198,7 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
 
 		try {
 			spnegoTokenForTestClass = testHelper.createSpnegoToken(user, password, TARGET_SERVER,
-					SERVER_KRB5_CONFIG_FILE, krb5Helper);
+					SPNEGOConstants.SERVER_KRB5_CONFIG_FILE, krb5Helper);
 		} catch (Exception e) {
 			String errorMsg = "Exception was caught while trying to create a SPNEGO token. Ensuing tests requiring use of this token might fail. "
 					+ e.getMessage();
@@ -507,7 +507,7 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
     protected static void createKrbConf(LibertyServer testServer) throws IOException {
         String thisMethod = "createKrbConf";
         Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot()
-                + SERVER_KRB5_CONFIG_FILE);
+                + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
         // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
         // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
         // Additionally, for this update to work the allowed skew also needs to be
@@ -520,17 +520,18 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
         }
         if (isZOS) {
             try (FileOutputStream out = new FileOutputStream(
-                    testServer.getServerRoot() + SERVER_KRB5_CONFIG_FILE);
+                    testServer.getServerRoot() + SPNEGOConstants.ZOS_SERVER_KRB5_CONFIG_FILE);
                     OutputStreamWriter osw = new OutputStreamWriter(out, "IBM-1047");
                     PrintWriter pw = new PrintWriter(osw)) {
                 pw.print(InitClass.KRB5_CONF.getBytes());
             } catch (IOException e) {
                 e.printStackTrace();
             }
+            Files.copy(Paths.get(SPNEGOConstants.ZOS_SERVER_KRB5_CONFIG_FILE), Paths.get(SPNEGOConstants.SERVER_KRB5_CONFIG_FILE), StandardCopyOption.REPLACE_EXISTING);
 
         } else {
             FileOutputStream out = new FileOutputStream(
-                    testServer.getServerRoot() + SERVER_KRB5_CONFIG_FILE);
+                    testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
             out.write(InitClass.KRB5_CONF.getBytes());
             out.close();
         }

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/spnego/SpnegoOIDCCommonTest.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/spnego/SpnegoOIDCCommonTest.java
@@ -512,6 +512,10 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
         // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
         // Additionally, for this update to work the allowed skew also needs to be
         // updated on the KDC machine
+        if (InitClass.KRB5_CONF == null) {
+            Log.info(c, thisMethod, "KRB5_CONF is null. This may be because we failed to obtain information from Consul.");
+            throw new IOException("KRB5_CONF is null. Cannot create krb.conf file.");
+        }
         InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
         if (InitClass.KRB5_CONF.contains("clockskew  = 600")) {
             Log.info(c, thisMethod, "Replaced clockskew  = 300 with clockskew  = 600");
@@ -523,7 +527,7 @@ public class SpnegoOIDCCommonTest extends AppPasswordsAndTokensCommonTest {
                     testServer.getServerRoot() + SPNEGOConstants.ZOS_SERVER_KRB5_CONFIG_FILE);
                     OutputStreamWriter osw = new OutputStreamWriter(out, "IBM-1047");
                     PrintWriter pw = new PrintWriter(osw)) {
-                pw.print(InitClass.KRB5_CONF.getBytes());
+                pw.print(InitClass.KRB5_CONF);
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
@@ -15,6 +15,8 @@ package com.ibm.ws.security.spnego.fat.config;
 import static org.junit.Assert.assertNull;
 
 import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.util.ArrayList;
@@ -41,7 +43,6 @@ import com.ibm.ws.webcontainer.security.test.servlets.SSLBasicAuthClient;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.ExternalTestService;
-import com.ibm.websphere.simplicity.OperatingSystem;
 
 public class CommonTest {
     private static final Class<?> c = CommonTest.class;
@@ -56,7 +57,10 @@ public class CommonTest {
     protected static JDKExpectationTestClass expectation;
     protected final static Krb5Helper krb5Helper = new Krb5Helper();
     protected static KdcHelper kdcHelper = null;
-    private static boolean isZOS = false;
+    private static boolean isZOS = System.getProperty("os.name").equals("z/OS");
+    // When running on zOS the file format is not properly converted for the krb.conf file currently,
+    // so we will use krb.conf, which is already formatted for zOS.
+    private static final String SERVER_KRB5_CONFIG_FILE = isZOS? SPNEGOConstants.ZOS_SERVER_KRB5_CONFIG_FILE : SPNEGOConstants.SERVER_KRB5_CONFIG_FILE;
     @Rule
     public TestName name = new TestName();
 
@@ -154,7 +158,7 @@ public class CommonTest {
     private static void createSpnegoToken(String thisMethod, String user, String password) throws Exception, InterruptedException {
         for (int i = 1; i <= 6; i++) {
             try {
-                spnegoTokenForTestClass = testHelper.createSpnegoToken(user, password, TARGET_SERVER, SPNEGOConstants.SERVER_KRB5_CONFIG_FILE, krb5Helper);
+                spnegoTokenForTestClass = testHelper.createSpnegoToken(user, password, TARGET_SERVER, SERVER_KRB5_CONFIG_FILE, krb5Helper);
                 break;
             } catch (LoginException e) {
                 if (i == 6) {
@@ -388,13 +392,7 @@ public class CommonTest {
     protected static void createKrbConf(LibertyServer testServer) throws IOException {
         String thisMethod = "createKrbConf";
         Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot()
-                + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
-        try {
-            isZOS = testServer.getMachine().getOperatingSystem().equals(OperatingSystem.ZOS);
-        } catch (Exception e) {
-            Throwable cause = new RuntimeException("Error determening if it's z/OS.");
-            Log.error(c, "createKrbConf", cause);
-        }
+                + SERVER_KRB5_CONFIG_FILE);
         // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
         // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
         // Additionally, for this update to work the allowed skew also needs to be
@@ -407,7 +405,7 @@ public class CommonTest {
         }
         if (isZOS) {
             try (FileOutputStream out = new FileOutputStream(
-                    testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
+                    testServer.getServerRoot() + SERVER_KRB5_CONFIG_FILE);
                     OutputStreamWriter osw = new OutputStreamWriter(out, "IBM-1047");
                     PrintWriter pw = new PrintWriter(osw)) {
                 pw.print(InitClass.KRB5_CONF.getBytes());
@@ -417,7 +415,7 @@ public class CommonTest {
 
         } else {
             FileOutputStream out = new FileOutputStream(
-                    testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
+                    testServer.getServerRoot() + SERVER_KRB5_CONFIG_FILE);
             out.write(InitClass.KRB5_CONF.getBytes());
             out.close();
         }
@@ -757,7 +755,7 @@ public class CommonTest {
         String spnegoToken = InitClass.COMMON_SPNEGO_TOKEN;
         // We might already have a SPNEGO token, so only create a new token if given a user different from the one used to create the common token
         if (spnegoTokenUser != InitClass.COMMON_TOKEN_USER) {
-            spnegoToken = testHelper.createSpnegoToken(spnegoTokenUser, spnegoTokenUserPwd, TARGET_SERVER, SPNEGOConstants.SERVER_KRB5_CONFIG_FILE, krb5Helper);
+            spnegoToken = testHelper.createSpnegoToken(spnegoTokenUser, spnegoTokenUserPwd, TARGET_SERVER, SERVER_KRB5_CONFIG_FILE, krb5Helper);
         }
 
         Map<String, String> headers = testHelper.setTestHeaders("Negotiate " + spnegoToken, SPNEGOConstants.FIREFOX, TARGET_SERVER, null);

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
@@ -396,15 +396,15 @@ public class CommonTest {
     protected static void createKrbConf(LibertyServer testServer) throws IOException {
         String thisMethod = "createKrbConf";
         Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE +
-        "the machine is z/OS? " + isZOS);
+        " is the machine z/OS? " + isZOS);
         // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
         // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
         // Additionally, for this update to work the allowed skew also needs to be updated on the KDC machine
+        InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
         if (InitClass.KRB5_CONF == null) {
             Log.info(c, thisMethod, "KRB5_CONF is null. This may be because we failed to obtain information from Consul.");
             throw new IOException("KRB5_CONF is null. Cannot create krb.conf file.");
         }
-        InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
         if (InitClass.KRB5_CONF.contains("clockskew  = 600")) {
             Log.info(c, thisMethod, "Replaced clockskew  = 300 with clockskew  = 600");
         } else {

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
@@ -1029,9 +1029,9 @@ public class CommonTest {
 
     public static String maskHostnameAndPassword(String message) {
         if (message != null) {
-            if (InitClass.KDC_HOSTNAME != null)
+            if (InitClass.KDC_HOSTNAME != null && InitClass.KDCP_VAR != null)
                 message = message.replace(InitClass.KDC_HOSTNAME, InitClass.KDCP_VAR);
-            if (InitClass.KDC2_HOSTNAME != null)
+            if (InitClass.KDC2_HOSTNAME != null && InitClass.KDCP_VAR != null)
                 message = message.replace(InitClass.KDC2_HOSTNAME, InitClass.KDCS_VAR);
             if (InitClass.KDC_USER != null)
                 message = message.replace(InitClass.KDC_USER, "InitClass.KDC_USER");

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
@@ -14,8 +14,10 @@ package com.ibm.ws.security.spnego.fat.config;
 
 import static org.junit.Assert.assertNull;
 
+import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,6 +43,7 @@ import com.ibm.ws.webcontainer.security.test.servlets.SSLBasicAuthClient;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.ExternalTestService;
+import com.ibm.websphere.simplicity.OperatingSystem;
 
 public class CommonTest {
     private static final Class<?> c = CommonTest.class;
@@ -386,20 +389,32 @@ public class CommonTest {
     }
 
     protected static void createKrbConf(LibertyServer testServer) throws IOException {
+        boolean isZOS = testServer.getMachine().getOperatingSystem().equals(OperatingSystem.ZOS);
         String thisMethod = "createKrbConf";
         Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
-        FileOutputStream out = new FileOutputStream(testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
-        // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
-        // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
-        // Additionally, for this update to work the allowed skew also needs to be updated on the KDC machine
-        InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
-        if (InitClass.KRB5_CONF.contains("clockskew  = 600")) {
-            Log.info(c, thisMethod, "Replaced clockskew  = 300 with clockskew  = 600");
-        } else {
-            Log.info(c, thisMethod, "Did not find clockskew  = 300 in krb5.conf");
+        try(FileOutputStream out = new FileOutputStream(testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
+            // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
+            // Additionally, for this update to work the allowed skew also needs to be updated on the KDC machine
+            InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
+            if (InitClass.KRB5_CONF.contains("clockskew  = 600")) {
+                Log.info(c, thisMethod, "Replaced clockskew  = 300 with clockskew  = 600");
+            } else {
+              Log.info(c, thisMethod, "Did not find clockskew  = 300 in krb5.conf");
+            }
+        if (isZOS) {
+            byte[] krbConfBytes = baos.toByteArray();
+            byte[] ebcdicBytes = convertStrToEBCDIC(krbConfBytes);
+            out.write(krbConfBytes);
+            out.close();
+        }else{
+            out.write(InitClass.KRB5_CONF.getBytes());
+            out.close();
         }
-        out.write(InitClass.KRB5_CONF.getBytes());
-        out.close();
+        } catch (IOException ioe) {
+            throw ioe;
+        }
     }
 
     public static void spnegoTokencommonSetUp(String testServerName, String serverXml, List<String> checkApps, Map<String, String> testProps,
@@ -1019,6 +1034,33 @@ public class CommonTest {
             Log.info(c, "maskHostnameAndPassword", "Unable to mask kdc login information...");
         }
         return message;
+    }
+
+    /**
+     * Convert an array of ASCII bytes to EBCDIC.
+     * 
+     * @param in -- an array containing ASCII data.
+     * @return -- an array containing EBCIDIC data.
+     */
+    public byte[] convertStrToEBCDIC(byte[] in) {
+        if (in != null) {
+            byte[] out = new byte[in.length];
+            for (int i = 0; i < in.length; ++i) {
+                out[i] = convertByteA2E(in[i]);
+            }
+            return out;
+        }
+        return null;
+    }
+
+    /**
+     * Make the lookup easier.
+     * Note that when numbers with the high bit are converted to integers
+     * they are converted as signed values. Thus the "& 0xFF" to ensure
+     * that we don't try to lookup negative values.
+     **/
+    private byte convertByteA2E(byte in) {
+        return ASCII2EBCDIC[in & 0xFF];
     }
 
 }

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
@@ -409,7 +409,7 @@ public class CommonTest {
         if (isZOS) {
             try (FileOutputStream out = new FileOutputStream(
                     testServer.getServerRoot() + SPNEGOConstants.ZOS_SERVER_KRB5_CONFIG_FILE);
-                    OutputStreamWriter osw = new OutputStreamWriter(out, "IBM-1047");
+                    OutputStreamWriter osw = new OutputStreamWriter(out, "Cp1047");
                     PrintWriter pw = new PrintWriter(osw)) {
                 pw.print(InitClass.KRB5_CONF.getBytes());
             } catch (IOException e) {

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
@@ -56,10 +56,10 @@ public class CommonTest {
     protected static String TARGET_SERVER = "";
     protected static boolean wasCommonTokenRefreshed = false;
     protected static JDKExpectationTestClass expectation;
-
     protected final static Krb5Helper krb5Helper = new Krb5Helper();
     protected static KdcHelper kdcHelper = null;
-
+    private static boolean isZOS = false;
+        private static byte[] ASCII2EBCDIC = new byte[256];
     @Rule
     public TestName name = new TestName();
 
@@ -389,9 +389,15 @@ public class CommonTest {
     }
 
     protected static void createKrbConf(LibertyServer testServer) throws IOException {
-        boolean isZOS = testServer.getMachine().getOperatingSystem().equals(OperatingSystem.ZOS);
         String thisMethod = "createKrbConf";
         Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
+        try{
+            isZOS = testServer.getMachine().getOperatingSystem().equals(OperatingSystem.ZOS);
+        }
+        catch (Exception e){
+            Throwable cause = new RuntimeException("Error determening if it's z/OS.");
+            Log.error(c, "createKrbConf", cause);
+        }
         try(FileOutputStream out = new FileOutputStream(testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
@@ -404,6 +410,7 @@ public class CommonTest {
               Log.info(c, thisMethod, "Did not find clockskew  = 300 in krb5.conf");
             }
         if (isZOS) {
+            Log.info(c, thisMethod, "OS is z/OS Converting krb.conf file to EBCDIC");
             byte[] krbConfBytes = baos.toByteArray();
             byte[] ebcdicBytes = convertStrToEBCDIC(krbConfBytes);
             out.write(krbConfBytes);
@@ -1042,7 +1049,7 @@ public class CommonTest {
      * @param in -- an array containing ASCII data.
      * @return -- an array containing EBCIDIC data.
      */
-    public byte[] convertStrToEBCDIC(byte[] in) {
+    public static byte[] convertStrToEBCDIC(byte[] in) {
         if (in != null) {
             byte[] out = new byte[in.length];
             for (int i = 0; i < in.length; ++i) {
@@ -1059,7 +1066,7 @@ public class CommonTest {
      * they are converted as signed values. Thus the "& 0xFF" to ensure
      * that we don't try to lookup negative values.
      **/
-    private byte convertByteA2E(byte in) {
+    private static byte convertByteA2E(byte in) {
         return ASCII2EBCDIC[in & 0xFF];
     }
 

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
@@ -400,6 +400,10 @@ public class CommonTest {
         // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
         // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
         // Additionally, for this update to work the allowed skew also needs to be updated on the KDC machine
+        if (InitClass.KRB5_CONF == null) {
+            Log.info(c, thisMethod, "KRB5_CONF is null. This may be because we failed to obtain information from Consul.");
+            throw new IOException("KRB5_CONF is null. Cannot create krb.conf file.");
+        }
         InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
         if (InitClass.KRB5_CONF.contains("clockskew  = 600")) {
             Log.info(c, thisMethod, "Replaced clockskew  = 300 with clockskew  = 600");
@@ -411,7 +415,7 @@ public class CommonTest {
                     testServer.getServerRoot() + SPNEGOConstants.ZOS_SERVER_KRB5_CONFIG_FILE);
                     OutputStreamWriter osw = new OutputStreamWriter(out, "Cp1047");
                     PrintWriter pw = new PrintWriter(osw)) {
-                pw.print(InitClass.KRB5_CONF.getBytes());
+                pw.print(InitClass.KRB5_CONF);
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
@@ -14,6 +14,10 @@ package com.ibm.ws.security.spnego.fat.config;
 
 import static org.junit.Assert.assertNull;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -158,7 +162,7 @@ public class CommonTest {
     private static void createSpnegoToken(String thisMethod, String user, String password) throws Exception, InterruptedException {
         for (int i = 1; i <= 6; i++) {
             try {
-                spnegoTokenForTestClass = testHelper.createSpnegoToken(user, password, TARGET_SERVER, SERVER_KRB5_CONFIG_FILE, krb5Helper);
+                spnegoTokenForTestClass = testHelper.createSpnegoToken(user, password, TARGET_SERVER, SPNEGOConstants.SERVER_KRB5_CONFIG_FILE, krb5Helper);
                 break;
             } catch (LoginException e) {
                 if (i == 6) {
@@ -391,12 +395,11 @@ public class CommonTest {
 
     protected static void createKrbConf(LibertyServer testServer) throws IOException {
         String thisMethod = "createKrbConf";
-        Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot()
-                + SERVER_KRB5_CONFIG_FILE);
+        Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE +
+        "the machine is z/OS? " + isZOS);
         // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
         // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
-        // Additionally, for this update to work the allowed skew also needs to be
-        // updated on the KDC machine
+        // Additionally, for this update to work the allowed skew also needs to be updated on the KDC machine
         InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
         if (InitClass.KRB5_CONF.contains("clockskew  = 600")) {
             Log.info(c, thisMethod, "Replaced clockskew  = 300 with clockskew  = 600");
@@ -405,17 +408,18 @@ public class CommonTest {
         }
         if (isZOS) {
             try (FileOutputStream out = new FileOutputStream(
-                    testServer.getServerRoot() + SERVER_KRB5_CONFIG_FILE);
+                    testServer.getServerRoot() + SPNEGOConstants.ZOS_SERVER_KRB5_CONFIG_FILE);
                     OutputStreamWriter osw = new OutputStreamWriter(out, "IBM-1047");
                     PrintWriter pw = new PrintWriter(osw)) {
                 pw.print(InitClass.KRB5_CONF.getBytes());
             } catch (IOException e) {
                 e.printStackTrace();
             }
+            Files.copy(Paths.get(SPNEGOConstants.ZOS_SERVER_KRB5_CONFIG_FILE), Paths.get(SPNEGOConstants.SERVER_KRB5_CONFIG_FILE), StandardCopyOption.REPLACE_EXISTING);
 
         } else {
             FileOutputStream out = new FileOutputStream(
-                    testServer.getServerRoot() + SERVER_KRB5_CONFIG_FILE);
+                    testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
             out.write(InitClass.KRB5_CONF.getBytes());
             out.close();
         }
@@ -755,7 +759,7 @@ public class CommonTest {
         String spnegoToken = InitClass.COMMON_SPNEGO_TOKEN;
         // We might already have a SPNEGO token, so only create a new token if given a user different from the one used to create the common token
         if (spnegoTokenUser != InitClass.COMMON_TOKEN_USER) {
-            spnegoToken = testHelper.createSpnegoToken(spnegoTokenUser, spnegoTokenUserPwd, TARGET_SERVER, SERVER_KRB5_CONFIG_FILE, krb5Helper);
+            spnegoToken = testHelper.createSpnegoToken(spnegoTokenUser, spnegoTokenUserPwd, TARGET_SERVER, SPNEGOConstants.SERVER_KRB5_CONFIG_FILE, krb5Helper);
         }
 
         Map<String, String> headers = testHelper.setTestHeaders("Negotiate " + spnegoToken, SPNEGOConstants.FIREFOX, TARGET_SERVER, null);

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
@@ -14,10 +14,8 @@ package com.ibm.ws.security.spnego.fat.config;
 
 import static org.junit.Assert.assertNull;
 
-import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -59,7 +57,6 @@ public class CommonTest {
     protected final static Krb5Helper krb5Helper = new Krb5Helper();
     protected static KdcHelper kdcHelper = null;
     private static boolean isZOS = false;
-        private static byte[] ASCII2EBCDIC = new byte[256];
     @Rule
     public TestName name = new TestName();
 
@@ -390,37 +387,39 @@ public class CommonTest {
 
     protected static void createKrbConf(LibertyServer testServer) throws IOException {
         String thisMethod = "createKrbConf";
-        Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
-        try{
+        Log.info(c, thisMethod, "Creating krb.conf file inside the following path: " + testServer.getServerRoot()
+                + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
+        try {
             isZOS = testServer.getMachine().getOperatingSystem().equals(OperatingSystem.ZOS);
-        }
-        catch (Exception e){
+        } catch (Exception e) {
             Throwable cause = new RuntimeException("Error determening if it's z/OS.");
             Log.error(c, "createKrbConf", cause);
         }
-        try(FileOutputStream out = new FileOutputStream(testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
-            ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
-            // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
-            // Additionally, for this update to work the allowed skew also needs to be updated on the KDC machine
-            InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
-            if (InitClass.KRB5_CONF.contains("clockskew  = 600")) {
-                Log.info(c, thisMethod, "Replaced clockskew  = 300 with clockskew  = 600");
-            } else {
-              Log.info(c, thisMethod, "Did not find clockskew  = 300 in krb5.conf");
-            }
+        // Some SUSE/AIX build machines have clock skews greater than 6 minutes.
+        // Updating the krb5.cnf allowed skew from 5 minutes (300s) to 10 minutes (600s)
+        // Additionally, for this update to work the allowed skew also needs to be
+        // updated on the KDC machine
+        InitClass.KRB5_CONF = InitClass.KRB5_CONF.replace("clockskew  = 300", "clockskew  = 600");
+        if (InitClass.KRB5_CONF.contains("clockskew  = 600")) {
+            Log.info(c, thisMethod, "Replaced clockskew  = 300 with clockskew  = 600");
+        } else {
+            Log.info(c, thisMethod, "Did not find clockskew  = 300 in krb5.conf");
+        }
         if (isZOS) {
-            Log.info(c, thisMethod, "OS is z/OS Converting krb.conf file to EBCDIC");
-            byte[] krbConfBytes = baos.toByteArray();
-            byte[] ebcdicBytes = convertStrToEBCDIC(krbConfBytes);
-            out.write(krbConfBytes);
-            out.close();
-        }else{
+            try (FileOutputStream out = new FileOutputStream(
+                    testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
+                    OutputStreamWriter osw = new OutputStreamWriter(out, "IBM-1047");
+                    PrintWriter pw = new PrintWriter(osw)) {
+                pw.print(InitClass.KRB5_CONF.getBytes());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+        } else {
+            FileOutputStream out = new FileOutputStream(
+                    testServer.getServerRoot() + SPNEGOConstants.SERVER_KRB5_CONFIG_FILE);
             out.write(InitClass.KRB5_CONF.getBytes());
             out.close();
-        }
-        } catch (IOException ioe) {
-            throw ioe;
         }
     }
 
@@ -1042,32 +1041,4 @@ public class CommonTest {
         }
         return message;
     }
-
-    /**
-     * Convert an array of ASCII bytes to EBCDIC.
-     * 
-     * @param in -- an array containing ASCII data.
-     * @return -- an array containing EBCIDIC data.
-     */
-    public static byte[] convertStrToEBCDIC(byte[] in) {
-        if (in != null) {
-            byte[] out = new byte[in.length];
-            for (int i = 0; i < in.length; ++i) {
-                out[i] = convertByteA2E(in[i]);
-            }
-            return out;
-        }
-        return null;
-    }
-
-    /**
-     * Make the lookup easier.
-     * Note that when numbers with the high bit are converted to integers
-     * they are converted as signed values. Thus the "& 0xFF" to ensure
-     * that we don't try to lookup negative values.
-     **/
-    private static byte convertByteA2E(byte in) {
-        return ASCII2EBCDIC[in & 0xFF];
-    }
-
 }

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/InitClass.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/InitClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/InitClass.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/InitClass.java
@@ -124,9 +124,10 @@ public class InitClass {
             KDC_HOST_SHORTNAME = services.get(0).getProperties().get(SPNEGOConstants.KDC_SHORTNAME_FROM_CONSUL);
             if (isZOS) {
                 KRB5_CONF = services.get(0).getProperties().get(SPNEGOConstants.ZKRB5_CONF_FROM_CONSUL);
-
+                Log.info(c, thisMethod, "Retrieved ZKRB5_CONF value: " + (KRB5_CONF != null ? "not null" : "null"));
             } else {
                 KRB5_CONF = services.get(0).getProperties().get(SPNEGOConstants.KRB5_CONF_FROM_CONSUL);
+                Log.info(c, thisMethod, "Retrieved KRB5_CONF value: " + (KRB5_CONF != null ? "not null" : "null"));
             }
             Z_USER = services.get(0).getProperties().get(SPNEGOConstants.Z_USER_FROM_CONSUL);
             FIRST_USER = services.get(0).getProperties().get(SPNEGOConstants.FIRST_USER_FROM_CONSUL);
@@ -159,7 +160,7 @@ public class InitClass {
                 Z_USER_PWD = services.get(1).getProperties().get(SPNEGOConstants.USER0_PWD_FROM_CONSUL);
 
                 Log.info(c, thisMethod, "connection to " + failedKdcShortName + " failed. Attempting failover KDC: "
-                        + KDC_HOST_SHORTNAME);
+                                        + KDC_HOST_SHORTNAME);
 
                 connInfo = new ConnectionInfo(KDC_HOSTNAME, InitClass.KDC_USER, InitClass.KDC_USER_PWD);
                 kdcMachine = Machine.getMachine(connInfo);
@@ -201,7 +202,7 @@ public class InitClass {
         }
 
         Log.info(c, thisMethod,
-                "We were able to retrieve the required information from consul, the test will now continue....");
+                 "We were able to retrieve the required information from consul, the test will now continue....");
         Log.info(c, thisMethod, "The following KDC's are being used: " + KDCP_VAR + " and " + KDCS_VAR + ".");
 
     }
@@ -212,8 +213,7 @@ public class InitClass {
      * @throws Exception
      * @throws InterruptedException
      */
-    private static void establishConnectionToKDC(String thisMethod, Machine kdcMachine)
-            throws Exception, InterruptedException {
+    private static void establishConnectionToKDC(String thisMethod, Machine kdcMachine) throws Exception, InterruptedException {
         for (int i = 1; i <= 3; i++) {
             try {
                 SshClient sshClient = getSshClient();
@@ -278,15 +278,15 @@ public class InitClass {
         if (canonicalHostName.equals(ipAddress)) {
             String asciiArtLineBreak = "\n=======================================================";
             Log.info(c, methodName, asciiArtLineBreak + "Can not resolve the hostname for IP address " + ipAddress +
-                    "\n SPNEGO tests cannot run on this machine. This is a machine set up issue with the host name. "
-                    + "\n This can be fixed by updating the hosts file or DNS server registration."
-                    + asciiArtLineBreak);
+                                    "\n SPNEGO tests cannot run on this machine. This is a machine set up issue with the host name. "
+                                    + "\n This can be fixed by updating the hosts file or DNS server registration."
+                                    + asciiArtLineBreak);
             Assume.assumeTrue(false); // This will stop the rest of tests from executing
             return serverCanonicalHostName = "tests cannot run";
         }
         if (canonicalHostName != null && canonicalHostName.length() > CANONICAL_HOST_NAME_CHAR_LIMIT) {
             Log.info(c, methodName, "Canonical host name [" + canonicalHostName
-                    + "] is longer than allowed character limit. Using a substring as the host name");
+                                    + "] is longer than allowed character limit. Using a substring as the host name");
             String tmpHostLowerCase = canonicalHostName.toLowerCase();
             if (tmpHostLowerCase.contains("ebc")) {
                 canonicalHostName = createRandomStringHostNameForEbc(canonicalHostName);
@@ -315,7 +315,7 @@ public class InitClass {
          */
         if ("localhost".equalsIgnoreCase(canonicalHostName)) {
             throw new UnknownHostException("The canonical host name of " + canonicalHostName
-                    + " is not supported. Ensure that your host name is resolvable.");
+                                           + " is not supported. Ensure that your host name is resolvable.");
         }
 
         serverCanonicalHostName = canonicalHostName;
@@ -347,7 +347,7 @@ public class InitClass {
             isRndHostName = true;
         }
         Log.info(c, methodName, "EBC canonical hostname " + canonicalHostName
-                + " mapped to the random generated hostname " + rndHostName);
+                                + " mapped to the random generated hostname " + rndHostName);
         return rndHostName;
     }
 
@@ -374,7 +374,7 @@ public class InitClass {
             isRndHostName = true;
         }
         Log.info(c, methodName,
-                "Canonical hostname " + canonicalHostName + " mapped to the random generated hostname " + rndHostName);
+                 "Canonical hostname " + canonicalHostName + " mapped to the random generated hostname " + rndHostName);
         return rndHostName;
     }
 
@@ -387,8 +387,8 @@ public class InitClass {
      *
      * @param canonicalHostName
      * @param issueMsg          - Boolean indicating whether a message should be
-     *                          logged if the canonical host name does not
-     *                          include the IBM domain.
+     *                              logged if the canonical host name does not
+     *                              include the IBM domain.
      * @return
      */
     public static String getShortHostName(String canonicalHostName, boolean issueMsg) {
@@ -437,11 +437,12 @@ public class InitClass {
      * @param machine   The machine to connect to.
      * @return The session.
      * @throws IOException If there was an error getting an SSH session to the
-     *                     machine.
+     *                         machine.
      */
     protected static ClientSession getSshSession(SshClient sshClient, Machine machine) throws IOException {
         ClientSession session = sshClient.connect(machine.getUsername(), machine.getHostname(), 22)
-                .verify(30, TimeUnit.SECONDS).getSession();
+                        .verify(30, TimeUnit.SECONDS)
+                        .getSession();
         session.addPasswordIdentity(machine.getPassword());
         session.auth().verify(30, TimeUnit.SECONDS).isSuccess();
         return session;

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/InitClass.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/InitClass.java
@@ -19,10 +19,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.session.ClientSession;
 import org.junit.Assume;
+import java.security.Security;
 
 import com.ibm.websphere.simplicity.ConnectionInfo;
 import com.ibm.websphere.simplicity.Machine;
@@ -36,8 +38,10 @@ import componenttest.topology.utils.ExternalTestService;
 public class InitClass {
     private static final Class<?> c = InitClass.class;
     /**
-     * Active Directory appears to allow user names with a max of 20 characters. We add "_http" or
-     * "_httpsn" to the end of the host name to create the user name, so the host name we use for
+     * Active Directory appears to allow user names with a max of 20 characters. We
+     * add "_http" or
+     * "_httpsn" to the end of the host name to create the user name, so the host
+     * name we use for
      * the user name must be 15 characters or less.
      */
     public static final int CANONICAL_HOST_NAME_CHAR_LIMIT = 13;
@@ -52,7 +56,7 @@ public class InitClass {
     public static String KDCP_VAR = null;
     public static String KDCS_VAR = null;
 
-    //KDC Users
+    // KDC Users
     public static String KDC_USER = null;
     public static String KDC_USER_PWD = null;
     public static String KDC2_USER = null;
@@ -82,14 +86,14 @@ public class InitClass {
     public static long COMMON_TOKEN_CREATION_DATE = 0;
     public static final double TOKEN_REFRESH_LIFETIME_SECONDS = 180;
     public static boolean RUN_TESTS = true;
-    public static boolean LOCALHOST_DEFAULT_IP_ADDRESS = true; //127.0.0.1       localhost
+    public static boolean LOCALHOST_DEFAULT_IP_ADDRESS = true; // 127.0.0.1 localhost
 
     public static boolean IBM_JDK_V8_LOWER = false;
     public static boolean OTHER_SUPPORT_JDKS = false;
     public static boolean SUN_ORACLE_JDK_V8_HIGHER = false;
     public static boolean IBM_HYBRID_JDK = false;
 
-    //Properties to make sure we only send the scripts once
+    // Properties to make sure we only send the scripts once
     public static boolean sendvbs = true;
     public static boolean needToPushaddSPNKeytab = true;
     public static boolean needToPushsetUserSPN = true;
@@ -112,17 +116,17 @@ public class InitClass {
         List<ExternalTestService> services = null;
 
         try {
-            //obtaining kdcp and kdc_r information
+            // obtaining kdcp and kdc_r information
             services = CommonTest.getKDCServices(2, SPNEGOConstants.KDC_HOST_FROM_CONSUL);
             KDC_HOSTNAME = services.get(0).getAddress();
             KDC_USER = services.get(0).getProperties().get(SPNEGOConstants.MS_KDC_USER_CONSUL);
             KDC_USER_PWD = services.get(0).getProperties().get(SPNEGOConstants.MS_KDC_USER_PASSWORD_CONSUL);
             KDC_REALM = services.get(0).getProperties().get(SPNEGOConstants.KDC_REALM_FROM_CONSUL);
             KDC_HOST_SHORTNAME = services.get(0).getProperties().get(SPNEGOConstants.KDC_SHORTNAME_FROM_CONSUL);
-            if(isZOS){
+            if (isZOS) {
                 KRB5_CONF = services.get(0).getProperties().get(SPNEGOConstants.ZKRB5_CONF_FROM_CONSUL);
 
-            }else {
+            } else {
                 KRB5_CONF = services.get(0).getProperties().get(SPNEGOConstants.KRB5_CONF_FROM_CONSUL);
             }
             Z_USER = services.get(0).getProperties().get(SPNEGOConstants.Z_USER_FROM_CONSUL);
@@ -144,9 +148,9 @@ public class InitClass {
                 KDC_USER_PWD = services.get(1).getProperties().get(SPNEGOConstants.MS_KDC_USER_PASSWORD_CONSUL);
                 KDC_REALM = services.get(1).getProperties().get(SPNEGOConstants.KDC_REALM_FROM_CONSUL);
                 KDC_HOST_SHORTNAME = services.get(1).getProperties().get(SPNEGOConstants.KDC_SHORTNAME_FROM_CONSUL);
-                if(isZOS){
+                if (isZOS) {
                     KRB5_CONF = services.get(1).getProperties().get(SPNEGOConstants.ZKRB5_CONF_FROM_CONSUL);
-                }else {
+                } else {
                     KRB5_CONF = services.get(1).getProperties().get(SPNEGOConstants.KRB5_CONF_FROM_CONSUL);
                 }
                 Z_USER = services.get(1).getProperties().get(SPNEGOConstants.Z_USER_FROM_CONSUL);
@@ -155,7 +159,8 @@ public class InitClass {
                 USER_PWD = services.get(1).getProperties().get(SPNEGOConstants.USER_PWD_FROM_CONSUL);
                 Z_USER_PWD = services.get(1).getProperties().get(SPNEGOConstants.USER0_PWD_FROM_CONSUL);
 
-                Log.info(c, thisMethod, "connection to " + failedKdcShortName + " failed. Attempting failover KDC: " + KDC_HOST_SHORTNAME);
+                Log.info(c, thisMethod, "connection to " + failedKdcShortName + " failed. Attempting failover KDC: "
+                        + KDC_HOST_SHORTNAME);
 
                 connInfo = new ConnectionInfo(KDC_HOSTNAME, InitClass.KDC_USER, InitClass.KDC_USER_PWD);
                 kdcMachine = Machine.getMachine(connInfo);
@@ -164,7 +169,7 @@ public class InitClass {
 
             KDCP_VAR = getKDCHostnameMask(KDC_HOSTNAME);
 
-            //obtaining kdcs and kdcs_r information
+            // obtaining kdcs and kdcs_r information
             services = CommonTest.getKDCServices(1, SPNEGOConstants.KDC2_HOST_FROM_CONSUL);
             KDC2_HOSTNAME = services.get(0).getAddress();
             KDC2_USER = services.get(0).getProperties().get(SPNEGOConstants.MS_KDC_USER_REALM_2_CONSUL);
@@ -196,7 +201,8 @@ public class InitClass {
             CommonTest.releaseServices(services);
         }
 
-        Log.info(c, thisMethod, "We were able to retrieve the required information from consul, the test will now continue....");
+        Log.info(c, thisMethod,
+                "We were able to retrieve the required information from consul, the test will now continue....");
         Log.info(c, thisMethod, "The following KDC's are being used: " + KDCP_VAR + " and " + KDCS_VAR + ".");
 
     }
@@ -207,7 +213,8 @@ public class InitClass {
      * @throws Exception
      * @throws InterruptedException
      */
-    private static void establishConnectionToKDC(String thisMethod, Machine kdcMachine) throws Exception, InterruptedException {
+    private static void establishConnectionToKDC(String thisMethod, Machine kdcMachine)
+            throws Exception, InterruptedException {
         for (int i = 1; i <= 3; i++) {
             try {
                 SshClient sshClient = getSshClient();
@@ -240,7 +247,7 @@ public class InitClass {
             } else if (hostname.contains("secondary")) {
                 maskedHostname = "kdcs";
             } else {
-                //Should never reach here, but if it does, this will be useful to know.
+                // Should never reach here, but if it does, this will be useful to know.
                 return "UNABLE TO GET KDC MASK: " + hostname;
             }
 
@@ -256,8 +263,10 @@ public class InitClass {
     }
 
     /**
-     * Gets the fully qualified domain name (i.e. canonical host name) of the local host. If the code is not allowed to
-     * know the hostname for this IP address, the textual representation of the IP address is returned.
+     * Gets the fully qualified domain name (i.e. canonical host name) of the local
+     * host. If the code is not allowed to
+     * know the hostname for this IP address, the textual representation of the IP
+     * address is returned.
      *
      * @return
      * @throws UnknownHostException
@@ -270,14 +279,15 @@ public class InitClass {
         if (canonicalHostName.equals(ipAddress)) {
             String asciiArtLineBreak = "\n=======================================================";
             Log.info(c, methodName, asciiArtLineBreak + "Can not resolve the hostname for IP address " + ipAddress +
-                                    "\n SPNEGO tests cannot run on this machine. This is a machine set up issue with the host name. "
-                                    + "\n This can be fixed by updating the hosts file or DNS server registration."
-                                    + asciiArtLineBreak);
-            Assume.assumeTrue(false); //This will stop the rest of tests from executing
+                    "\n SPNEGO tests cannot run on this machine. This is a machine set up issue with the host name. "
+                    + "\n This can be fixed by updating the hosts file or DNS server registration."
+                    + asciiArtLineBreak);
+            Assume.assumeTrue(false); // This will stop the rest of tests from executing
             return serverCanonicalHostName = "tests cannot run";
         }
         if (canonicalHostName != null && canonicalHostName.length() > CANONICAL_HOST_NAME_CHAR_LIMIT) {
-            Log.info(c, methodName, "Canonical host name [" + canonicalHostName + "] is longer than allowed character limit. Using a substring as the host name");
+            Log.info(c, methodName, "Canonical host name [" + canonicalHostName
+                    + "] is longer than allowed character limit. Using a substring as the host name");
             String tmpHostLowerCase = canonicalHostName.toLowerCase();
             if (tmpHostLowerCase.contains("ebc")) {
                 canonicalHostName = createRandomStringHostNameForEbc(canonicalHostName);
@@ -287,19 +297,26 @@ public class InitClass {
         }
 
         /*
-         * If we can't resolve a canonical hostname other than localhost, we will have problems with
-         * the input and output keytab being named the same. This in itself isn't a big deal,
-         * but multiple hosts using the same keytab file on the shared remote KDCs will cause issues.
+         * If we can't resolve a canonical hostname other than localhost, we will have
+         * problems with
+         * the input and output keytab being named the same. This in itself isn't a big
+         * deal,
+         * but multiple hosts using the same keytab file on the shared remote KDCs will
+         * cause issues.
          *
-         * Perhaps we could create a random hostname above, but I don't think this should be much
+         * Perhaps we could create a random hostname above, but I don't think this
+         * should be much
          * of an issue unless running on your local machine.
          *
-         * This might be due to a DNS not being able to resolve the host name, or perhaps b/c of network
-         * configuration on the local machine. For example on linux, /etc/hosts resolves 127.0.0.1 to
+         * This might be due to a DNS not being able to resolve the host name, or
+         * perhaps b/c of network
+         * configuration on the local machine. For example on linux, /etc/hosts resolves
+         * 127.0.0.1 to
          * localhost before a FQDN.
          */
         if ("localhost".equalsIgnoreCase(canonicalHostName)) {
-            throw new UnknownHostException("The canonical host name of " + canonicalHostName + " is not supported. Ensure that your host name is resolvable.");
+            throw new UnknownHostException("The canonical host name of " + canonicalHostName
+                    + " is not supported. Ensure that your host name is resolvable.");
         }
 
         serverCanonicalHostName = canonicalHostName;
@@ -308,7 +325,8 @@ public class InitClass {
     }
 
     /**
-     * EBC test machines have long host names, create a random string host name for EBC test machine.
+     * EBC test machines have long host names, create a random string host name for
+     * EBC test machine.
      *
      * @param canonicalHostName
      * @return
@@ -329,12 +347,14 @@ public class InitClass {
             libertyHostMap.put(canonicalHostName, rndHostName);
             isRndHostName = true;
         }
-        Log.info(c, methodName, "EBC canonical hostname " + canonicalHostName + " mapped to the random generated hostname " + rndHostName);
+        Log.info(c, methodName, "EBC canonical hostname " + canonicalHostName
+                + " mapped to the random generated hostname " + rndHostName);
         return rndHostName;
     }
 
     /**
-     * Some test machines have long host names, create a random string host name for long named test machines.
+     * Some test machines have long host names, create a random string host name for
+     * long named test machines.
      *
      * @param canonicalHostName
      * @return
@@ -354,19 +374,22 @@ public class InitClass {
             libertyHostMap.put(canonicalHostName, rndHostName);
             isRndHostName = true;
         }
-        Log.info(c, methodName, "Canonical hostname " + canonicalHostName + " mapped to the random generated hostname " + rndHostName);
+        Log.info(c, methodName,
+                "Canonical hostname " + canonicalHostName + " mapped to the random generated hostname " + rndHostName);
         return rndHostName;
     }
 
     final static HashMap<String, String> hostMap = new HashMap<String, String>();
 
     /**
-     * Returns the short host name from the canonical host name provided. If canonicalHostName does not include
+     * Returns the short host name from the canonical host name provided. If
+     * canonicalHostName does not include
      * "ibm.com", the same value provided for canonicalHostName is returned.
      *
      * @param canonicalHostName
-     * @param issueMsg          - Boolean indicating whether a message should be logged if the canonical host name does not
-     *                              include the IBM domain.
+     * @param issueMsg          - Boolean indicating whether a message should be
+     *                          logged if the canonical host name does not
+     *                          include the IBM domain.
      * @return
      */
     public static String getShortHostName(String canonicalHostName, boolean issueMsg) {
@@ -386,7 +409,8 @@ public class InitClass {
     }
 
     /**
-     * Gets the short host name of the local host. If the code is not allowed to know the host name for this IP address,
+     * Gets the short host name of the local host. If the code is not allowed to
+     * know the host name for this IP address,
      * the textual representation of the IP address is returned.
      *
      * @return
@@ -402,6 +426,9 @@ public class InitClass {
      * @return The SshClient.
      */
     protected static SshClient getSshClient() {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
         SshClient sshClient = SshClient.setUpDefaultClient();
         sshClient.start();
         return sshClient;
@@ -413,10 +440,12 @@ public class InitClass {
      * @param sshClient The SSH client.
      * @param machine   The machine to connect to.
      * @return The session.
-     * @throws IOException If there was an error getting an SSH session to the machine.
+     * @throws IOException If there was an error getting an SSH session to the
+     *                     machine.
      */
     protected static ClientSession getSshSession(SshClient sshClient, Machine machine) throws IOException {
-        ClientSession session = sshClient.connect(machine.getUsername(), machine.getHostname(), 22).verify(30, TimeUnit.SECONDS).getSession();
+        ClientSession session = sshClient.connect(machine.getUsername(), machine.getHostname(), 22)
+                .verify(30, TimeUnit.SECONDS).getSession();
         session.addPasswordIdentity(machine.getPassword());
         session.auth().verify(30, TimeUnit.SECONDS).isSuccess();
         return session;

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/InitClass.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/InitClass.java
@@ -104,6 +104,7 @@ public class InitClass {
     public static String serverCanonicalHostName = null;
     public static String serverShortHostName = null;
     public static boolean randomizeHostName = false;
+    private static boolean isZOS = System.getProperty("os.name").equals("z/OS");
 
     public static void getKDCInfoFromConsul() throws Exception {
         String thisMethod = "getKDCInfoFromConsul";
@@ -118,7 +119,12 @@ public class InitClass {
             KDC_USER_PWD = services.get(0).getProperties().get(SPNEGOConstants.MS_KDC_USER_PASSWORD_CONSUL);
             KDC_REALM = services.get(0).getProperties().get(SPNEGOConstants.KDC_REALM_FROM_CONSUL);
             KDC_HOST_SHORTNAME = services.get(0).getProperties().get(SPNEGOConstants.KDC_SHORTNAME_FROM_CONSUL);
-            KRB5_CONF = services.get(0).getProperties().get(SPNEGOConstants.KRB5_CONF_FROM_CONSUL);
+            if(isZOS){
+                KRB5_CONF = services.get(0).getProperties().get(SPNEGOConstants.ZKRB5_CONF_FROM_CONSUL);
+
+            }else {
+                KRB5_CONF = services.get(0).getProperties().get(SPNEGOConstants.KRB5_CONF_FROM_CONSUL);
+            }
             Z_USER = services.get(0).getProperties().get(SPNEGOConstants.Z_USER_FROM_CONSUL);
             FIRST_USER = services.get(0).getProperties().get(SPNEGOConstants.FIRST_USER_FROM_CONSUL);
             SECOND_USER = services.get(0).getProperties().get(SPNEGOConstants.SECOND_USER_FROM_CONSUL);
@@ -138,7 +144,11 @@ public class InitClass {
                 KDC_USER_PWD = services.get(1).getProperties().get(SPNEGOConstants.MS_KDC_USER_PASSWORD_CONSUL);
                 KDC_REALM = services.get(1).getProperties().get(SPNEGOConstants.KDC_REALM_FROM_CONSUL);
                 KDC_HOST_SHORTNAME = services.get(1).getProperties().get(SPNEGOConstants.KDC_SHORTNAME_FROM_CONSUL);
-                KRB5_CONF = services.get(1).getProperties().get(SPNEGOConstants.KRB5_CONF_FROM_CONSUL);
+                if(isZOS){
+                    KRB5_CONF = services.get(1).getProperties().get(SPNEGOConstants.ZKRB5_CONF_FROM_CONSUL);
+                }else {
+                    KRB5_CONF = services.get(1).getProperties().get(SPNEGOConstants.KRB5_CONF_FROM_CONSUL);
+                }
                 Z_USER = services.get(1).getProperties().get(SPNEGOConstants.Z_USER_FROM_CONSUL);
                 FIRST_USER = services.get(1).getProperties().get(SPNEGOConstants.FIRST_USER_FROM_CONSUL);
                 SECOND_USER = services.get(1).getProperties().get(SPNEGOConstants.SECOND_USER_FROM_CONSUL);

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/InitClass.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/InitClass.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.session.ClientSession;
@@ -426,9 +425,6 @@ public class InitClass {
      * @return The SshClient.
      */
     protected static SshClient getSshClient() {
-        if (Security.getProvider("BC") == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
         SshClient sshClient = SshClient.setUpDefaultClient();
         sshClient.start();
         return sshClient;

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/KdcHelper.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/KdcHelper.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.channel.ChannelExec;
 import org.apache.sshd.client.channel.ClientChannelEvent;
@@ -864,9 +863,6 @@ public abstract class KdcHelper {
      * @return The SshClient.
      */
     protected SshClient getSshClient() {
-        if (Security.getProvider("BC") == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
         SshClient sshClient = SshClient.setUpDefaultClient();
         sshClient.start();
         return sshClient;

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/KdcHelper.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/KdcHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@ import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.channel.ChannelExec;
 import org.apache.sshd.client.channel.ClientChannelEvent;
@@ -40,6 +40,7 @@ import org.apache.sshd.common.channel.ChannelListener;
 import org.apache.sshd.scp.client.ScpClient;
 import org.apache.sshd.scp.client.ScpClientCreator;
 import org.junit.Ignore;
+import java.security.Security;
 
 import com.ibm.websphere.simplicity.ConnectionInfo;
 import com.ibm.websphere.simplicity.LocalFile;
@@ -863,6 +864,9 @@ public abstract class KdcHelper {
      * @return The SshClient.
      */
     protected SshClient getSshClient() {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
         SshClient sshClient = SshClient.setUpDefaultClient();
         sshClient.start();
         return sshClient;

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/SPNEGOConstants.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/SPNEGOConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/SPNEGOConstants.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/SPNEGOConstants.java
@@ -26,6 +26,7 @@ public class SPNEGOConstants {
     public final static String KDC_REALM_FROM_CONSUL = "realm";
     public final static String KDC2_REALM_FROM_CONSUL = "realm";
     public final static String KRB5_CONF_FROM_CONSUL = "krb5Conf";
+    public final static String ZKRB5_CONF_FROM_CONSUL = "zkrb5Conf";
 
     public final static String IBM_DOMAIN = "ibm.com";
     public final static String MS_KDC_USER_CONSUL = "user";

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/SPNEGOConstants.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/SPNEGOConstants.java
@@ -70,6 +70,7 @@ public class SPNEGOConstants {
     public final static String CYGWIN_HOME_REALM_1 = "c:\\cygwin\\home\\Administrator\\";
     public final static String KRB_RESOURCE_LOCATION = "/resources/security/kerberos/";
     public final static String SERVER_KRB5_CONFIG_FILE = KRB_RESOURCE_LOCATION + "krb5.conf";
+    public final static String ZOS_SERVER_KRB5_CONFIG_FILE = KRB_RESOURCE_LOCATION + "zkrb5.conf";
     public final static String CLIENT_JAAS_CONFIG_FILE = KRB_RESOURCE_LOCATION + "jaas.conf";
     public final static String ZOS_CLIENT_JAAS_CONFIG_FILE = KRB_RESOURCE_LOCATION + "zjaas.conf";
     public final static String SERVER_KRB5_CONFIG_FILE_BACKUP = KRB_RESOURCE_LOCATION + "KDCbackup-krb5.conf";

--- a/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/S4U2ProxyTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/S4U2ProxyTest.java
@@ -127,17 +127,17 @@ public class S4U2ProxyTest extends CommonTest {
     public static void setUp() throws Exception {
         String thisMethod = "setUp";
 
-        if (InitClass.isRndHostName) {
-            Log.info(c, thisMethod, "Not running S4U2ProxyTest because randomized hostname is used.");
-            Assume.assumeTrue(false); //This disables this test class. None of the tests in the class will be run.
-        } else {
+        // if (InitClass.isRndHostName) {
+        //     Log.info(c, thisMethod, "Not running S4U2ProxyTest because randomized hostname is used.");
+        //     Assume.assumeTrue(false); //This disables this test class. None of the tests in the class will be run.
+        // } else {
             Log.info(c, thisMethod, "Starting the server and kerberos setup ...");
             spnegoTokencommonSetUp("S4U2ProxyTest", "serverSpnego.xml", SPNEGOConstants.NO_APPS, SPNEGOConstants.NO_PROPS,
                                    SPNEGOConstants.DONT_CREATE_SSL_CLIENT, SPNEGOConstants.DONT_CREATE_SPN_AND_KEYTAB,
                                    SPNEGOConstants.DEFAULT_REALM, SPNEGOConstants.CREATE_SPNEGO_TOKEN, SPNEGOConstants.SET_AS_COMMON_TOKEN, SPNEGOConstants.USE_CANONICAL_NAME,
                                    SPNEGOConstants.USE_COMMON_KEYTAB, SPNEGOConstants.DONT_START_SERVER,
                                    tokenAPIServletName, tokenAPIServletRootContext, SPNEGOConstants.USE_USER1);
-        }
+        // }
 
         FATSuite.transformApps(myServer, "basicauth.war", "SPNEGOTokenHelperFVT.ear");
     }

--- a/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/S4U2ProxyTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/S4U2ProxyTest.java
@@ -127,17 +127,17 @@ public class S4U2ProxyTest extends CommonTest {
     public static void setUp() throws Exception {
         String thisMethod = "setUp";
 
-        // if (InitClass.isRndHostName) {
-        //     Log.info(c, thisMethod, "Not running S4U2ProxyTest because randomized hostname is used.");
-        //     Assume.assumeTrue(false); //This disables this test class. None of the tests in the class will be run.
-        // } else {
+        if (InitClass.isRndHostName) {
+            Log.info(c, thisMethod, "Not running S4U2ProxyTest because randomized hostname is used.");
+            Assume.assumeTrue(false); //This disables this test class. None of the tests in the class will be run.
+        } else {
             Log.info(c, thisMethod, "Starting the server and kerberos setup ...");
             spnegoTokencommonSetUp("S4U2ProxyTest", "serverSpnego.xml", SPNEGOConstants.NO_APPS, SPNEGOConstants.NO_PROPS,
                                    SPNEGOConstants.DONT_CREATE_SSL_CLIENT, SPNEGOConstants.DONT_CREATE_SPN_AND_KEYTAB,
                                    SPNEGOConstants.DEFAULT_REALM, SPNEGOConstants.CREATE_SPNEGO_TOKEN, SPNEGOConstants.SET_AS_COMMON_TOKEN, SPNEGOConstants.USE_CANONICAL_NAME,
                                    SPNEGOConstants.USE_COMMON_KEYTAB, SPNEGOConstants.DONT_START_SERVER,
                                    tokenAPIServletName, tokenAPIServletRootContext, SPNEGOConstants.USE_USER1);
-        // }
+        }
 
         FATSuite.transformApps(myServer, "basicauth.war", "SPNEGOTokenHelperFVT.ear");
     }

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/KerberosContainer.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/KerberosContainer.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.nio.charset.Charset;
 
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -44,6 +45,7 @@ public class KerberosContainer extends GenericContainer<KerberosContainer> {
     public static final String KRB5_KDC = "kerberos";
     public static final String KRB5_PASS = "password";
     public static String KDC_HOSTNAME = "notSetYet";
+        private static boolean isZOS = System.getProperty("os.name").equals("z/OS");
 
     private static final RemoteDockerImage SPNEGO_KDC_SERVER = ImageBuilder.build("spnego-kdc-server:1.0.0.1").getFuture();
 
@@ -155,7 +157,8 @@ public class KerberosContainer extends GenericContainer<KerberosContainer> {
                       "        ." + KRB5_REALM.toLowerCase() + " = " + KRB5_REALM.toUpperCase() + "\n" +
                       "        " + KRB5_REALM.toLowerCase() + " = " + KRB5_REALM.toUpperCase() + "\n";
         outputPath.getParent().toFile().mkdirs();
-        Files.write(outputPath, conf.getBytes(StandardCharsets.UTF_8));
+        Charset charSet = isZOS?Charset.forName("IBM-1047"):StandardCharsets.UTF_8;
+        Files.write(outputPath, conf.getBytes(charSet));
     }
 
     public void generateJAASConf(Path outputPath) throws IOException {


### PR DESCRIPTION
The SPNEGO bucket is not running on z/OS Machines. This is becuase we need to convert the krb.conf file to ebcidic.


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
