### PR TITLE
Small cleanup from recent updates

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.internal.common/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.internal.common/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -47,8 +47,7 @@ WS-TraceGroup: MPOPENAPI
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	com.ibm.wsspi.org.osgi.service.event;version=latest,\
-	org.apache.commons.lang3
+	com.ibm.wsspi.org.osgi.service.event;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file

--- a/dev/io.openliberty.org.jctools/.classpath
+++ b/dev/io.openliberty.org.jctools/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>


### PR DESCRIPTION
- Remove non existent source path from .classpath
- Remove org.apache.commons.lang3 from the buildpath.  It should be com.ibm.ws.org.apache.commons.lang3 if it is needed, but it appears not to be needed so just removing it.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
