### PR TITLE
Add Kernel boot jar to jcache tests

### DIFF
--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/bnd.bnd
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/bnd.bnd
@@ -49,6 +49,7 @@ generate.replacement: true
 	com.ibm.ws.security.spnego.fat.common;version=latest,\
 	com.ibm.ws.security.jaas.common;version=latest,\
 	com.ibm.ws.security.oauth.oidc_fat.common;version=latest,\
+    com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.kernel.service;version=latest,\
 	com.hazelcast:hazelcast;version=5.1.3
     


### PR DESCRIPTION
During test execution we cannot find the ProductInfo class that is present in the kernel.boot jar


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".