### PR TITLE
Changes to the queue implementation used for Liberty ThreadPool

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ConcurrentPriorityBlockingQueue.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ConcurrentPriorityBlockingQueue.java
@@ -14,7 +14,9 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -83,6 +85,64 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
         }
     }
 
+    private static ConcurrentLinkedQueue<GetQueueLock> waitingThreadLocks = new ConcurrentLinkedQueue<GetQueueLock>();
+
+    private static final ThreadLocal<GetQueueLock> threadLocalGetLock = new ThreadLocal<GetQueueLock>() {
+        @Override
+        protected GetQueueLock initialValue() {
+            return new GetQueueLock();
+        }
+    };
+
+    // D638088: Added two fields to the getQueueLock for book keeping
+    // D371967: An easily-identified marker class used for locking
+    private static class GetQueueLock extends Object {
+        private boolean notified;
+
+        public boolean isNotified() {
+            return notified;
+        }
+
+        public void setNotified(boolean notified) {
+            this.notified = notified;
+        }
+    }
+
+    private void notifyGet_() {
+        // Notify a waiting thread that work has arrived on the queue.  A notification may be lost in some cases - however as none of the
+        // threads wait endlessly, a waiting thread will either be notified, or will eventually wake up.  If there are no waiting threads,
+        // the new work will be picked up when an active thread completes its task.
+        GetQueueLock lock = waitingThreadLocks.poll();
+        if (lock != null) {
+            synchronized (lock) {
+                lock.setNotified(true);
+                lock.notify();
+            }
+        }
+    }
+
+    private GetQueueLock waitGet_(GetQueueLock getQueueLock, long timeout) throws InterruptedException {
+        if (getQueueLock == null) {
+            getQueueLock = threadLocalGetLock.get();
+        }
+
+        try {
+            synchronized (getQueueLock) {
+                getQueueLock.setNotified(false);
+                waitingThreadLocks.add(getQueueLock);
+                getQueueLock.wait(timeout == -1 ? 0 : timeout);
+            }
+        } finally {
+            if (!getQueueLock.isNotified()) {
+                // we either timed out or were interrupted, so remove ourselves from the queue...  it's okay if a producer already has the
+                // lock because we're going to exit and go try to get more work anyway, so it's okay if we don't get the signal
+                waitingThreadLocks.remove(getQueueLock);
+            }
+        }
+
+        return getQueueLock;
+    }
+
     final Head<T> expeditedHead;
 
     final AtomicReference<Node<T>> expeditedTail = new AtomicReference<>();
@@ -94,7 +154,7 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
     /**
      * Count of items available for poll/removal.
      */
-    final ReduceableSemaphore size = new ReduceableSemaphore(0, false);
+    final AtomicInteger size = new AtomicInteger(0);
 
     /**
      * The currentHead field is set to nonExpeditedHead initially until an expedited item is added to the queue
@@ -204,7 +264,7 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
 
     @Override
     public boolean isEmpty() {
-        return size.availablePermits() <= 0;
+        return size.get() <= 0;
     }
 
     @Override
@@ -290,7 +350,7 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
             }
             T prevItem = node.get();
             if (prevItem != null && node.compareAndSet(prevItem, null)) {
-                size.reducePermits(1);
+                size.getAndDecrement();
             }
             // Null out unconditionally since a remove on the queue could be called at the same time
             // as remove on the iterator which would cause the above if statement to not process.
@@ -344,12 +404,13 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
                 // if we win the race to update the tail's next, the new item is added to the queue
                 if (currentTail.next.compareAndSet(end, newTail)) {
                     // increase the queue size
-                    size.release();
+                    size.getAndIncrement();
 
                     // don't update the tail each time.  update the tail on a later insert into the queue
                     if (currentTail != startingTail) {
                         tail.compareAndSet(startingTail, newTail);
                     }
+                    notifyGet_();
                     return true;
                 }
 
@@ -388,7 +449,7 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
         Head<T> head = currentHead.get();
         T first = getFirstWithAction(head, null, REMOVE_FIRST_ITEM);
         if (first != null) {
-            size.reducePermits(1);
+            size.getAndDecrement();
         }
         return first;
     }
@@ -399,17 +460,22 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
         if (first != null) {
             return first;
         }
-        for (long start = System.nanoTime(), remain = timeout = unit.toNanos(timeout); //
-                        remain >= 0 && size.tryAcquire(remain, TimeUnit.NANOSECONDS); //
-                        remain = timeout - (System.nanoTime() - start)) {
-            Head<T> head = currentHead.get();
-            first = getFirstWithAction(head, null, REMOVE_FIRST_ITEM);
+
+        long timeLeftMillis = unit.toMillis(timeout);
+        long endTimeMillis = System.currentTimeMillis() + timeLeftMillis;
+        GetQueueLock getQueueLock = null;
+
+        while (first == null && timeLeftMillis > 0) {
+            // block on lock
+            getQueueLock = waitGet_(getQueueLock, timeLeftMillis);
+            first = poll();
             if (first != null) {
-                return first;
+                break;
             }
-            size.release(); // another thread is removing, put the permit back
+
+            timeLeftMillis = endTimeMillis - System.currentTimeMillis();
         }
-        return null;
+        return first;
     }
 
     @Override
@@ -470,7 +536,7 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
                 prev.next.compareAndSet(current, next);
             }
             if (removed) {
-                size.reducePermits(1);
+                size.getAndDecrement();
                 return true;
             }
         }
@@ -479,7 +545,7 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
 
     @Override
     public final int size() {
-        int s = size.availablePermits();
+        int s = size.get();
         return s < 0 ? 0 : s;
     }
 
@@ -490,16 +556,15 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
             return first;
         }
 
-        while (true) {
-            size.acquire();
+        GetQueueLock getQueueLock = null;
 
-            Head<T> head = currentHead.get();
-            first = getFirstWithAction(head, null, REMOVE_FIRST_ITEM);
-            if (first != null) {
-                return first;
-            }
-            size.release(); // another thread is removing, put the permit back
+        while (first == null) {
+            // block on lock
+            getQueueLock = waitGet_(getQueueLock, -1);
+            first = poll();
         }
+
+        return first;
     }
 
     <F> F getFirstWithAction(Head<T> head, Node<T> end, FirstAction<T, F> firstAction) {
@@ -628,7 +693,7 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
-        b.append(size.availablePermits()).append(' ');
+        b.append(size.get()).append(' ');
         Iterator<T> it = iterator();
         if (!it.hasNext()) {
             b.append("[]");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
