### PR TITLE
use SHA-256

### DIFF
--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/encryption/AuditKeyEncryptor.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/encryption/AuditKeyEncryptor.java
@@ -19,7 +19,7 @@ import com.ibm.ws.security.audit.source.utils.ByteArray;
  * A package local class for performing encryption and decryption of keys based on a key
  */
 public class AuditKeyEncryptor {
-    private final String algorithm = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    private final String algorithm = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256; // Semerun 1.8 does not support string SHA256
     byte[] password;
     byte[] passwordDigestBytes;
     AuditCrypto des;


### PR DESCRIPTION
Semeru version  1.8 does not recognize the SHA256 for getting the message digest instance. 
It supports SHA-256.