### PR TITLE
add fips guard for sha512 hash algorithm - com.ibm.ws.ui

### DIFF
--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/ToolDataAPI.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/ToolDataAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,20 +34,23 @@ import com.ibm.ws.ui.internal.v1.utils.Utils;
 import com.ibm.wsspi.rest.handler.RESTRequest;
 import com.ibm.wsspi.rest.handler.RESTResponse;
 
+import com.ibm.ws.common.crypto.CryptoUtils;
+
 /**
  * <p>Defines the per user tool data API for the version 1 of the adminCenter REST API.</p>
- * <p>Http header ETag (entity tag) is used in the response header to send back the MD5 checksum of
- * the tool data.</p>
- * <p>When a client performs a GET call, the response header's ETag contains the MD5 checksum of the
+ * <p>Http header ETag (entity tag) is used in the response header to send back the SHA512 or MD5 checksum of
+ * the tool data in respect to the FIPS guard boolen for messageDigest in Utils.java. </p>
+ * <p>When a client performs a GET call, the response header's ETag contains the SHA512 or MD5 checksum of the
  * returned tool data. When the same client tries to perform a PUT (update data) call, the "IF-Match"
- * request header must contain the MD5 checksum of the original tool data. If the MD5 checksum
- * ("IF-Match" request header value) does not match the MD5 checksum of the tool data in the storage
+ * request header must contain the SHA512 or MD5 checksum of the original tool data. If the SHA512 or MD5 checksum
+ * ("IF-Match" request header value) does not match the SHA512 or MD5 checksum of the tool data in the storage
  * layer, HTTP BAD REQUEST (error 400) will be returned.</p>
- * <p>GET, POST and PUT responses contain ETag response header, the value is the MD5 checksum of
+ * <p>GET, POST and PUT responses contain ETag response header, the value is the SHA512 or  MD5 checksum of
  * the returned tool data.</p>
  *
  * <p>Maps to host:port/ibm/api/adminCenter/v1/tooldata</p>
  */
+
 public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
     private final IToolDataService toolDataService;
     private final IToolboxService toolboxService;
@@ -94,7 +97,8 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
 
     /**
      * Gets the tool data of for the giving tool/user.
-     * When the tool data is returned, a md5 checksum of the data is also returned using the Response's HTTP header Etag.
+     * When the tool data is returned, a sha512 or md5 checksum of the data is also returned in respect to the FIPS guard boolen for messageDigest in Utils.java 
+     * using the Response's HTTP header Etag.
      *
      *
      * {@inheritDoc}
@@ -118,8 +122,8 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
                     throw new RESTException(HTTP_INTERNAL_ERROR);
                 }
 
-                String md5 = Utils.getMD5String(object.toString());
-                response.setResponseHeader(HTTP_HEADER_ETAG, md5);
+                String eTag = Utils.getChecksumString(object.toString());
+                response.setResponseHeader(HTTP_HEADER_ETAG, eTag);
                 return object;
             }
             // Return 204 (no content) so as to get rid of the 404 console error
@@ -170,8 +174,8 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
                 POSTResponse postResponse = new POSTResponse();
                 postResponse.createdURL = request.getURL() + "/" + child;
                 postResponse.jsonPayload = td;
-                String md5 = Utils.getMD5String(td);
-                response.setResponseHeader(HTTP_HEADER_ETAG, md5);
+                String eTag = Utils.getChecksumString(td);
+                response.setResponseHeader(HTTP_HEADER_ETAG, eTag);
                 return postResponse;
             } catch (IOException e) {
                 if (tc.isDebugEnabled()) {
@@ -216,9 +220,9 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
      * Updates the tool data for the giving tool/user.
      *
      * The pre-condition for the update operation is the http request header "If-Match".
-     * The "If-Match" should contain the MD5 checksum of the tool data that is being updated.
-     * The GET response of the tool contains response header Etag. The value of Etag is the MD5 checksum
-     * of the tool data returned to the caller.
+     * The "If-Match" should contain the SHA512 or MD5 checksum of the tool data that is being updated in respect to the FIPS guard boolen for messageDigest in Utils.java.
+     * The GET response of the tool contains response header Etag. 
+     * The value of Etag is the SHA512 or MD5 checksum of the tool data returned to the caller.
      *
      * {@inheritDoc}
      *
@@ -226,8 +230,8 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
      *         code {@link Response.Status.OK} if the tool data is updated successfully;
      *         or code {@link Response.Status.HTTP_NOT_FOUND} if the tool data does not exist;
      *         or code {@link Response.Status.HTTP_PRECONDITION_FAILED } if the request doesn't contain If-Match header;
-     *         or code {@link Response.Status.HTTP_PRECONDITION_FAILED } if the MD5 checksum (ETag value of the request header) passed
-     *         in doesn't match the MD5 checksum of the data being replaced;
+     *         or code {@link Response.Status.HTTP_PRECONDITION_FAILED } if the SHA512 or MD5 checksum (ETag value of the request header) passed
+     *         in doesn't match the SHA512 or MD5 checksum of the data being replaced;
      *         or code {@link Response.Status.HTTP_INTERNAL_ERROR } if other failure occurred.
      *
      */
@@ -239,8 +243,8 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
         if (isKnownChildResource(child, request)) {
 
             try {
-                String md5In = request.getHeader(HTTP_HEADER_IF_MATCH);
-                if (md5In == null)
+                String input = request.getHeader(HTTP_HEADER_IF_MATCH);
+                if (input == null)
                     throw new RESTException(HTTP_PRECONDITION_FAILED);
                 boolean exists = toolDataService.exists(request.getUserPrincipal().getName(), child);
                 if (!exists) {
@@ -252,13 +256,13 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
                 if (!Utils.isValidJsonString(originalData.toString())) {
                     throw new RESTException(HTTP_INTERNAL_ERROR);
                 }
-
-                String md5 = Utils.getMD5String(originalData.toString());
-
-                if (md5In.equals(md5) == false) {
+               
+                String checksum = Utils.getChecksumString(originalData.toString());
+                
+                if (input.equals(checksum) == false) {
                     throw new RESTException(HTTP_PRECONDITION_FAILED, MEDIA_TYPE_TEXT_PLAIN, RequestNLS.formatMessage(tc, "TOOLDATA_UPDATE_CHECKSUM_NOT_MATCH",
                                                                                                                       request.getUserPrincipal().getName(),
-                                                                                                                      child));
+                                                                                                                child));
                 }
 
                 String tooldata = getReaderContents(request.getInputStream(), POST_MAX_PLAIN_TEXT_SIZE);
@@ -272,8 +276,8 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
                 if (td == null)
                     throw new RESTException(HTTP_INTERNAL_ERROR);
 
-                md5 = Utils.getMD5String(td);
-                response.setResponseHeader(HTTP_HEADER_ETAG, md5);
+                String eTag = Utils.getChecksumString(td);
+                response.setResponseHeader(HTTP_HEADER_ETAG, eTag);
 
                 return td;
             } catch (IOException e) {

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/utils/Utils.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/utils/Utils.java
@@ -40,7 +40,7 @@ public class Utils {
 
     static {
         try {
-            messagedigest = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256) : MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5);
+            messagedigest = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_512) : MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5);
         } catch (NoSuchAlgorithmException e) {
             //should not happen
             throw new RuntimeException(e);
@@ -118,12 +118,12 @@ public class Utils {
     }
 
     /**
-     * Generates the md5 checksum of the given string
+     * Generates the SHA512 or MD5 checksum of the given string in respect to FIPS is enabled or not.
      *
      * @param str The input string
-     * @return The MD5 checksum of the given string.
+     * @return The checksum of the given string.
      */
-    public synchronized static String getMD5String(String str) {
+    public synchronized static String getChecksumString(String str) {
         byte[] hash;
         try {
             hash = messagedigest.digest(str.getBytes(StandardCharsets.UTF_8));
@@ -140,6 +140,7 @@ public class Utils {
         }
         return sb.toString();
     }
+
 
     /**
      * This method validates whether the input string is a valid JSON or not.

--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/TooldataAPIv1Test.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/TooldataAPIv1Test.java
@@ -50,8 +50,8 @@ public class TooldataAPIv1Test extends CommonRESTTest implements APIConstants {
     private final String tooldataExploreEntryURL = API_V1_TOOLDATA + "/com.ibm.websphere.appserver.adminCenter.tool.explore";
     private final String dataString = "{\"key\":\"value\"}";
     private final String dataString1 = "{\"key\":\"value1\"}";
-    private final String etagCheckSum1 = isFIPSEnabledOnServer() ? "e43abcf3375244839c012f9633f95862d232a95b00d5bc7348b3098b9fed7f32" : "a7353f7cddce808de0032747a0b7be50";
-    private final String etagCheckSum2 = isFIPSEnabledOnServer() ? "dfada72ccc2244e8c7aef8f0dbe7c026a6553bc5bda3f7654f3d0b94dd51a23b" : "9ecb15df65a2ceddcb3b2c726f5aa522";
+    private final String etagCheckSum1 = isFIPSEnabledOnServer() ? "0213f898602b6a489de25f20d8d32c3dbf3d6fee0fbe468f89ac803874ac846f8cd239294a78c2bddf3e0988acb8cd3d00e067a981c9c7933b43a42d3b273eae" : "a7353f7cddce808de0032747a0b7be50";
+    private final String etagCheckSum2 = isFIPSEnabledOnServer() ? "30a9c1549c94169bc284e21ea24d49084b1d661d01a8f6c194b7823bcad429da2aafae945b6a1573994234806fb6000ca092718e8b92c02b062223650e6817e1" : "9ecb15df65a2ceddcb3b2c726f5aa522";
 
     public TooldataAPIv1Test() {
         super(c);
@@ -270,7 +270,7 @@ public class TooldataAPIv1Test extends CommonRESTTest implements APIConstants {
     /**
      * Determine if FIPS is enabled and supported on the test server
      * Determines which etag checksum will be used for validation:
-     * MD5 when FIPS 140-3 is disabled, and SHA256 when FIPS 140-3 is enabled
+     * MD5 when FIPS 140-3 is disabled, and SHA512 when FIPS 140-3 is enabled
      */
     private boolean isFIPSEnabledOnServer() {
         try {


### PR DESCRIPTION
Update with FIPS guard to use valid hash algorithm when FIPS 140-3 is enabled.
This PR is used for test comparison with another proposed update: https://github.com/OpenLiberty/open-liberty/pull/32244


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
