### PR TITLE
Netty wc server http unit

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerHttpUnit.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerHttpUnit.java
@@ -97,7 +97,8 @@ public class WCServerHttpUnit {
     // Integer.MAX_VALUE is 2^31-1, or 2,147,483,647.
     // 'sendPostRequest' does writes of the requested length,
     // making for a very, very, long test.
-    // @Test
+    // Fails in netty due to https://github.com/OpenLiberty/open-liberty/issues/30702
+    @Test
     @Mode(TestMode.FULL)
     public void testSendContentLengthLongLong_test() throws Exception {
         long len = Integer.MAX_VALUE + 32769L;


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Related to https://github.com/OpenLiberty/open-liberty/pull/32330

Will fail in Netty, but we don't want to loose GA coverage.