### PR TITLE
Update otel collector image and update fats to use a `network` for io.openliberty.http.monitor_fat

### DIFF
--- a/dev/io.openliberty.http.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.http.monitor_fat/bnd.bnd
@@ -57,9 +57,9 @@ tested.features:\
   jsf-2.2
 
 # Uncomment to use remote docker host to simulate continuous build behavior.
-#fat.test.use.remote.docker: true
+# fat.test.use.remote.docker: true
 
-fat.test.container.images: otel/opentelemetry-collector:0.127.0
+fat.test.container.images: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.127.0
 
 -buildpath: \
 	com.ibm.ws.webcontainer.servlet.4.0.jakarta,\
@@ -80,4 +80,5 @@ fat.test.container.images: otel/opentelemetry-collector:0.127.0
 	net.sourceforge.htmlunit:neko-htmlunit;strategy=exact;version=2.44.0,\
 	net.sourceforge.htmlunit:webdriver;version=2.6,\
 	io.openliberty.org.apache.xercesImpl;version=latest,\
-	xml-apis:xml-apis;version=1.4.01
+	xml-apis:xml-apis;version=1.4.01,\
+	com.ibm.ws.org.apache.commons.lang3;version=latest

--- a/dev/io.openliberty.http.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.http.monitor_fat/bnd.bnd
@@ -59,7 +59,7 @@ tested.features:\
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true
 
-fat.test.container.images: otel/opentelemetry-collector-contrib:0.103.0
+fat.test.container.images: otel/opentelemetry-collector:0.127.0
 
 -buildpath: \
 	com.ibm.ws.webcontainer.servlet.4.0.jakarta,\

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
@@ -53,7 +53,7 @@ public abstract class BaseTestClass {
     protected static final String PATH_TO_AUTOFVT_TESTFILES = "lib/LibertyFATTestFiles/";
 
     protected static final String IMAGE_NAME = ImageNameSubstitutor.instance() //
-                    .apply(DockerImageName.parse("otel/opentelemetry-collector-contrib:0.103.0")).asCanonicalNameString();
+                    .apply(DockerImageName.parse("otel/opentelemetry-collector:0.127.0")).asCanonicalNameString();
 
     protected static void trustAll() throws Exception {
         try {
@@ -389,12 +389,12 @@ public abstract class BaseTestClass {
         matchString += expectedCount;
 
         Log.info(c, "validatePrometheusHTTPMetricCount", "Trying to match: " + matchString);
-        
+
         if (vendorMetricsOutput == null) {
-        	Log.info(c, "validatePrometheusHTTPMetricCount", "vendorMetricsOutput is null - metrics endpoint may not be responding");
-        	return false;
+            Log.info(c, "validatePrometheusHTTPMetricCount", "vendorMetricsOutput is null - metrics endpoint may not be responding");
+            return false;
         }
-        
+
         try (Scanner sc = new Scanner(vendorMetricsOutput)) {
             while (sc.hasNextLine()) {
                 String line = sc.nextLine();
@@ -449,12 +449,12 @@ public abstract class BaseTestClass {
         matchString += expectedSum;
 
         Log.info(c, "validatePrometheusHTTPMetricSum", "Trying to match: " + matchString);
-        
+
         if (vendorMetricsOutput == null) {
             Log.info(c, "validatePrometheusHTTPMetricSum", "vendorMetricsOutput is null - metrics endpoint may not be responding");
             return false;
         }
-        
+
         try (Scanner sc = new Scanner(vendorMetricsOutput)) {
             while (sc.hasNextLine()) {
                 String line = sc.nextLine();

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/BaseTestClass.java
@@ -53,7 +53,7 @@ public abstract class BaseTestClass {
     protected static final String PATH_TO_AUTOFVT_TESTFILES = "lib/LibertyFATTestFiles/";
 
     protected static final String IMAGE_NAME = ImageNameSubstitutor.instance() //
-                    .apply(DockerImageName.parse("otel/opentelemetry-collector:0.127.0")).asCanonicalNameString();
+                    .apply(DockerImageName.parse("ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.127.0")).asCanonicalNameString();
 
     protected static void trustAll() throws Exception {
         try {

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSPApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSPApplicationTest.java
@@ -12,6 +12,7 @@ package io.openliberty.http.monitor.fat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.time.Duration;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.FileAsset;
@@ -24,6 +25,7 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -56,9 +58,11 @@ public class ContainerJSPApplicationTest extends BaseTestClass {
                     .withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME)
                                     .copy("/etc/otelcol/config.yaml", "/etc/otelcol/config.yaml"))
                     .withFileFromFile("/etc/otelcol/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
-                    .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector-contrib"))
+                    .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector"))
+                    .withExposedPorts(8888, 8889, 4317)
                     .withNetwork(network)
-                    .withExposedPorts(8888, 8889, 4317);
+                    .withNetworkAliases("otel-collector-metrics")
+                    .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Begin running and processing data.*").withStartupTimeout(Duration.ofMinutes(1)));
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(network)
@@ -83,7 +87,7 @@ public class ContainerJSPApplicationTest extends BaseTestClass {
         ShrinkHelper.exportDropinAppToServer(server, testWAR,
                                              DeployOptions.SERVER_ONLY);
 
-        server.addEnvVar("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://" + container.getHost() + ":" + container.getMappedPort(4317));
+        server.addEnvVar("OTEL_EXPORTER_OTLP_ENDPOINT", "http://" + container.getHost() + ":" + container.getMappedPort(4317));
         server.startServer();
 
         //Read to run a smarter planet

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSPApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerJSPApplicationTest.java
@@ -20,8 +20,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -45,18 +47,23 @@ public class ContainerJSPApplicationTest extends BaseTestClass {
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
-    @ClassRule
     public static RepeatTests rt = FATSuite.allMPRepeatsWithMPTel20OrLater(SERVER_NAME);
 
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
+    public static Network network = Network.newNetwork();
+
     //TODO remove withDockerfileFromBuilder and instead create a dockerfile
-    @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
                     .withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME)
-                                    .copy("/etc/otelcol-contrib/config.yaml", "/etc/otelcol-contrib/config.yaml"))
-                    .withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
+                                    .copy("/etc/otelcol/config.yaml", "/etc/otelcol/config.yaml"))
+                    .withFileFromFile("/etc/otelcol/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
                     .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector-contrib"))
+                    .withNetwork(network)
                     .withExposedPorts(8888, 8889, 4317);
+
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(network)
+                    .around(container)
+                    .around(rt);
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerNoAppTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerNoAppTest.java
@@ -12,6 +12,7 @@ package io.openliberty.http.monitor.fat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.time.Duration;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -21,6 +22,7 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import componenttest.annotation.Server;
@@ -55,9 +57,11 @@ public class ContainerNoAppTest extends BaseTestClass {
                     .withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME)
                                     .copy("/etc/otelcol/config.yaml", "/etc/otelcol/config.yaml"))
                     .withFileFromFile("/etc/otelcol/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
-                    .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector-contrib"))
+                    .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector"))
+                    .withExposedPorts(8888, 8889, 4317)
                     .withNetwork(network)
-                    .withExposedPorts(8888, 8889, 4317);
+                    .withNetworkAliases("otel-collector-metrics")
+                    .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Begin running and processing data.*").withStartupTimeout(Duration.ofMinutes(1)));
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(network)
                     .around(container)
@@ -66,7 +70,8 @@ public class ContainerNoAppTest extends BaseTestClass {
     @BeforeClass
     public static void beforeClass() throws Exception {
         trustAll();
-        server.addEnvVar("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://" + container.getHost() + ":" + container.getMappedPort(4317));
+        server.addEnvVar("OTEL_EXPORTER_OTLP_ENDPOINT", "http://" + container.getHost() + ":" + container.getMappedPort(4317));
+
         server.startServer();
 
         //Read to run a smarter planet

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerNoAppTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerNoAppTest.java
@@ -17,8 +17,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import componenttest.annotation.Server;
@@ -44,18 +46,22 @@ public class ContainerNoAppTest extends BaseTestClass {
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
-    @ClassRule
     public static RepeatTests rt = FATSuite.allMPRepeatsWithMPTel20OrLater(SERVER_NAME);
 
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
+    public static Network network = Network.newNetwork();
+
     //TODO remove withDockerfileFromBuilder and instead create a dockerfile
-    @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
                     .withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME)
-                                    .copy("/etc/otelcol-contrib/config.yaml", "/etc/otelcol-contrib/config.yaml"))
-                    .withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
+                                    .copy("/etc/otelcol/config.yaml", "/etc/otelcol/config.yaml"))
+                    .withFileFromFile("/etc/otelcol/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
                     .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector-contrib"))
+                    .withNetwork(network)
                     .withExposedPorts(8888, 8889, 4317);
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(network)
+                    .around(container)
+                    .around(rt);
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerRestApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerRestApplicationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,8 +21,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -53,18 +55,23 @@ public class ContainerRestApplicationTest extends BaseTestClass {
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
-    @ClassRule
     public static RepeatTests rt = FATSuite.allMPRepeatsWithMPTel20OrLater(SERVER_NAME);
 
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
+    public static Network network = Network.newNetwork();
+
     //TODO remove withDockerfileFromBuilder and instead create a dockerfile
-    @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
                     .withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME)
-                                    .copy("/etc/otelcol-contrib/config.yaml", "/etc/otelcol-contrib/config.yaml"))
-                    .withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
+                                    .copy("/etc/otelcol/config.yaml", "/etc/otelcol/config.yaml"))
+                    .withFileFromFile("/etc/otelcol/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
                     .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector-contrib"))
+                    .withNetwork(network)
                     .withExposedPorts(8888, 8889, 4317);
+
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(network)
+                    .around(container)
+                    .around(rt);
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerRestApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerRestApplicationTest.java
@@ -12,6 +12,7 @@ package io.openliberty.http.monitor.fat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.time.Duration;
 
 import javax.ws.rs.HttpMethod;
 
@@ -25,6 +26,7 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -64,9 +66,11 @@ public class ContainerRestApplicationTest extends BaseTestClass {
                     .withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME)
                                     .copy("/etc/otelcol/config.yaml", "/etc/otelcol/config.yaml"))
                     .withFileFromFile("/etc/otelcol/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
-                    .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector-contrib"))
+                    .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector"))
+                    .withExposedPorts(8888, 8889, 4317)
                     .withNetwork(network)
-                    .withExposedPorts(8888, 8889, 4317);
+                    .withNetworkAliases("otel-collector-metrics")
+                    .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Begin running and processing data.*").withStartupTimeout(Duration.ofMinutes(1)));
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(network)
@@ -86,7 +90,8 @@ public class ContainerRestApplicationTest extends BaseTestClass {
         ShrinkHelper.exportDropinAppToServer(server, testWAR,
                                              DeployOptions.SERVER_ONLY);
 
-        server.addEnvVar("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://" + container.getHost() + ":" + container.getMappedPort(4317));
+        server.addEnvVar("OTEL_EXPORTER_OTLP_ENDPOINT", "http://" + container.getHost() + ":" + container.getMappedPort(4317));
+
         server.startServer();
 
         //Read to run a smarter planet

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerServletApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerServletApplicationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,8 +19,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -49,18 +51,23 @@ public class ContainerServletApplicationTest extends BaseTestClass {
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
-    @ClassRule
     public static RepeatTests rt = FATSuite.allMPRepeatsWithMPTel20OrLater(SERVER_NAME);
 
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
+    public static Network network = Network.newNetwork();
+
     //TODO remove withDockerfileFromBuilder and instead create a dockerfile
-    @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
                     .withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME)
-                                    .copy("/etc/otelcol-contrib/config.yaml", "/etc/otelcol-contrib/config.yaml"))
-                    .withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
+                                    .copy("/etc/otelcol/config.yaml", "/etc/otelcol/config.yaml"))
+                    .withFileFromFile("/etc/otelcol/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
                     .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector-contrib"))
+                    .withNetwork(network)
                     .withExposedPorts(8888, 8889, 4317);
+
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(network)
+                    .around(container)
+                    .around(rt);
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerServletApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ContainerServletApplicationTest.java
@@ -12,6 +12,7 @@ package io.openliberty.http.monitor.fat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.time.Duration;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -23,6 +24,7 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -60,9 +62,11 @@ public class ContainerServletApplicationTest extends BaseTestClass {
                     .withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME)
                                     .copy("/etc/otelcol/config.yaml", "/etc/otelcol/config.yaml"))
                     .withFileFromFile("/etc/otelcol/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
-                    .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector-contrib"))
+                    .withLogConsumer(new SimpleLogConsumer(ContainerServletApplicationTest.class, "opentelemetry-collector"))
+                    .withExposedPorts(8888, 8889, 4317)
                     .withNetwork(network)
-                    .withExposedPorts(8888, 8889, 4317);
+                    .withNetworkAliases("otel-collector-metrics")
+                    .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Begin running and processing data.*").withStartupTimeout(Duration.ofMinutes(1)));
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(network)
@@ -91,7 +95,7 @@ public class ContainerServletApplicationTest extends BaseTestClass {
 
         ShrinkHelper.exportDropinAppToServer(server, wildCardServletWAR, DeployOptions.SERVER_ONLY);
 
-        server.addEnvVar("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://" + container.getHost() + ":" + container.getMappedPort(4317));
+        server.addEnvVar("OTEL_EXPORTER_OTLP_ENDPOINT", "http://" + container.getHost() + ":" + container.getMappedPort(4317));
 
         server.startServer();
 

--- a/dev/io.openliberty.http.monitor_fat/publish/files/config.yaml
+++ b/dev/io.openliberty.http.monitor_fat/publish/files/config.yaml
@@ -2,13 +2,13 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: otel-collector-metrics:4317
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: otel-collector-metrics:4318
 
 exporters:
   prometheus:
-    endpoint: "0.0.0.0:8889"
+    endpoint: otel-collector-metrics:8889
   debug:
     verbosity: basic
 

--- a/dev/io.openliberty.org.testcontainers/cache/externals
+++ b/dev/io.openliberty.org.testcontainers/cache/externals
@@ -5,6 +5,7 @@ elastic/logstash:7.16.3
 fbicodex/spnego-kdc-server:1.0
 ghcr.io/gvenzl/oracle-free:23-full-faststart
 ghcr.io/gvenzl/oracle-free:23-slim-faststart
+ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.127.0
 ghcr.io/testcontainers/ryuk:0.12.0
 ghcr.io/testcontainers/sshd:1.3.0
 ghcr.io/testcontainers/vnc-recorder:1.4.0

--- a/dev/io.openliberty.org.testcontainers/cache/images
+++ b/dev/io.openliberty.org.testcontainers/cache/images
@@ -9,6 +9,7 @@ wasliberty-aws-docker-remote/docker/library/postgres:17-alpine
 wasliberty-aws-docker-remote/docker/library/python:3.11.6
 wasliberty-ghcr-docker-remote/gvenzl/oracle-free:23-full-faststart
 wasliberty-ghcr-docker-remote/gvenzl/oracle-free:23-slim-faststart
+wasliberty-ghcr-docker-remote/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.127.0
 wasliberty-ghcr-docker-remote/testcontainers/ryuk:0.12.0
 wasliberty-ghcr-docker-remote/testcontainers/sshd:1.3.0
 wasliberty-ghcr-docker-remote/testcontainers/vnc-recorder:1.4.0


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Update to `opentelemetry-collector:0.127.0` from `0.103.0`. Also pulling from ghcr instead now.
################################################################################################

