### PR TITLE
Use jpackcore to process java dump files on newer Semeru versions

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -1624,7 +1624,7 @@ public class LibertyClient {
                         Log.info(c, "runJextract stderr", output.getStderr());
                         Log.info(c, "runJextract", "rc = " + output.getReturnCode());
                     } else {
-                        Log.info(c, "runJextract stdout", "Skipping, unable to find jpackcore or jextract to run");
+                        Log.info(c, "runJextract", "Skipping, unable to find jpackcore or jextract to run");
                     }
                 }
             }

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -1605,15 +1605,27 @@ public class LibertyClient {
 
                     Properties envVars = new Properties();
                     envVars.setProperty("JAVA_HOME", machineJava);
-                    Log.info(c, "runJextract", "Running jextract on file: " + filename);
 
                     String outputFilename = filename + ".zip.DMP"; //adding .DMP to ensure it is collected even when not collecting archives
-                    String cmd = machineJava + "/bin/jextract";
-                    String[] parms = new String[] { filename, outputFilename };
-                    ProgramOutput output = machine.execute(cmd, parms, clientFolder.getAbsolutePath(), envVars);
-                    Log.info(c, "runJextract stdout", output.getStdout());
-                    Log.info(c, "runJextract stderr", output.getStderr());
-                    Log.info(c, "runJextract", "rc = " + output.getReturnCode());
+                    String tool = null;
+
+                    if (new File(machineJava + "/bin/jpackcore").exists()) {
+                        tool = "jpackcore";
+                    } else if (new File(machineJava + "/bin/jextract").exists()) {
+                        tool = "jextract";
+                    }
+
+                    if (tool != null) {
+                        String cmd = machineJava + "/bin/" + tool;
+                        Log.info(c, "runJextract", "Running " + tool + " on file: " + filename);
+                        String[] parms = new String[] { filename, outputFilename };
+                        ProgramOutput output = machine.execute(cmd, parms, clientFolder.getAbsolutePath(), envVars);
+                        Log.info(c, "runJextract stdout", output.getStdout());
+                        Log.info(c, "runJextract stderr", output.getStderr());
+                        Log.info(c, "runJextract", "rc = " + output.getReturnCode());
+                    } else {
+                        Log.info(c, "runJextract stdout", "Skipping, unable to find jpackcore or jextract to run");
+                    }
                 }
             }
         }

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1738,8 +1738,7 @@ public class LibertyServer implements LogMonitorClient {
         if (isFIPS140_3EnabledAndSupported(info) || isFIPS140_2EnabledAndSupported(info)) {
             if (!GLOBAL_ENHANCED_ALGO) {
                 JVM_ARGS += getJvmArgString(this.getFipsJvmOptions(info, false));
-            }else
-            {
+            } else {
                 JVM_ARGS += getJvmArgString(this.getEnhancedAlgorithmOptions());
             }
         }
@@ -3946,15 +3945,27 @@ public class LibertyServer implements LogMonitorClient {
                 if (filename.endsWith(".dmp")) {
                     Properties useEnvVars = new Properties();
                     useEnvVars.setProperty("JAVA_HOME", machineJava);
-                    Log.info(c, "runJextract", "Running jextract on file: " + filename);
 
                     String outputFilename = filename + ".zip.DMP"; //adding .DMP to ensure it is collected even when not collecting archives
-                    String cmd = machineJava + "/bin/jextract";
-                    String[] parms = new String[] { filename, outputFilename };
-                    ProgramOutput output = machine.execute(cmd, parms, serverFolder.getAbsolutePath(), useEnvVars);
-                    Log.info(c, "runJextract stdout", output.getStdout());
-                    Log.info(c, "runJextract stderr", output.getStderr());
-                    Log.info(c, "runJextract", "rc = " + output.getReturnCode());
+                    String tool = null;
+
+                    if (new File(machineJava + "/bin/jpackcore").exists()) {
+                        tool = "jpackcore";
+                    } else if (new File(machineJava + "/bin/jextract").exists()) {
+                        tool = "jextract";
+                    }
+
+                    if (tool != null) {
+                        String cmd = machineJava + "/bin/" + tool;
+                        Log.info(c, "runJextract", "Running " + tool + " on file: " + filename);
+                        String[] parms = new String[] { filename, outputFilename };
+                        ProgramOutput output = machine.execute(cmd, parms, serverFolder.getAbsolutePath(), useEnvVars);
+                        Log.info(c, "runJextract stdout", output.getStdout());
+                        Log.info(c, "runJextract stderr", output.getStderr());
+                        Log.info(c, "runJextract", "rc = " + output.getReturnCode());
+                    } else {
+                        Log.info(c, "runJextract stdout", "Skipping, unable to find jpackcore or jextract to run");
+                    }
                 }
             }
         }

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3964,7 +3964,7 @@ public class LibertyServer implements LogMonitorClient {
                         Log.info(c, "runJextract stderr", output.getStderr());
                         Log.info(c, "runJextract", "rc = " + output.getReturnCode());
                     } else {
-                        Log.info(c, "runJextract stdout", "Skipping, unable to find jpackcore or jextract to run");
+                        Log.info(c, "runJextract", "Skipping, unable to find jpackcore or jextract to run");
                     }
                 }
             }


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

I saw this error in an output.txt file:
```
[07/29/2025 13:26:54:938 PDT] 002 LibertyServer                  runJextract                    I Running jextract on file: /home/ci/Build/workspace/ebcTestRunner/dev/autoFVT/image/output/wlp/usr/servers/JPA10EJBEntityServer/jitdump.20250729.132630.48231.0004.dmp
[07/29/2025 13:26:54:953 PDT] 002 LibertyServer                  runJextract stdout             I sh: line 1: /home/ci/Build/workspace/ebcTestRunner/dev/jvm/undertest/jdk-21.0.7+6/bin/jextract: No such file or directory

[07/29/2025 13:26:54:954 PDT] 002 LibertyServer                  runJextract stderr             I 
[07/29/2025 13:26:54:954 PDT] 002 LibertyServer                  runJextract                    I rc = 127
```

For newer versions of Semeru, jpackcore should be used instead of jextract.  So attempt to look for jcorepack first, then jextract, otherwise exit more gracefully.