### PR TITLE
Add Fips option for CLI commands

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -48,6 +48,13 @@ task copyPropertiesToBuildImage (type:Copy) {
            tokens: [PRODUCT_VERSION: bnd.libertyRelease, PRODUCT_EDITION: bnd.productEdition, PRODUCT_LICENSE_TYPE: bnd.productLicenseType])
 }
 
+task copyFips1403PropertiesToBuildImage( type: Copy) {
+    dependsOn jar
+    from project.file('publish/wlp/security')
+    into project.file('wlp/lib/security/fips140_3')
+    include 'FIPS140-3-Liberty.properties'
+}
+
 task copyPublicKeyToBuildImage (type:Copy) {
     dependsOn jar
     from project.file('publish')
@@ -154,6 +161,7 @@ jar {
 assemble {
     dependsOn publishTemplates
     dependsOn copyPropertiesToBuildImage
+    dependsOn copyFips1403PropertiesToBuildImage
     dependsOn addServiceFingerprint
     dependsOn copyReadmeToBuildImage
     dependsOn copyBetaLicenseToBuildImage
@@ -314,6 +322,12 @@ class PackageLibertyWithFeatures extends DefaultTask {
             project.copy {
                 from project.file('wlp')
                 include 'LICENSE'
+                into "$outputTo/wlp"
+            }
+
+            project.copy {
+                from project.file('wlp')
+                include 'lib/security/fips140_3/FIPS140-3-Liberty.properties'
                 into "$outputTo/wlp"
             }
 

--- a/dev/build.image/publish/wlp/security/FIPS140-3-Liberty.properties
+++ b/dev/build.image/publish/wlp/security/FIPS140-3-Liberty.properties
@@ -1,0 +1,28 @@
+# org.objectweb.asm.commons.SerialVersionUIDAdder: Allow for SHA-1 to generate SerialVersionUID's to conform Java specification
+# org.eclipse.persistence.internal.libraries.asm.commons.SerialVersionUIDAdder: Allow for SHA-1 to generate SerialVersionUID's to conform Java specification
+# org.apache.yoko.rmi.impl.ValueDescriptor: Alloww for SHA-1 to generate the hash code for the RepositoryId
+# com.ibm.ws.wsoc.util.Utils: Allow SHA-1 for the generation of the Sec-WebSocket-Accept header
+# com.ibm.security.certclient.util.PkUtils: Allof for SHA-1 to generate of certificate Key Identifier(KID) value
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3 for Liberty
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS [+ \
+    {MessageDigest, SHA-1, *, FullClassName:org.objectweb.asm.commons.SerialVersionUIDAdder}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.eclipse.persistence.internal.libraries.asm.commons.SerialVersionUIDAdder}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.yoko.rmi.impl.ValueDescriptor}, \
+    {MessageDigest, SHA-1, *, FullClassName:com.ibm.ws.wsoc.util.Utils}, \
+    {MessageDigest, SHA-1, *, FullClassName:com.ibm.security.certclient.util.PkUtils}]
+
+# For Collectives
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.7 = com.ibm.ws.collective.security.internal.provider.CollectiveProvider
+
+# For WebServices / SAML (uses JCE underneath)
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.8 = org.apache.jcp.xml.dsig.internal.dom.XMLDSigRI
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.9 = org.apache.wss4j.dom.transform.STRTransformProvider
+# Reserved Providers in case new providers are required
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.10 = io.openliberty.PLACEHOLDER
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.11 = io.openliberty.PLACEHOLDER
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.12 = io.openliberty.PLACEHOLDER
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.13 = io.openliberty.PLACEHOLDER
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.14 = io.openliberty.PLACEHOLDER
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.15 = io.openliberty.PLACEHOLDER
+

--- a/dev/build.sharedResources/usrShared/resources/security/semeruFips140_3CustomProfile.properties
+++ b/dev/build.sharedResources/usrShared/resources/security/semeruFips140_3CustomProfile.properties
@@ -20,3 +20,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = com.ibm.ws.collective.security.internal.provider.CollectiveProvider

--- a/dev/cnf/resources/bin/tool
+++ b/dev/cnf/resources/bin/tool
@@ -278,14 +278,32 @@ if [ -z "${JAVA_HOME}" ]; then
   JAVA_PATH_FROM_PATH=$(command -v java)
   if [ -n "${JAVA_PATH_FROM_PATH}" ] ; then
     JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $JAVA_PATH_FROM_PATH))/lib/modules
+    IBM_SDK_FIPS140_3_FILE_LOCATION=$(dirname "$(dirname "${JAVA_PATH_FROM_PATH}")")/jre/fips140-3
   fi
 else
   JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
+  IBM_SDK_FIPS140_3_FILE_LOCATION="${JAVA_HOME}/fips140-3"
 fi
 
 # If this is a Java 9 JDK, add some JDK 9 workarounds to the JVM_ARGS
 if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
   JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED ${JVM_ARGS}"
+fi
+
+# If ENABLE_FIPS140_3 is set by the user then add appropiate FIPS140-3 JVM options
+if [ -n "${ENABLE_FIPS140_3+set}" ] && [ "${ENABLE_FIPS140_3}" != false ]; then
+  if [ -d "${IBM_SDK_FIPS140_3_FILE_LOCATION}" ]; then
+    JVM_ARGS="-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS ${JVM_ARGS}"
+  else
+    if grep -q "OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced" "${JAVA_HOME}/conf/security/java.security" ; then
+      SEMERU_FIPS=true
+    elif grep -q "OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced" "$(dirname $(dirname $(command -v java)))/conf/security/java.security" ; then
+      SEMERU_FIPS=true
+    fi
+    if [ -n SEMERU_FIPS ]; then
+      JVM_ARGS="-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Liberty -Djava.security.properties=${WLP_INSTALL_DIR}/lib/security/fips140_3/FIPS140-3-Liberty.properties ${JVM_ARGS}"
+    fi
+  fi
 fi
 
 # Prevent the Java invocation appearing as an application on a mac

--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
@@ -390,7 +390,7 @@ clientEnvDefaults()
       JVM_ARGS="${JVM_ARGS} -Dfile.encoding=$defaultFileEncoding"
     fi
   fi
-  
+
   clientUmask
 }
 
@@ -441,6 +441,8 @@ clientEnvAndJVMOptions()
     mergeJVMOptions "${WLP_INSTALL_DIR}/lib/platform/java/java9.options"
   fi
 
+  enableFIPS140_3
+
   return $rc
 }
 
@@ -466,6 +468,39 @@ mergeJVMOptions()
       done
       IFS=$saveIFS
     fi
+}
+
+enableFIPS140_3()
+{
+  if [ -n "${ENABLE_FIPS140_3+set}" ] && [ "$ENABLE_FIPS140_3" != false ]; then
+    if [ -d "${JAVA_HOME}/jre/fips140-3" ] || [ -d "${JAVA_HOME}/fips140-3" ] || [ -d "$(dirname $(dirname $(command -v java)))/jre/fips140-3" ]; then
+      JVM_ARGS="${JVM_ARGS} -Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
+    else
+      if [ -f "${JAVA_HOME}/conf/security/java.security" ]; then
+        if grep -q "OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced" "${JAVA_HOME}/conf/security/java.security" ; then
+          SEMERU_FIPS=true
+        elif grep -q "OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced" "$(dirname $(dirname $(command -v java)))/conf/security/java.security" ; then
+          SEMERU_FIPS=true
+        fi
+        if [ -n "${SEMERU_FIPS}" ]; then
+          saveIFS=$IFS
+          IFS=":"
+          ENABLE_FIPS140_3="${WLP_INSTALL_DIR}/lib/security/fips140_3/FIPS140-3-Liberty.properties:${ENABLE_FIPS140_3}"
+          for file in ${ENABLE_FIPS140_3}; do
+            profileFile=$file
+          done
+          IFS=$saveIFS
+          for line in $(readNativeFile "$profileFile" '[#_A-Za-z=]' | tr -d '\r'); do
+            match=$(echo "$line" | sed -n 's/.*RestrictedSecurity\.\([a-zA-Z0-9\.-]*\)\.extends$/\1/p')
+            if [ -n "$match" ]; then
+              profile=$match
+            fi
+          done
+          JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.propertiesList=${ENABLE_FIPS140_3}"
+        fi
+      fi
+    fi
+  fi
 }
 
 ##

--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client.bat
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client.bat
@@ -175,6 +175,8 @@ goto:eof
   if %RC% == 2 goto:eof
 
   call:clientWorkingDirectory
+  call:enableFIPS140_3
+
   !JAVA_CMD_QUOTED! !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED!
   set RC=%errorlevel%
   call:javaCmdResult
@@ -260,7 +262,6 @@ goto:eof
     if exist "%JAVA_HOME%\jre\bin\java.exe" set JAVA_HOME=!JAVA_HOME!\jre
     set JAVA_CMD_QUOTED="!JAVA_HOME!\bin\java"
   )
-
 goto:eof
 
 @REM
@@ -302,7 +303,7 @@ goto:eof
   )
   
   set JVM_OPTIONS=!JVM_OPTIONS!%JVM_TEMP_OPTIONS%
-  
+
 goto:eof
 
 @REM
@@ -349,6 +350,61 @@ goto:eof
   if not exist "%CLIENT_OUTPUT_DIR%" mkdir "%CLIENT_OUTPUT_DIR%"
   cd /d "%CLIENT_OUTPUT_DIR%"
 goto:eof
+
+@REM Check if the ENABLE_FIPS140_3 variable has been set by the user
+@REM If ENABLE_FIPS140_3 is set, determine the correct JVM options depending on the version of Java to be used and add to list
+@REM The version of java is determined to correctly set IBM SDK 8 or Semeru FIPS140-3 flags
+:enableFIPS140_3
+  @REM CHeck if FIPS140-3 is enabled for the client
+  if defined ENABLE_FIPS140_3 (
+    if "%ENABLE_FIPS140_3%" neq "false" (
+      @REM determine if we are using IBM SDK 8 with FIPS140-3 support
+      if exist "%JAVA_HOME%\fips140-3" set IBM_SDK_8=true
+      if NOT defined IBM_SDK_8 (
+        if exist "%JRE_HOME%\fips140-3" set IBM_SDK_8=true
+        if NOT defined IBM_SDK_8 (
+          if exist "%WLP_DEFAULT_JAVA_HOME%\jre\fips140-3" set IBM_SDK_8=true
+        )
+      )
+      if not defined IBM_SDK_8 (
+        for /f "delims=" %%a in ('find "OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced" "!JAVA_HOME!\conf\security\java.security"') do (
+          if defined SKIP_FIRST_LINE (
+             set SEMERU_FIPS=true
+          ) else (
+             set SKIP_FIRST_LINE="true"
+          )
+        )
+      )
+
+      if defined IBM_SDK_8 (
+        set JVM_OPTIONS=-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS !JVM_OPTIONS!
+      ) else (
+        if defined SEMERU_FIPS (
+          @REM de-quote input variable
+          set ENABLE_FIPS140_3=!ENABLE_FIPS140_3:"=!
+          @REM add Liberty FIPS profile
+          set ENABLE_FIPS140_3=!WLP_INSTALL_DIR!\lib\security\fips140_3\FIPS140-3-Liberty.properties;!ENABLE_FIPS140_3!
+          @REM Retrieve name of Semeru FIPS140-3 profile from the last file in provided paths
+          for %%i in ("!ENABLE_FIPS140_3:;=";"!") do (
+            set "file=%%~i"
+          )
+          for /f "delims== " %%l in (!file!) do (
+            set line=%%l
+            if /i "!line:~0,18!" == "RestrictedSecurity" (
+              set "line=!line:~19!"
+              if "!line:~-7!" == "extends" (
+                set profileName=!line:~0,-8!
+              )
+            )
+          )
+          set JVM_OPTIONS=-Dsemeru.fips=true -Dsemeru.customprofile=!profileName! -Djava.security.propertiesList=!ENABLE_FIPS140_3! !JVM_OPTIONS!
+        )
+      )
+    )
+  )
+
+goto:eof
+
 
 @REM
 @REM Check the result of a Java command.

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -524,7 +524,7 @@ serverEnvAndJVMOptions()
   mergeJVMOptions "${WLP_USER_DIR}/shared/jvm.options"
   if [ $rc -ne 0 ]; then
     return $rc
-  fi  
+  fi
   # This location is intentionally not documented  but removing might break existing installations
   mergeJVMOptions "${WLP_INSTALL_DIR}/usr/shared/jvm.options"
   if [ $rc -ne 0 ]; then
@@ -556,7 +556,7 @@ serverEnvAndJVMOptions()
     # JAVA_HOME not set.  Locate java using the PATH.
     JAVA_PATH=$(command -v java)
     if [ -n "${JAVA_PATH}" ] ; then
-      
+
       # Resolve symlinks.  JAVA_HOME is parent of parent of 'java'
       REAL_JAVA_PATH=$(findRealPath "${JAVA_PATH}")
       JAVA_HOME=$(dirname "${REAL_JAVA_PATH}")/..
@@ -586,11 +586,13 @@ serverEnvAndJVMOptions()
   # If there is a lib/modules directory under JAVA_HOME, then it is at least Java 9.   Ensure java9.options gets loaded.
   if [ -n "${JAVA_HOME}" ]; then
     JPMS_MODULE_FILE_LOCATION=${JAVA_HOME}/lib/modules
-  
+
     if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
        mergeJVMOptions "${WLP_INSTALL_DIR}/lib/platform/java/java9.options"
     fi
   fi
+
+  enableFIPS140_3
 
   return $rc
 }
@@ -609,13 +611,13 @@ findRealPath() {
 
       resolvedPath=$(realpath "${path}" 2>/dev/null)
     fi
-  
+
     # If unsuccessful, try readlink -e
     if [ -z "${resolvedPath}" ] && command -v readlink >/dev/null; then
       resolvedPath=$(readlink -e "${path}" 2>/dev/null)
     fi
 
-    # If unsuccessful, try cd -P command. 
+    # If unsuccessful, try cd -P command.
     if [ -z "${resolvedPath}" ]; then
       resolvedPath=$(unset CDPATH; cd -P "${path}" >/dev/null 2>&1 && pwd)
     fi
@@ -623,10 +625,10 @@ findRealPath() {
   fi
 
   # If none of those methods work, try a more basic approach
-  if [ -z "${resolvedPath}" ]; then 
+  if [ -z "${resolvedPath}" ]; then
     symLinkCount=0
 
-    # Loop ends when resolvedPath does not contain any symlinks  
+    # Loop ends when resolvedPath does not contain any symlinks
     while true; do
 
       resolvedPath=""
@@ -635,7 +637,7 @@ findRealPath() {
       set -- $path
       pathContainsSymLink="false"
       for component; do
-	  
+
         if [ -z "$component" ]; then
           continue # Skip empty components
         fi
@@ -657,7 +659,7 @@ findRealPath() {
         if [ -L "$resolvedPath" ]; then
           pathContainsSymLink="true"
           symLinkCount=$((symLinkCount + 1))
-		  
+
           # Get the target of the symbolic link
           target=$(ls -l "$resolvedPath" | awk '{print $NF}')
           # The line above might have problems with special characters. Possible replacement to consider and test:
@@ -675,7 +677,7 @@ findRealPath() {
 
           # Save the prefix up one level from the symlink
           savePrefix=$(cd "$(dirname "$resolvedPath")" && pwd)
-		  
+
           case "$target" in
           /*)
             # Absolute path case
@@ -719,11 +721,11 @@ mergeJVMOptions()
     READ_ETC=0
     saveIFS=$IFS
     IFS=$newline
-    
+
     for option in $(readNativeFile "$jvmOptions" '[#-]' | LC_ALL=C tr -d '\r'); do
       if [ -n "$option" ]; then
         case $option in
-          \#*) 
+          \#*)
               ;;
           *)
               escapeForEval "${option}"
@@ -769,7 +771,7 @@ readServerEnv()
           # characters. Only accept alphanumeric variable names to avoid eval complexities.
           if [ "$uname" != "SunOS" ] && [ "$uname" != "OS/390" ]; then
 
-            # This is the preferred pattern, because it handles characters 
+            # This is the preferred pattern, because it handles characters
             # from multiple languages, but it doesn't work on Solaris.
             var=$(safeEcho "$line" | sed -n -e 's/^\([_[:alpha:]][_[:alnum:]]*\)=.*/\1/p')
 
@@ -791,7 +793,7 @@ readServerEnv()
               then
                  eval "export ${var}"
               else
-                 # Variable expansion is not enabled.  Just set the variable to whatever is on the right side 
+                 # Variable expansion is not enabled.  Just set the variable to whatever is on the right side
                  # of the assignment and export it.  If a later line enables variable expansion, the source
                  # command will reassign the variable (which is already exported) to the resolved value.
                  extractValueAndEscapeForEval "${line}"
@@ -861,7 +863,7 @@ serverWorkingDirectory()
     case "${SERVER_WORKING_DIR}" in
       /*) len=${#SERVER_WORKING_DIR}
           if [ $len -eq 1 ]; then
-            SERVER_WORKING_DIR=$SERVER_OUTPUT_DIR 
+            SERVER_WORKING_DIR=$SERVER_OUTPUT_DIR
           fi ;;
       *) SERVER_WORKING_DIR="${SERVER_OUTPUT_DIR}/${SERVER_WORKING_DIR}" ;;
     esac
@@ -908,7 +910,7 @@ javaCmd()
 {
   JAVA_CMD_LOG=$1
   shift
-  
+
   # Filter all of the -D and -X arguments off of the argument line and add them to $JVM_OPTIONS_QUOTED
   REMAINING_ARGS=""
   for option in "$@"; do
@@ -955,7 +957,7 @@ javaCmd()
       JVM_OPTIONS_QUOTED="$JVM_OPTIONS_QUOTED -Dio.openliberty.checkpoint.criu.unprivileged=true"
     fi
     if [ -n "$CRIU_LOG_LEVEL" ]; then
-      # A system property is used here to avoid having to read env on the 
+      # A system property is used here to avoid having to read env on the
       # checkpoint side. If reading the env from the Java checkpoint side we need
       # to make the env an immutable value but we don't want to force the
       # same CRIU_LOG_LEVEL on both the checkpoint and restore side here.
@@ -963,7 +965,7 @@ javaCmd()
     fi
     criuEnvDefaults
   fi
-  
+
   # Set all the parameters for the java command.  We use eval so that each line
   # in jvm.options is treated as a distinct argument.
   eval "set -- ${JAVA_AGENT_QUOTED} ${JVM_OPTIONS_QUOTED} ${JAVA_DEBUG} ${JVM_ARGS} -jar ${WLP_INSTALL_DIR_QUOTED}/bin/tools/ws-server.jar ""$REMAINING_ARGS"
@@ -972,11 +974,11 @@ javaCmd()
   if [ $ACTION = "checkpoint" ]; then
     if [ -d "${SERVER_OUTPUT_DIR}/workarea/checkpoint" ]; then
       rm -rf ${SERVER_OUTPUT_DIR}/workarea/checkpoint
-      rc=$? 
+      rc=$?
       if [ $rc -ne 0 ]; then
          issueMessage --message:error.checkpoint.delete "${SERVER_OUTPUT_DIR}/workarea/checkpoint"
          return $rc
-      fi   
+      fi
     fi
   fi
 
@@ -1030,7 +1032,7 @@ javaCmd()
       fi
     fi
     kill $TAIL_PID
-    # Above JAVA_CMD should terminate after a criu dump and SIGKILL. 
+    # Above JAVA_CMD should terminate after a criu dump and SIGKILL.
     # Check for expected return code of 137 from the KILL.
     if [ $rc -eq 137 ]; then
       backupWorkarea
@@ -1149,7 +1151,7 @@ serverCmd()
 
   SAVE_JVM_OPTIONS_QUOTED=${JVM_OPTIONS_QUOTED}
   JVM_OPTIONS_QUOTED=${SERVER_JVM_OPTIONS_QUOTED}
-  
+
   SAVE_IBM_JAVA_OPTIONS=${IBM_JAVA_OPTIONS}
   IBM_JAVA_OPTIONS=${SERVER_IBM_JAVA_OPTIONS}
   SAVE_OPENJ9_JAVA_OPTIONS=${OPENJ9_JAVA_OPTIONS}
@@ -1240,14 +1242,14 @@ serverCmd()
         fi
       fi
 
-  
+
   else
     X_CMD="${JAVA_CMD} ${ARGS}"
     export X_CMD
 
     javaCmd "${SERVER_CMD_BACKGROUND_LOG}" "${SERVER_NAME}" "$@"
     rc=$?
-      
+
     PID=$!
 
     JVM_OPTIONS_QUOTED=${SAVE_JVM_OPTIONS_QUOTED}
@@ -1261,7 +1263,7 @@ serverCmd()
       # write the pid file if return is OK or UNKNOWN
       if [ $rc = 0 -o $rc = $SERVER_UNKNOWN_STATUS ]; then
           safeEcho "${PID}" > "${X_PID_FILE}"
-      fi        
+      fi
     fi
   fi
   return $rc
@@ -1346,12 +1348,12 @@ criuRestore()
   if [ $rc -ne 0 ]; then
     issueMessage --message:error.checkpoint.workarea.restore "${SERVER_OUTPUT_DIR}/workarea/checkpoint/workarea"
     return $rc
-  fi 
+  fi
 
   BACKGROUND_RESTORE=$1
   if [ -z "${CRIU_LOG_LEVEL}" ]; then
     CRIU_LOG_LEVEL=2
-  fi  
+  fi
 
   checkCriuUnprivileged
   if [ $DO_CRIU_UNPRIVILEGED = true ]; then
@@ -1386,7 +1388,7 @@ criuRestore()
       if [ $rc = 0 -o $rc = $SERVER_UNKNOWN_STATUS ]; then
         safeEcho "${PID}" > "${X_PID_FILE}"
       fi
-    fi        
+    fi
   else
     # For checkpoint we always write to the log file.
     # Use tail to bring the content to the console output
@@ -1428,18 +1430,18 @@ restoreServer()
   done
 
   # restore artifacts and environment prior to checkpoint here
-    
+
   # no good way to check for criu support since fast startup is imperative
   #   just let criu invocation fail with a hopefully informative error message.
   mkdirs ${X_LOG_DIR}/checkpoint
 
-  # save off the log during checkpoint and start fresh from restore 
+  # save off the log during checkpoint and start fresh from restore
   RESTORE_CONSOLE_LOG="${X_LOG_DIR}/${X_LOG_FILE}"
   CHECKPOINT_CONSOLE_LOG="${X_LOG_DIR}/checkpoint-${X_LOG_FILE}"
   backupIfNeededOrRemove $RESTORE_CONSOLE_LOG $CHECKPOINT_CONSOLE_LOG
   mkdirs "${X_LOG_DIR}"
   touchIfNotExist "${RESTORE_CONSOLE_LOG}"
- 
+
   # record the start of restoreTime
   echo `date +%s%3N` > ${SERVER_OUTPUT_DIR}/workarea/checkpoint/restoreTime
 
@@ -1460,7 +1462,7 @@ restoreServer()
   env | grep -E "^[^\=]*.=" > ${SERVER_OUTPUT_DIR}/workarea/checkpoint/.env.properties
 
   rm -f ${SERVER_OUTPUT_DIR}/workarea/checkpoint/.restoreFailedMarker
-  
+
   criuRestore $BACKGROUND_RESTORE
   rc=$?
   if [ -f "${SERVER_OUTPUT_DIR}/workarea/checkpoint/.restoreFailedMarker" ]; then
@@ -1507,12 +1509,12 @@ defineEscapeForEvalFunctions()
       {
         escapeForEvalResult=\\'\${1//\\'/\\'\\\"\\'\\\"\\'}\\'
       }
-  
+
       extractValueAndEscapeForEval()
       {
         escapeForEval \"\${1#*=}\"
       }
-  
+
       substitutePrefixVar()
       {
         case \$1 in
@@ -1530,7 +1532,7 @@ defineEscapeForEvalFunctions()
     {
       escapeForEvalResult=\'$(safeEcho "$1" | sed s/\'/\'\"\'\"\'/g)\'
     }
-  
+
     ##
     ## extractValueAndEscapeForEval: Extract the value of a var=value string,
     ##                               and set escapeForEvalResult with the result.
@@ -1539,7 +1541,7 @@ defineEscapeForEvalFunctions()
     {
       escapeForEvalResult=\'`safeEcho "$1" | sed -e 's/[^=]*=//' -e s/\'/\'\"\'\"\'/g`\'
     }
-  
+
     ##
     ## substitutePrefixVar: If $1 has a prefix @$2@, set substitutePrefixVarResult
     ##                      to $1 with the prefix replaced by $3.  Otherwise, set
@@ -1554,6 +1556,39 @@ defineEscapeForEvalFunctions()
   fi
 }
 
+enableFIPS140_3()
+{
+  if [ -n "${ENABLE_FIPS140_3+set}" ] && [ "${ENABLE_FIPS140_3}" != false ]; then
+    if [ -d "${JAVA_HOME}/jre/fips140-3" ] || [ -d "${JAVA_HOME}/fips140-3" ] || [ -d "$(dirname $(dirname $(command -v java)))/jre/fips140-3" ]; then
+      JVM_ARGS="${JVM_ARGS} -Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
+    else
+      if [ -f "${JAVA_HOME}/conf/security/java.security" ]; then
+        if grep -q "OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced" "${JAVA_HOME}/conf/security/java.security" ; then
+          SEMERU_FIPS=true
+        elif grep -q "OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced" "$(dirname $(dirname $(command -v java)))/conf/security/java.security" ; then
+          SEMERU_FIPS=true
+        fi
+        if [ -n "${SEMERU_FIPS}" ]; then
+          saveIFS=$IFS
+          IFS=":"
+          ENABLE_FIPS140_3="${WLP_INSTALL_DIR}/lib/security/fips140_3/FIPS140-3-Liberty.properties:${ENABLE_FIPS140_3}"
+          for file in ${ENABLE_FIPS140_3}; do
+            profileFile=$file
+          done
+          IFS=$saveIFS
+          for line in $(readNativeFile "$profileFile" '[#_A-Za-z=]' | tr -d '\r'); do
+            match=$(echo "$line" | sed -n 's/.*RestrictedSecurity\.\([a-zA-Z0-9\.-]*\)\.extends$/\1/p')
+            if [ -n "$match" ]; then
+              profile=$match
+            fi
+          done
+          JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.propertiesList=${ENABLE_FIPS140_3}"
+        fi
+      fi
+    fi
+  fi
+}
+
 # ########################################################################### #
 # main()                                                                      #
 # ########################################################################### #
@@ -1563,9 +1598,9 @@ SERVER_UNKNOWN_STATUS=5
 ##
 ## Determine the platform and absolute path of the installation directory.
 ##
-## IMPORTANT: Be cautious when updating WLP_INSTALL_DIR as it affects the process name of the 
-## Liberty server shown by the Linux 'ps' command. Changes introducing ".." to the path 
-## may break users' ability to find the Liberty process based on the normalized path. The pwd 
+## IMPORTANT: Be cautious when updating WLP_INSTALL_DIR as it affects the process name of the
+## Liberty server shown by the Linux 'ps' command. Changes introducing ".." to the path
+## may break users' ability to find the Liberty process based on the normalized path. The pwd
 ## command normalizes the path.
 ##
 case $OSTYPE in
@@ -1600,12 +1635,12 @@ case $OSTYPE in
 
     case $uname in
       CYGWIN_*)
-        # This is a very unlikely path. 
+        # This is a very unlikely path.
         WLP_INSTALL_DIR=$(cygpath -ma "$(findRealPath "$0" | sed 's|\\|/|g' | sed 's|/[^/]*$||')"/..)
         ;;
 
       *)
-        # The directory of this script (the server script) 
+        # The directory of this script (the server script)
         scriptDir="$(dirname "$0")"
 
         # Get absolute path.  Needed because "." (current directory) never tests positive as a symbolic link, even if it is.
@@ -1618,7 +1653,7 @@ case $OSTYPE in
         # Else the directory containing this script is a symbolic link.
         # Must find the real path in order to find the installation directory (The parent of scriptDir).
         else
-          resolvedScriptDir=$(findRealPath "${scriptDir}")             
+          resolvedScriptDir=$(findRealPath "${scriptDir}")
           WLP_INSTALL_DIR=$(unset CDPATH; cd "${resolvedScriptDir}/.." && pwd)
         fi
     esac
@@ -1741,11 +1776,11 @@ case "$ACTION" in
 
     if [ -d "${SERVER_OUTPUT_DIR}/workarea/checkpoint/image" ] && [ ${ACTION} != "checkpoint" ]; then
       # Avoid call to restoreServer below if server already running.
-      # If there is no checkpoint, then maintain legacy behavior of 
+      # If there is no checkpoint, then maintain legacy behavior of
       # allowing server launch to check for already running instance.
       if serverStatus false --status:starting; then
         exit 0
-      fi  
+      fi
     fi
 
     serverWorkingDirectory
@@ -1784,21 +1819,21 @@ case "$ACTION" in
       fi
 
       # WLP_JAR_CYGWIN is used only in support of java -jar startup of a Liberty server.
-      # When WLP_JAR_CYGWIN=true (or synonym) is specified, the PID of the launching 
+      # When WLP_JAR_CYGWIN=true (or synonym) is specified, the PID of the launching
       # process (i.e. parent of server process) is determined and stored in the PID file
-      # for use by the java -jar shutdown hook to ensure termination of the launching 
+      # for use by the java -jar shutdown hook to ensure termination of the launching
       # process. This is necessary because the launching process does not terminate on
       # its own under cygwin and if left behind holds file locks that prevent cleanup
-      # of the java -jar extraction directory. 
+      # of the java -jar extraction directory.
       if [ "$WLP_JAR_CYGWIN" = "true" -o "$WLP_JAR_CYGWIN" = "1" -o "$WLP_JAR_CYGWIN" = "TRUE" -o "$WLP_JAR_CYGWIN" = "True" ]
-      then 
+      then
 	      serverCmd '' "$@" &
 	      PID=$!
 	      mkdirs "${X_PID_DIR}"
-	      # find parent PID and store it 
+	      # find parent PID and store it
 	      SPID=`ps -ef | while read l; do grep $PID | awk -v PID=$PID '{ if ( $3 == PID ) print $2 }'; done`
 	      safeEcho "${SPID}" > "${X_PID_FILE}"
-	      wait "${PID}" # wait because this 
+	      wait "${PID}" # wait because this
 	      rc=$?
       else
 	      serverCmd '' "$@"
@@ -1809,9 +1844,9 @@ case "$ACTION" in
       exit 2
     fi
   ;;
-   
+
   # Start the server in the background
-  start)    
+  start)
 
     if serverEnvAndJVMOptions
     then
@@ -1875,7 +1910,7 @@ case "$ACTION" in
       exit $rc
     else
       exit 2
-    fi    
+    fi
   ;;
 
   create)
@@ -1883,8 +1918,8 @@ case "$ACTION" in
     createServer "$@"
     exit $rc
   ;;
-  
-  # Stop the server. 
+
+  # Stop the server.
   stop)
     serverEnv
     if checkServer true
@@ -1911,7 +1946,7 @@ case "$ACTION" in
       exit 2
     fi
   ;;
-  
+
   # Check if server is running
   status)
     serverEnv
@@ -1950,19 +1985,19 @@ case "$ACTION" in
     else
      exit $?
     fi
-    
+
     # Check to see if the server exists
     if checkServer true
     then
       serverPIDStatus
-      JVM_OPTIONS_QUOTED=${SERVER_JVM_OPTIONS_QUOTED} 
+      JVM_OPTIONS_QUOTED=${SERVER_JVM_OPTIONS_QUOTED}
       javaCmd '' "${SERVER_NAME}" --pid="${PID}" --package "$@"
       exit $?
     else
       exit 2
-    fi    
+    fi
   ;;
-  
+
 
   # dump the server's configs/logs/status to a zip file
   dump)
@@ -1970,11 +2005,11 @@ case "$ACTION" in
     # Check to see if the server exists
     if checkServer true
     then
-      javaCmd '' "${SERVER_NAME}" --dump "$@" 
+      javaCmd '' "${SERVER_NAME}" --dump "$@"
       exit $?
     else
       exit 2
-    fi    
+    fi
   ;;
 
   # dump JVM status
@@ -1988,18 +2023,18 @@ case "$ACTION" in
       exit 2
     fi
   ;;
-  
+
   # pause the server
   pause)
     serverEnv
     # Check to see if the server exists
     if checkServer true
     then
-      javaCmd '' "${SERVER_NAME}" --pause "$@" 
+      javaCmd '' "${SERVER_NAME}" --pause "$@"
       exit $?
     else
       exit 2
-    fi    
+    fi
   ;;
 
   # resume the server
@@ -2008,33 +2043,33 @@ case "$ACTION" in
     # Check to see if the server exists
     if checkServer true
     then
-      javaCmd '' "${SERVER_NAME}" --resume "$@" 
+      javaCmd '' "${SERVER_NAME}" --resume "$@"
       exit $?
     else
       exit 2
-    fi    
+    fi
   ;;
 
   version)
     serverEnv
     javaCmd '' --version
-  ;;  
-  
+  ;;
+
   list)
     installEnv
     javaCmd '' --list
-  ;;  
-  
+  ;;
+
   help)
     installEnv
     javaCmd '' --help ${SERVER_NAME}
-  ;;  
+  ;;
 
   help:usage)
     installEnv
     javaCmd '' --help:usage
   ;;
-  
+
   *)
     installEnv
     javaCmd '' --help:actions:${ACTION}

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -277,6 +277,7 @@ goto:eof
   set OPENJ9_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
 
   call:checkForVerboseGC
+  call:enableFIPS140_3
 
   !JAVA_CMD_QUOTED! !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED!
   set RC=%errorlevel%
@@ -298,6 +299,7 @@ goto:eof
   set OPENJ9_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
 
   call:checkForVerboseGC
+  call:enableFIPS140_3
 
   !JAVA_CMD_QUOTED! !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED!
   set RC=%errorlevel%
@@ -348,6 +350,7 @@ goto:eof
     set OPENJ9_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
 	
     call:checkForVerboseGC
+    call:enableFIPS140_3
 
     @REM Use javaw so command windows can be closed.
     start /min /b "" !JAVA_CMD_QUOTED!w !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED! >> "%X_LOG_DIR%\%X_LOG_FILE%" 2>&1
@@ -741,6 +744,60 @@ goto:eof
     )
 
     set OPENJ9_JAVA_OPTIONS="-Xverbosegclog:!X_LOG_DIR!\verbosegc.%%seq.log,10,1024" !OPENJ9_JAVA_OPTIONS!
+goto:eof
+
+@REM Check if the ENABLE_FIPS140_3 variable has been set by the user
+@REM If ENABLE_FIPS140_3 is set, determine the correct JVM options depending on the version of Java to be used and add to list
+@REM The version of java is determined to correctly set IBM SDK 8 or Semeru FIPS140-3 flags
+:enableFIPS140_3
+  if defined ENABLE_FIPS140_3 (
+    if "%ENABLE_FIPS140_3%" neq "false" (
+      @REM determine if we are using IBM SDK 8 with FIPS140-3 support
+      if exist "%JAVA_HOME%\fips140-3\" set IBM_SDK_8=true
+      if NOT defined IBM_SDK_8 (
+        if exist "%JRE_HOME%\fips140-3\" set IBM_SDK_8=true
+        if NOT defined IBM_SDK_8 (
+          if exist "%WLP_DEFAULT_JAVA_HOME%\jre\fips140-3\" set IBM_SDK_8=true
+        )
+      )
+      if not defined IBM_SDK_8 (
+        for /f "delims=" %%a in ('find "OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced" "!JAVA_HOME!\conf\security\java.security"') do (
+            if defined SKIP_FIRST_LINE (
+               set SEMERU_FIPS=true
+            ) else (
+               set SKIP_FIRST_LINE="true"
+            )
+        )
+      )
+
+      if defined IBM_SDK_8 (
+        set JVM_OPTIONS=-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS !JVM_OPTIONS!
+      ) else (
+        if defined SEMERU_FIPS (
+            @REM de-quote input variable
+            set ENABLE_FIPS140_3=!ENABLE_FIPS140_3:"=!
+            set ENABLE_FIPS140_3=!WLP_INSTALL_DIR!\lib\security\fips140_3\FIPS140-3-Liberty.properties;!ENABLE_FIPS140_3!
+            @REM Retrieve name of Semeru FIPS140-3 profile from the last file in provided paths
+            for %%i in ("!ENABLE_FIPS140_3:;=";"!") do (
+              set "file=%%~i"
+            )
+            if not defined file (
+               set file=!WLP_INSTALL_DIR!\lib\security\fips140_3\FIPS140-3-Liberty.properties
+            )
+            for /f "delims== " %%l in (!file!) do (
+              set line=%%l
+              if /i "!line:~0,18!" == "RestrictedSecurity" (
+                set "line=!line:~19!"
+                if "!line:~-7!" == "extends" (
+                  set profileName=!line:~0,-8!
+                )
+              )
+            )
+            set JVM_OPTIONS=-Dsemeru.fips=true -Dsemeru.customprofile=!profileName! -Djava.security.propertiesList=!ENABLE_FIPS140_3! !JVM_OPTIONS!
+        )
+      )
+    )
+  )
 goto:eof
 
 @REM


### PR DESCRIPTION
Add support for a flag that allows all CLI commands to run with the various FIPS options set.

By Specifying `ENABLE_FIPS140_3=<Path to profile>` (case-insensitive) in the environment, recommendation would be in java.env or default.env that are referenced within the tools. The should be the User profile, not the liberty profile. Once We can supply multiple files, the Liberty base will be included via the scripts. 

All scripts have the ability to detect whether they are using IBM SDK8 or not and use this 
in IBM SDK8 installs there is a `<Java install>/jre/fips140-3` folder, meaning we can ensure for this that 
Work need on Windows if system java i.e. not defined in <JAVA|JRE>_HOME is used. In Linux we are covered via `command -v java`

The Linux scripts currently support the retrieval of the profile name from the final file in the list of provided files. Need to work on the equivalent logic within batch. This should mean we only need a single property to be set.

Scripts that are generated from `tool` and `tool.bat` use that the property has been set (does require a value), though any value is acceptable. The profile name currently used is just what we have, will need to be formalized before this is merged.

Add Base Liberty Profile that is extended by user profiles. This includes the core shipped requirements of the Liberty runtime. Explanations are provided for each one. an additional 6 slots are included so that we can add new providers if we find we need to for Liberty

https://github.com/OpenLiberty/open-liberty/pull/32537

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".