### PR TITLE
Update jdbc loadfromapp FAT to work in Java 25+

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/jvm.options
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/jvm.options
@@ -1,0 +1,1 @@
+-Djava.util.concurrent.ForkJoinPool.common.parallelism=2


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

In Java 25, `CompletableFuture` was changed so that all async methods without an explicit `Executor` are performed using the `ForkJoinPool` common pool.  This differs to previous releases where a new thread was created for each async task when the `ForkJoinPool` common pool was configured with parallelism less than 2 ([reference](https://bugs.openjdk.org/browse/JDK-8362881)).

Because of this change, the `com.ibm.ws.jdbc_fat_loadfromapp` FAT hits a thread deadlock (which eventually times out) because ForkJoinPool defaults to 1 thread (ForkJoinPool.common.parallelism=1) and this FAT requires at least 2 threads.

This change took place in Java 25+17 (and later).  We are able to work around this restriction by setting
```
-Djava.util.concurrent.ForkJoinPool.common.parallelism=2
```

in the server `jvm.options` file.

Further information
https://bugs.openjdk.org/browse/JDK-8360593
https://bugs.openjdk.org/browse/JDK-8319447