### PR TITLE
Added comments for MD5, DES, RC4 constants in the context of FIPS 140-3

### DIFF
--- a/dev/com.ibm.ws.ssl/src/com/ibm/websphere/ssl/Constants.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/websphere/ssl/Constants.java
@@ -296,7 +296,9 @@ public class Constants {
     // unknown cipher
     public static final String SSL_UNKNOWN_CIPHER = "UNKNOWN_CIPHER";
 
-    /** SSL V2 cipher specifications */
+    // FIPS 140-3: Algorithm assessment complete; no changes required.
+    // These constants are unused with FIPS enabled, but cannot update them as they would break the backward compatibility.
+   /** SSL V2 cipher specifications */
     public static final String SSL_CK_RC4_128_WITH_MD5 = "SSL_CK_RC4_128_WITH_MD5",
                     SSL_CK_RC4_128_EXPORT40_WITH_MD5 = "SSL_CK_RC4_128_EXPORT40_WITH_MD5",
                     SSL_CK_RC2_128_CBC_WITH_MD5 = "SSL_CK_RC2_128_CBC_WITH_MD5",


### PR DESCRIPTION
Added comments for MD5, DES, RC4 constants in the context of FIPS 140-3 feature.
These constants are just string definitions and don't introduce any security vulnerabilities by their mere presence. 