### PR TITLE
Fix Max Open Connections in Websocket Netty

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/TransportHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/TransportHandler.java
@@ -69,7 +69,7 @@ public final class TransportHandler extends ChannelDuplexHandler{
                 ChannelPipeline pipeline = context.pipeline();
                 pipeline.remove(TransportHandler.this);
                 removeIfPresent(pipeline, HttpServerCodec.class);
-                removeIfPresent(pipeline, MaxOpenConnectionsHandler.class);
+                // removeIfPresent(pipeline, MaxOpenConnectionsHandler.class);
                 removeIfPresent(pipeline, TimeoutHandler.class);
 
                 if(pipeline.get(NettyServletUpgradeHandler.class) == null){

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/TransportHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/TransportHandler.java
@@ -69,7 +69,6 @@ public final class TransportHandler extends ChannelDuplexHandler{
                 ChannelPipeline pipeline = context.pipeline();
                 pipeline.remove(TransportHandler.this);
                 removeIfPresent(pipeline, HttpServerCodec.class);
-                // removeIfPresent(pipeline, MaxOpenConnectionsHandler.class);
                 removeIfPresent(pipeline, TimeoutHandler.class);
 
                 if(pipeline.get(NettyServletUpgradeHandler.class) == null){


### PR DESCRIPTION
Fixed missing logic for peer connection closing and fixed removal of max open connections when upgrading to a websocket request