### PR TITLE
java.lang.StringBuffer.append failed because session is null

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -864,13 +864,16 @@ public class SessionCacheTestServlet extends FATServlet {
     public void testStringBufferAppendWithoutSetAttribute(HttpServletRequest request, HttpServletResponse response) throws Exception {
         String key = request.getParameter("key");
         HttpSession session = request.getSession(true);
-        StringBuffer value = (StringBuffer) session.getAttribute(key);
-        value.append("Appended");
+        if (session != null) {
+            StringBuffer value = (StringBuffer) session.getAttribute(key);
+            value.append("Appended");
+        }
     }
 
     public void testTimeoutExtensionA(HttpServletRequest request, HttpServletResponse response) throws Exception {
         HttpSession session = request.getSession(true);
-        session.setMaxInactiveInterval(500); // seconds
+        if (session != null)
+            session.setMaxInactiveInterval(500); // seconds
     }
 
     public void testTimeoutExtensionB(HttpServletRequest request, HttpServletResponse response) throws Exception {

--- a/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat/test-applications/sessionCacheApp/src/session/cache/web/SessionCacheTestServlet.java
@@ -866,7 +866,8 @@ public class SessionCacheTestServlet extends FATServlet {
         HttpSession session = request.getSession(true);
         if (session != null) {
             StringBuffer value = (StringBuffer) session.getAttribute(key);
-            value.append("Appended");
+            if (value!= null)
+                value.append("Appended");
         }
     }
 


### PR DESCRIPTION
java.lang.NullPointerException: Cannot invoke "java.lang.StringBuffer.append(java.lang.String)" because "value" is null
at session.cache.web.SessionCacheTestServlet.testStringBufferAppendWithoutSetAttribute(SessionCacheTestServlet.java:863)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at componenttest.app.FATServlet.doGet(FATServlet.java:69)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:686)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:791)
at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1260)
at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:748)
at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:445)
at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1361)
at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1077)
at com.ibm.ws.webcontainer.servlet.CacheServletWrapper.handleRequest(CacheServletWrapper.java:77)
at com.ibm.ws.webcontainer40.servlet.CacheServletWrapper40.handleRequest(CacheServletWrapper40.java:87)
at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:969)
at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:293)
at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1260)
at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:476)
at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:435)
at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:569)
at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:503)
at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:363)
at com.ibm.ws.http.channel.internal.inbound.HttpICLReadCallback.complete(HttpICLReadCallback.java:72)
at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:516)
at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:586)
at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:970)
at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1059)
at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:280)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
at java.base/java.lang.Thread.run(Thread.java:857)

at com.ibm.ws.session.cache.fat.FATSuite.run(FATSuite.java:79)
at com.ibm.ws.session.cache.fat.SessionCacheApp.invokeServlet(SessionCacheApp.java:38)
at com.ibm.ws.session.cache.fat.SessionCacheTwoServerTest.testModifyWithoutPut(SessionCacheTwoServerTest.java:241)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:203)
at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:145)
at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:363)
at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:177)
at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:145)