### PR TITLE
Netty: HttpRequest.getURL returns requested URL as-is

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
@@ -417,12 +417,16 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
 
     @Override
     public StringBuffer getRequestURL() {
-
-        String host = context.getLocalAddr().getCanonicalHostName();
-        int port = context.getLocalPort();
-
-        return new StringBuffer(getScheme() + "://" + host + ":" + port + getRequestURI());
-
+        StringBuffer sb = new StringBuffer(getScheme() + "://");
+        sb.append(getTargetHost());
+        sb.append(':');
+        sb.append(getTargetPort());
+        sb.append(getRequestURI());
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "getRequestURL() returning [" + sb.toString() + "]");
+        }
+        
+        return sb;
     }
 
     @Override


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #32342


