### PR TITLE
LTPA Token Generation should happen after security service has started

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
+++ b/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
@@ -23,6 +23,8 @@ WS-TraceGroup: \
 Import-Package: \
 	!*.internal.*,\
 	!com.ibm.ws.kernel.boot.cmdline,\
+    com.ibm.ws.security, \
+    com.ibm.ws.security.registry, \
 	*
 
 Export-Package: com.ibm.ws.security.token.ltpa
@@ -86,6 +88,7 @@ instrument.classesExcludes: com/ibm/ws/security/token/ltpa/internal/resources/*.
 	com.ibm.ws.security.token;version=latest,\
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.websphere.org.osgi.core,\
+    com.ibm.ws.security;version=latest,\
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.websphere.appserver.spi.kernel.filemonitor,\
 	com.ibm.websphere.appserver.spi.kernel.service,\
@@ -97,6 +100,7 @@ instrument.classesExcludes: com/ibm/ws/security/token/ltpa/internal/resources/*.
 	com.ibm.ws.logging;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.security.fat.common;version=latest,\
+    com.ibm.ws.security.registry;version=latest,\
 	com.ibm.ws.config;version=latest
 
 -testpath: \


### PR DESCRIPTION
We need to make sure that the LTPA Token Generation happens after the security service starts.


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".