### PR TITLE
Reverting to legacy split() behavior

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/genericbnf/internal/BNFHeadersImpl.java
@@ -4528,7 +4528,7 @@ public abstract class BNFHeadersImpl implements BNFHeaders, Externalizable {
 
                 //Note that HTTP list allows white spaces between the identifiers, as such,
                 //trim the string before evaluating.
-                node = value.replaceAll("\\s", "");;
+                node = value.trim();
                 try {
                     nodeExtract = node.substring(node.indexOf("=") + 1);
                 } catch (IndexOutOfBoundsException e) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".