### PR TITLE
Defect-303179-timeout-fix

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -51,14 +51,6 @@ public class CxfClientPropsTestServlet extends FATServlet {
     private final static String proxyHost = "127.0.0.1";
     private final static String myHost = "1.1.1.1";
     private static final long slowHardwareMargin = 61000;    
-    
-    private static final boolean isZOS() {
-        String osName = System.getProperty("os.name");
-        if (osName.contains("OS/390") || osName.contains("z/OS") || osName.contains("zOS")) {
-            return true;
-        }
-        return false;
-    }
  
     private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
     private static final boolean isAIX = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("aix");

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -107,13 +107,8 @@ public class CxfClientPropsTestServlet extends FATServlet {
                                      .property("client.ConnectionTimeout", CXF_TIMEOUT)
                                      .build();
         
-        if (isZOS()) {
-            // https://stackoverflow.com/a/904609/6575578
-               target = "http://example.com:81";
-           } else {
-             //Connect to telnet port - which should be disabled on all non-Z test machines - so we should expect a timeout
-               target = "http://localhost:23/blah";
-           }
+        // https://stackoverflow.com/a/904609/6575578
+        target = "http://10.255.255.1/blah";
         
         long startTime = System.currentTimeMillis();
         try {
@@ -176,13 +171,8 @@ public class CxfClientPropsTestServlet extends FATServlet {
                                      .property("client.ConnectionTimeout", CXF_TIMEOUT)
                                      .build();
         
-        if (isZOS()) {
-         // https://stackoverflow.com/a/904609/6575578
-            target = "http://example.com:81";
-        } else {
-          //Connect to telnet port - which should be disabled on all non-Z test machines - so we should expect a timeout
-            target = "http://localhost:23/blah";
-        }
+        // https://stackoverflow.com/a/904609/6575578
+        target = "http://10.255.255.1/blah";
         
         long startTime = System.currentTimeMillis();
         try {

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -190,6 +190,7 @@ public class CxfClientPropsTestServlet extends FATServlet {
         long CXF_TIMEOUT = 35000;
         if (isAIX || isWindows) {
             MARGIN = slowHardwareMargin;
+            CXF_TIMEOUT = 66000;
         }    
         
         Client client = ClientBuilder.newBuilder()

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -187,7 +187,7 @@ public class CxfClientPropsTestServlet extends FATServlet {
         final String m = "testIBMReadTimeoutOverridesCXFReadTimeout";
         long IBM_TIMEOUT = 5000;
         long MARGIN = defaultMargin;
-        long CXF_TIMEOUT = 70000;
+        long CXF_TIMEOUT = 35000;
         if (isAIX || isWindows) {
             MARGIN = slowHardwareMargin;
         }    

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -166,10 +166,10 @@ public class CxfClientPropsTestServlet extends FATServlet {
         String target = null;
         long IBM_TIMEOUT = 5000;
         long MARGIN = defaultMargin;
-        long CXF_TIMEOUT = 20000;
+        long CXF_TIMEOUT = 70000;
         if (isAIX || isWindows) {
             MARGIN = slowHardwareMargin;
-        }    
+        }
         
         Client client = ClientBuilder.newBuilder()
                                      .property("com.ibm.ws.jaxrs.client.connection.timeout", IBM_TIMEOUT)

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -156,6 +156,7 @@ public class CxfClientPropsTestServlet extends FATServlet {
         long CXF_TIMEOUT = 35000;
         if (isAIX || isWindows) {
             MARGIN = slowHardwareMargin;
+            CXF_TIMEOUT = 66,000
         }
         
         Client client = ClientBuilder.newBuilder()

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -153,7 +153,7 @@ public class CxfClientPropsTestServlet extends FATServlet {
         String target = null;
         long IBM_TIMEOUT = 5000;
         long MARGIN = defaultMargin;
-        long CXF_TIMEOUT = 70000;
+        long CXF_TIMEOUT = 35000;
         if (isAIX || isWindows) {
             MARGIN = slowHardwareMargin;
         }

--- a/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.x_fat_clientProps/test-applications/cxfClientPropsApp/src/jaxrs2x/cxfClientProps/CxfClientPropsTestServlet.java
@@ -46,7 +46,7 @@ import componenttest.app.FATServlet;
 public class CxfClientPropsTestServlet extends FATServlet {
    
     private final static Logger _log = Logger.getLogger(CxfClientPropsTestServlet.class.getName());
-    private static final long defaultMargin = 14000;
+    private static final long defaultMargin = 30000;
     private final static String proxyPort = "8888";
     private final static String proxyHost = "127.0.0.1";
     private final static String myHost = "1.1.1.1";
@@ -204,7 +204,7 @@ public class CxfClientPropsTestServlet extends FATServlet {
         final String m = "testIBMReadTimeoutOverridesCXFReadTimeout";
         long IBM_TIMEOUT = 5000;
         long MARGIN = defaultMargin;
-        long CXF_TIMEOUT = 20000;
+        long CXF_TIMEOUT = 70000;
         if (isAIX || isWindows) {
             MARGIN = slowHardwareMargin;
         }    


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fix for defect 
https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=303179

Changed the CXF_TIMEOUT and defaultMargin values to make the test valid for Windows and Linux and to allow for the occasional problems that are caused by slow hardware.