### PR TITLE
Do not infer java:comp/env for datastore

### DIFF
--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -60,8 +60,10 @@ import jakarta.data.constraint.EqualTo;
 import jakarta.data.constraint.GreaterThan;
 import jakarta.data.constraint.In;
 import jakarta.data.constraint.LessThan;
+import jakarta.data.constraint.Like;
 import jakarta.data.constraint.NotBetween;
 import jakarta.data.constraint.NotEqualTo;
+import jakarta.data.constraint.NotIn;
 import jakarta.data.constraint.NotLike;
 import jakarta.data.constraint.NotNull;
 import jakarta.data.constraint.Null;
@@ -529,10 +531,14 @@ public class Data_1_1 implements DataVersionCompatibility {
             constraint = AttributeConstraint.In;
         else if (LessThan.class.equals(type))
             constraint = AttributeConstraint.LessThan;
+        else if (Like.class.equals(type))
+            constraint = AttributeConstraint.Like;
         else if (NotBetween.class.equals(type))
             constraint = AttributeConstraint.NotBetween;
         else if (NotEqualTo.class.equals(type))
             constraint = AttributeConstraint.Not;
+        else if (NotIn.class.equals(type))
+            constraint = AttributeConstraint.NotIn;
         else if (NotLike.class.equals(type))
             constraint = AttributeConstraint.NotLike;
         else if (NotNull.class.equals(type))

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/PersistenceUnitRepo.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/PersistenceUnitRepo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ import javax.sql.DataSource;
  * This repository has its dataStore set to a PersistenceUnit reference from DataStoreTestServlet
  * that is pointing to the MyPersistenceUnit persistence-unit in persistence.xml
  */
-@Repository(dataStore = "persistence/MyPersistenceUnitRef") // java:comp/env/ is implied
+@Repository(dataStore = "java:comp/env/persistence/MyPersistenceUnitRef")
 public interface PersistenceUnitRepo {
 
     Connection connection();

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/test-applications/DataJPAHibernateIntegrationApp/src/test/jakarta/data/jpa/hibernate/integration/web/Segments.java
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/test-applications/DataJPAHibernateIntegrationApp/src/test/jakarta/data/jpa/hibernate/integration/web/Segments.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import jakarta.data.repository.Save;
 @Repository(provider = "Liberty",
             // NOTE: Repository API JavaDoc requires use of a
             // PersistenceUnit reference (not name)
-            dataStore = "jpa/LibertyProvider")
+            dataStore = "java:comp/env/jpa/LibertyProvider")
 public interface Segments {
 
     @Delete


### PR DESCRIPTION
As discussed during the team meeting, Jakarta Data repositories should not infer java:comp/env on a dataStore name that lacks that namespace.
Also, this fixes a bug in other Jakarta Data that was missing two constraints.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
