### PR TITLE
32494 telemetry trace

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/MetricsMonitorServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/MetricsMonitorServer/server.xml
@@ -5,6 +5,9 @@
     	<feature>jdbc-4.0</feature>
     	<feature>mpMetrics-2.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF1/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF1/server.xml
@@ -5,6 +5,9 @@
     	<feature>jdbc-4.0</feature>
     	<feature>mpMetrics-2.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF10/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF10/server.xml
@@ -8,6 +8,9 @@
     </featureManager>
 
     <monitor  filter="ThreadPool,WebContainer,Session,ConnectionPool"/>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF11/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF11/server.xml
@@ -5,6 +5,9 @@
     	<feature>mpMetrics-2.0</feature>
     	<feature>monitor-1.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF12/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF12/server.xml
@@ -5,6 +5,9 @@
     	<feature>mpMetrics-2.0</feature>
     	<feature>monitor-1.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF2/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF2/server.xml
@@ -5,6 +5,9 @@
     	<feature>jdbc-4.0</feature>
     	<feature>mpMetrics-2.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF3/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF3/server.xml
@@ -6,6 +6,9 @@
     	<feature>mpMetrics-2.0</feature>
     	<feature>monitor-1.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF4/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF4/server.xml
@@ -6,6 +6,9 @@
     	<feature>mpMetrics-2.0</feature>
     	<feature>monitor-1.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF5/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF5/server.xml
@@ -6,6 +6,9 @@
     	<feature>mpMetrics-2.0</feature>
     	<feature>monitor-1.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF6/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF6/server.xml
@@ -6,6 +6,9 @@
     	<feature>mpMetrics-2.0</feature>
     	<feature>monitor-1.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF8/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF8/server.xml
@@ -6,6 +6,9 @@
     	<feature>mpMetrics-2.0</feature>
     	<feature>monitor-1.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF9/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/publish/servers/TestEDF9/server.xml
@@ -6,6 +6,9 @@
     	<feature>mpMetrics-2.0</feature>
     	<feature>monitor-1.0</feature>
     </featureManager>
+    
+    <httpSession useSeparateSessionInvalidatorThreadPool="false"
+                 delayInvalidationAlarmDuringServerStartup="60"/>
 
     <include location="../fatTestPorts.xml"/>
     <include location="serverJDBCConfig.xml"/>

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/publish/servers/TelemetryLogsServer/server.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/publish/servers/TelemetryLogsServer/server.xml
@@ -20,5 +20,5 @@
 	<!--Java2 security-->
 	<javaPermission className="java.security.AllPermission"  name="*" actions="*" />
     
-	<mpTelemetry source="message"/>
+	<mpTelemetry source="message,trace"/>
 </server>


### PR DESCRIPTION
fixes #32494 

Updated TelemetryLogsServer to collect both message and trace logs via mpTelemetry. This ensures trace log records are exported and resolves the intermittent failure in testTraceLogs_EE11_FEATURES_MicroProfile_70.