### PR TITLE
Experimental comparison package was removed and no longer exists

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.1/io.openliberty.data-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.1/io.openliberty.data-1.1.feature
@@ -9,17 +9,23 @@ IBM-ShortName: data-1.1
 # the next version.
 IBM-API-Package: \
   io.openliberty.data.repository; type="ibm-api",\
-  io.openliberty.data.repository.comparison; type="ibm-api",\
   io.openliberty.data.repository.function; type="ibm-api",\
   io.openliberty.data.repository.update; type="ibm-api",\
   jakarta.data; type="spec",\
+  jakarta.data.constraint; type="spec",\
+  jakarta.data.event; type="spec",\
   jakarta.data.exceptions; type="spec",\
+  jakarta.data.expression; type="spec",\
   jakarta.data.metamodel; type="spec",\
   jakarta.data.metamodel.impl; type="spec",\
   jakarta.data.page; type="spec",\
   jakarta.data.page.impl; type="spec",\
   jakarta.data.repository; type="spec",\
-  jakarta.data.spi; type="spec"
+  jakarta.data.restrict; type="spec",\
+  jakarta.data.spi; type="spec",\
+  jakarta.data.spi.expression.function; type="spec",\
+  jakarta.data.spi.expression.literal; type="spec",\
+  jakarta.data.spi.expression.path; type="spec"
 Subsystem-Name: Jakarta Data 1.1
 -features=\
   com.ibm.websphere.appserver.eeCompatible-11.0,\


### PR DESCRIPTION
The experimental package `io.openliberty.data.repository.comparison` was previously removed but is still being referenced by a noship feature file.  This PR removes it from that file, and while I'm there also refreshes the list of packages to match the spec.  I'd like to remove the other experimental packages as well, but given that some tests are still using them that can't be done yet.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".