### PR TITLE
Use the spec defined name

### DIFF
--- a/dev/com.ibm.ws.dynacache.web/src/com/ibm/ws/cache/servlet/WebServicesCacheProcessor.java
+++ b/dev/com.ibm.ws.dynacache.web/src/com/ibm/ws/cache/servlet/WebServicesCacheProcessor.java
@@ -43,7 +43,7 @@ public class WebServicesCacheProcessor extends FragmentCacheProcessor {
    // id constants for type=BODY
    public static final String HASH = "Hash";
    public static final String LITERAL = "Literal";
-   private static final String HASH_TYPE = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256 : CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA;
+   private static final String HASH_TYPE = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256 : CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA;
 
    SAXParserFactory factory = null;
    SAXParser parser = null;

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
@@ -209,9 +209,8 @@ public class ArtifactDownloader implements AutoCloseable {
 
         checksumFormats[3] = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5;
         checksumFormats[2] = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1;
-        checksumFormats[1] = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
-        checksumFormats[0] = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512;
-
+        checksumFormats[1] = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
+        checksumFormats[0] = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_512;
 
         dLocation = FormatPathSuffix(dLocation);
         String repo = FormatUrlSuffix(repository.getRepositoryUrl());

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
@@ -156,7 +156,7 @@ public class ArtifactDownloaderUtils {
     }
 
     public static String getChecksum(String filename, String format) throws NoSuchAlgorithmException, IOException {
-        if (format.equals(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256)) {
+        if (format.equals(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256)) {
             format = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
         }
         byte[] b = createChecksum(filename, format);

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/class_scanner/ano/EntityMappingsScannerResults.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/class_scanner/ano/EntityMappingsScannerResults.java
@@ -32,7 +32,7 @@ import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ClassInform
 import com.ibm.ws.common.crypto.CryptoUtils;
 
 public class EntityMappingsScannerResults {
-    private final String shaDigestAlg = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    private final String shaDigestAlg = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
     public static final String KEY_SHA256HASH = "SHA256HASH"; // Value is a String
     public static final String KEY_CITXML = "CITXML";   // Value is byte[]
     

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/ormparser/Constants.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/ormparser/Constants.java
@@ -17,7 +17,7 @@ import com.ibm.ws.common.crypto.CryptoUtils;
 
 public final class Constants {
     public final static String JVM_Property_ORMXML_DIGEST_ALGORITHM = "jpaormviewer.ormxml.digest.algorithm";
-    public final static String DEFAULT_DIGEST_ALGORITHM = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    public final static String DEFAULT_DIGEST_ALGORITHM = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
 
     public final static String JPA_10_JAXB_PACKAGE = "com.ibm.ws.jpa.diagnostics.ormparser.jaxb.orm10xml";
     public final static String JPA_20_JAXB_PACKAGE = "com.ibm.ws.jpa.diagnostics.ormparser.jaxb.orm20xml";

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puparser/Constants.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puparser/Constants.java
@@ -17,7 +17,7 @@ import com.ibm.ws.common.crypto.CryptoUtils;
 
 public final class Constants {
     public final static String JVM_Property_PXML_DIGEST_ALGORITHM = "jpaormviewer.pxml.digest.algorithm";
-    public final static String DEFAULT_DIGEST_ALGORITHM = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    public final static String DEFAULT_DIGEST_ALGORITHM = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
 
     public final static String JPA_10_JAXB_PACKAGE = "com.ibm.ws.jpa.diagnostics.puparser.jaxb.puxml10";
     public final static String JPA_20_JAXB_PACKAGE = "com.ibm.ws.jpa.diagnostics.puparser.jaxb.puxml20";

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/utils/encapsulation/EncapsulatedData.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/utils/encapsulation/EncapsulatedData.java
@@ -44,9 +44,9 @@ import com.ibm.ws.common.crypto.CryptoUtils;
 import com.ibm.ws.common.crypto.CryptoUtils;
 
 public class EncapsulatedData {
-    private final String shaDigestAlg = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    private final String shaDigestAlg = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
     public static EncapsulatedData createEncapsulatedData(String name, String id, byte[] data) throws Exception {
-        return createEncapsulatedData(name, id, CompressionType.GZIP, CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256, data);
+        return createEncapsulatedData(name, id, CompressionType.GZIP, CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256, data);
     }
 
     public static EncapsulatedData createEncapsulatedData(String name, String id, CompressionType ct,

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/CryptoUtils.java
@@ -40,13 +40,9 @@ public class CryptoUtils {
     private static boolean issuedBetaMessage = false;
 
     public static final String MESSAGE_DIGEST_ALGORITHM_SHA_128 = "SHA-128";
-    public static final String MESSAGE_DIGEST_ALGORITHM_SHA128 = "SHA128";
     public static final String MESSAGE_DIGEST_ALGORITHM_SHA_256 = "SHA-256";
-    public static final String MESSAGE_DIGEST_ALGORITHM_SHA256 = "SHA256";
     public static final String MESSAGE_DIGEST_ALGORITHM_SHA_384 = "SHA-384";
-    public static final String MESSAGE_DIGEST_ALGORITHM_SHA384 = "SHA384";
     public static final String MESSAGE_DIGEST_ALGORITHM_SHA_512 = "SHA-512";
-    public static final String MESSAGE_DIGEST_ALGORITHM_SHA512 = "SHA512";
     public static final String MESSAGE_DIGEST_ALGORITHM_SHA = "SHA";
     public static final String MESSAGE_DIGEST_ALGORITHM_SHA1 = "SHA1";
     public static final String MESSAGE_DIGEST_ALGORITHM_SHA_1 = "SHA-1";
@@ -183,11 +179,11 @@ public class CryptoUtils {
 
     private static Map<String, String> secureAlternative = new HashMap<>();
     static {
-        secureAlternative.put(MESSAGE_DIGEST_ALGORITHM_SHA, MESSAGE_DIGEST_ALGORITHM_SHA256);
-        secureAlternative.put(MESSAGE_DIGEST_ALGORITHM_SHA1, MESSAGE_DIGEST_ALGORITHM_SHA256);
-        secureAlternative.put(MESSAGE_DIGEST_ALGORITHM_SHA_1, MESSAGE_DIGEST_ALGORITHM_SHA256);
-        secureAlternative.put(MESSAGE_DIGEST_ALGORITHM_SHA128, MESSAGE_DIGEST_ALGORITHM_SHA256);
-        secureAlternative.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5, MESSAGE_DIGEST_ALGORITHM_SHA256);
+        secureAlternative.put(MESSAGE_DIGEST_ALGORITHM_SHA, MESSAGE_DIGEST_ALGORITHM_SHA_256);
+        secureAlternative.put(MESSAGE_DIGEST_ALGORITHM_SHA1, MESSAGE_DIGEST_ALGORITHM_SHA_256);
+        secureAlternative.put(MESSAGE_DIGEST_ALGORITHM_SHA_1, MESSAGE_DIGEST_ALGORITHM_SHA_256);
+        secureAlternative.put(MESSAGE_DIGEST_ALGORITHM_SHA_128, MESSAGE_DIGEST_ALGORITHM_SHA_256);
+        secureAlternative.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5, MESSAGE_DIGEST_ALGORITHM_SHA_256);
     }
 
     /**
@@ -351,17 +347,17 @@ public class CryptoUtils {
         return provider;
     }
 
-    public static final String MESSAGE_DIGEST_ALGORITHM = (fipsEnabled ? MESSAGE_DIGEST_ALGORITHM_SHA256 : MESSAGE_DIGEST_ALGORITHM_SHA);
+    public static final String MESSAGE_DIGEST_ALGORITHM = (fipsEnabled ? MESSAGE_DIGEST_ALGORITHM_SHA_256 : MESSAGE_DIGEST_ALGORITHM_SHA);
     /**
      * List of supported Message Digest Algorithms.
      */
     private static final List<String> supportedMessageDigestAlgorithms = Arrays.asList(
-                                                                                       MESSAGE_DIGEST_ALGORITHM_SHA256,
+                                                                                       MESSAGE_DIGEST_ALGORITHM_SHA_256,
                                                                                        MESSAGE_DIGEST_ALGORITHM_SHA_384,
                                                                                        MESSAGE_DIGEST_ALGORITHM_SHA_512);
 
     public static String getMessageDigestAlgorithm() {
-        return MESSAGE_DIGEST_ALGORITHM_SHA256;
+        return MESSAGE_DIGEST_ALGORITHM_SHA_256;
     }
 
     public static MessageDigest getMessageDigest() throws NoSuchAlgorithmException {

--- a/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/src/org/apache/xml/security/stax/ext/XMLSecurityConstants.java
+++ b/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/src/org/apache/xml/security/stax/ext/XMLSecurityConstants.java
@@ -282,8 +282,8 @@ public class XMLSecurityConstants {
     public static final String NS_MGF1_SHA384 = NS_XMLENC11 + "mgf1sha384";
     public static final String NS_MGF1_SHA512 = NS_XMLENC11 + "mgf1sha512";
 
-    public static final String NS_XENC_SHA256 = NS_XMLENC + CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256.toLowerCase();
-    public static final String NS_XENC_SHA512 = NS_XMLENC + CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512.toLowerCase();
+    public static final String NS_XENC_SHA256 = NS_XMLENC + CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256.toLowerCase();
+    public static final String NS_XENC_SHA512 = NS_XMLENC + CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_512.toLowerCase();
 
     public static final String PREFIX_C14N_EXCL = "c14nEx";
     public static final QName ATT_NULL_PrefixList = new QName(null, "PrefixList");

--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/encryption/AuditKeyEncryptor.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/encryption/AuditKeyEncryptor.java
@@ -19,7 +19,7 @@ import com.ibm.ws.security.audit.source.utils.ByteArray;
  * A package local class for performing encryption and decryption of keys based on a key
  */
 public class AuditKeyEncryptor {
-    private final String algorithm = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    private final String algorithm = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
     byte[] password;
     byte[] passwordDigestBytes;
     AuditCrypto des;

--- a/dev/com.ibm.ws.security.openid/src/com/ibm/ws/security/openid20/internal/OpenidClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openid/src/com/ibm/ws/security/openid20/internal/OpenidClientConfigImpl.java
@@ -85,7 +85,7 @@ public class OpenidClientConfigImpl implements OpenidClientConfig {
     public static final String SIGNATURE_HMAC_SHA256 = "HMAC-SHA256";
 
     public static final String HASH_ALG_SHA1 = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1;
-    public static final String HASH_ALG_SHA256 = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    public static final String HASH_ALG_SHA256 = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
 
     public static final String KEY_CONFIGURATION_ADMIN = "configurationAdmin";
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/SAMLMisc2ConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/SAMLMisc2ConfigTests.java
@@ -515,7 +515,7 @@ public class SAMLMisc2ConfigTests extends SAMLConfigCommonTests {
         SAMLProviderSettings updatedSamlProviderSettings = updatedSamlConfigSettings.getDefaultSamlProviderSettings();
         updatedSamlProviderSettings.setHttpsRequired("true");
         updatedSamlProviderSettings.setNameIDFormat("unspecified");
-        updatedSamlProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256);
+        updatedSamlProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256);
 
         updateConfigFile(testSAMLServer, baseSamlServerConfig, updatedSamlConfigSettings, testServerConfigFile);
 
@@ -545,7 +545,7 @@ public class SAMLMisc2ConfigTests extends SAMLConfigCommonTests {
         SAMLProviderSettings updatedSamlProviderSettings = updatedSamlConfigSettings.getDefaultSamlProviderSettings();
         updatedSamlProviderSettings.setHttpsRequired("true");
         updatedSamlProviderSettings.setNameIDFormat("unspecified");
-        updatedSamlProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256);
+        updatedSamlProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256);
 
         updateConfigFile(testSAMLServer, baseSamlServerConfig, updatedSamlConfigSettings, testServerConfigFile);
 
@@ -684,7 +684,7 @@ public class SAMLMisc2ConfigTests extends SAMLConfigCommonTests {
         SAMLProviderSettings updatedSamlProviderSettings = updatedSamlConfigSettings.getDefaultSamlProviderSettings();
         updatedSamlProviderSettings.setHttpsRequired("false");
         updatedSamlProviderSettings.setNameIDFormat("unspecified");
-        updatedSamlProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256);
+        updatedSamlProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256);
 
         updateConfigFile(testSAMLServer, baseSamlServerConfig, updatedSamlConfigSettings, testServerConfigFile);
 
@@ -714,7 +714,7 @@ public class SAMLMisc2ConfigTests extends SAMLConfigCommonTests {
         SAMLProviderSettings updatedSamlProviderSettings = updatedSamlConfigSettings.getDefaultSamlProviderSettings();
         updatedSamlProviderSettings.setHttpsRequired("false");
         updatedSamlProviderSettings.setNameIDFormat("unspecified");
-        updatedSamlProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256);
+        updatedSamlProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256);
 
         updateConfigFile(testSAMLServer, baseSamlServerConfig, updatedSamlConfigSettings, testServerConfigFile);
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedMiscConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedMiscConfigTests.java
@@ -977,7 +977,7 @@ public class RSSamlIDPInitiatedMiscConfigTests extends RSSamlIDPInitiatedConfigC
         defaultRsSettings.setInboundPropagation("none");
         defaultRsSettings.setAudiences("none");
         defaultRsSettings.setHeaderName("SomethingOdd");
-        defaultRsSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256);
+        defaultRsSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256);
 
         // Update the bootstrap prop for IdP server since that variable doesn't
         // get set for the app server

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedSSLConfigWithReconfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedSSLConfigWithReconfigTests.java
@@ -84,7 +84,7 @@ public class RSSamlIDPInitiatedSSLConfigWithReconfigTests extends RSSamlIDPIniti
 
         RSSamlConfigSettings updatedRsSamlSettings = rsConfigSettings.copyConfigSettings();
         RSSamlProviderSettings updatedProviderSettings = updatedRsSamlSettings.getDefaultRSSamlProviderSettings();
-        updatedProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA128);
+        updatedProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_128);
 
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, testSettings);
 
@@ -104,7 +104,7 @@ public class RSSamlIDPInitiatedSSLConfigWithReconfigTests extends RSSamlIDPIniti
 
         RSSamlConfigSettings updatedRsSamlSettings = rsConfigSettings.copyConfigSettings();
         RSSamlProviderSettings updatedProviderSettings = updatedRsSamlSettings.getDefaultRSSamlProviderSettings();
-        updatedProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256);
+        updatedProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256);
 
         List<validationData> expectations = get401ExpectationsForJaxrsGet("Did not get the expected message saying the received signature was not valid and weaker than required.",
                 SAMLMessageConstants.CWWKS5049E_SIGNATURE_NOT_TRUSTED_OR_VALID);
@@ -123,7 +123,7 @@ public class RSSamlIDPInitiatedSSLConfigWithReconfigTests extends RSSamlIDPIniti
 
         RSSamlConfigSettings updatedRsSamlSettings = rsConfigSettings.copyConfigSettings();
         RSSamlProviderSettings updatedProviderSettings = updatedRsSamlSettings.getDefaultRSSamlProviderSettings();
-        updatedProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA128);
+        updatedProviderSettings.setSignatureMethodAlgorithm(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_128);
 
         // Update test settings to use an SP that encrypts SAML assertions
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/SsoConfigImpl.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/internal/SsoConfigImpl.java
@@ -130,7 +130,7 @@ public class SsoConfigImpl extends PkixTrustEngineConfig implements SsoConfig, F
     String keyStoreRef = null;
     String keyAlias = null;
     String keyPassword = null;
-    String signatureMethodAlgorithm = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    String signatureMethodAlgorithm = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
     String userIdentifier = "NameID";
     String groupIdentifier = null;
     String userUniqueIdentifier = "NameID";
@@ -583,7 +583,7 @@ public class SsoConfigImpl extends PkixTrustEngineConfig implements SsoConfig, F
      */
     @Override
     public String getSignatureMethodAlgorithm() {
-        if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256.equalsIgnoreCase(signatureMethodAlgorithm)) {
+        if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256.equalsIgnoreCase(signatureMethodAlgorithm)) {
             return SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256;
         } else if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1.equalsIgnoreCase(signatureMethodAlgorithm)) {
             // FIPS 140-3: Algorithm assessment complete; no changes required.

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/rs/RsSamlConfigImpl.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/rs/RsSamlConfigImpl.java
@@ -130,7 +130,7 @@ public class RsSamlConfigImpl extends PkixTrustEngineConfig implements SsoConfig
     String keyStoreRef = null;
     String keyAlias = null;
     String keyPassword = null;
-    String signatureMethodAlgorithm = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    String signatureMethodAlgorithm = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
     String userIdentifier = "NameID";
     String groupIdentifier = null;
     String userUniqueIdentifier = "NameID";
@@ -311,9 +311,9 @@ public class RsSamlConfigImpl extends PkixTrustEngineConfig implements SsoConfig
      */
     @Override
     public String getSignatureMethodAlgorithm() {
-        if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256.equalsIgnoreCase(signatureMethodAlgorithm)) {
+        if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256.equalsIgnoreCase(signatureMethodAlgorithm)) {
             return SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256;
-        } else if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA128.equalsIgnoreCase(signatureMethodAlgorithm)) {
+        } else if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_128.equalsIgnoreCase(signatureMethodAlgorithm)) {
             return SignatureConstants.MORE_ALGO_NS + "rsa-sha128"; //???????
         } else if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1.equalsIgnoreCase(signatureMethodAlgorithm)) {
             // FIPS 140-3: Algorithm assessment complete; no changes required.

--- a/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/SsoConfigImplTest.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/test/com/ibm/ws/security/saml/sso20/internal/SsoConfigImplTest.java
@@ -598,7 +598,7 @@ public class SsoConfigImplTest {
             e.printStackTrace();
             fail("Unexpected exception was thrown: " + e);
         }
-        SAML_CONFIG_PROPS.put(SsoConfigImpl.KEY_signatureMethodAlgorithm, CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256);
+        SAML_CONFIG_PROPS.put(SsoConfigImpl.KEY_signatureMethodAlgorithm, CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256);
 
         String result = ssoConfig.getSignatureMethodAlgorithm();
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/security/auth/ThreadLocalStorage.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/security/auth/ThreadLocalStorage.java
@@ -33,7 +33,7 @@ public class ThreadLocalStorage
 		MessageDigest digester = null;
 		try {
 			//Based on whether fips is enabled or not
-			digester = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256) : MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5);
+			digester = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256) : MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5);
 			_msgDigest.set( digester);
 		} catch (NoSuchAlgorithmException e) {
 			e.printStackTrace();

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/KeyStoreManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/KeyStoreManager.java
@@ -142,7 +142,7 @@ public class KeyStoreManager {
             Tr.entry(tc, "checkIfSignerAlreadyExistsInTrustStore");
 
         try {
-            String signerDigest = generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256, signer);
+            String signerDigest = generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256, signer);
             if (signerDigest == null) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
                     Tr.exit(tc, "checkIfSignerAlreadyExistsInTrustStore -> false (could not generate digest)");
@@ -157,7 +157,7 @@ public class KeyStoreManager {
                 if (trustStore.containsAlias(alias)) {
                     X509Certificate cert = (X509Certificate) trustStore.getCertificate(alias);
 
-                    String certDigest = generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256, cert);
+                    String certDigest = generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256, cert);
 
                     if (signerDigest.equals(certDigest)) {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509TrustManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/core/WSX509TrustManager.java
@@ -359,7 +359,7 @@ public final class WSX509TrustManager extends X509ExtendedTrustManager {
                                                                                                      + ".\n\nHere's the signer information (verify the digest value matches what is displayed at the server):"));
             for (int j = 0; j < chain.length; j++) {
                 stdout.println("");
-                String shaDigest = KeyStoreManager.getInstance().generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256, chain[j]);
+                String shaDigest = KeyStoreManager.getInstance().generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256, chain[j]);
                 stdout.println(TraceNLSHelper.getInstance().getString("ssl.trustmanager.signer.prompt.CWPKI0102I", "  Subject DN:    ")
                                + chain[j].getSubjectDN());
                 stdout.println(TraceNLSHelper.getInstance().getString("ssl.trustmanager.signer.prompt.CWPKI0103I", "  Issuer DN:     ")

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConstants.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/internal/WSSecurityConstants.java
@@ -89,5 +89,5 @@ public class WSSecurityConstants {
     public static final String KEY_timeToLive = "timeToLive";
     public static final String KEY_audienceRestrictions = "audienceRestrictions";
 
-    public static final String WSSEC_DEFAULT_SIGNATURE_ALGORITHM = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256 : CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1;
+    public static final String WSSEC_DEFAULT_SIGNATURE_ALGORITHM = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256 : CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1;
 }

--- a/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/signature/SignatureAlgorithms.java
+++ b/dev/com.ibm.ws.wssecurity.3.4.1/src/com/ibm/ws/wssecurity/signature/SignatureAlgorithms.java
@@ -52,18 +52,18 @@ public class SignatureAlgorithms {
     static {
         if (!fipsEnabled){
         RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1.toLowerCase(), rsa_sha1);}
-        RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256.toLowerCase(), rsa_sha256);
-        RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA384.toLowerCase(), rsa_sha384);
-        RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512.toLowerCase(), rsa_sha512);
+        RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256.toLowerCase(), rsa_sha256);
+        RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_384.toLowerCase(), rsa_sha384);
+        RSA_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_512.toLowerCase(), rsa_sha512);
     }
 
     static Map<String, String> HMAC_MAP = new HashMap<String, String>();
     static {
         if (!fipsEnabled){
         HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1.toLowerCase(), hmac_sha1);}
-        HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256.toLowerCase(), hmac_sha256);
-        HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA384.toLowerCase(), hmac_sha384);
-        HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512.toLowerCase(), hmac_sha512);
+        HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256.toLowerCase(), hmac_sha256);
+        HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_384.toLowerCase(), hmac_sha384);
+        HMAC_MAP.put(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_512.toLowerCase(), hmac_sha512);
     }
 
     public static void setAlgorithm(SoapMessage message, String method) {


### PR DESCRIPTION
Use the spec defined name instead of alias
use SHA-128 instead of SHA128
use SHA-256 instead of SHA256
use SHA-384 instead of SHA384
use SHA-512 instead of SHA512