### PR TITLE
Alternative resolution for resolving server output directory if `server.output.dir` is not set.

### DIFF
--- a/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthFileUtils.java
+++ b/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthFileUtils.java
@@ -44,9 +44,10 @@ public class HealthFileUtils {
                 String wlpOutputDirEnv = System.getenv("WLP_OUTPUT_DIR").trim();
 
                 if (wlpOutputDirEnv == null || wlpOutputDirEnv.isEmpty()) {
+                    Tr.warning(tc, "file.healthcheck.health.directory.resolution.fail.CWMMH0102W");
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc,
-                                 "The /health directory can not be created. The server was unable to resolve server.output.dir property nor the WLP_OUTPUT_DIR environment variable.");
+                                 "The server was unable to resolve server.output.dir property nor the WLP_OUTPUT_DIR environment variable.");
                     }
                     return null;
                 }
@@ -56,9 +57,10 @@ public class HealthFileUtils {
                 if (serverName == null || serverName.isEmpty()) {
                     serverName = System.getenv("SERVER_NAME").trim();
                     if (serverName == null || serverName.isEmpty()) {
+                        Tr.warning(tc, "file.healthcheck.health.directory.resolution.fail.CWMMH0102W");
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Tr.debug(tc,
-                                     "The /health directory can not be created. The server was unable to resolve wlp.server.name property nor the SERVER_NAME environment variable.");
+                                     "The server was unable to resolve wlp.server.name property nor the SERVER_NAME environment variable.");
                         }
                         return null;
                     }

--- a/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthFileUtils.java
+++ b/dev/io.openliberty.microprofile.health.4.0.internal/src/io/openliberty/microprofile/health40/internal/HealthFileUtils.java
@@ -31,7 +31,43 @@ public class HealthFileUtils {
     public static File getHealthDirFile() {
 
         if (healthDirFile == null) {
-            File serverConfigDirFile = new File(System.getProperty("server.output.dir"));
+
+            String serverOutputDir = System.getProperty("server.output.dir").trim();
+
+            File serverConfigDirFile;
+
+            /*
+             * server.output.dir may not be set.
+             * Construct the directory with WLP_OUTPUT_DIR and wlp.server.name or SERVER_NAME
+             */
+            if (serverOutputDir == null || serverOutputDir.isEmpty()) {
+                String wlpOutputDirEnv = System.getenv("WLP_OUTPUT_DIR").trim();
+
+                if (wlpOutputDirEnv == null || wlpOutputDirEnv.isEmpty()) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc,
+                                 "The /health directory can not be created. The server was unable to resolve server.output.dir property nor the WLP_OUTPUT_DIR environment variable.");
+                    }
+                    return null;
+                }
+
+                String serverName = System.getProperty("wlp.server.name").trim();
+
+                if (serverName == null || serverName.isEmpty()) {
+                    serverName = System.getenv("SERVER_NAME").trim();
+                    if (serverName == null || serverName.isEmpty()) {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc,
+                                     "The /health directory can not be created. The server was unable to resolve wlp.server.name property nor the SERVER_NAME environment variable.");
+                        }
+                        return null;
+                    }
+                }
+
+                serverOutputDir = wlpOutputDirEnv + System.getProperty("file.separator") + serverName;
+            }
+            serverConfigDirFile = new File(serverOutputDir);
+
             healthDirFile = new File(serverConfigDirFile, "health");
         }
 
@@ -98,6 +134,13 @@ public class HealthFileUtils {
      */
     public static boolean isValidSystem() throws IOException {
         healthDirFile = getHealthDirFile();
+
+        /*
+         * Failed to resolve the Health directory File object. (i.e., could not resolve the path to create the path)
+         */
+        if (healthDirFile == null) {
+            return false;
+        }
 
         //Health Dir does not exist -> create and test write
         if (!healthDirFile.exists()) {

--- a/dev/io.openliberty.microprofile.health.internal.common/resources/io/openliberty/microprofile/health/resources/Health.nlsprops
+++ b/dev/io.openliberty.microprofile.health.internal.common/resources/io/openliberty/microprofile/health/resources/Health.nlsprops
@@ -70,9 +70,9 @@ file.healthcheck.health.directory.write.fail.CWMMH0101W=CWMMH0101W: Unable to wr
 file.healthcheck.health.directory.write.fail.CWMMH0101W.explanation=The runtime requires write permissions to the /health directory to create the "live", "ready" and "started" files for the file-based health checks to function properly.
 file.healthcheck.health.directory.write.fail.CWMMH0101W.useraction=The user must identify the root cause of the permission issue.
 
-file.healthcheck.health.directory.resolution.fail.CWMMH0102W=CWMMH0102W: Unable to resolve the path for the /health directory. The file-based health check function will be disabled.
+file.healthcheck.health.directory.resolution.fail.CWMMH0102W=CWMMH0102W: The runtime cannot resolve the path for the /health directory. The file-based health check function will be disabled.
 file.healthcheck.health.directory.resolution.fail.CWMMH0102W.explanation=The runtime requires the internal server.output.dir property or WLP_OUTPUT_DIR environment variable to be set to determine the location of the /health directory.
-file.healthcheck.health.directory.resolution.fail.CWMMH0102W.useraction=The user must ensure that the WLP_OUTPUT_DIR environment variable is properly set.
+file.healthcheck.health.directory.resolution.fail.CWMMH0102W.useraction=Ensure that the WLP_OUTPUT_DIR environment variable is properly set.
 
 file.healthcheck.file.name.conflict.CWMMH0105W=CWMMH0106W: The runtime has detected the presence of the following directory [{0}]. A file with the same name is required for the file-based health check function at this path. The file-based health check function will be disabled.
 file.healthcheck.file.name.conflict.CWMMH0105W.explanation=The file-based health checks require the creation and use of the files "live", "ready" and "started" in the /health directory. An existing directory with one of those names is already present in the /health directory which prevents the required files from being created.

--- a/dev/io.openliberty.microprofile.health.internal.common/resources/io/openliberty/microprofile/health/resources/Health.nlsprops
+++ b/dev/io.openliberty.microprofile.health.internal.common/resources/io/openliberty/microprofile/health/resources/Health.nlsprops
@@ -70,6 +70,9 @@ file.healthcheck.health.directory.write.fail.CWMMH0101W=CWMMH0101W: Unable to wr
 file.healthcheck.health.directory.write.fail.CWMMH0101W.explanation=The runtime requires write permissions to the /health directory to create the "live", "ready" and "started" files for the file-based health checks to function properly.
 file.healthcheck.health.directory.write.fail.CWMMH0101W.useraction=The user must identify the root cause of the permission issue.
 
+file.healthcheck.health.directory.resolution.fail.CWMMH0102W=CWMMH0102W: Unable to resolve the path for the /health directory. The file-based health check function will be disabled.
+file.healthcheck.health.directory.resolution.fail.CWMMH0102W.explanation=The runtime requires the internal server.output.dir property or WLP_OUTPUT_DIR environment variable to be set to determine the location of the /health directory.
+file.healthcheck.health.directory.resolution.fail.CWMMH0102W.useraction=The user must ensure that the WLP_OUTPUT_DIR environment variable is properly set.
 
 file.healthcheck.file.name.conflict.CWMMH0105W=CWMMH0106W: The runtime has detected the presence of the following directory [{0}]. A file with the same name is required for the file-based health check function at this path. The file-based health check function will be disabled.
 file.healthcheck.file.name.conflict.CWMMH0105W.explanation=The file-based health checks require the creation and use of the files "live", "ready" and "started" in the /health directory. An existing directory with one of those names is already present in the /health directory which prevents the required files from being created.


### PR DESCRIPTION



- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Fixes #32394