### PR TITLE
Use date-time cache for HTTP access logging

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/values/AccessLogCurrentTime.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/values/AccessLogCurrentTime.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2020 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,9 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.http.channel.internal.values;
 
-import java.util.Date;
-
 import com.ibm.ws.http.dispatcher.internal.HttpDispatcher;
+import com.ibm.ws.http.internal.HttpDateFormatImpl;
 import com.ibm.wsspi.http.channel.HttpRequestMessage;
 import com.ibm.wsspi.http.channel.HttpResponseMessage;
 
@@ -44,7 +43,7 @@ public class AccessLogCurrentTime extends AccessLogData {
                        HttpResponseMessage response, HttpRequestMessage request, Object data) {
         if (data == null) {
             long currentTime = System.currentTimeMillis();
-            String currentTimeFormatted = "[" + HttpDispatcher.getDateFormatter().getNCSATime(new Date(currentTime)) + "]";
+            String currentTimeFormatted = "[" + ((HttpDateFormatImpl) HttpDispatcher.getDateFormatter()).getNCSATime(currentTime, true) + "]";
             accessLogEntry.append(currentTimeFormatted);
             accessLogDatetime.set(currentTime);
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/values/AccessLogStartTime.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/values/AccessLogStartTime.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2020 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package com.ibm.ws.http.channel.internal.values;
 
-import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import com.ibm.ws.http.channel.internal.HttpRequestMessageImpl;
 import com.ibm.ws.http.dispatcher.internal.HttpDispatcher;
+import com.ibm.ws.http.internal.HttpDateFormatImpl;
 import com.ibm.wsspi.http.channel.HttpRequestMessage;
 import com.ibm.wsspi.http.channel.HttpResponseMessage;
 
@@ -37,8 +37,7 @@ public class AccessLogStartTime extends AccessLogData {
         long startTime = getStartTime(response, request, data);
 
         if (startTime != 0) {
-            Date startDate = new Date(startTime);
-            String formattedDate = "[" + HttpDispatcher.getDateFormatter().getNCSATime(startDate) + "]";
+            String formattedDate = "[" + ((HttpDateFormatImpl) HttpDispatcher.getDateFormatter()).getNCSATime(startTime, false) + "]";
             accessLogEntry.append(formattedDate);
             accessLogStartTime.set(startTime);
         } else {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

HTTP access logging currently formats a new date for every timestamp, which is cpu-intensive. This PR modifies that so that access logging uses the cached time mechanism already in place for HTTP messages. 