### PR TITLE
Fix MD5 algorithm reference

### DIFF
--- a/dev/com.ibm.ws.security.csiv2.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.csiv2.common/bnd.bnd
@@ -105,5 +105,4 @@ instrument.classesExcludes: com/ibm/ws/security/csiv2/internal/resources/*.class
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.security.mp.jwt.proxy;version=latest,\
 	com.ibm.ws.config;version=latest,\
-	com.ibm.ws.kernel.service,\
 	com.ibm.ws.kernel.service

--- a/dev/com.ibm.ws.security.csiv2.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.csiv2.common/bnd.bnd
@@ -96,12 +96,14 @@ instrument.classesExcludes: com/ibm/ws/security/csiv2/internal/resources/*.class
 	com.ibm.ws.org.apache.yoko.corba.spec.1.5;version=latest,\
 	com.ibm.ws.org.apache.yoko.core.1.5;version=latest,\
 	com.ibm.ws.org.apache.yoko.osgi.1.5;version=latest,\
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.security.authentication;version=latest,\
-	com.ibm.ws.security.credentials;version=latest, \
+	com.ibm.ws.security.credentials;version=latest,\
 	com.ibm.ws.security;version=latest,\
 	com.ibm.ws.ssl;version=latest,\
 	com.ibm.ws.transport.iiop;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.security.mp.jwt.proxy;version=latest,\
-	com.ibm.ws.config;version=latest
+	com.ibm.ws.config;version=latest,\
+	com.ibm.ws.kernel.service,\
+	com.ibm.ws.kernel.service

--- a/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/asn1/x509/AlgorithmIdentifier.java
+++ b/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/asn1/x509/AlgorithmIdentifier.java
@@ -24,6 +24,8 @@ import com.ibm.ws.transport.iiop.asn1.DEREncodable;
 import com.ibm.ws.transport.iiop.asn1.DERObject;
 import com.ibm.ws.transport.iiop.asn1.DERObjectIdentifier;
 import com.ibm.ws.transport.iiop.asn1.DERSequence;
+import com.ibm.ws.common.crypto.CryptoUtils;
+
 
 public class AlgorithmIdentifier
     extends ASN1Encodable
@@ -47,9 +49,14 @@ public class AlgorithmIdentifier
             return (AlgorithmIdentifier)obj;
         }
 
-        if (obj instanceof DERObjectIdentifier)
-        {
-            return new AlgorithmIdentifier((DERObjectIdentifier)obj);
+        if (obj instanceof DERObjectIdentifier) {
+            DERObjectIdentifier oid = (DERObjectIdentifier) obj;
+            if (CryptoUtils.isFips140_3EnabledWithBetaGuard()) {
+                if ("1.2.840.113549.2.5".equals(oid.getId())) {
+                    throw new IllegalArgumentException("MD5 is not allowed in FIPS 140-3 mode");
+                }
+            }
+            return new AlgorithmIdentifier(oid);
         }
 
         if (obj instanceof String)


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
Added a FIPS toggle for the MD5 reference in dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/asn1/pkcs/PKCSObjectIdentifiers.java

`static final DERObjectIdentifier    md5                     = new DERObjectIdentifier(digestAlgorithm + ".5");`

################################################################################################
