### PR TITLE
Added a fips check for the wssecurity's older algorithms

### DIFF
--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/signature/SignatureAlgorithms.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/signature/SignatureAlgorithms.java
@@ -48,7 +48,7 @@ public class SignatureAlgorithms {
     static final String hmac_sha512 = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha512";
 
     static Map<String, String> RSA_MAP = new HashMap<String, String>();
-    boolean fipsEnabled = CryptoUtils.isFips140_3EnabledWithBetaGuard();
+    static boolean fipsEnabled = CryptoUtils.isFips140_3EnabledWithBetaGuard();
     static {
         if (!fipsEnabled){
         RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1.toLowerCase(), rsa_sha1);}

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/signature/SignatureAlgorithms.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/signature/SignatureAlgorithms.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020,2023 IBM Corporation and others.
+ * Copyright (c) 2020,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -48,8 +48,10 @@ public class SignatureAlgorithms {
     static final String hmac_sha512 = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha512";
 
     static Map<String, String> RSA_MAP = new HashMap<String, String>();
+    boolean fipsEnabled = CryptoUtils.isFips140_3EnabledWithBetaGuard();
     static {
-        RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1.toLowerCase(), rsa_sha1);
+        if (!fipsEnabled){
+        RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1.toLowerCase(), rsa_sha1);}
         RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256.toLowerCase(), rsa_sha256);
         RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA384.toLowerCase(), rsa_sha384);
         RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512.toLowerCase(), rsa_sha512);
@@ -57,7 +59,8 @@ public class SignatureAlgorithms {
 
     static Map<String, String> HMAC_MAP = new HashMap<String, String>();
     static {
-        HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1.toLowerCase(), hmac_sha1);
+        if (!fipsEnabled){
+        HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1.toLowerCase(), hmac_sha1);}
         HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256.toLowerCase(), hmac_sha256);
         HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA384.toLowerCase(), hmac_sha384);
         HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512.toLowerCase(), hmac_sha512);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

For ./dev/com.ibm.ws.wssecurity.3.4.1 It looks like we're appending the older algs to the rsa_map and hmac_map and setting the signatures like so: https://github.com/OpenLiberty/open-liberty/blob/7739f141e46f293a3a1bb1ab5f30a2634f3a966b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/signature/SignatureAlgorithms.java#L52. 

As a result, I have beta-guarded the older algorithms.

################################################################################################
