### PR TITLE
Netty fix API after update to legacy Request Context classes

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/inbound/NettyTCPReadRequestContext.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/inbound/NettyTCPReadRequestContext.java
@@ -11,6 +11,7 @@ package com.ibm.ws.http.netty.inbound;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
@@ -80,6 +81,11 @@ public class NettyTCPReadRequestContext implements TCPReadRequestContext {
     @Override
     public TCPConnectionContext getInterface() {
         return this.connectionContext;
+    }
+
+    @Override
+    public Socket getSocket() {
+        throw new UnsupportedOperationException("Can not get the socket from a Netty connection!");
     }
 
     /**

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/inbound/NettyTCPWriteRequestContext.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/inbound/NettyTCPWriteRequestContext.java
@@ -10,6 +10,7 @@
 package com.ibm.ws.http.netty.inbound;
 
 import java.io.IOException;
+import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -98,6 +99,11 @@ public class NettyTCPWriteRequestContext implements TCPWriteRequestContext {
 
     public void setStreamId(String streamId) {
         this.streamID = streamId;
+    }
+
+    @Override
+    public Socket getSocket() {
+        throw new UnsupportedOperationException("Can not get the socket from a Netty connection!");
     }
 
     @Override


### PR DESCRIPTION
Added missing API after update to request context classes for zOS feature request. Triggered by changes merged on https://github.com/OpenLiberty/open-liberty/pull/31246

fixes #32339