### PR TITLE
add comments for using SHA512 message digest algorithm - com.ibm.ws.ui

### DIFF
--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/ToolDataAPI.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/rest/v1/ToolDataAPI.java
@@ -49,6 +49,8 @@ import com.ibm.ws.common.crypto.CryptoUtils;
  * the returned tool data.</p>
  *
  * <p>Maps to host:port/ibm/api/adminCenter/v1/tooldata</p>
+ *
+ * The algorithm assessment of FIPS 140-3 by updating SHA512 checksum is based on slack discussion with component SMEs.
  */
 public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
     private final IToolDataService toolDataService;
@@ -96,7 +98,7 @@ public class ToolDataAPI extends CommonRESTHandler implements V1Constants {
 
     /**
      * Gets the tool data of for the giving tool/user.
-     * When the tool data is returned, a sha5125 checksum of the data is also returned using the Response's HTTP header Etag.
+     * When the tool data is returned, a sha512 checksum of the data is also returned using the Response's HTTP header Etag.
      *
      *
      * {@inheritDoc}

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/utils/Utils.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/utils/Utils.java
@@ -33,6 +33,7 @@ import com.ibm.wsspi.rest.handler.RESTRequest;
 
 /**
  * This class is designed to hold utility methods that different parts of the server side UI will need to use.
+ * The algorithm assessment of FIPS 140-3 by updating SHA512 message digest algorithm is based on slack discussion with component SMEs.
  */
 public class Utils {
     private static final TraceComponent tc = Tr.register(Utils.class);

--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/TooldataAPIv1Test.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/TooldataAPIv1Test.java
@@ -39,7 +39,7 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 /**
- *
+ * The algorithm assessment of FIPS 140-3 by updating SHA512 checksum is based on slack discussion with component SMEs.   
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)


### PR DESCRIPTION
Add comment for using SHA512 in the recent update:
https://github.com/OpenLiberty/open-liberty/pull/32244  (OL: com.ibm.ws.ui and com.ibm.ws.ui_rest_fat)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
