### PR TITLE
Remove workaround of retrying lookups and add debug

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -290,7 +290,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
      * @return PUnitEMBuilder (for persistence unit references) or
      *         DBStoreEMBuilder (data sources, databaseStore)
      */
-    @FFDCIgnore({ NamingException.class, Throwable.class })
+    @FFDCIgnore(Throwable.class)
     public EntityManagerBuilder createEMBuilder() {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
@@ -368,22 +368,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                 else
                     accessor.beginContext(metadata);
                 try {
-                    //Object resource = InitialContext.doLookup(dataStore);
-                    // TODO use the above instead of the following temporary workaround
-                    Object resource = null;
-                    NamingException failure = null;
-                    for (long start = System.nanoTime(); //
-                                    resource == null && System.nanoTime() - start //
-                                                    < TimeUnit.SECONDS.toNanos(30); //
-                                    TimeUnit.SECONDS.sleep(2))
-                        try {
-                            resource = InitialContext.doLookup(dataStore);
-                        } catch (NamingException namingX) {
-                            failure = namingX;
-                        }
-                    if (failure != null && resource == null)
-                        throw failure;
-                    // end of code to replace
+                    Object resource = InitialContext.doLookup(dataStore);
 
                     if (trace && tc.isDebugEnabled())
                         Tr.debug(this, tc, dataStore + " is the JNDI name for " + resource);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestEJB.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestEJB.java
@@ -29,6 +29,7 @@ public class DataTestEJB {
 
     @PostConstruct
     public void init() {
+        System.out.println("Singleton Startup EJB PostConstruct");
         animals.findAll();
     }
 }

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/ejb/StartupSingletonEJB.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/ejb/StartupSingletonEJB.java
@@ -26,6 +26,8 @@ public class StartupSingletonEJB {
 
     @PostConstruct
     public void init() {
+        System.out.println("Startup Singleton EJB PostConstruct");
+
         repo.acquire(0);
     }
 }

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/DataGlobalRestApp.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/DataGlobalRestApp.java
@@ -27,6 +27,8 @@ public class DataGlobalRestApp extends Application {
      * Set up some data before tests run.
      */
     public void startup(@Observes Startup event) {
+        System.out.println("REST Application Observed Startup");
+
         referrals.save(Referral.of("startup@openliberty.io",
                                    "Startup Event",
                                    5075556789L));


### PR DESCRIPTION
Remove the workaround of retrying lookups because it should not be needed anymore.  Add temporary debug just in case that can be removed prior to GA.