### PR TITLE
Scheduled Asynchronous Method on a Repository

### DIFF
--- a/dev/io.openliberty.data.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat/bnd.bnd
@@ -42,14 +42,14 @@ tested.features: databaseRotation, checkpoint, persistence-3.2
 	com.ibm.wsspi.org.osgi.service.component.annotations,\
 	com.ibm.ws.componenttest.2.0;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	io.openliberty.jakarta.annotation.2.1,\
-	io.openliberty.jakarta.cdi.4.0,\
-	io.openliberty.jakarta.concurrency.3.0,\
+	io.openliberty.jakarta.annotation.3.0,\
+	io.openliberty.jakarta.cdi.4.1,\
+	io.openliberty.jakarta.concurrency.3.1,\
 	io.openliberty.jakarta.data.1.0,\
 	io.openliberty.jakarta.enterpriseBeans.4.0,\
-	io.openliberty.jakarta.interceptor.2.1,\
-	io.openliberty.jakarta.persistence.3.1,\
-	io.openliberty.jakarta.servlet.6.0;version=latest,\
+	io.openliberty.jakarta.interceptor.2.2,\
+	io.openliberty.jakarta.persistence.3.2,\
+	io.openliberty.jakarta.servlet.6.1;version=latest,\
 	io.openliberty.jakarta.transaction.2.0;version=latest,\
 	io.openliberty.org.testcontainers;version=latest
 	

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participants.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Participants.java
@@ -13,6 +13,7 @@
 package test.jakarta.data.web;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import jakarta.data.repository.By;
@@ -23,6 +24,8 @@ import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.enterprise.concurrent.Asynchronous;
+import jakarta.enterprise.concurrent.Schedule;
 
 import test.jakarta.data.web.Participant.Name;
 
@@ -46,6 +49,13 @@ public interface Participants extends DataRepository<Participant, Integer> {
 
     @Delete
     long remove(@By("name.last") String lastName);
+
+    @Asynchronous(runAt = @Schedule(hours = {}, // all
+                                    minutes = {}, // all
+                                    seconds = { 5, 15, 25, 35, 45, 55 }))
+    @Delete
+    CompletableFuture<Long> scheduledRemoval(String name_first,
+                                             String name_last);
 
     @Find
     @OrderBy("name.first")


### PR DESCRIPTION
A repository method can also be a Scheduled Asynchronous Method, in which case the method must run after the next time on the schedule rather than immediately.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
