### PR TITLE
Fix ldap krb5 fat badPrincipalName test

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.1/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/CommonBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.1/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/CommonBindTest.java
@@ -576,8 +576,10 @@ public class CommonBindTest {
          * invalid krb.config file and couldn't find a realm name for the principal.
          */
         boolean foundBadPrincipalName = !server.findStringsInLogsAndTraceUsingMark("CWIML4512E").isEmpty();
+        boolean foundKerberosLoginFailed = !server.findStringsInLogsAndTraceUsingMark(failMessage).isEmpty();
         boolean foundRealmNotFound = !server.findStringsInLogsAndTraceUsingMark("Cannot locate default realm").isEmpty(); // java message, could change in future
-        assertTrue("Expected to find Kerberos bind failure: Either `CWIML4512E` or `Cannot locate default realm`", foundBadPrincipalName || foundRealmNotFound);
+        assertTrue("Expected to find Kerberos bind failure: Either `" + failMessage + "`, `CWIML4512E` or `Cannot locate default realm`",
+                   foundKerberosLoginFailed || foundBadPrincipalName || foundRealmNotFound);
 
         newServer.getKerberos().configFile = configFile; // reset to valid config file so the realm name is found
         ldap.setKrb5Principal("badPrincipalName2@" + DOMAIN);

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.2/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2024 IBM Corporation and others.
+# Copyright (c) 2021, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -17,8 +17,6 @@ src: \
 	fat/src
 
 fat.project: true
-
-fat.test.container.images: zachhein/ldap-server:0.5,zachhein/krb5-server:0.2
 
 -buildpath: \
 	io.openliberty.org.testcontainers;version=latest,\


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

On Semeru Java 17, the test would fail because the JDK does not print the same message when the krb5loginmodule fails