### PR TITLE
Use SHA256 in plugin utility when FIPS is enabled 

### DIFF
--- a/dev/com.ibm.ws.webserver.plugin.utility/resources/com/ibm/ws/webserver/plugin/utility/resources/CUtilityMessages.nlsprops
+++ b/dev/com.ibm.ws.webserver.plugin.utility/resources/com/ibm/ws/webserver/plugin/utility/resources/CUtilityMessages.nlsprops
@@ -1,14 +1,11 @@
 ###############################################################################
-# Copyright (c) 2010, 2016 IBM Corporation and others.
+# Copyright (c) 2010, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 #CMVCPATHNAME com.ibm.ws.collective.utility/resources/com/ibm/ws/collective/utility/resources/UtilityMessages.nlsprops
 #ISMESSAGEFILE FALSE
@@ -134,6 +131,9 @@ sslTrust.certSerial=\
 
 sslTrust.certExpires=\
   Expires: {0}
+
+sslTrust.certSHA256Digest=\
+  SHA256 digest: {0}
 
 sslTrust.certSHADigest=\
   SHA-1 digest: {0}

--- a/dev/com.ibm.ws.webserver.plugin.utility/src/com/ibm/ws/webserver/plugin/utility/utils/PromptX509TrustManager.java
+++ b/dev/com.ibm.ws.webserver.plugin.utility/src/com/ibm/ws/webserver/plugin/utility/utils/PromptX509TrustManager.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.webserver.plugin.utility.utils;
 
@@ -40,7 +37,7 @@ public class PromptX509TrustManager implements X509TrustManager {
     private final TrustManager[] trustManagers;
     private final boolean autoAccept;
     private static Map<String, Boolean> answeredCertificates = new HashMap<String, Boolean>();
-
+    private static boolean FIPS_ENABLED;
     /**
      * Clears the cache of certificates which were either accepted or rejected by the user.
      */
@@ -53,6 +50,8 @@ public class PromptX509TrustManager implements X509TrustManager {
         this.stdout = stdout;
         this.trustManagers = trustManagers;
         this.autoAccept = autoAccept;
+
+        this.FIPS_ENABLED = CryptoUtils.isFips140_3EnabledWithBetaGuard();
     }
 
     @Override
@@ -65,6 +64,8 @@ public class PromptX509TrustManager implements X509TrustManager {
     /**
      * This method is used to create a "SHA1" or "MD5" digest on an
      * X509Certificate as the "fingerprint".
+     * 
+     * If FIPS 140-3 is enabled, then it will opt to use SHA-256.
      * 
      * @param algorithmName
      * 
@@ -140,18 +141,22 @@ public class PromptX509TrustManager implements X509TrustManager {
         // it just has to be unique enough to know if we've seen this certificate
         // before. If we have, we do not have to prompt again. This entire class
         // will eventually be replaced when we have a client-side SSL solution.
-        StringBuilder fullMD5Buf = new StringBuilder();
+        StringBuilder messageDigestBuilder = new StringBuilder();
         for (int i = 0; i < chain.length; i++) {
-            fullMD5Buf.append(generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5, chain[i]));
+            if(FIPS_ENABLED){
+                messageDigestBuilder.append(generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256, chain[i]));
+            } else {
+                messageDigestBuilder.append(generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5, chain[i]));
+            }
             if (i < (chain.length - 1)) {
                 // Still more to go, so append a comma
-                fullMD5Buf.append(',');
+                messageDigestBuilder.append(',');
             }
         }
-        final String fullMD5 = fullMD5Buf.toString();
+        final String generatedDigest = messageDigestBuilder.toString();
 
         // If we have already provided an accept answer, do not prompt again
-        final Boolean previousAnswer = answeredCertificates.get(fullMD5);
+        final Boolean previousAnswer = answeredCertificates.get(generatedDigest);
         if (previousAnswer != null) {
             if (previousAnswer) {
                 return;
@@ -165,7 +170,7 @@ public class PromptX509TrustManager implements X509TrustManager {
             stdout.println();
             stdout.println(getMessage("sslTrust.autoAccept", chain[0].getSubjectDN()));
             stdout.println();
-            answeredCertificates.put(fullMD5, Boolean.TRUE);
+            answeredCertificates.put(generatedDigest, Boolean.TRUE);
             return;
         }
 
@@ -180,17 +185,21 @@ public class PromptX509TrustManager implements X509TrustManager {
             stdout.println(getMessage("sslTrust.certIssueDN", chain[i].getIssuerDN()));
             stdout.println(getMessage("sslTrust.certSerial", chain[i].getSerialNumber()));
             stdout.println(getMessage("sslTrust.certExpires", chain[i].getNotAfter()));
-            stdout.println(getMessage("sslTrust.certSHADigest", generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_1, chain[i])));
-            stdout.println(getMessage("sslTrust.certMD5Digest", generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5, chain[i])));
+            if(FIPS_ENABLED) {
+                stdout.println(getMessage("sslTrust.certSHA256Digest", generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256, chain[i])));
+            } else {
+                stdout.println(getMessage("sslTrust.certSHADigest", generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_1, chain[i])));
+                stdout.println(getMessage("sslTrust.certMD5Digest", generateDigest(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5, chain[i])));
+            }
             stdout.println();
         }
 
         String read = stdin.readText(getMessage("sslTrust.promptToAcceptTrust"));
         if (isYes(read)) {
             // We are trusted
-            answeredCertificates.put(fullMD5, Boolean.TRUE);
+            answeredCertificates.put(generatedDigest, Boolean.TRUE);
         } else {
-            answeredCertificates.put(fullMD5, Boolean.FALSE);
+            answeredCertificates.put(generatedDigest, Boolean.FALSE);
             throw new CertificateException(getMessage("sslTrust.rejectTrust"));
         }
     }

--- a/dev/com.ibm.ws.webserver.plugin.utility/src/com/ibm/ws/webserver/plugin/utility/utils/PromptX509TrustManager.java
+++ b/dev/com.ibm.ws.webserver.plugin.utility/src/com/ibm/ws/webserver/plugin/utility/utils/PromptX509TrustManager.java
@@ -137,7 +137,7 @@ public class PromptX509TrustManager implements X509TrustManager {
         }
         logger.fine("None of the default trust managers trusts the certificate...");
 
-        // Compute the full MD5 digest. This does not have to be perfectly unique,
+        // Compute the full MD5 or SHA256 digest. This does not have to be perfectly unique,
         // it just has to be unique enough to know if we've seen this certificate
         // before. If we have, we do not have to prompt again. This entire class
         // will eventually be replaced when we have a client-side SSL solution.

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/bnd.bnd
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2018 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -17,3 +14,6 @@ src: \
 	fat/src
 	
 fat.project: true
+
+-buildpath: \
+	com.ibm.ws.kernel.service;version=latest

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/build.gradle
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 025 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,5 +10,5 @@
 
 dependencies {
     // Needed for the FIPS check in PluginUtilityGenerateTest
- requiredLibs project(':com.ibm.ws.kernel.service')
+    requiredLibs project(':com.ibm.ws.kernel.service')
 }

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/build.gradle
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/build.gradle
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+dependencies {
+    // Needed for the FIPS check in PluginUtilityGenerateTest
+ requiredLibs project(':com.ibm.ws.kernel.service')
+}

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/fat/src/com/ibm/ws/webserver/plugin/utility/fat/PluginUtilityGenerateTest.java
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/fat/src/com/ibm/ws/webserver/plugin/utility/fat/PluginUtilityGenerateTest.java
@@ -204,7 +204,7 @@ public class PluginUtilityGenerateTest {
     @Test
     public void verifyDigestAlgorithmsWhenFIPSEnabled() throws Exception {
 
-        final String methodName = "testPluginUtilityRemoteGenerate";
+        final String methodName = "verifyDigestAlgorithmsWhenFIPSEnabled";
         Log.entering(c, methodName);
 
         if(CryptoUtils.isFips140_3EnabledWithBetaGuard()){
@@ -327,13 +327,13 @@ public class PluginUtilityGenerateTest {
         env.put("JVM_ARGS", "-Dcom.ibm.webserver.plugin.utility.autoAcceptCertificates=" + AUTO_ACCEPT_CERTIFICATES);
         env.put("JAVA_HOME", server.getMachineJavaJDK());
 
-        return runCommandWithReturnednOutput(server, serverId, cluster, targetPath, env);
+        return runCommandWithReturnedOutput(server, serverId, cluster, targetPath, env);
     }
     
     
     private void runCommand(LibertyServer server, String serverId, String cluster,String targetPath, Properties env) throws Exception {
 
-        String outputResult = runCommandWithReturnednOutput(server,serverId,cluster,targetPath,env);
+        String outputResult = runCommandWithReturnedOutput(server,serverId,cluster,targetPath,env);
 
         Log.info(c, "runCommand", "Resulting output : \n" + outputResult);
 
@@ -342,7 +342,7 @@ public class PluginUtilityGenerateTest {
     /*
      * Used to return commnand output in order to verify Digest Alogrithms used. 
      */
-    private String runCommandWithReturnednOutput(LibertyServer server, String serverId, String cluster,String targetPath, Properties env) throws Exception {
+    private String runCommandWithReturnedOutput(LibertyServer server, String serverId, String cluster,String targetPath, Properties env) throws Exception {
 
         String pluginUtilityCommand = server.getInstallRoot() + "/bin/pluginUtility";
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes https://github.com/OpenLiberty/open-liberty/issues/32592

Local testing when connecting to a remote server: 
 
 ./pluginUtility generate --server=@<ip:port>
```
[DEBUG] FIPS IS ENABLED!

SSL trust has not been established with the target server.

Certificate chain information:
Certificate [0]
Subject DN: CN=localhost, OU=remoteServer1
Issuer DN: CN=localhost, OU=remoteServer1
Serial Number: 1,585,607,149,157,871,291
Expires: 8/12/26, 11:42 AM
SHA256 digest: 8E:64:6E:E1:09:D9:32:62:89:47:F3:1B:56:E7:AA:29:0E:5F:B9:F6:24:26:9A:2C:D1:85:2E:24:71:BB:EB:44

```

As we can see, the `SHA256 digest:` is shown above. 
When FIPS is not enabled, the existing digests are shown: 
```
SHA-1 digest: 72:D0:BA:E2:DF:C9:DD:62:47:6F:DD:DB:0A:53:84:80:EA:B9:3D:FB
MD5 digest: D4:C0:AA:2D:6B:5F:F0:EB:9E:D9:6F:37:12:45:EB:55
```
