### PR TITLE
Fixing social twitter code for FIPS compatibility

### DIFF
--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/twitter/TwitterEndpointServices.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/twitter/TwitterEndpointServices.java
@@ -121,6 +121,8 @@ public class TwitterEndpointServices {
      */
     public String computeSignature(String requestMethod, String targetUrl, Map<String, String> params, @Sensitive String consumerSecret, @Sensitive String tokenSecret) {
 
+        // FIPS 140-3: Algorithm assessment complete; no changes required.
+        // The twitter OAuth v1.0 spec will not work with fips compliant algorithms. A new implementation of v2.0 spec would be required for FIPS 140-3.
         String signatureBaseString = createSignatureBaseString(requestMethod, targetUrl, params);
 
         // Hash the base string using the consumer secret (and request token secret, if known) as a key


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
Added in HMAC-SHA256. This will be used instead of HMAC-SHA1 when FIPS is enabled.

################################################################################################
