### PR TITLE
create unittest 'test' folder to com.ibm.ws.ui

### DIFF
--- a/dev/com.ibm.ws.ui/.classpath
+++ b/dev/com.ibm.ws.ui/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+        <classpathentry kind="src" output="bin_test" path="test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.ui/bnd.bnd
+++ b/dev/com.ibm.ws.ui/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2016, 2022 IBM Corporation and others.
+# Copyright (c) 2016, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -38,3 +38,19 @@ instrument.disabled: true
 	com.ibm.wsspi.org.osgi.service.event;version=latest,\
 	com.ibm.ws.org.apache.commons.fileupload;version=latest,\
 	io.openliberty.com.google.gson;version=latest
+
+
+-testpath: \
+    ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
+    com.ibm.ws.junit.extensions;version=latest, \
+    org.hamcrest:hamcrest-all;version=1.3,\
+    org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
+    org.jmock:jmock;strategy=exact;version=2.5.1, \
+    org.jmock:jmock-legacy;version=2.5.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest,\
+    com.ibm.ws.kernel.boot;version=latest,\
+    com.ibm.ws.logging;version=latest,\
+    cglib:cglib;version=3.3.0,\
+    org.objenesis:objenesis;version=3.2,\
+    com.ibm.ws.common.encoder;version=latest,\
+    io.openliberty.org.codehaus.jackson;version=latest

--- a/dev/com.ibm.ws.ui/build.gradle
+++ b/dev/com.ibm.ws.ui/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,4 +17,12 @@ jar {
     dependsOn 'compile-js'
     dependsOn 'compile-dojo'
     dependsOn 'post-compile'
+}
+
+
+test {
+     jvmArgs = ["--add-opens", "java.base/java.lang=ALL-UNNAMED",
+                "--add-opens", "java.base/java.io=ALL-UNNAMED",
+                "--add-opens", "java.base/java.net=ALL-UNNAMED"]
+     
 }

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/FilterTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/FilterTest.java
@@ -1,0 +1,281 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class FilterTest {
+    private Filter f;
+
+    @Before
+    public void setUp() {
+        f = new Filter();
+    }
+
+    @After
+    public void tearDown() {
+        f = null;
+    }
+
+    @Test
+    public void testApplyFilterNullFilter() throws Exception
+    {
+        String filter = null;
+        Map<Object, Object> map = new HashMap<Object, Object>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        @SuppressWarnings("unchecked")
+        Map<Object, Object> newmap = (Map<Object, Object>) f.applyFieldFilter(filter, map);
+        assertEquals("value1", newmap.get("key1"));
+        assertEquals("value2", newmap.get("key2"));
+        assertEquals(2, newmap.size());
+
+    }
+
+    @Test
+    public void testApplyFilterEmptyFilter() throws Exception
+    {
+        String filter = "";
+        Map<Object, Object> map = new HashMap<Object, Object>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        @SuppressWarnings("unchecked")
+        Map<Object, Object> newmap = (Map<Object, Object>) f.applyFieldFilter(filter, map);
+        assertEquals("value1", newmap.get("key1"));
+        assertEquals("value2", newmap.get("key2"));
+        assertEquals(2, newmap.size());
+    }
+
+    @Test
+    public void testApplyFilterSimpleFilter() throws Exception
+    {
+        String filter = "key1";
+        Map<Object, Object> map = new HashMap<Object, Object>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        @SuppressWarnings("unchecked")
+        Map<Object, Object> newmap = (Map<Object, Object>) f.applyFieldFilter(filter, map);
+        assertEquals("value1", newmap.get("key1"));
+        assertEquals(1, newmap.size());
+
+    }
+
+    @Test
+    public void testApplyFilterSimpleFilterNoExist() throws Exception
+    {
+        String filter = "key";
+        Map<Object, Object> map = new HashMap<Object, Object>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        @SuppressWarnings("unchecked")
+        Map<Object, Object> newmap = (Map<Object, Object>) f.applyFieldFilter(filter, map);
+        assertEquals(0, newmap.size());
+
+    }
+
+    @Test
+    public void testApplyFilterSimpleFilterNoExist1() throws Exception
+    {
+        String filter = "key11";
+        Map<Object, Object> map = new HashMap<Object, Object>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        @SuppressWarnings("unchecked")
+        Map<Object, Object> newmap = (Map<Object, Object>) f.applyFieldFilter(filter, map);
+        assertEquals(0, newmap.size());
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testApplyFilterFilter1() throws Exception
+    {
+        String filter = "tools.key1";
+        Map<Object, Object> map = new HashMap<Object, Object>();
+
+        Map<Object, Object> map1 = new HashMap<Object, Object>();
+        map1.put("key1", "Tool1value1");
+        map1.put("key2", "Tool1value2");
+
+        Map<Object, Object> map2 = new HashMap<Object, Object>();
+        map2.put("key1", "Tool2value1");
+        map2.put("key2", "Tool2value2");
+
+        List<Object> list = new ArrayList<Object>();
+        list.add(map1);
+        list.add(map2);
+        map.put("tools", list);
+
+        Map<Object, Object> newmap = (Map<Object, Object>) f.applyFieldFilter(filter, map);
+        assertEquals(1, newmap.size());
+        List<Object> list1 = (List<Object>) newmap.get("tools");
+        assertEquals(2, list1.size());
+        Map<Object, Object> newmap1 = (Map<Object, Object>) list1.get(0);
+        assertEquals(1, newmap1.size());
+        assertEquals("Tool1value1", newmap1.get("key1"));
+
+        Map<Object, Object> newmap2 = (Map<Object, Object>) list1.get(1);
+        assertEquals(1, newmap2.size());
+        assertEquals("Tool2value1", newmap2.get("key1"));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testApplyFilterFilter2() throws Exception
+    {
+        String filter = "tools.key1, tools.key3.key3-1";
+        Map<Object, Object> map = new HashMap<Object, Object>();
+
+        Map<Object, Object> map1 = new HashMap<Object, Object>();
+        map1.put("key1", "Tool1value1");
+        map1.put("key2", "Tool1value2");
+
+        Map<Object, Object> map11 = new HashMap<Object, Object>();
+        map11.put("key3-1", "Tool1key3-1value1");
+        map11.put("key3-2", "Tool1key3-2value2");
+        map1.put("key3", map11);
+
+        Map<Object, Object> map2 = new HashMap<Object, Object>();
+        map2.put("key1", "Tool2value1");
+        map2.put("key2", "Tool2value2");
+
+        Map<Object, Object> map21 = new HashMap<Object, Object>();
+        map21.put("key3-1", "Tool2key3-1value1");
+        map21.put("key3-2", "Tool2key3-2value2");
+        map2.put("key3", map21);
+
+        List<Object> list = new ArrayList<Object>();
+        list.add(map1);
+        list.add(map2);
+        map.put("tools", list);
+
+        Map<Object, Object> newmap = (Map<Object, Object>) f.applyFieldFilter(filter, map);
+        assertEquals(1, newmap.size());
+        List<Object> list1 = (List<Object>) newmap.get("tools");
+        assertEquals(2, list1.size());
+        Map<Object, Object> newmap1 = (Map<Object, Object>) list1.get(0);
+        assertEquals(2, newmap1.size());
+        assertEquals("Tool1value1", newmap1.get("key1"));
+
+        Map<Object, Object> newmap13 = (Map<Object, Object>) newmap1.get("key3");
+        assertEquals(1, newmap13.size());
+        assertEquals("Tool1key3-1value1", newmap13.get("key3-1"));
+
+        Map<Object, Object> newmap2 = (Map<Object, Object>) list1.get(1);
+        assertEquals(2, newmap2.size());
+        assertEquals("Tool2value1", newmap2.get("key1"));
+
+        Map<Object, Object> newmap23 = (Map<Object, Object>) newmap2.get("key3");
+        assertEquals(1, newmap23.size());
+        assertEquals("Tool2key3-1value1", newmap23.get("key3-1"));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void applyFilter_preserveCase() throws Exception {
+        String filter = "map.Key1,list.keyONE,list.camelCase";
+
+        Map<Object, Object> obj = new HashMap<Object, Object>();
+
+        Map<Object, Object> map = new HashMap<Object, Object>();
+        map.put("Key1", "Key1Value");
+        map.put("key2", "key2Value");
+
+        Map<Object, Object> listElement = new HashMap<Object, Object>();
+        listElement.put("keyONE", "keyONEValue");
+        listElement.put("camelCase", "camelCaseValue");
+
+        List<Object> list = new ArrayList<Object>();
+        list.add(listElement);
+
+        obj.put("map", map);
+        obj.put("list", list);
+
+        Map<Object, Object> filteredMap = (Map<Object, Object>) f.applyFieldFilter(filter, obj);
+        System.out.println(filteredMap);
+
+        assertEquals("FAIL: The filetered map was not of the correct size",
+                     2, filteredMap.size());
+
+        Map<Object, Object> filteredMapMap = (Map<Object, Object>) filteredMap.get("map");
+        assertEquals("FAIL: The filtered map map was not of the correct size",
+                     1, filteredMapMap.size());
+        assertEquals("FAIL: The filtered map map did not have the correct key/value for 'Key1'",
+                     "Key1Value", filteredMapMap.get("Key1"));
+
+        List<Object> filteredList = (List<Object>) filteredMap.get("list");
+        assertEquals("FAIL: The filtered list was not of the correct size",
+                     1, filteredList.size());
+
+        Map<Object, Object> filteredListMap = (Map<Object, Object>) filteredList.get(0);
+        assertEquals("FAIL: The filtered list map should have two elements",
+                     2, filteredListMap.size());
+        assertEquals("FAIL: The filtered list map did not have the correct key/value for 'keyONE'",
+                     "keyONEValue", filteredListMap.get("keyONE"));
+        assertEquals("FAIL: The filtered list map did not have the correct key/value for 'camelCase'",
+                     "camelCaseValue", filteredListMap.get("camelCase"));
+    }
+
+    static class SimpleMBeanSetter {
+        @SuppressWarnings("unused")
+        private String noGetter;
+        private String hasGetter;
+
+        public void setNoGetter(String noGetter) {
+            this.noGetter = noGetter;
+        }
+
+        public String getHasGetter() {
+            return hasGetter;
+        }
+
+        public void setHasGetter(String hasGetter) {
+            this.hasGetter = hasGetter;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void applyFilter_ignoresSetterWithoutGetter() throws Exception {
+
+        SimpleMBeanSetter mbean = new SimpleMBeanSetter();
+        mbean.setNoGetter("MUST NOT BE SEEN");
+        mbean.setHasGetter("FindMe");
+
+        String filter = "hasGetter";
+
+        System.out.println(mbean);
+        System.out.println(f.applyFieldFilter(filter, mbean));
+
+        Map<Object, Object> filteredMap = (Map<Object, Object>) f.applyFieldFilter(filter, mbean);
+        assertEquals("FAIL: Filtered map should only have 1 element",
+                     1, filteredMap.size());
+        assertEquals("FAIL: Filtered map did not contain the 'hasGetter' element",
+                     "FindMe", filteredMap.get("hasGetter"));
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/RequestNLSTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/RequestNLSTest.java
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.wsspi.rest.handler.RESTRequest;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class RequestNLSTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private final Mockery mock = new JUnit4Mockery();
+    private final RESTRequest request = mock.mock(RESTRequest.class);
+
+    @Before
+    public void setUp() {
+        RequestNLS.clearThreadLocal();
+    }
+
+    @After
+    public void tearDown() {
+        RequestNLS.clearThreadLocal();
+    }
+
+    @Test
+    public void getSetAndClear() {
+        RESTRequest stored = RequestNLS.getRESTRequest();
+        assertNull("FAIL: The initial value of the ThreadLocal should be null",
+                   stored);
+
+        RequestNLS.setRESTRequest(request);
+        stored = RequestNLS.getRESTRequest();
+        assertSame("FAIL: The stored RESTRequest was not the expected value",
+                   request, stored);
+
+        RequestNLS.clearThreadLocal();
+        stored = RequestNLS.getRESTRequest();
+        assertNull("FAIL: The ThreadLocal should be null after a clear",
+                   stored);
+    }
+
+    @Test
+    public void getLocale_en() {
+        final Locale en = new Locale("en");
+        final List<Locale> locales = new ArrayList<Locale>();
+        locales.add(en);
+
+        Locale bestMatch = RequestNLS.getLocale(Collections.enumeration(locales));
+        assertSame("FAIL: When the requested locale is english, that locale should be returned",
+                   en, bestMatch);
+    }
+
+    @Test
+    public void getLocale_enUS() {
+        final Locale enUS = new Locale("en", "us");
+        final List<Locale> locales = new ArrayList<Locale>();
+        locales.add(enUS);
+
+        Locale bestMatch = RequestNLS.getLocale(Collections.enumeration(locales));
+        assertSame("FAIL: When the requested locale is english, that locale should be returned",
+                   enUS, bestMatch);
+    }
+
+    @Test
+    public void getLocale_fr() {
+        final Locale fr = new Locale("fr");
+        final List<Locale> locales = new ArrayList<Locale>();
+        locales.add(fr);
+
+        Locale bestMatch = RequestNLS.getLocale(Collections.enumeration(locales));
+        assertEquals("FAIL: When the requested locale is french, that locale should be returned",
+                     fr, bestMatch);
+    }
+
+    @Test
+    public void getLocale_frCA() {
+        final Locale frCA = new Locale("fr", "ca");
+        final List<Locale> locales = new ArrayList<Locale>();
+        locales.add(frCA);
+
+        final Locale fr = new Locale("fr");
+        Locale bestMatch = RequestNLS.getLocale(Collections.enumeration(locales));
+        assertEquals("FAIL: When the requested locale a dialect of French, French should be returned",
+                     fr, bestMatch);
+    }
+
+    @Test
+    public void getLocale_pt() {
+        final Locale pt = new Locale("pt");
+        final List<Locale> locales = new ArrayList<Locale>();
+        locales.add(pt);
+
+        Locale bestMatch = RequestNLS.getLocale(Collections.enumeration(locales));
+        assertEquals("FAIL: Portugese is not supported. The JVM default should be returned",
+                     Locale.getDefault(), bestMatch);
+    }
+
+    @Test
+    public void getLocale_ptBR() {
+        final Locale ptBR = new Locale("pt", "br");
+        final List<Locale> locales = new ArrayList<Locale>();
+        locales.add(ptBR);
+
+        Locale bestMatch = RequestNLS.getLocale(Collections.enumeration(locales));
+        assertEquals("FAIL: When the requested locale is Portugese Brazillian, that locale should be returned",
+                     ptBR, bestMatch);
+    }
+
+    @Test
+    public void getLocale_az() {
+        final Locale az = new Locale("az");
+        final List<Locale> locales = new ArrayList<Locale>();
+        locales.add(az);
+
+        Locale bestMatch = RequestNLS.getLocale(Collections.enumeration(locales));
+        assertEquals("FAIL: Azerbaijanii is not supported. The JVM default should be returned",
+                     Locale.getDefault(), bestMatch);
+    }
+
+    @Test
+    public void getLocale_az_enUS() {
+        final Locale az = new Locale("az");
+        final Locale enUS = new Locale("en", "us");
+        final List<Locale> locales = new ArrayList<Locale>();
+        locales.add(az);
+        locales.add(enUS);
+
+        Locale bestMatch = RequestNLS.getLocale(Collections.enumeration(locales));
+        assertEquals("FAIL: AZ is not supported, but en_us is. en_us should be returned.",
+                     enUS, bestMatch);
+    }
+
+    @Test
+    public void getLocale_az_pt_ru() {
+        final Locale az = new Locale("az");
+        final Locale pt = new Locale("pt");
+        final Locale ru = new Locale("ru");
+        final List<Locale> locales = new ArrayList<Locale>();
+        locales.add(az);
+        locales.add(pt);
+        locales.add(ru);
+
+        Locale bestMatch = RequestNLS.getLocale(Collections.enumeration(locales));
+        assertEquals("FAIL: Only a requested locale should be returned",
+                     ru, bestMatch);
+    }
+
+    @Test
+    public void getLocale_az_pt() {
+        final Locale az = new Locale("az");
+        final Locale pt = new Locale("pt");
+        final List<Locale> locales = new ArrayList<Locale>();
+        locales.add(az);
+        locales.add(pt);
+
+        Locale bestMatch = RequestNLS.getLocale(Collections.enumeration(locales));
+        assertEquals("FAIL: When no locales are supported, return JVM default",
+                     Locale.getDefault(), bestMatch);
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceDebuggerTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceDebuggerTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.persistence;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import test.common.SharedOutputManager;
+
+/**
+ * This test DOES hit the file system (namely it reads import.xml).
+ * This file should be safe to rely on to exist.
+ */
+public class FilePersistenceDebuggerTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private final FilePersistenceDebugger debugger = new FilePersistenceDebugger();
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.persistence.FilePersistenceDebugger#getFileContents(java.io.File)}.
+     */
+    @Test
+    public void getFileContentsDoesntExist() {
+        String contents = debugger.getFileContents(new File("idontexist"));
+        assertTrue("FAIL: Contents did not start with 'Unable to load file contents:'",
+                   contents.startsWith("Unable to load file contents:"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.persistence.FilePersistenceDebugger#getFileContents(java.io.File)}.
+     */
+    @Test
+    public void getFileContentsExists() {
+        String contents = debugger.getFileContents(new File("import.xml"));
+        assertFalse("FAIL: Contents should not start with 'Unable to load file contents:'",
+                    contents.startsWith("Unable to load file contents:"));
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceDebuggerWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceDebuggerWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.persistence;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class FilePersistenceDebuggerWithTraceTest extends FilePersistenceDebuggerTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceProviderTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceProviderTest.java
@@ -1,0 +1,260 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.persistence;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+import org.apache.commons.io.FileUtils;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+
+import test.common.SharedOutputManager;
+
+import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
+import com.ibm.wsspi.kernel.service.location.WsResource;
+
+/**
+ * This test DOES back-end to disk. However it does so under the build directory
+ * so any effects this has will be resolved with a clean.
+ */
+public class FilePersistenceProviderTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final ComponentContext cc = mock.mock(ComponentContext.class);
+    @SuppressWarnings("unchecked")
+    private final ServiceReference<WsLocationAdmin> locRef = mock.mock(ServiceReference.class);
+    private final WsLocationAdmin loc = mock.mock(WsLocationAdmin.class);
+    private final WsResource resource = mock.mock(WsResource.class);
+
+    private static final String TEST_DATA_DIR_NAME = "build/libs/testdata/";
+    private static final File TEST_DATA_DIR_FILE = new File(TEST_DATA_DIR_NAME);
+    private static final String LAST_MODIFIED_TARGET = "lastModified";
+    private static final String TOOLDATA_TARGET = "tooldata";
+    private static final long LAST_MODIFIED_CREATE_TIME = getRoundedDownTime();
+    private static final File LAST_MODIFIED_FILE = new File(TEST_DATA_DIR_NAME + LAST_MODIFIED_TARGET + ".json");
+    private static final File TOOLDATA_TARGET_FILE = new File(TEST_DATA_DIR_NAME + TOOLDATA_TARGET + ".json");
+    private static final String fakeContent = "fakeme";
+    private static final String fakeContent2 = "Anotherfakeme";
+
+    private FilePersistenceProvider persist;
+
+    /**
+     * Gets the time of the current second (dropping the millisecond precision).
+     * We do this to work around a JVM problem with getting file timestamps on Linux & JDK 6.
+     * 
+     * @return The seconds since epoch
+     */
+    private static long getRoundedDownTime() {
+        long t = new Date().getTime();
+        long roundedT = t = t - (t % 1000L);
+        System.out.println("Computed rounded down time: " + roundedT + ", was " + t);
+        return roundedT;
+    }
+
+    /**
+     * Create the initial working area for this test.
+     */
+    @BeforeClass
+    public static void setupFiles() throws IOException {
+        if (TEST_DATA_DIR_FILE.exists()) {
+            assertTrue("FAIL: " + TEST_DATA_DIR_FILE.getAbsolutePath() + " must be a directory",
+                       TEST_DATA_DIR_FILE.isDirectory());
+        } else {
+            assertTrue("FAIL: Could not create " + TEST_DATA_DIR_FILE.getAbsolutePath() + " directory",
+                       TEST_DATA_DIR_FILE.mkdir());
+        }
+
+        assertTrue("FAIL: Could not create new last modified file: " + LAST_MODIFIED_FILE.getAbsolutePath(),
+                   LAST_MODIFIED_FILE.createNewFile());
+        FileUtils.writeStringToFile(LAST_MODIFIED_FILE, fakeContent, "UTF-8");
+
+        assertEquals("FAIL: Could not write to file.", FileUtils.readFileToString(LAST_MODIFIED_FILE, "UTF-8"),
+                     fakeContent);
+
+        assertTrue("FAIL: Could not create new tool data file: " + TOOLDATA_TARGET_FILE.getAbsolutePath(),
+                   TOOLDATA_TARGET_FILE.createNewFile());
+        FileUtils.writeStringToFile(TOOLDATA_TARGET_FILE, fakeContent, "UTF-8");
+
+        assertEquals("FAIL: Could not write to file.", FileUtils.readFileToString(TOOLDATA_TARGET_FILE, "UTF-8"),
+                     fakeContent);
+    }
+
+    /**
+     * Activate the service using with mocks.
+     */
+    @Before
+    public void setUp() {
+        mock.checking(new Expectations() {
+            {
+                allowing(cc).locateService(FilePersistenceProvider.KEY_LOCATION_SERVICE, locRef);
+                will(returnValue(loc));
+            }
+        });
+
+        persist = new FilePersistenceProvider();
+        persist.setLocationService(locRef);
+        persist.activate(cc);
+    }
+
+    /**
+     * Deactive the service.
+     */
+    @After
+    public void tearDown() {
+        persist.deactivate();
+        persist.unsetLocationService(locRef);
+        persist = null;
+
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Perform test disk clean up.
+     */
+    @AfterClass
+    public static void removeFiles() {
+        assertTrue("FAIL: expected an error because of the null JSON service",
+                   outputMgr.isEmptyMessageLog());
+
+        if (LAST_MODIFIED_FILE.exists())
+        {
+            assertTrue("FAIL: Could not delete last modified file: " + LAST_MODIFIED_FILE.getAbsolutePath(),
+                       LAST_MODIFIED_FILE.delete());
+        }
+
+        if (TOOLDATA_TARGET_FILE.exists())
+        {
+            assertTrue("FAIL: Could not delete tool data file: " + TOOLDATA_TARGET_FILE.getAbsolutePath(),
+                       TOOLDATA_TARGET_FILE.delete());
+        }
+    }
+
+    private void setMockFileLocation(final String name) {
+        final File f = new File("build/libs/testdata/" + name + ".json");
+
+        mock.checking(new Expectations() {
+            {
+                one(loc).resolveResource(FilePersistenceProvider.DEFAULT_PERSIST_LOCATION + name + ".json");
+                will(returnValue(resource));
+
+                one(resource).asFile();
+                will(returnValue(f));
+            }
+        });
+    }
+
+    /**
+     * We do not need to handle multiple error paths since the underlying
+     * services do that for us.
+     */
+    @Test
+    public void storeAndLoad() throws Exception {
+        setMockFileLocation("testObject");
+
+        String testObject = "myTestObject";
+
+        try {
+            persist.store("testObject", testObject);
+            String loadedTestObject = persist.load("testObject", String.class);
+
+            // Check a very basic property of the stored catalog. We can rely
+            // on the POJOs being JSONable and that Jackson did the right thing.
+            assertEquals("FAIL: loaded Object did not match the expected Object",
+                         "myTestObject", loadedTestObject);
+        } catch (IOException e) {
+            assertTrue("JSON OSGi service won't be available for a unittest", e.getMessage().contains("CWWKX1066E"));
+        }
+    }
+
+    @Test
+    public void lastModified() throws Exception {
+        setMockFileLocation(LAST_MODIFIED_TARGET);
+
+        long lastModified = persist.getLastModified(LAST_MODIFIED_TARGET);
+        assertTrue("FAIL: lastModified should be equal or greater than the time of creation. Saw: " + lastModified + ", expected: " + LAST_MODIFIED_CREATE_TIME,
+                   lastModified >= LAST_MODIFIED_CREATE_TIME);
+    }
+
+    @Test
+    public void lastModifiedDoesntExist() throws Exception {
+        setMockFileLocation("idontexist");
+
+        assertEquals("FAIL: lastModified should be zero when the target does not exist",
+                     0L, persist.getLastModified("idontexist"));
+    }
+
+    /**
+     * Tests the load, store, exists and delete method of FilePersistenceProvider.
+     * The loadPlainText requires the file to be existed, if delete runs first, then the loadPlainText would fail.
+     * Thus, put all the tests in a single method so that the run sequence is guaranteed.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testLoadStoreExistsDelete() throws Exception
+    {
+        setMockFileLocation(TOOLDATA_TARGET);
+        // Load test, the file already exists (setup step).
+        loadPlainText();
+        // Store new content.
+        storePlainText();
+        // Check if the file exists.
+        exists();
+        // Delete the file.
+        delete();
+    }
+
+    private void loadPlainText() throws Exception {
+        String s = persist.loadPlainText(TOOLDATA_TARGET);
+        assertEquals("FAIL: loadPlainText should match.", fakeContent, s);
+    }
+
+    private void storePlainText() throws Exception {
+        persist.storePlainText(TOOLDATA_TARGET, fakeContent2);
+        assertEquals("FAIL: storePlainText is not correct.", FileUtils.readFileToString(TOOLDATA_TARGET_FILE, "UTF-8"),
+                     fakeContent2);
+    }
+
+    private void exists() throws Exception {
+        boolean e = persist.exists(TOOLDATA_TARGET);
+        assertTrue("FAIL: exists failed.", e);
+    }
+
+    private void delete() throws Exception {
+        boolean e = persist.delete(TOOLDATA_TARGET);
+        assertTrue("FAIL: Delete failed.", e);
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceProviderWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceProviderWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.persistence;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class FilePersistenceProviderWithTraceTest extends FilePersistenceProviderTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceProvider_ErrorTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceProvider_ErrorTest.java
@@ -1,0 +1,384 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.persistence;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+
+import test.common.SharedOutputManager;
+
+import com.ibm.websphere.jsonsupport.JSON;
+import com.ibm.websphere.jsonsupport.JSONMarshallException;
+import com.ibm.ws.ui.internal.v1.pojo.Catalog;
+import com.ibm.ws.ui.persistence.IPersistenceDebugger;
+import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
+import com.ibm.wsspi.kernel.service.location.WsResource;
+
+/**
+ * This test DOES back-end to disk. However it does so under the build directory
+ * so any effects this has will be resolved with a clean.
+ */
+public class FilePersistenceProvider_ErrorTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final ComponentContext cc = mock.mock(ComponentContext.class);
+    @SuppressWarnings("unchecked")
+    private final ServiceReference<WsLocationAdmin> locRef = mock.mock(ServiceReference.class);
+    private final WsLocationAdmin loc = mock.mock(WsLocationAdmin.class);
+    private final WsResource resource = mock.mock(WsResource.class);
+    private final IPersistenceDebugger mockDebugger = mock.mock(IPersistenceDebugger.class);
+    private final JSON mockJson = mock.mock(JSON.class);
+
+    private FilePersistenceProvider persist;
+
+    /**
+     * Activate the service using with mocks.
+     */
+    @Before
+    public void setUp() {
+        mock.checking(new Expectations() {
+            {
+                allowing(cc).locateService(FilePersistenceProvider.KEY_LOCATION_SERVICE, locRef);
+                will(returnValue(loc));
+            }
+        });
+
+        persist = new FilePersistenceProvider(mockJson, mockDebugger);
+        persist.setLocationService(locRef);
+        persist.activate(cc);
+    }
+
+    /**
+     * Deactive the service.
+     */
+    @After
+    public void tearDown() {
+        persist.deactivate();
+        persist.unsetLocationService(locRef);
+        persist = null;
+
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Sets up the mock so that the requested name will return a File object.
+     * That File can be the file passed in, or it will be created if null.
+     * 
+     * @param name Expected persistence name
+     * @param mockFile Desired file to return. Can be {@code null}
+     * @return The File (which may be a mock)
+     */
+    private File setMockFileLocation(final String name, final File mockFile) {
+        final File f = (mockFile != null) ? mockFile : new File("build/unittest/testdata/" + name + ".json");
+
+        mock.checking(new Expectations() {
+            {
+                one(loc).resolveResource(FilePersistenceProvider.DEFAULT_PERSIST_LOCATION + name + ".json");
+                will(returnValue(resource));
+
+                one(resource).asFile();
+                will(returnValue(f));
+            }
+        });
+
+        return f;
+    }
+
+    /**
+     * Set the mapper to expect a read call to the given file and class, and
+     * to respond with the specified exception.
+     * 
+     * @param f Expected file
+     * @param c Expected class
+     * @param ex Exception to throw
+     */
+    private void setMapperExpectedException(final File f, final Class<?> c, final Exception ex) throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockJson).parse(f, c);
+                will(throwException(ex));
+            }
+        });
+    }
+
+    /**
+     * Set the mock to expect a debugger call to get the file contents.
+     * 
+     * @param f The file to debug
+     */
+    private void setMockDebugException(final File f) throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockDebugger).getFileContents(f);
+                will(returnValue("MockedContents"));
+            }
+        });
+    }
+
+    /**
+     * Create a mock File which will fail to create its parent directories.
+     * 
+     * @return The mock File
+     */
+    private File createMockStoreFileMkdirsFails(final String name) {
+        final File mockFile = mock.mock(File.class, "mockFile");
+        final File mockParentFile = mock.mock(File.class, "mockParentFile");
+
+        mock.checking(new Expectations() {
+            {
+                allowing(mockFile).getAbsolutePath();
+                will(returnValue(name));
+
+                one(mockFile).getParentFile();
+                will(returnValue(mockParentFile));
+
+                one(mockParentFile).exists();
+                will(returnValue(false));
+
+                one(mockParentFile).mkdirs();
+                will(returnValue(false));
+            }
+        });
+        return mockFile;
+    }
+
+    /**
+     * Create a mock File which will fail to create its parent directories.
+     * 
+     * @return The mock File
+     */
+    private File createMockStoreFile(final String name) {
+        final File mockFile = mock.mock(File.class, "mockFile");
+        final File mockParentFile = mock.mock(File.class, "mockParentFile");
+
+        mock.checking(new Expectations() {
+            {
+                allowing(mockFile).getAbsolutePath();
+                will(returnValue(name));
+
+                one(mockFile).getParentFile();
+                will(returnValue(mockParentFile));
+
+                one(mockParentFile).exists();
+                will(returnValue(true));
+            }
+        });
+        return mockFile;
+    }
+
+    @Test
+    public void storeCanNotCreateParentDirs() throws Exception {
+        final String name = "idontexist";
+        final String expectedMsgContent = "Unable to create required parent directories";
+
+        final File mockFile = createMockStoreFileMkdirsFails(name);
+        setMockFileLocation("idontexist", mockFile);
+
+        try {
+            persist.store(name, new Object());
+            fail("Store should throw a IOException when it can not create the parent directories");
+        } catch (IOException e) {
+            assertTrue("FAIL: The expected message did not contain '" + expectedMsgContent + "'",
+                       e.getMessage().contains(expectedMsgContent));
+        }
+
+        assertTrue("FAIL: the expected error message was not logged",
+                   outputMgr.checkForMessages("CWWKX1014E:.*" + name + ".*" + expectedMsgContent));
+    }
+
+    @Test
+    public void storeJsonGenerationException() throws Exception {
+        final String name = "idontexist";
+        final Object pojo = new Object();
+
+        final File mockFile = createMockStoreFile(name);
+        setMockFileLocation("idontexist", mockFile);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockJson).serializeToFile(mockFile, pojo);
+                will(throwException(new JSONMarshallException("TestException")));
+            }
+        });
+
+        try {
+            persist.store(name, pojo);
+            fail("Load should throw a JSONMarshallException");
+        } catch (JSONMarshallException e) {
+            assertTrue("FAIL: The JSONMarshallException was not re-thrown as-is",
+                       e.getMessage().equals("TestException"));
+        }
+
+        assertTrue("FAIL: an unexpected message was logged",
+                   outputMgr.isEmptyMessageLog());
+    }
+
+    @Test
+    public void storeCantConvertPOJO() throws Exception {
+        final String name = "idontexist";
+        final Object pojo = new Object();
+
+        final File mockFile = createMockStoreFile(name);
+        setMockFileLocation("idontexist", mockFile);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockJson).serializeToFile(mockFile, pojo);
+                will(throwException(new JSONMarshallException("TestException")));
+            }
+        });
+
+        try {
+            persist.store(name, pojo);
+            fail("Load should throw a JSONMarshallException");
+        } catch (JSONMarshallException e) {
+            assertTrue("FAIL: The JSONMarshallException was not re-thrown as-is",
+                       e.getMessage().equals("TestException"));
+        }
+
+        assertTrue("FAIL: an unexpected message was logged",
+                   outputMgr.isEmptyMessageLog());
+    }
+
+    @Test
+    public void storeJacksonIOError() throws Exception {
+        final String name = "idontexist";
+        final Object pojo = new Object();
+
+        final File mockFile = createMockStoreFile(name);
+        setMockFileLocation("idontexist", mockFile);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockJson).serializeToFile(mockFile, pojo);
+                will(throwException(new JSONMarshallException("I/O exception of some sort has occurred")));
+            }
+        });
+
+        try {
+            persist.store(name, pojo);
+            fail("Load should throw a JSONMarshallException when the JSON API does");
+        } catch (JSONMarshallException e) {
+            assertTrue("FAIL: The JSONMarshallException was not re-thrown as-is",
+                       e.getMessage().equals("I/O exception of some sort has occurred"));
+        }
+
+        assertTrue("FAIL: the expected error message was not logged",
+                   outputMgr.checkForMessages("CWWKX1014E:.*" + name + ".*I/O exception of some sort has occurred"));
+    }
+
+    @Test
+    public void loadDoesntExist() throws Exception {
+        final String name = "idontexist";
+        final Class<Catalog> c = Catalog.class;
+
+        final File f = setMockFileLocation("idontexist", null);
+        setMapperExpectedException(f, c, new FileNotFoundException("TestException"));
+
+        try {
+            persist.load(name, c);
+            fail("FAIL: Expected FileNotFoundException was not thrown");
+        } catch (FileNotFoundException e) {
+            assertTrue("FAIL: The FileNotFoundException was not rethrown as-is",
+                       e.getMessage().equals("TestException"));
+        }
+
+        assertTrue("No message should be logged on a FileNotFoundException",
+                   outputMgr.isEmptyMessageLog());
+    }
+
+    @Test
+    public void loadBadJsonSyntax() throws Exception {
+        final String name = "idontexist";
+        final Class<Catalog> c = Catalog.class;
+
+        final File f = setMockFileLocation("idontexist", null);
+        setMapperExpectedException(f, c, new JSONMarshallException("Unable to parse non-well-formed content"));
+        setMockDebugException(f);
+
+        try {
+            persist.load(name, c);
+            fail("FAIL: Expected JSONMarshallException was not thrown");
+        } catch (JSONMarshallException e) {
+            assertTrue("FAIL: The JSONMarshallException was not rethrown as-is",
+                       e.getMessage().equals("Unable to parse non-well-formed content"));
+        }
+
+        assertTrue("FAIL: Did not find expected CWWKX1009E message. Possibly the injected variables were bad",
+                   outputMgr.checkForMessages("CWWKX1009E:.*idontexist.*MockedContents"));
+    }
+
+    @Test
+    public void loadWrongJsonContent() throws Exception {
+        final String name = "idontexist";
+        final Class<Catalog> c = Catalog.class;
+
+        final File f = setMockFileLocation("idontexist", null);
+        setMapperExpectedException(f, c, new JSONMarshallException("Fatal problems occurred while mapping content"));
+        setMockDebugException(f);
+
+        try {
+            persist.load(name, c);
+            fail("FAIL: Expected JSONMarshallException was not thrown");
+        } catch (JSONMarshallException e) {
+            assertTrue("FAIL: The JSONMarshallException was not rethrown as-is",
+                       e.getMessage().equals("Fatal problems occurred while mapping content"));
+        }
+
+        assertTrue("FAIL: Did not find expected CWWKX1010E message. Possibly the injected variables were bad",
+                   outputMgr.checkForMessages("CWWKX1010E:.*idontexist.*Catalog.*MockedContents"));
+    }
+
+    @Test
+    public void loadIOError() throws Exception {
+        final String name = "idontexist";
+        final Class<Catalog> c = Catalog.class;
+
+        final File f = setMockFileLocation("idontexist", null);
+        setMapperExpectedException(f, c, new IOException("TestException"));
+
+        try {
+            persist.load(name, c);
+            fail("FAIL: Expected IOException was not thrown");
+        } catch (IOException e) {
+            assertTrue("FAIL: The IOException was not rethrown as-is",
+                       e.getMessage().equals("TestException"));
+        }
+
+        assertTrue("FAIL: Did not find expected CWWKX1011E message. Possibly the injected variables were bad",
+                   outputMgr.checkForMessages("CWWKX1011E:.*idontexist.*TestException"));
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceProvider_ErrorWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceProvider_ErrorWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.persistence;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class FilePersistenceProvider_ErrorWithTraceTest extends FilePersistenceProvider_ErrorTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceProvider_SynchronousTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/persistence/FilePersistenceProvider_SynchronousTest.java
@@ -1,0 +1,431 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.persistence;
+
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+
+import test.common.SharedOutputManager;
+
+import com.ibm.websphere.jsonsupport.JSON;
+import com.ibm.ws.ui.internal.v1.ICatalog;
+import com.ibm.ws.ui.persistence.IPersistenceDebugger;
+import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
+import com.ibm.wsspi.kernel.service.location.WsResource;
+
+/**
+ * Multi-threaded concurrency test. Two threads contend for the same
+ * resource, while a second pair of thread contends for an alternate
+ * resource. This alternate resource design is on purpose because of
+ * how things are implemented in the FilePersistenceProvider.
+ * 
+ * Thread 1: persist nameA
+ * Thread 2: persist nameA
+ * Thread 3: persist nameB
+ * Thread 4: persist nameB
+ * 
+ * Perform 10,000 operations in each thread.
+ * 
+ * The test model is not so much around the ultimate correctness of
+ * the access sequence as it is to test that:
+ * 1. nameA and nameB are only created one time.
+ * 2. Invocations to each resource are properly within count.
+ * 
+ * How can we check order? We essentially can not because we can not predict
+ * the order of the operations. There is no way to know which operation will
+ * ultimately win out and execute last, and because the synchronicity is handled
+ * inside the method, we can't really sense with a mock expectations which
+ * thread will set up the mock and get into the inner lock first.
+ * 
+ * Note that the use of the ICatalog interface is not special. It was chosen
+ * as its an interface and is therefore mockable.
+ */
+public class FilePersistenceProvider_SynchronousTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final ComponentContext cc = mock.mock(ComponentContext.class);
+    @SuppressWarnings("unchecked")
+    private final ServiceReference<WsLocationAdmin> locRef = mock.mock(ServiceReference.class);
+    private final WsLocationAdmin loc = mock.mock(WsLocationAdmin.class);
+    private final WsResource resource = mock.mock(WsResource.class);
+    private final IPersistenceDebugger mockDebugger = mock.mock(IPersistenceDebugger.class);
+    private final JSON mockJson = mock.mock(JSON.class);
+
+    private final int THREAD_LOOP_COUNT = 10000;
+
+    private static volatile Throwable inThreadThrowable = null;
+    private FilePersistenceProvider persist;
+
+    /**
+     * Activate the service using with mocks. Also reset the static thread
+     * Throwable detector to null.
+     */
+    @Before
+    public void setUp() {
+        mock.checking(new Expectations() {
+            {
+                allowing(cc).locateService(FilePersistenceProvider.KEY_LOCATION_SERVICE, locRef);
+                will(returnValue(loc));
+            }
+        });
+
+        persist = new FilePersistenceProvider(mockJson, mockDebugger);
+        persist.setLocationService(locRef);
+        persist.activate(cc);
+
+        inThreadThrowable = null;
+    }
+
+    /**
+     * Deactive the service.
+     */
+    @After
+    public void tearDown() {
+        persist.deactivate();
+        persist.unsetLocationService(locRef);
+        persist = null;
+
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Create a mock File which will successfully create its parent directories.
+     * 
+     * @return The mock File
+     */
+    private File createMockFile(final String name, final boolean isStorePath, final int count) {
+        final File mockFile = mock.mock(File.class, name);
+        final File mockParentFile = mock.mock(File.class, name + ".parent");
+
+        mock.checking(new Expectations() {
+            {
+                allowing(mockFile).getAbsolutePath();
+                will(returnValue("mockFile"));
+            }
+        });
+
+        if (isStorePath)
+            mock.checking(new Expectations() {
+                {
+                    exactly(count).of(mockFile).getParentFile();
+                    will(returnValue(mockParentFile));
+
+                    exactly(1).of(mockParentFile).exists();
+                    will(returnValue(false));
+
+                    exactly(1).of(mockParentFile).mkdirs();
+                    will(returnValue(true));
+
+                    exactly(count - 1).of(mockParentFile).exists();
+                    will(returnValue(true));
+                }
+            });
+
+        return mockFile;
+    }
+
+    /**
+     * Sets up the mock so that the requested name will return a File object.
+     * That File can be the file passed in, or it will be created if null.
+     * 
+     * @param name Expected persistence name
+     * @param mockFile Desired file to return. Can be {@code null}
+     * @return The File (which may be a mock)
+     */
+    private File setMockFileLocation(final String name, final File mockFile) {
+        final File f = (mockFile != null) ? mockFile : new File("build/unittest/testdata/" + name + ".json");
+
+        mock.checking(new Expectations() {
+            {
+                one(loc).resolveResource(FilePersistenceProvider.DEFAULT_PERSIST_LOCATION + name + ".json");
+                will(returnValue(resource));
+
+                one(resource).asFile();
+                will(returnValue(f));
+            }
+        });
+
+        return f;
+    }
+
+    /**
+     * Set the mapper to expect read calls to the given file and class.
+     * 
+     * @param f Expected file
+     * @param c Expected class
+     * @param expectedCalls Expected number of invocations
+     */
+    private void setMapperExpectedLoad(final File f, final Class<?> c, final int expectedCalls) throws Exception {
+        mock.checking(new Expectations() {
+            {
+                exactly(expectedCalls).of(mockJson).parse(f, c);
+            }
+        });
+    }
+
+    /**
+     * Set the mapper to expect write calls to the given file and class.
+     * 
+     * @param f Expected file
+     * @param o Expected object
+     * @param expectedCalls Expected number of invocations
+     */
+    private void setMapperExpectedStore(final File f, final Object o, final int expectedCalls) throws Exception {
+        mock.checking(new Expectations() {
+            {
+                exactly(expectedCalls).of(mockJson).serializeToFile(f, o);
+            }
+        });
+    }
+
+    /**
+     * Set the mapper to expect write calls to the given file and class.
+     * 
+     * @param f Expected file
+     * @param expectedCalls Expected number of invocations
+     */
+    private void setFileExpecteLastModified(final File f, final int expectedCalls) throws Exception {
+        mock.checking(new Expectations() {
+            {
+                exactly(expectedCalls).of(f).lastModified();
+            }
+        });
+    }
+
+    /**
+     * Define a LatchedRunnable, in which the latch is setable.
+     */
+    abstract class LatchedRunnable implements Runnable {
+        CountDownLatch latch = null;
+
+        void setCountDownLatch(CountDownLatch latch) {
+            this.latch = latch;
+        }
+    }
+
+    /**
+     * Spawn all of the threads in the list and wait for them all to finish.
+     * 
+     * @param threads
+     * @throws InterruptedException
+     */
+    private void spawnThreads(final List<LatchedRunnable> threads) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(threads.size());
+
+        // Set the latch
+        for (LatchedRunnable thread : threads) {
+            thread.setCountDownLatch(latch);
+        }
+
+        // Spawn the threads
+        for (Runnable thread : threads) {
+            thread.run();
+        }
+
+        // Wait for all threads to finish
+        latch.await();
+    }
+
+    class LoadTest extends LatchedRunnable {
+        final String threadId;
+        final int max;
+        final String persistName;
+        final Class<?> c;
+
+        LoadTest(final String threadId, final int max, final String persistName, final Class<?> c) {
+            this.threadId = threadId;
+            this.max = max;
+            this.persistName = persistName;
+            this.c = c;
+        }
+
+        @Override
+        public void run() {
+            for (int i = 0; (i < max) && (inThreadThrowable == null); i++) {
+                try {
+                    persist.load(persistName, c);
+                } catch (Throwable t) {
+                    inThreadThrowable = t;
+                    t.printStackTrace();
+                    break;
+                }
+            }
+            latch.countDown();
+        }
+    }
+
+    @Test
+    public void loadConcurrentAccess() throws Exception {
+        final String nameA = "nameA";
+        final String nameB = "nameB";
+        final Class<ICatalog> c = ICatalog.class;
+
+        final File fileA = createMockFile(nameA, false, 0);
+        setMockFileLocation(nameA, fileA);
+
+        final File fileB = createMockFile(nameB, false, 0);
+        setMockFileLocation(nameB, fileB);
+
+        setMapperExpectedLoad(fileA, c, 2 * THREAD_LOOP_COUNT);
+        setMapperExpectedLoad(fileB, c, 2 * THREAD_LOOP_COUNT);
+
+        final List<LatchedRunnable> threads = new ArrayList<LatchedRunnable>();
+        threads.add(new LoadTest("t1", THREAD_LOOP_COUNT, nameA, c));
+        threads.add(new LoadTest("t2", THREAD_LOOP_COUNT, nameA, c));
+        threads.add(new LoadTest("t3", THREAD_LOOP_COUNT, nameB, c));
+        threads.add(new LoadTest("t4", THREAD_LOOP_COUNT, nameB, c));
+
+        spawnThreads(threads);
+
+        assertNull("FAIL: An exception was caught in at least one of the concurrency invocations: " + inThreadThrowable,
+                   inThreadThrowable);
+    }
+
+    class StoreTest extends LatchedRunnable {
+        final String threadId;
+        final int max;
+        final String persistName;
+        final Object pojo;
+
+        StoreTest(final String threadId, final int max, final String persistName, final Object pojo) {
+            this.threadId = threadId;
+            this.max = max;
+            this.persistName = persistName;
+            this.pojo = pojo;
+        }
+
+        @Override
+        public void run() {
+            for (int i = 0; (i < max) && (inThreadThrowable == null); i++) {
+                try {
+                    persist.store(persistName, pojo);
+                } catch (Throwable t) {
+                    inThreadThrowable = t;
+                    t.printStackTrace();
+                    break;
+                }
+            }
+            latch.countDown();
+        }
+    }
+
+    /**
+     * Build a StoreTest and set the appropriate expectations.
+     */
+    private StoreTest createStoreTestWithExpectations(final String threadId,
+                                                      final int loopCount,
+                                                      final String persistName,
+                                                      final Object pojo,
+                                                      final File persistFile) throws Exception {
+        setMapperExpectedStore(persistFile, pojo, loopCount);
+        return new StoreTest(threadId, loopCount, persistName, pojo);
+    }
+
+    @Test
+    public void storeConcurrentAccess() throws Exception {
+        final String nameA = "nameA";
+        final String nameB = "nameB";
+
+        final File fileA = createMockFile(nameA, true, 2 * THREAD_LOOP_COUNT);
+        setMockFileLocation(nameA, fileA);
+
+        final File fileB = createMockFile(nameB, true, 2 * THREAD_LOOP_COUNT);
+        setMockFileLocation(nameB, fileB);
+
+        final List<LatchedRunnable> threads = new ArrayList<LatchedRunnable>();
+        threads.add(createStoreTestWithExpectations("t1", THREAD_LOOP_COUNT, nameA, "dataA1", fileA));
+        threads.add(createStoreTestWithExpectations("t2", THREAD_LOOP_COUNT, nameA, "dataA2", fileA));
+        threads.add(createStoreTestWithExpectations("t3", THREAD_LOOP_COUNT, nameB, "dataB3", fileB));
+        threads.add(createStoreTestWithExpectations("t4", THREAD_LOOP_COUNT, nameB, "dataB4", fileB));
+
+        spawnThreads(threads);
+
+        assertNull("FAIL: An exception was caught in at least one of the concurrency invocations: " + inThreadThrowable,
+                   inThreadThrowable);
+    }
+
+    class LastModifiedTest extends LatchedRunnable {
+        final String threadId;
+        final int max;
+        final String persistName;
+
+        LastModifiedTest(final String threadId, final int max, final String persistName) {
+            this.threadId = threadId;
+            this.max = max;
+            this.persistName = persistName;
+        }
+
+        @Override
+        public void run() {
+            for (int i = 0; (i < max) && (inThreadThrowable == null); i++) {
+                try {
+                    persist.getLastModified(persistName);
+                } catch (Throwable t) {
+                    inThreadThrowable = t;
+                    t.printStackTrace();
+                    break;
+                }
+            }
+            latch.countDown();
+        }
+    }
+
+    @Test
+    public void getLastModifiedConcurrentAccess() throws Exception {
+        final String nameA = "nameA";
+        final String nameB = "nameB";
+
+        final File fileA = createMockFile(nameA, false, 0);
+        setMockFileLocation(nameA, fileA);
+
+        final File fileB = createMockFile(nameB, false, 0);
+        setMockFileLocation(nameB, fileB);
+
+        setFileExpecteLastModified(fileA, 2 * THREAD_LOOP_COUNT);
+        setFileExpecteLastModified(fileB, 2 * THREAD_LOOP_COUNT);
+
+        final List<LatchedRunnable> threads = new ArrayList<LatchedRunnable>();
+        threads.add(new LastModifiedTest("t1", THREAD_LOOP_COUNT, nameA));
+        threads.add(new LastModifiedTest("t2", THREAD_LOOP_COUNT, nameA));
+        threads.add(new LastModifiedTest("t3", THREAD_LOOP_COUNT, nameB));
+        threads.add(new LastModifiedTest("t4", THREAD_LOOP_COUNT, nameB));
+
+        spawnThreads(threads);
+
+        assertNull("FAIL: An exception was caught in at least one of the concurrency invocations: " + inThreadThrowable,
+                   inThreadThrowable);
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/APIRootTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/APIRootTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+/**
+ *
+ */
+public class APIRootTest {
+    private final Mockery mock = new JUnit4Mockery();;
+    private final RESTRequest restRequest = mock.mock(RESTRequest.class);
+    private final RESTResponse restResponse = mock.mock(RESTResponse.class);
+
+    private APIRoot handler;
+
+    @Before
+    public void setUp() {
+        handler = new APIRoot();
+    }
+
+    @After
+    public void tearDown() {
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Validates the setup of the object matches our expectations. This is a
+     * validation and not really a business logic test.
+     */
+    @Test
+    public void objectValidation() {
+        assertEquals("The handler's base URL was not what was expected",
+                     "/adminCenter", handler.baseURL());
+        assertFalse("The handler should not expect to handle children",
+                    handler.hasChildren());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.APIRoot#getBase(RESTRequest, RESTResponse)}.
+     *
+     * @throws RESTException
+     */
+    @Test
+    public void getBase() throws RESTException {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getURL();
+                will(returnValue("/adminCenter"));
+            }
+        });
+
+        Map<String, String> map = handler.getBase(restRequest, restResponse);
+        assertTrue("FAIL: the API root JSON object did not contain a 'v1' field",
+                   map.containsKey("v1"));
+        assertEquals("FAIL: the API root 'v1' URL was incorrect",
+                     "/adminCenter/v1",
+                     map.get("v1"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.APIRoot#getBase(RESTRequest, RESTResponse)}.
+     *
+     * @throws RESTException
+     */
+    @Test
+    public void doGETBase_trailingSlash() throws RESTException {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getURL();
+                will(returnValue("/adminCenter/"));
+            }
+        });
+
+        Map<String, String> map = handler.getBase(restRequest, restResponse);
+        assertTrue("FAIL: the API root JSON object did not contain a 'v1' field",
+                   map.containsKey("v1"));
+        assertEquals("FAIL: the API root 'v1' URL was incorrect",
+                     "/adminCenter/v1",
+                     map.get("v1"));
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/AdminCenterRouterTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/AdminCenterRouterTest.java
@@ -1,0 +1,585 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.ws.ui.internal.RequestNLS;
+import com.ibm.ws.ui.internal.rest.v1.CatalogAPI;
+import com.ibm.ws.ui.internal.rest.v1.DeployValidation;
+import com.ibm.ws.ui.internal.rest.v1.IconRestHandler;
+import com.ibm.ws.ui.internal.rest.v1.ToolDataAPI;
+import com.ibm.ws.ui.internal.rest.v1.ToolboxAPI;
+import com.ibm.ws.ui.internal.rest.v1.V1Root;
+import com.ibm.ws.ui.internal.rest.v1.utils.FeatureUtils;
+import com.ibm.ws.ui.internal.rest.v1.utils.URLUtils;
+import com.ibm.ws.ui.internal.rest.v1.utils.UtilsRoot;
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+/**
+ *
+ */
+public class AdminCenterRouterTest {
+    private final Mockery mock = new JUnit4Mockery();;
+    private final RESTRequest restRequest = mock.mock(RESTRequest.class);
+    private final RESTResponse restResponse = mock.mock(RESTResponse.class);
+    private final AdminCenterRestHandler baseHandler = mock.mock(AdminCenterRestHandler.class, "baseHandler");
+    private final AdminCenterRestHandler handler1 = mock.mock(AdminCenterRestHandler.class, "handler1");
+    private final AdminCenterRestHandler handler1subHandler = mock.mock(AdminCenterRestHandler.class, "handler1subHandler");
+    private final AdminCenterRestHandler handler2 = mock.mock(AdminCenterRestHandler.class, "handler2");
+    private AdminCenterRouter router;
+
+    @Before
+    public void setUp() {
+        mock.checking(new Expectations() {
+            {
+                allowing(baseHandler).hasChildren();
+                will(returnValue(false));
+
+                allowing(handler1).hasChildren();
+                will(returnValue(true));
+
+                allowing(handler1subHandler).hasChildren();
+                will(returnValue(true));
+
+                allowing(handler2).hasChildren();
+                will(returnValue(false));
+            }
+        });
+        Map<String, AdminCenterRestHandler> testHandlers = new HashMap<String, AdminCenterRestHandler>();
+        testHandlers.put("/adminCenter", baseHandler);
+        testHandlers.put("/adminCenter/handler1", handler1);
+        testHandlers.put("/adminCenter/handler1/subHandler", handler1subHandler);
+        testHandlers.put("/adminCenter/handler2", handler2);
+        router = new AdminCenterRouter(testHandlers);
+    }
+
+    @After
+    public void tearDown() {
+        mock.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void resetRESTHandler() {
+        RequestNLS.setRESTRequest(null);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#AdminCenterRouter()}.
+     */
+    @Test
+    public void defaultAdminCenterRouter() {
+        AdminCenterRouter defaultRouter = new AdminCenterRouter();
+        defaultRouter.activate();
+
+        Map<String, AdminCenterRestHandler> handlers = defaultRouter.getHandlers();
+        assertEquals("The default handlers map had an unexpected number of elements. Was a handler removed or added?",
+                     10, handlers.size());
+
+        // Validate the mapping is correct. This guards against accidental changes.
+        assertTrue("URL to handler mismatch", handlers.get("/adminCenter") instanceof APIRoot);
+        assertTrue("URL to handler mismatch", handlers.get("/adminCenter/v1") instanceof V1Root);
+        assertTrue("URL to handler mismatch", handlers.get("/adminCenter/v1/catalog") instanceof CatalogAPI);
+        assertTrue("URL to handler mismatch", handlers.get("/adminCenter/v1/toolbox") instanceof ToolboxAPI);
+        assertTrue("URL to handler mismatch", handlers.get("/adminCenter/v1/utils") instanceof UtilsRoot);
+        assertTrue("URL to handler mismatch", handlers.get("/adminCenter/v1/utils/feature") instanceof FeatureUtils);
+        assertTrue("URL to handler mismatch", handlers.get("/adminCenter/v1/utils/url") instanceof URLUtils);
+        assertTrue("URL to handler mismatch", handlers.get("/adminCenter/v1/icons") instanceof IconRestHandler);
+        assertTrue("URL to handler mismatch", handlers.get("/adminCenter/v1/deployValidation") instanceof DeployValidation);
+        assertTrue("URL to handler mismatch", handlers.get("/adminCenter/v1/tooldata") instanceof ToolDataAPI);
+
+        for (String key : handlers.keySet()) {
+            assertFalse("Path " + key + "ends with a '/', this will cause problems. Do not register keys with trailing slashes",
+                        key.endsWith("/"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_nullPath() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue(null));
+
+                one(restRequest).getContextPath();
+                will(returnValue(null));
+
+                one(restRequest).getPath();
+                will(returnValue(null));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_emptyPath() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue(""));
+
+                one(restRequest).getContextPath();
+                will(returnValue(""));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_noHandlers() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        // Create with an empty map of handlers
+        router = new AdminCenterRouter(new HashMap<String, AdminCenterRestHandler>());
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_noMatch() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/wrong"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_noMatchSubstrings() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminU"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_noMatchSubstringsTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminU/"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_noMatchSuperstrings() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenterv1"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_noMatchSuperstringsTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenterv1/"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_directMatchHandler() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                one(restResponse).setResponseHeader("X-XSS-Protection", "1");
+                one(restResponse).setResponseHeader("X-Content-Type-Options", "nosniff");
+                one(restResponse).setResponseHeader("X-Frame-Options", "SAMEORIGIN");
+                one(restResponse).setResponseHeader("Content-Security-Policy", "default-src 'self'");
+
+                // Test assertion
+                one(baseHandler).handleRequest(restRequest, restResponse);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_matchHandlerTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                one(restResponse).setResponseHeader("X-XSS-Protection", "1");
+                one(restResponse).setResponseHeader("X-Content-Type-Options", "nosniff");
+                one(restResponse).setResponseHeader("X-Frame-Options", "SAMEORIGIN");
+                one(restResponse).setResponseHeader("Content-Security-Policy", "default-src 'self'");
+
+                // Test assertion
+                one(baseHandler).handleRequest(restRequest, restResponse);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_matchSubHandler() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/handler1"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                one(restResponse).setResponseHeader("X-XSS-Protection", "1");
+                one(restResponse).setResponseHeader("X-Content-Type-Options", "nosniff");
+                one(restResponse).setResponseHeader("X-Frame-Options", "SAMEORIGIN");
+                one(restResponse).setResponseHeader("Content-Security-Policy", "default-src 'self'");
+
+                // Test assertion
+                one(handler1).handleRequest(restRequest, restResponse);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_matchSubHandlerTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/handler1/"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));   
+
+                one(restResponse).setResponseHeader("X-XSS-Protection", "1");
+                one(restResponse).setResponseHeader("X-Content-Type-Options", "nosniff");
+                one(restResponse).setResponseHeader("X-Frame-Options", "SAMEORIGIN");
+                one(restResponse).setResponseHeader("Content-Security-Policy", "default-src 'self'");
+
+                // Test assertion
+                one(handler1).handleRequest(restRequest, restResponse);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_matchChildHandler() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/handler1/child"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                one(restResponse).setResponseHeader("X-XSS-Protection", "1");
+                one(restResponse).setResponseHeader("X-Content-Type-Options", "nosniff");
+                one(restResponse).setResponseHeader("X-Frame-Options", "SAMEORIGIN");
+                one(restResponse).setResponseHeader("Content-Security-Policy", "default-src 'self'");
+
+                // Test assertion
+                one(handler1).handleRequest(restRequest, restResponse);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_matchChildHandlerTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/handler1/child/"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                one(restResponse).setResponseHeader("X-XSS-Protection", "1");
+                one(restResponse).setResponseHeader("X-Content-Type-Options", "nosniff");
+                one(restResponse).setResponseHeader("X-Frame-Options", "SAMEORIGIN");
+                one(restResponse).setResponseHeader("Content-Security-Policy", "default-src 'self'");
+
+                // Test assertion
+                one(handler1).handleRequest(restRequest, restResponse);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_doNotMatchChildWhenNoChildren() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/handler2/child"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_doNotMatchChildWhenNoChildrenTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/handler2/child/"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_doNotMatchGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/handler2/child/grandchild"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_doNotMatchGrandchildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/handler2/child/grandchild/"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_matchGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/handler1/child/grandchild"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                one(restResponse).setResponseHeader("X-XSS-Protection", "1");
+                one(restResponse).setResponseHeader("X-Content-Type-Options", "nosniff");
+                one(restResponse).setResponseHeader("X-Frame-Options", "SAMEORIGIN");
+                one(restResponse).setResponseHeader("Content-Security-Policy", "default-src 'self'");
+
+                // Test assertion
+                one(handler1).handleRequest(restRequest, restResponse);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.AdminCenterRouter#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_matchGrandchildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/handler1/child/grandchild/"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                one(restResponse).setResponseHeader("X-XSS-Protection", "1");
+                one(restResponse).setResponseHeader("X-Content-Type-Options", "nosniff");
+                one(restResponse).setResponseHeader("X-Frame-Options", "SAMEORIGIN");
+                one(restResponse).setResponseHeader("Content-Security-Policy", "default-src 'self'");
+
+                // Test assertion
+                one(handler1).handleRequest(restRequest, restResponse);
+            }
+        });
+
+        router.handleRequest(restRequest, restResponse);
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/CommonJSONRESTHandlerTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/CommonJSONRESTHandlerTest.java
@@ -1,0 +1,5086 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.beans.IntrospectionException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.websphere.jsonsupport.JSON;
+import com.ibm.websphere.jsonsupport.JSONMarshallException;
+import com.ibm.ws.ui.internal.Filter;
+import com.ibm.ws.ui.internal.rest.AdminCenterRestHandler.POSTResponse;
+import com.ibm.ws.ui.internal.rest.exceptions.BadRequestException;
+import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
+import com.ibm.ws.ui.internal.v1.pojo.Message;
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class CommonJSONRESTHandlerTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final RESTRequest restRequest = mock.mock(RESTRequest.class);
+    private final RESTResponse restResponse = mock.mock(RESTResponse.class);
+    private final Filter mockFilter = mock.mock(Filter.class);
+    private final JSON mockJson = mock.mock(JSON.class);
+
+    private static final String RESOURCE_PATH = "/adminCenter/myResource";
+    private static final String CHILD_RESOURCE = "myChild";
+    private static final String GRANDCHILD_RESOURCE = "myGrandchild";
+    private static final int GET_BASE_FLAG = 1;
+    private static final int GET_CHILD_FLAG = 11;
+    private static final int GET_GRANDCHILD_FLAG = 111;
+    private static final int POST_BASE_FLAG = 2;
+    private static final int POST_CHILD_FLAG = 22;
+    private static final int POST_GRANDCHILD_FLAG = 222;
+    private static final int PUT_BASE_FLAG = 3;
+    private static final int PUT_CHILD_FLAG = 33;
+    private static final int PUT_GRANDCHILD_FLAG = 333;
+    private static final int DELETE_BASE_FLAG = 4;
+    private static final int DELETE_CHILD_FLAG = 44;
+    private static final int DELETE_GRANDCHILD_FLAG = 444;
+    private static final int GET_BASE_EXCEPTION = 5;
+    private static final int GET_CHILD_EXCEPTION = 55;
+    private static final int GET_GRANDCHILD_EXCEPTION = 555;
+    private static final int POST_BASE_EXCEPTION = 6;
+    private static final int POST_CHILD_EXCEPTION = 66;
+    private static final int POST_GRANDCHILD_EXCEPTION = 666;
+    private static final int PUT_BASE_EXCEPTION = 7;
+    private static final int PUT_CHILD_EXCEPTION = 77;
+    private static final int PUT_GRANDCHILD_EXCEPTION = 777;
+    private static final int DELETE_BASE_EXCEPTION = 8;
+    private static final int DELETE_CHILD_EXCEPTION = 88;
+    private static final int DELETE_GRANDCHILD_EXCEPTION = 888;
+
+    private CommonJSONRESTHandler handler;
+
+    /**
+     * Give our abstract class some substance for testing the default implementations.
+     */
+    class EmptyCommonJSONRESTHandler extends CommonJSONRESTHandler {
+        EmptyCommonJSONRESTHandler(String handlerURL, boolean handlesChildResource, boolean handlesGrandchildResource) {
+            this(handlerURL, handlesChildResource, handlesGrandchildResource, new Filter());
+        }
+
+        EmptyCommonJSONRESTHandler(String handlerURL, boolean handlesChildResource, boolean handlesGrandchildResource, Filter f) {
+            super(handlerURL, handlesChildResource, handlesGrandchildResource, f, mockJson);
+        }
+
+        @Override
+        public boolean isKnownChildResource(String child, RESTRequest request) {
+            return CHILD_RESOURCE.equals(child);
+        }
+
+        @Override
+        public boolean isKnownGrandchildResource(String child, String grandchild, RESTRequest request) {
+            return CHILD_RESOURCE.equals(child) && GRANDCHILD_RESOURCE.equals(grandchild);
+        }
+    }
+
+    /**
+     * Override the doX methods and set some clearly non-valid HTTP status
+     * codes in the RESTResponse. This is how we "sense" we went down the right
+     * code path.
+     */
+    class MethodCommonJSONRESTHandler extends CommonJSONRESTHandler {
+        private final RESTException throwRESTException;
+
+        MethodCommonJSONRESTHandler(String handlerURL, boolean handlesChildResource, boolean handlesGrandchildResource) {
+            this(handlerURL, handlesChildResource, handlesGrandchildResource, null);
+        }
+
+        MethodCommonJSONRESTHandler(String handlerURL, boolean handlesChildResource, boolean handlesGrandchildResource, RESTException throwRESTException) {
+            //super(handlerURL, handlesChildResource, handlesGrandchildResource);
+            super(handlerURL, handlesChildResource, handlesGrandchildResource, null, mockJson);
+            this.throwRESTException = throwRESTException;
+        }
+
+        /**
+         * 1 - success GET base
+         * 5 - failure GET base
+         */
+        @Override
+        public Object getBase(RESTRequest request, RESTResponse response) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(GET_BASE_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(GET_BASE_FLAG);
+                return null;
+            }
+        }
+
+        /**
+         * 11 - success GET child
+         * 55 - failure GET child
+         */
+        @Override
+        public Object getChild(RESTRequest request, RESTResponse response, String child) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(GET_CHILD_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(GET_CHILD_FLAG);
+                return null;
+            }
+        }
+
+        /**
+         * 111 - success GET grandchild
+         * 555 - failure GET grandchild
+         */
+        @Override
+        public Object getGrandchild(RESTRequest request, RESTResponse response, String child, String grandchild) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(GET_GRANDCHILD_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(GET_GRANDCHILD_FLAG);
+                return null;
+            }
+        }
+
+        /**
+         * 2 - success POST base
+         * 6 - failure POST base
+         */
+        @Override
+        public POSTResponse postBase(RESTRequest request, RESTResponse response) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(POST_BASE_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(POST_BASE_FLAG);
+                POSTResponse pr = new POSTResponse();
+                pr.createdURL = "url";
+                pr.jsonPayload = null;
+                return pr;
+            }
+        }
+
+        /**
+         * 22 - success POST child
+         * 66 - failure POST child
+         */
+        @Override
+        public POSTResponse postChild(RESTRequest request, RESTResponse response, String child) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(POST_CHILD_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(POST_CHILD_FLAG);
+                POSTResponse pr = new POSTResponse();
+                pr.createdURL = "url";
+                pr.jsonPayload = null;
+                return pr;
+            }
+        }
+
+        /**
+         * 222 - success POST grandchild
+         * 666 - failure POST grandchild
+         */
+        @Override
+        public POSTResponse postGrandchild(RESTRequest request, RESTResponse response, String child, String grandchild) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(POST_GRANDCHILD_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(POST_GRANDCHILD_FLAG);
+                POSTResponse pr = new POSTResponse();
+                pr.createdURL = "url";
+                pr.jsonPayload = null;
+                return pr;
+            }
+        }
+
+        /**
+         * 3 - success PUT base
+         * 7 - failure PUT base
+         */
+        @Override
+        public Object putBase(RESTRequest request, RESTResponse response) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(PUT_BASE_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(PUT_BASE_FLAG);
+                return null;
+            }
+        }
+
+        /**
+         * 33 - success PUT child
+         * 77 - failure PUT child
+         */
+        @Override
+        public Object putChild(RESTRequest request, RESTResponse response, String child) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(PUT_CHILD_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(PUT_CHILD_FLAG);
+                return null;
+            }
+        }
+
+        /**
+         * 333 - success PUT grandchild
+         * 777 - failure PUT grandchild
+         */
+        @Override
+        public Object putGrandchild(RESTRequest request, RESTResponse response, String child, String grandchild) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(PUT_GRANDCHILD_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(PUT_GRANDCHILD_FLAG);
+                return null;
+            }
+        }
+
+        /**
+         * 4 - success DELETE base
+         * 8 - failure DELETE base
+         */
+        @Override
+        public Object deleteBase(RESTRequest request, RESTResponse response) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(DELETE_BASE_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(DELETE_BASE_FLAG);
+                return null;
+            }
+        }
+
+        /**
+         * 44 - success DELETE child
+         * 88 - failure DELETE child
+         */
+        @Override
+        public Object deleteChild(RESTRequest request, RESTResponse response, String child) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(DELETE_CHILD_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(DELETE_CHILD_FLAG);
+                return null;
+            }
+        }
+
+        /**
+         * 444 - success DELETE grandchild
+         * 888 - failure DELETE grandchild
+         */
+        @Override
+        public Object deleteGrandchild(RESTRequest request, RESTResponse response, String child, String grandchild) throws RESTException {
+            if (throwRESTException != null) {
+                throw new RESTException(DELETE_GRANDCHILD_EXCEPTION, throwRESTException.getContentType(), throwRESTException.getPayload());
+            } else {
+                response.setStatus(DELETE_GRANDCHILD_FLAG);
+                return null;
+            }
+        }
+    }
+
+    @Before
+    public void setUp() {
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+    }
+
+    @After
+    public void tearDown() {
+        mock.assertIsSatisfied();
+    }
+
+    @Test
+    public void constructor() {
+        assertEquals("FAIL: The handler's baseURL was not returned as expected",
+                     RESOURCE_PATH, handler.baseURL());
+        assertFalse("FAIL: The handler's hasChildren should be false",
+                    handler.hasChildren());
+    }
+
+    /**
+     * Sets the correct expectations for an invocation of setJSONResponse.
+     *
+     * @throws JSONMarshallException
+     */
+    private void jsonResponseExpectations(final int status) throws IOException, JSONMarshallException {
+        final OutputStream mockWriter = mock.mock(OutputStream.class);
+        mock.checking(new Expectations() {
+            {
+                allowing(mockWriter);
+            }
+        });
+
+        jsonResponseExpectations(status, mockWriter);
+    }
+
+    /**
+     * Sets the correct expectations for an invocation of setJSONResponse.
+     *
+     * @throws JSONMarshallException
+     */
+    private void jsonResponseExpectations(final int status, final OutputStream spyWriter) throws IOException, JSONMarshallException {
+        mock.checking(new Expectations() {
+            {
+                one(restResponse).setResponseHeader("Content-Type", "application/json; charset=UTF-8");
+
+                one(restResponse).getOutputStream();
+                will(returnValue(spyWriter));
+
+                one(restResponse).setStatus(status);
+            }
+        });
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#setJSONResponse(com.ibm.wsspi.rest.handler.RESTResponse, java.lang.Object)}.
+     */
+    @Test
+    public void setJSONResponse_success() throws Exception {
+        final ByteArrayOutputStream spyWriter = new ByteArrayOutputStream();
+        final String pojo = "\"String POJO!\"";
+        spyWriter.write(pojo.getBytes("UTF-8"));
+        mock.checking(new Expectations() {
+            {
+                allowing(mockJson).asBytes(pojo);
+                will(returnValue(pojo.getBytes()));
+                one(restResponse).getOutputStream().write(pojo.getBytes("UTF-8"));
+                one(restResponse).setResponseHeader("Content-Type", "application/json; charset=UTF-8");
+                one(restResponse).setStatus(200);
+            }
+        });
+
+        handler.setJSONResponse(restResponse, pojo, 200);
+
+        assertEquals("FAIL: Did not get the expected output written to the response Writer",
+                     "\"String POJO!\"", new String(spyWriter.toByteArray(), "UTF-8"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#setJSONResponse(com.ibm.wsspi.rest.handler.RESTResponse, java.lang.Object)}.
+     */
+    @Test
+    public void setJSONResponse_WriterIOException() throws Exception {
+        final OutputStream mockWriter = mock.mock(OutputStream.class);
+        final Object pojo = "String POJO!";
+
+        mock.checking(new Expectations() {
+            {
+                one(restResponse).setResponseHeader("Content-Type", "application/json; charset=UTF-8");
+
+                allowing(mockJson).asBytes(pojo);
+
+                one(restResponse).setStatus(200);
+
+                one(restResponse).getOutputStream();
+                will(returnValue(mockWriter));
+
+                allowing(mockWriter);
+                will(throwException(new IOException("TestException")));
+
+                // Test assertion - IOException will cause 500
+                one(restResponse).setStatus(500);
+            }
+        });
+
+        handler.setJSONResponse(restResponse, pojo, 200);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#setJSONResponse(com.ibm.wsspi.rest.handler.RESTResponse, java.lang.Object)}.
+     */
+    @Test
+    public void setJSONResponse_ObjectMapperIOException() throws Exception {
+        handler = new EmptyCommonJSONRESTHandler(null, false, false, null);
+        final Object pojo = "String POJO!";
+
+        mock.checking(new Expectations() {
+            {
+                one(restResponse).setResponseHeader("Content-Type", "application/json; charset=UTF-8");
+
+                one(mockJson).asBytes(pojo);
+                will(throwException(new JSONMarshallException("TestException")));
+
+                // Test assertion - IOException will cause 500
+                one(restResponse).setStatus(500);
+
+                // Test assertion - status should never be set to 200
+                never(restResponse).setStatus(200);
+
+                // Test assertion - the output stream should never be asked for
+                never(restResponse).getOutputStream();
+            }
+        });
+
+        handler.setJSONResponse(restResponse, pojo, 200);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>This is a highly unlikely event, but best to code and test defensively</p>
+     */
+    @Test
+    public void handleRequest_nullPath() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue(null));
+
+                one(restRequest).getContextPath();
+                will(returnValue(null));
+
+                one(restRequest).getPath();
+                will(returnValue(null));
+
+                // Test expectation
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>This is a highly unlikely event, but best to code and test defensively</p>
+     */
+    @Test
+    public void handleRequest_emptyPath() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getURI();
+                will(returnValue("/ibm/api"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test expectation
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>This is a highly unlikely event, but best to code and test defensively</p>
+     */
+    @Test
+    public void handleRequest_wrongPath1() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api/wrong/myResource"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test expectation
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>This is a highly unlikely event, but best to code and test defensively</p>
+     */
+    @Test
+    public void handleRequest_wrongPath2() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/wrongResource"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test expectation
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>This is a highly unlikely event, but best to code and test defensively</p>
+     */
+    @Test
+    public void handleRequest_wrongPath3() throws Exception {
+        mock.checking(new Expectations() {
+            {
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api/adminCenter/myResource/a"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test expectation
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_notHandlingChildPath() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test expectation
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_notHandlingGrandchildPath() throws Exception {
+        mock.checking(new Expectations() {
+            {
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/myGrandchild"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test expectation
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_greatgrandchildPath() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/myGrandchild/myGreatgrandchild"));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test expectation
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_unknownMethod() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                one(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("UNKNOWN"));
+
+                // Test expectation
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getBase() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getBase_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getChild_noChildren() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getChild_noChildrenTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getChild_hasChildrenUnknownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getChild_hasChildrenUnknownChildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getChild_hasChildrenKnownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getChild_hasChildrenKnownChildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getGrandchild_noGrandchildren() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getGrandchild_noGrandchildrenTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getGrandchild_hasGrandchildrenUnknownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getGrandchild_hasGrandchildrenUnknownGrandchildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getGrandchild_hasGrandchildrenKnownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/myGrandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_getGrandchild_hasGrandchildrenKnownGrandchildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/myGrandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_post_noMediaType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue(null));
+
+                // Test expectation
+                one(restResponse).setStatus(415);
+            }
+        });
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_post_nonJSONMediaType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("text/plain"));
+
+                // Test expectation
+                one(restResponse).setStatus(415);
+            }
+        });
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postBase_default() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postBase_defaultTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postChild_noChildren() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postChild_noChildrenTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postChild_hasChildrenUnknownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postChild_hasChildrenUnknownChildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postChild_hasChildrenKnownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postChild_hasChildrenKnownChildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postGrandchild_noGrandchildren() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postGrandchild_noGrandchildrenTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postGrandchild_hasGrandchildrenUnknownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postGrandchild_hasGrandchildrenUnknownGrandchildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postGrandchild_hasGrandchildrenKnownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/myGrandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_postGrandchild_hasGrandchildrenKnownGrandchildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/myGrandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_put_noMediaType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue(null));
+
+                // Test expectation
+                one(restResponse).setStatus(415);
+            }
+        });
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_put_nonJSONMediaType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("text/plain"));
+
+                // Test expectation
+                one(restResponse).setStatus(415);
+            }
+        });
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putBase_default() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putBase_defaultTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putChild_noChildren() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putChild_noChildrenTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putChild_hasChildrenUnknownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putChild_hasChildrenUnknownChildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putChild_hasChildrenKnownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putChild_hasChildrenKnownChildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putGrandchild_noGrandchildren() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putGrandchild_noGrandchildrenTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putGrandchild_hasGrandchildrenUnknownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putGrandchild_hasGrandchildrenUnknownGrandchildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putGrandchild_hasGrandchildrenKnownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/myGrandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_putGrandchild_hasGrandchildrenKnownGrandchildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/myGrandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteBase_default() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteBase_defaultTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteChild_noChildren() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteChild_noChildrenTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteChild_hasChildrenUnknownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteChild_hasChildrenUnknownChildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/child/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteChild_hasChildrenKnownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteChild_hasChildrenKnownChildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteGrandchild_noGrandchildren() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteGrandchild_noGrandchildrenTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteGrandchild_hasGrandchildrenUnknownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteGrandchild_hasGrandchildrenUnknownGrandchildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/grandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(404);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteGrandchild_hasGrandchildrenKnownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/myGrandchild"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    @Test
+    public void handleRequest_default_deleteGrandchild_hasGrandchildrenKnownGrandchildTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/myChild/myGrandchild/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                // Test assertion
+                one(restResponse).setStatus(405);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getBase() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(GET_BASE_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getBase_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(GET_BASE_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getBase_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test expectation
+                one(restResponse).setStatus(GET_BASE_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Sets the correct expectations for an invocation of setJSONResponse.
+     */
+    private void textResponseExpectations(final int status) throws IOException {
+        final OutputStream mockWriter = mock.mock(OutputStream.class);
+        mock.checking(new Expectations() {
+            {
+                one(restResponse).setResponseHeader("Content-Type", "text/plain");
+
+                one(restResponse).getOutputStream();
+                will(returnValue(mockWriter));
+
+                allowing(mockWriter);
+
+                one(restResponse).setStatus(status);
+            }
+        });
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getBase_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(GET_BASE_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getBase_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(mockJson).asBytes(null);
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(GET_BASE_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getBase_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(GET_CHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getChild_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(GET_CHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getChild_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test expectation
+                one(restResponse).setStatus(GET_CHILD_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getChild_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(GET_CHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getChild_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(GET_CHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getChild_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>getChild is called when its defined, irrespective of the child being known or not.</p>
+     */
+    @Test
+    public void handleRequest_getChild_unknownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/unknown"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test assertion
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(GET_CHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(GET_GRANDCHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getGrandchild_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(GET_GRANDCHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getGRandchild_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test expectation
+                one(restResponse).setStatus(GET_GRANDCHILD_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getGrandchild_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(GET_GRANDCHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getGrandchild_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(GET_GRANDCHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_getGrandchild_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>getChild is called when its defined, irrespective of the child being known or not.</p>
+     */
+    @Test
+    public void handleRequest_getGrandchild_unknownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + "/unknown"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                // Test assertion
+                one(restResponse).setStatus(GET_GRANDCHILD_FLAG);
+                one(mockJson).asBytes(null);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postBase() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectations
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(POST_BASE_FLAG);
+                one(restResponse).setResponseHeader("Location", "url");
+            }
+        });
+
+        jsonResponseExpectations(201);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postBase_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectations
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(POST_BASE_FLAG);
+                one(restResponse).setResponseHeader("Location", "url");
+            }
+        });
+
+        jsonResponseExpectations(201);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postBase_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(restResponse).setStatus(POST_BASE_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postBase_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(POST_BASE_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postBase_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(POST_BASE_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postBase_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectations
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(POST_CHILD_FLAG);
+                one(restResponse).setResponseHeader("Location", "url");
+            }
+        });
+
+        jsonResponseExpectations(201);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postChild_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectations
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(POST_CHILD_FLAG);
+                one(restResponse).setResponseHeader("Location", "url");
+            }
+        });
+
+        jsonResponseExpectations(201);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postChild_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(restResponse).setStatus(POST_CHILD_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postChild_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(POST_CHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postChild_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(POST_CHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postChild_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>postChild is called when its defined, irrespective of the child being known or not.</p>
+     */
+    @Test
+    public void handleRequest_postChild_unknownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/unknown"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test assertions
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(POST_CHILD_FLAG);
+                one(restResponse).setResponseHeader("Location", "url");
+            }
+        });
+
+        jsonResponseExpectations(201);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectations
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(POST_GRANDCHILD_FLAG);
+                one(restResponse).setResponseHeader("Location", "url");
+            }
+        });
+
+        jsonResponseExpectations(201);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postGrandchild_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectations
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(POST_GRANDCHILD_FLAG);
+                one(restResponse).setResponseHeader("Location", "url");
+            }
+        });
+
+        jsonResponseExpectations(201);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postGrandchild_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(restResponse).setStatus(POST_GRANDCHILD_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postGrandchild_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(POST_GRANDCHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postGrandchild_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(POST_GRANDCHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_postGrandchild_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("GET"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>postChild is called when its defined, irrespective of the child being known or not.</p>
+     */
+    @Test
+    public void handleRequest_postGrandchild_unknownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/unknown"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("POST"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test assertions
+                allowing(mockJson).asBytes(null);
+                allowing(mockJson).asBytes("hi there");
+                one(restResponse).setStatus(POST_GRANDCHILD_FLAG);
+                one(restResponse).setResponseHeader("Location", "url");
+            }
+        });
+
+        jsonResponseExpectations(201);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putBase() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(PUT_BASE_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putBase_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(PUT_BASE_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putBase_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(restResponse).setStatus(PUT_BASE_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putBase_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(PUT_BASE_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putBase_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(PUT_BASE_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putBase_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(PUT_CHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putChild_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(PUT_CHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putChild_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(restResponse).setStatus(PUT_CHILD_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putChild_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(PUT_CHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putChild_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(PUT_CHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putChild_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>putChild is called when its defined, irrespective of the child being known or not.</p>
+     */
+    @Test
+    public void handleRequest_putChild_unknownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/unknown"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test assertion
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(PUT_CHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(PUT_GRANDCHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putGrandchild_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(PUT_GRANDCHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putGrandchild_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test expectation
+                one(restResponse).setStatus(PUT_GRANDCHILD_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putGrandchild_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(PUT_GRANDCHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putGrandchild_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(PUT_GRANDCHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_putGrandchild_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>putChild is called when its defined, irrespective of the child being known or not.</p>
+     */
+    @Test
+    public void handleRequest_putGrandchild_unknownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/unknown"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("PUT"));
+
+                allowing(restRequest).getHeader(HTTPConstants.HTTP_HEADER_CONTENT_TYPE);
+                will(returnValue("application/json"));
+
+                // Test assertion
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(PUT_GRANDCHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteBase() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(DELETE_BASE_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteBase_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(DELETE_BASE_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteBase_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test expectation
+                one(restResponse).setStatus(DELETE_BASE_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteBase_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(DELETE_BASE_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteBase_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(DELETE_BASE_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteBase_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, false, false, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(DELETE_CHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteChild_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(DELETE_CHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteChild_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test expectation
+                one(restResponse).setStatus(DELETE_CHILD_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteChild_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(DELETE_CHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteChild_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                allowing(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(DELETE_CHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteChild_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>putChild is called when its defined, irrespective of the child being known or not.</p>
+     */
+    @Test
+    public void handleRequest_deleteChild_unknownChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/unknown"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test assertion
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(DELETE_CHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, false);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(DELETE_GRANDCHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteGrandchild_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE + "/"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test expectation
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(DELETE_GRANDCHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteGrandchild_RESTException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test expectation
+                one(restResponse).setStatus(DELETE_GRANDCHILD_EXCEPTION);
+            }
+        });
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteGrandchild_RESTExceptionStringPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+            }
+        });
+
+        // Test expectation
+        textResponseExpectations(DELETE_GRANDCHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteGrandchild_RESTExceptionJSONPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                one(mockJson).asBytes("hi there");
+            }
+        });
+
+        // Test expectation
+        jsonResponseExpectations(DELETE_GRANDCHILD_EXCEPTION);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void handleRequest_deleteGrandchild_RESTExceptionMissingContentType() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/" + GRANDCHILD_RESOURCE));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+            }
+        });
+
+        // Test expectation - 500 means we had a problem
+        textResponseExpectations(500);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true, new RESTException(0, null, "hi there"));
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>putChild is called when its defined, irrespective of the child being known or not.</p>
+     */
+    @Test
+    public void handleRequest_deleteGrandchild_unknownGrandchild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + RESOURCE_PATH + "/" + CHILD_RESOURCE + "/unknown"));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                allowing(restRequest).getMethod();
+                will(returnValue("DELETE"));
+
+                // Test assertion
+                one(mockJson).asBytes(null);
+                one(restResponse).setStatus(DELETE_GRANDCHILD_FLAG);
+            }
+        });
+
+        jsonResponseExpectations(200);
+
+        // RESTException status of 0 will be replaced by the method that gets called
+        handler = new MethodCommonJSONRESTHandler(RESOURCE_PATH, true, true);
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#handleRequest(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     * <p>This is a highly unlikely event, but best to code and test defensively</p>
+     */
+    @Test
+    public void handleRequest_runtimeException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getURI();
+                will(throwException(new RuntimeException("TestException")));
+
+                // Test expectation
+                one(restResponse).setStatus(500);
+            }
+        });
+
+        handler.handleRequest(restRequest, restResponse);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getChildResourceName(String)}.
+     */
+    @Test
+    public void getChildResourceName_null() {
+        assertNull("When the requested resource is null, return null",
+                   handler.getChildResourceName(null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getChildResourceName(String)}.
+     */
+    @Test
+    public void getChildResourceName_empty() {
+        assertNull("When the requested resource is empty, return null",
+                   handler.getChildResourceName(""));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getChildResourceName(String)}.
+     */
+    @Test
+    public void getChildResourceName_notHandledResourcePath() {
+        assertNull("When the requested resource is not handled, return null",
+                   handler.getChildResourceName("/wrong"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getChildResourceName(String)}.
+     */
+    @Test
+    public void getChildResourceName_isBaseResourcePath() {
+        assertNull("When the requested resource is the handler's base resource path, return null",
+                   handler.getChildResourceName(RESOURCE_PATH));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getChildResourceName(String)}.
+     */
+    @Test
+    public void getChildResourceName_isChildResourcePath() {
+        assertEquals("When the requested resource is a child of the handler's base resource path, return it",
+                     "child", handler.getChildResourceName(RESOURCE_PATH + "/child"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getChildResourceName(String)}.
+     */
+    @Test
+    public void getChildResourceName_isGrandchildResourcePath() {
+        assertEquals("When the requested resource is a grandchild of the handler's base resource path, return null",
+                     "child", handler.getChildResourceName(RESOURCE_PATH + "/child/grandchild"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getGrandchildResourceName(String)}.
+     */
+    @Test
+    public void getGrandchildResourceName_null() {
+        assertNull("When the requested resource is null, return null",
+                   handler.getGrandchildResourceName(null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getGrandchildResourceName(String)}.
+     */
+    @Test
+    public void getGrandchildResourceName_empty() {
+        assertNull("When the requested resource is empty, return null",
+                   handler.getGrandchildResourceName(""));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getGrandchildResourceName(String)}.
+     */
+    @Test
+    public void getGrandchildResourceName_notHandledResourcePath() {
+        assertNull("When the requested resource is not handled, return null",
+                   handler.getGrandchildResourceName("/wrong"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getGrandchildResourceName(String)}.
+     */
+    @Test
+    public void getGrandchildResourceName_isBaseResourcePath() {
+        assertNull("When the requested resource is the handler's base resource path, return null",
+                   handler.getGrandchildResourceName(RESOURCE_PATH));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getChildResourceName(String)}.
+     */
+    @Test
+    public void getGrandchildResourceName_isChildResourcePath() {
+        assertNull("When the requested resource is a child of the handler's base resource path, return null",
+                   handler.getGrandchildResourceName(RESOURCE_PATH + "/child"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getChildResourceName(String)}.
+     */
+    @Test
+    public void getGrandchildResourceName_isGrandchildResourcePath() {
+        assertEquals("When the requested resource is a grandchild of the handler's base resource path, return it",
+                     "grandchild", handler.getGrandchildResourceName(RESOURCE_PATH + "/child/grandchild"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#getChildResourceName(String)}.
+     */
+    @Test
+    public void getGrandchildResourceName_isGreatGrandchildResourcePath() {
+        assertEquals("When the requested resource is a grandchild of the handler's base resource path, return it",
+                     "grandchild", handler.getGrandchildResourceName(RESOURCE_PATH + "/child/grandchild/greatgrandchild"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isChildResource(String)}.
+     */
+    @Test
+    public void isChildResource_nullRequestPath() {
+        assertFalse("A null request path should result in a false isChildResource",
+                    handler.isChildResource(null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isChildResource(String)}.
+     */
+    @Test
+    public void isChildResource_emptyRequestPath() {
+        assertFalse("An empty request path should result in a false isChildResource",
+                    handler.isChildResource(""));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isChildResource(String)}.
+     */
+    @Test
+    public void isChildResource_baseRequestPath() {
+        assertFalse("The base hanlded request path should result in a false isChildResource",
+                    handler.isChildResource(RESOURCE_PATH));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isChildResource(String)}.
+     */
+    @Test
+    public void isChildResource_baseRequestPathTrailingSlash() {
+        assertFalse("The base hanlded request path should result in a false isChildResource",
+                    handler.isChildResource(RESOURCE_PATH + "/"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isChildResource(String)}.
+     */
+    @Test
+    public void isChildResource_childRequestPath() {
+        assertTrue("A child request path should result in a true isChildResource when not matching a specific name",
+                   handler.isChildResource(RESOURCE_PATH + "/child"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isChildResource(String)}.
+     */
+    @Test
+    public void isChildResource_childRequestPathTrailingSlash() {
+        assertTrue("A child request path should result in a true isChildResource when not matching a specific name",
+                   handler.isChildResource(RESOURCE_PATH + "/child/"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isChildResource(String)}.
+     */
+    @Test
+    public void isChildResource_grandchildRequestPath() {
+        assertFalse("A child request path should result in a true isChildResource when not matching a specific name",
+                    handler.isChildResource(RESOURCE_PATH + "/child/grandchild"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isChildResource(String)}.
+     */
+    @Test
+    public void isChildResource_grandchildRequestPathTrailingSlash() {
+        assertFalse("A child request path should result in a true isChildResource when not matching a specific name",
+                    handler.isChildResource(RESOURCE_PATH + "/child/grandchild/"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isChildResource(String)}.
+     */
+    @Test
+    public void isChildResource_notHandledRequestPath() {
+        assertFalse("A non-handled request path should result in a false isChildResource",
+                    handler.isChildResource("/wrong"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_nullRequestPath() {
+        assertFalse("A null request path should result in a false isGrandchildResource",
+                    handler.isGrandchildResource(null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_emptyRequestPath() {
+        assertFalse("An empty request path should result in a false isGrandchildResource",
+                    handler.isGrandchildResource(""));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_baseRequestPath() {
+        assertFalse("The base hanlded request path should result in a false isGrandchildResource",
+                    handler.isGrandchildResource(RESOURCE_PATH));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_baseRequestPathTrailingSlash() {
+        assertFalse("The base hanlded request path should result in a false isGrandchildResource",
+                    handler.isGrandchildResource(RESOURCE_PATH + "/"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_childRequestPath() {
+        assertFalse("A child request path should result in a true isGrandchildResource when not matching a specific name",
+                    handler.isGrandchildResource(RESOURCE_PATH + "/child"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_childRequestPathTrailingSlash() {
+        assertFalse("A child request path should result in a true isGrandchildResource when not matching a specific name",
+                    handler.isGrandchildResource(RESOURCE_PATH + "/child/"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_grandchildRequestPath() {
+        assertTrue("A matching grandchild request path should result in a true isGrandchildResource",
+                   handler.isGrandchildResource(RESOURCE_PATH + "/child/grandchild"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_grandchildRequestPathMatchingTrailingSlashSucceeds() {
+        assertTrue("A matching grandchild request path should result in a true isGrandchildResource",
+                   handler.isGrandchildResource(RESOURCE_PATH + "/child/grandchild/"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_greatgrandchildRequestPath() {
+        assertFalse("A greatgrandchild request path should result in a false isGrandchildResource",
+                    handler.isGrandchildResource(RESOURCE_PATH + "/child/grandchild/greatgrandchild"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_greatchildRequestPathMatchingTrailingSlashSucceeds() {
+        assertFalse("A greatgrandchild request path should result in a false isGrandchildResource",
+                    handler.isGrandchildResource(RESOURCE_PATH + "/child/grandchild/greatgrandchild/"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#isGrandchildResource(String)}.
+     */
+    @Test
+    public void isGrandchildResource_notHandledRequestPath() {
+        assertFalse("A non-handled request path should result in a false isGrandchildResource",
+                    handler.isGrandchildResource("/wrong"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#applyFilter(RESTRequest, Object)}.
+     */
+    @Test
+    public void applyFilter_nullObject() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+            }
+        });
+
+        assertNull("Applying the filter to a null Object should beget null",
+                   handler.applyFilter(restRequest, null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#applyFilter(RESTRequest, Object)}.
+     */
+    @Test
+    public void applyFilter_objectNoFilter() throws Exception {
+        final Object obj = "Object";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, obj);
+                will(returnValue(obj));
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false, mockFilter);
+        assertSame("Applying the filter when no filter is defined should result in no change to the Object",
+                   obj, handler.applyFilter(restRequest, obj));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#applyFilter(RESTRequest, Object)}.
+     */
+    @Test
+    public void applyFilter_objectWithFilter() throws Exception {
+        final String filter = "id";
+        final Object obj = "Object";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getParameter("fields");
+                will(returnValue(filter));
+
+                one(mockFilter).applyFieldFilter(filter, obj);
+                will(returnValue(obj));
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false, mockFilter);
+        assertSame("Applying the filter when no filter is defined should result in no change to the Object",
+                   obj, handler.applyFilter(restRequest, obj));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#applyFilter(RESTRequest, Object)}.
+     */
+    @Test
+    public void applyFilter_exception() throws Exception {
+        final Object obj = "Object";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, obj);
+                will(throwException(new IntrospectionException("TestException")));
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false, mockFilter);
+        try {
+            handler.applyFilter(restRequest, obj);
+            fail("Expected a RESTException to be thrown");
+        } catch (RESTException e) {
+            assertEquals("Did not get back expected 500 status code",
+                         500, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#readJSONPayload(RESTRequest, Class)}.
+     * <p>This probably will never happen, but code defensively!</p>
+     */
+    @Test
+    public void readJSONPayload_noInputStream() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getInputStream();
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.readJSONPayload(restRequest, String.class);
+            fail("Should have caught a RESTException");
+        } catch (RESTException e) {
+            assertEquals("Should have caught a 500 RESTException",
+                         500, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#readJSONPayload(RESTRequest, Class)}.
+     * <p>This probably will never happen, but code defensively!</p>
+     */
+    @Test
+    public void readJSONPayload_emptyInputStream() throws Exception {
+        final InputStream mockInputStream = mock.mock(InputStream.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getInputStream();
+                will(returnValue(mockInputStream));
+
+                one(mockInputStream).read(with(any(byte[].class)));
+                will(throwException(new EOFException("TestException")));
+
+                one(mockInputStream).close();
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false, null);
+        try {
+            handler.readJSONPayload(restRequest, String.class);
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertTrue("ErrorMessage message start with CWWKX1019E and contain String. Message: " + error.getMessage(),
+                       error.getMessage().matches("CWWKX1019E:.*String.*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#readJSONPayload(RESTRequest, Class)}.
+     */
+    @Test
+    public void readJSONPayload_veryLargeInputStream() throws Exception {
+        final InputStream mockInputStream = mock.mock(InputStream.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getInputStream();
+                will(returnValue(mockInputStream));
+
+                one(mockInputStream).read(with(any(byte[].class)));
+                will(returnValue(APIConstants.POST_MAX_JSON_SIZE + 1));
+
+                one(mockInputStream).close();
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false, null);
+        try {
+            handler.readJSONPayload(restRequest, String.class);
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertTrue("ErrorMessage message start with CWWKX1054E and contain String. Message: " + error.getMessage(),
+                       error.getMessage().matches("CWWKX1054E:.*8,192.*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#readJSONPayload(RESTRequest, Class)}.
+     */
+    @Test
+    public void readJSONPayload_jsonSyntaxProblem() throws Exception {
+        final String mockPayload = "a";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse("a", String.class);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false);
+        try {
+            handler.readJSONPayload(restRequest, String.class);
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertTrue("ErrorMessage message start with CWWKX1020E and contain String. Message: " + error.getMessage(),
+                       error.getMessage().matches("CWWKX1020E:.*String.*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#readJSONPayload(RESTRequest, Class)}.
+     *
+     */
+    @Test
+    public void readJSONPayload_deserializationProblem() throws Exception {
+        final String mockPayload = "{}";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse("{}", String.class);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false);
+        try {
+            handler.readJSONPayload(restRequest, String.class);
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertTrue("ErrorMessage message start with CWWKX1021E and contain String. Message: " + error.getMessage(),
+                       error.getMessage().matches("CWWKX1021E:.*String.*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#readJSONPayload(RESTRequest, Class)}.
+     *
+     */
+    @Test
+    public void readJSONPayload_ioProblem() throws Exception {
+        final InputStream mockInputStream = mock.mock(InputStream.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getInputStream();
+                will(returnValue(mockInputStream));
+
+                one(mockInputStream).read(with(any(byte[].class)));
+                will(throwException(new IOException("TestException")));
+
+                one(mockInputStream).close();
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false, null);
+        try {
+            handler.readJSONPayload(restRequest, String.class);
+            fail("Should have caught a RESTException");
+        } catch (RESTException e) {
+            assertEquals("Should have caught a 500 RESTException",
+                         500, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#readJSONPayload(RESTRequest, Class)}.
+     */
+    @Test
+    public void readJSONPayload_success() throws Exception {
+        final String mockPayload = "\"SUCCESS\"";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, String.class);
+                will(returnValue("SUCCESS"));
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false);
+        assertEquals("Should have gotten back mock'd response",
+                     "SUCCESS", handler.readJSONPayload(restRequest, String.class));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#readJSONPayload(RESTRequest, Class)}.
+     */
+    @Test
+    public void readJSONPayload_successMultitype() throws Exception {
+        final String mockPayload = "\"stringy\"";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+                one(mockJson).parse(mockPayload, Integer.class);
+                will(returnValue("stringy"));
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false);
+        List<Class<? extends Object>> types = new ArrayList<Class<? extends Object>>();
+        types.add(Integer.class);
+        types.add(String.class);
+
+        assertEquals("Should have gotten back mock'd response",
+                     "stringy", handler.readJSONPayload(restRequest, Object.class, types));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#readJSONPayload(RESTRequest, Class)}.
+     */
+    @Test
+    public void readJSONPayload_successMultitypeOrder() throws Exception {
+        final String mockPayload = "1";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+                one(mockJson).parse(mockPayload, Long.class);
+                will(returnValue(new Long("1")));
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false);
+        List<Class<? extends Object>> types = new ArrayList<Class<? extends Object>>();
+        types.add(Long.class);
+        types.add(Integer.class);
+
+        assertEquals("Should have gotten back mock'd response",
+                     Long.valueOf(1L), handler.readJSONPayload(restRequest, Object.class, types));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.CommonJSONRESTHandler#readJSONPayload(RESTRequest, Class)}.
+     */
+    @Test
+    public void readJSONPayload_failMultitype() throws Exception {
+        final String mockPayload = "{}";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+                one(mockJson).parse("{}", Integer.class);
+            }
+        });
+
+        handler = new EmptyCommonJSONRESTHandler(null, false, false);
+        List<Class<? extends Object>> types = new ArrayList<Class<? extends Object>>();
+        types.add(Integer.class);
+        types.add(String.class);
+
+        try {
+            handler.readJSONPayload(restRequest, Object.class, types);
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertTrue("ErrorMessage message start with CWWKX1021E and contain String. Message: " + error.getMessage(),
+                       error.getMessage().matches("CWWKX1021E:.*java.lang.Integer, java.lang.String.*"));
+        }
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/CommonJSONRESTHandlerWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/CommonJSONRESTHandlerWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class CommonJSONRESTHandlerWithTraceTest extends CommonJSONRESTHandlerTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/exceptions/BadRequestExceptionTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/exceptions/BadRequestExceptionTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.exceptions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.ibm.ws.ui.internal.rest.HTTPConstants;
+import com.ibm.ws.ui.internal.rest.exceptions.BadRequestException;
+import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
+
+/**
+ *
+ */
+public class BadRequestExceptionTest {
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.exceptions.BadRequestException#BadRequestException()}.
+     */
+    @Test
+    public void NoSuchResourceException() {
+        RESTException e = new BadRequestException();
+        assertEquals("Exception status should be 400",
+                     400, e.getStatus());
+        assertNull("Status-only constructor should have no content type",
+                   e.getContentType());
+        assertNull("Status-only constructor should have no payload",
+                   e.getPayload());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.exceptions.BadRequestException#BadRequestException(java.lang.String, java.lang.Object)}.
+     */
+    @Test
+    public void payloadConstructor() {
+        RESTException e = new BadRequestException(HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi!");
+        assertEquals("Exception status should be 400",
+                     400, e.getStatus());
+        assertEquals("Content type was not returned as set",
+                     HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, e.getContentType());
+        assertEquals("Payload was not returned as set",
+                     "hi!", e.getPayload());
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/exceptions/MethodNotSupportedExceptionTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/exceptions/MethodNotSupportedExceptionTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.exceptions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.ibm.ws.ui.internal.rest.exceptions.MethodNotSupportedException;
+import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
+
+/**
+ *
+ */
+public class MethodNotSupportedExceptionTest {
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.exceptions.MethodNotSupportedException#MethodNotSupportedException()}.
+     */
+    @Test
+    public void MethodNotSupportedException() {
+        RESTException e = new MethodNotSupportedException();
+        assertEquals("Exception status should be 405",
+                     405, e.getStatus());
+        assertNull("Status-only constructor should have no content type",
+                   e.getContentType());
+        assertNull("Status-only constructor should have no payload",
+                   e.getPayload());
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/exceptions/NoSuchResourceExceptionTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/exceptions/NoSuchResourceExceptionTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.exceptions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.ibm.ws.ui.internal.rest.HTTPConstants;
+import com.ibm.ws.ui.internal.rest.exceptions.NoSuchResourceException;
+import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
+
+/**
+ *
+ */
+public class NoSuchResourceExceptionTest {
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.exceptions.NoSuchResourceException#NoSuchResourceException()}.
+     */
+    @Test
+    public void NoSuchResourceException() {
+        RESTException e = new NoSuchResourceException();
+        assertEquals("Exception status should be 404",
+                     404, e.getStatus());
+        assertNull("Status-only constructor should have no content type",
+                   e.getContentType());
+        assertNull("Status-only constructor should have no payload",
+                   e.getPayload());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.exceptions.NoSuchResourceException#NoSuchResourceException(String, Object)}.
+     */
+    @Test
+    public void payloadConstructor() {
+        RESTException e = new NoSuchResourceException(HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi!");
+        assertEquals("Exception status should be 404",
+                     404, e.getStatus());
+        assertEquals("Content type was not returned as set",
+                     HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, e.getContentType());
+        assertEquals("Payload was not returned as set",
+                     "hi!", e.getPayload());
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/exceptions/RESTExceptionTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/exceptions/RESTExceptionTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.exceptions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.ibm.ws.ui.internal.rest.HTTPConstants;
+import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
+
+/**
+ *
+ */
+public class RESTExceptionTest {
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.exceptions.RESTException#RESTException(int)}.
+     */
+    @Test
+    public void statusConstructor() {
+        RESTException e = new RESTException(123);
+        assertEquals("Status code was not returned as set",
+                     123, e.getStatus());
+        assertNull("Status-only constructor should have no content type",
+                   e.getContentType());
+        assertNull("Status-only constructor should have no payload",
+                   e.getPayload());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.exceptions.RESTException#RESTException(int, java.lang.String, java.lang.Object)}.
+     */
+    @Test
+    public void payloadConstructor() {
+        RESTException e = new RESTException(123, HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, "hi!");
+        assertEquals("Status code was not returned as set",
+                     123, e.getStatus());
+        assertEquals("Content type was not returned as set",
+                     HTTPConstants.MEDIA_TYPE_TEXT_PLAIN, e.getContentType());
+        assertEquals("Payload was not returned as set",
+                     "hi!", e.getPayload());
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/CatalogAPITest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/CatalogAPITest.java
@@ -1,0 +1,890 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.v1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.InputStream;
+import java.util.Collections;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.websphere.jsonsupport.JSON;
+import com.ibm.ws.ui.internal.Filter;
+import com.ibm.ws.ui.internal.rest.AdminCenterRestHandler.POSTResponse;
+import com.ibm.ws.ui.internal.rest.HTTPConstants;
+import com.ibm.ws.ui.internal.rest.exceptions.BadRequestException;
+import com.ibm.ws.ui.internal.rest.exceptions.MethodNotSupportedException;
+import com.ibm.ws.ui.internal.rest.exceptions.NoSuchResourceException;
+import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
+import com.ibm.ws.ui.internal.v1.ICatalog;
+import com.ibm.ws.ui.internal.v1.ICatalogService;
+import com.ibm.ws.ui.internal.v1.pojo.Bookmark;
+import com.ibm.ws.ui.internal.v1.pojo.DuplicateException;
+import com.ibm.ws.ui.internal.v1.pojo.FeatureTool;
+import com.ibm.ws.ui.internal.v1.pojo.Message;
+import com.ibm.ws.ui.internal.validation.InvalidToolException;
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class CatalogAPITest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final RESTRequest restRequest = mock.mock(RESTRequest.class);
+    private final RESTResponse restResponse = mock.mock(RESTResponse.class);
+    private final InputStream mockInputStream = mock.mock(InputStream.class);
+    private final ICatalogService mockCatalogService = mock.mock(ICatalogService.class);
+    private final ICatalog mockCatalog = mock.mock(ICatalog.class);
+    private final JSON mockJson = mock.mock(JSON.class);
+    private final Filter mockFilter = mock.mock(Filter.class);
+    private CatalogAPI handler;
+
+    @Before
+    public void setUp() {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockCatalogService).getCatalog();
+                will(returnValue(mockCatalog));
+            }
+        });
+        handler = new CatalogAPI(mockCatalogService, mockFilter, mockJson);
+    }
+
+    @After
+    public void tearDown() {
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Validates the setup of the object matches our expectations. This is a
+     * validation and not really a business logic test.
+     */
+    @Test
+    public void objectValidation() {
+        handler = new CatalogAPI(mockCatalogService, mockFilter, mockJson);
+        assertEquals("The handler's base URL was not what was expected",
+                     "/adminCenter/v1/catalog", handler.baseURL());
+        assertTrue("The handler should expect to handle children",
+                   handler.hasChildren());
+    }
+
+    @Test
+    public void isKnownChildResource_unknown() {
+        assertFalse("When the tool is not known, isKnown should be false",
+                    handler.isKnownChildResource("child", restRequest));
+    }
+
+    @Test
+    public void isKnownChildResource_known() {
+        assertTrue("'bookmarks' should be a known child",
+                   handler.isKnownChildResource("bookmarks", restRequest));
+        assertTrue("'featureTools' should be a known child",
+                   handler.isKnownChildResource("featureTools", restRequest));
+        assertTrue("'_metadata' should be a known child",
+                   handler.isKnownChildResource("_metadata", restRequest));
+    }
+
+    @Test
+    public void isKnownGrandchildResource_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockCatalog).getBookmark("unknown");
+                will(returnValue(null));
+
+                one(mockCatalog).getFeatureTool("unknown");
+                will(returnValue(null));
+            }
+        });
+        assertFalse("When the child is not known, isKnown should be false",
+                    handler.isKnownGrandchildResource("unknown", "ignored", restRequest));
+        assertFalse("When the grandchild is not known, isKnown should be false",
+                    handler.isKnownGrandchildResource("bookmarks", "unknown", restRequest));
+        assertFalse("When the grandchild is not known, isKnown should be false",
+                    handler.isKnownGrandchildResource("featureTools", "unknown", restRequest));
+    }
+
+    @Test
+    public void isKnownGrandchildResource_known() {
+        mock.checking(new Expectations() {
+            {
+                one(mockCatalog).getBookmark("known");
+                will(returnValue(new Bookmark("", "", "")));
+
+                one(mockCatalog).getFeatureTool("known");
+                will(returnValue(new FeatureTool("", "", "", "", "", "", "")));
+            }
+        });
+        assertTrue("Any 'bookmarks' should be a known grandchild",
+                   handler.isKnownGrandchildResource("bookmarks", "known", restRequest));
+        assertTrue("Any 'featureTools' should be a known grandchild",
+                   handler.isKnownGrandchildResource("featureTools", "known", restRequest));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getBase(RESTRequest, RESTResponse)}.
+     */
+    @Test
+    public void getBase_catalog() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+                one(mockFilter).applyFieldFilter(null, mockCatalog);
+                will(returnValue(mockCatalog));
+            }
+        });
+
+        assertSame("Did not get Catalog back",
+                   mockCatalog, handler.getBase(restRequest, restResponse));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void getChild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.getChild(restRequest, restResponse, "unknown");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_metadata() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockCatalog).get_metadata();
+                will(returnValue(Collections.EMPTY_MAP));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+                one(mockFilter).applyFieldFilter(null, Collections.EMPTY_MAP);
+                will(returnValue(Collections.EMPTY_MAP));
+            }
+        });
+
+        assertSame("Did not get mock Catalog response back",
+                   Collections.EMPTY_MAP, handler.getChild(restRequest, restResponse, "_metadata"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_featureTools() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockCatalog).getFeatureTools();
+                will(returnValue(Collections.EMPTY_LIST));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, Collections.EMPTY_LIST);
+                will(returnValue(Collections.EMPTY_LIST));
+            }
+        });
+
+        assertSame("Did not get mock Catalog response back",
+                   Collections.EMPTY_LIST, handler.getChild(restRequest, restResponse, "featureTools"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_bookmarks() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockCatalog).getBookmarks();
+                will(returnValue(Collections.EMPTY_LIST));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, Collections.EMPTY_LIST);
+                will(returnValue(Collections.EMPTY_LIST));
+            }
+        });
+
+        assertSame("Did not get mock Catalog response back",
+                   Collections.EMPTY_LIST, handler.getChild(restRequest, restResponse, "bookmarks"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void getGrandchild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.getGrandchild(restRequest, restResponse, "unknown", "ignored");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void getGrandchild_featureToolDoesntExist() throws Exception {
+        final String toolId = "doesntExist";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                allowing(restRequest).getPath();
+                will(returnValue(V1Constants.CATALOG_PATH + "/" + toolId));
+
+                one(mockCatalog).getFeatureTool(toolId);
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.getGrandchild(restRequest, restResponse, "featureTools", toolId);
+            fail("Should have thrown a NoSuchhandlerException");
+        } catch (NoSuchResourceException e) {
+            Message error = (Message) e.getPayload();
+            assertTrue("Thrown exception did not contain an ErrorMessage with the expected translated message",
+                       error.getMessage().matches("CWWKX1001E:.*" + toolId + ".*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getGrandchild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getGrandchild_featureToolExists() throws Exception {
+        final String toolId = "myName-1.0";
+        final FeatureTool myTool = new FeatureTool("feature", "1.0", "tool-1.0", "my Name", "myURL", "myIcon", "myDescription");
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                allowing(restRequest).getPath();
+                will(returnValue(V1Constants.CATALOG_PATH + "/" + toolId));
+
+                one(mockCatalog).getFeatureTool(toolId);
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        assertSame("Did not get back mock returned tool",
+                   myTool, handler.getGrandchild(restRequest, restResponse, "featureTools", toolId));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getGrandchild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getGrandchild_featureToolIdWithSpaceExists() throws Exception {
+        final FeatureTool myTool = new FeatureTool("my Name", "1.0", "tool-1.0", "my Name", "myURL", "myIcon", "myDescription");
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockCatalog).getFeatureTool("my Name-1.0");
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        assertSame("Did not get back mock returned tool",
+                   myTool, handler.getGrandchild(restRequest, restResponse, "featureTools", "my Name-1.0"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void getGrandchild_bookmarkDoesntExist() throws Exception {
+        final String toolId = "doesntExist";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + V1Constants.CATALOG_PATH + "/" + toolId));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                one(mockCatalog).getBookmark(toolId);
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.getGrandchild(restRequest, restResponse, "bookmarks", toolId);
+            fail("Should have thrown a NoSuchhandlerException");
+        } catch (NoSuchResourceException e) {
+            Message error = (Message) e.getPayload();
+            assertTrue("Thrown exception did not contain an ErrorMessage with the expected translated message",
+                       error.getMessage().matches("CWWKX1001E:.*" + toolId + ".*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getGrandchild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getGrandchild_toolExists() throws Exception {
+        final String toolId = "myName-1.0";
+        final Bookmark myTool = new Bookmark("myName", "myURL", "myIcon", "myDescription");
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                allowing(restRequest).getURI();
+                will(returnValue("/ibm/api" + V1Constants.CATALOG_PATH + "/" + toolId));
+
+                allowing(restRequest).getContextPath();
+                will(returnValue("/ibm/api"));
+
+                one(mockCatalog).getBookmark(toolId);
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        assertSame("Did not get back mock returned tool",
+                   myTool, handler.getGrandchild(restRequest, restResponse, "bookmarks", toolId));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#getGrandchild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getGrandchild_toolIdWithSpaceExists() throws Exception {
+        final Bookmark myTool = new Bookmark("my Name", "myURL", "myIcon", "myDescription");
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockCatalog).getBookmark("my Name");
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        assertSame("Did not get back mock returned tool",
+                   myTool, handler.getGrandchild(restRequest, restResponse, "bookmarks", "my Name"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test(expected = MethodNotSupportedException.class)
+    public void postChild_notBookmarks() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.postChild(restRequest, restResponse, "notBookmarks");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_noToolPayload() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(mockInputStream));
+
+                one(mockInputStream).read(with(any(byte[].class)));
+                will(throwException(new EOFException("TestException")));
+
+                one(mockInputStream).close();
+            }
+        });
+
+        try {
+            handler.postChild(restRequest, restResponse, CatalogAPI.CHILD_RESOURCE_BOOKMARKS);
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertTrue("ErrorMessage message start with CWWKX1019E and contain Tool. Message: " + error.getMessage(),
+                       error.getMessage().matches("CWWKX1019E:.*Bookmark.*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_invalidTool() throws Exception {
+        final String mockPayload = "{\"name\":\"myName\",\"url\":\"myURL\",\"icon\":\"myIcon\",\"description\":\"myDescription\"}";
+        final Bookmark mockBk = mock.mock(Bookmark.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, Bookmark.class);
+                will(returnValue(mockBk));
+
+                one(mockCatalog).addBookmark(with(any(Bookmark.class)));
+                will(throwException(new InvalidToolException("TestException")));
+            }
+        });
+
+        try {
+            handler.postChild(restRequest, restResponse, CatalogAPI.CHILD_RESOURCE_BOOKMARKS);
+            fail("Posting an invalid tool should result in a BadRequestException");
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertEquals("ErrorMessage message should be the exception message",
+                         "TestException", error.getMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_duplicateTool() throws Exception {
+        final String mockPayload = "{\"name\":\"myName\",\"url\":\"myURL\",\"icon\":\"myIcon\",\"description\":\"myDescription\"}";
+        final Bookmark mockBk = mock.mock(Bookmark.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, Bookmark.class);
+                will(returnValue(mockBk));
+
+                one(mockCatalog).addBookmark(with(any(Bookmark.class)));
+                will(throwException(new DuplicateException("TestException")));
+            }
+        });
+
+        try {
+            handler.postChild(restRequest, restResponse, CatalogAPI.CHILD_RESOURCE_BOOKMARKS);
+            fail("Posting a duplicate tool should result in a RESTException");
+        } catch (RESTException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 409 (conflict)",
+                         409, error.getStatus());
+            assertEquals("ErrorMessage message should be the exception message",
+                         "TestException", error.getMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_validTool() throws Exception {
+        final String mockPayload = "{\"id\":\"myName\",\"type\":\"Bookmark\",\"name\":\"myName\",\"url\":\"myURL\",\"icon\":\"myIcon\",\"description\":\"myDescription\"}";
+        final Bookmark myTool = new Bookmark("myName", "myURL", "myIcon", "myDescription");
+        final String url = "ibm/api/adminCenter/v1/catalog";
+        final String createdURL = url + "/" + myTool.getId();
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, Bookmark.class);
+                will(returnValue(myTool));
+
+                one(mockCatalog).addBookmark(with(any(Bookmark.class)));
+                will(returnValue(myTool));
+
+                one(restRequest).getURL();
+                will(returnValue(url));
+            }
+        });
+
+        POSTResponse response = handler.postChild(restRequest, restResponse, CatalogAPI.CHILD_RESOURCE_BOOKMARKS);
+        assertEquals("Did not get back the added tool",
+                     myTool, response.jsonPayload);
+        assertEquals("Did not get back the expected created URL",
+                     createdURL, response.createdURL);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_impliedTool() throws Exception {
+        final String mockPayload = "{\"name\":\"myName\",\"url\":\"myURL\",\"icon\":\"myIcon\",\"description\":\"myDescription\"}";
+        final Bookmark myTool = new Bookmark("myName", "myURL", "myIcon", "myDescription");
+        final String url = "ibm/api/adminCenter/v1/catalog";
+        final String createdURL = url + "/" + myTool.getId();
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, Bookmark.class);
+                will(returnValue(myTool));
+
+                one(mockCatalog).addBookmark(with(any(Bookmark.class)));
+                will(returnValue(myTool));
+
+                one(restRequest).getURL();
+                will(returnValue(url));
+            }
+        });
+
+        POSTResponse response = handler.postChild(restRequest, restResponse, CatalogAPI.CHILD_RESOURCE_BOOKMARKS);
+        assertEquals("Did not get back the added tool",
+                     myTool, response.jsonPayload);
+        assertEquals("Did not get back the expected created URL",
+                     createdURL, response.createdURL);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#deleteBase(RESTRequest, RESTResponse)}.
+     */
+    @Test
+    public void deleteBase_noConfirmation() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getParameter("resetCatalog");
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.deleteBase(restRequest, restResponse);
+            fail("Expected BadRequestException to be thrown");
+        } catch (BadRequestException e) {
+            Message msg = (Message) e.getPayload();
+            assertEquals("FAIL: Even though the request did not complete, we want to response with 400",
+                         400, msg.getStatus());
+            assertTrue("FAIL: The NLS message CWWKX1024E was not the content of the message",
+                       msg.getMessage().startsWith("CWWKX1024E"));
+            assertNotNull("FAIL: The developer message was not set",
+                          msg.getDeveloperMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#deleteBase(RESTRequest, RESTResponse)}.
+     */
+    @Test
+    public void deleteBase_wrongConfirmation() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getParameter("resetCatalog");
+                will(returnValue("false"));
+            }
+        });
+
+        try {
+            handler.deleteBase(restRequest, restResponse);
+            fail("Expected BadRequestException to be thrown");
+        } catch (BadRequestException e) {
+            Message msg = (Message) e.getPayload();
+            assertEquals("FAIL: Even though the request did not complete, we want to response with 400",
+                         400, msg.getStatus());
+            assertTrue("FAIL: The NLS message CWWKX1024E was not the content of the message",
+                       msg.getMessage().startsWith("CWWKX1024E"));
+            assertNotNull("FAIL: The developer message was not set",
+                          msg.getDeveloperMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#deleteBase(RESTRequest, RESTResponse)}.
+     */
+    @Test
+    public void deleteBase_goodConfirmation() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getParameter("resetCatalog");
+                will(returnValue("true"));
+
+                one(mockCatalog).reset();
+            }
+        });
+
+        Message msg = (Message) handler.deleteBase(restRequest, restResponse);
+        assertEquals("FAIL: Even though the request did not complete, we want to response with 200",
+                     200, msg.getStatus());
+        assertTrue("FAIL: The NLS message CWWKX1023I was not the content of the message",
+                   msg.getMessage().startsWith("CWWKX1023I"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#deleteGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test(expected = MethodNotSupportedException.class)
+    public void deleteGrandchild_notBookmarks() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.deleteGrandchild(restRequest, restResponse, "notBookmarks", "ignored");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#deleteGrandchild(RESTRequest, RESTResponse, String, String}.
+     */
+    @Test
+    public void deleteGrandchild_noSuchTool() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockCatalog).deleteBookmark("noSuchTool");
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.deleteGrandchild(restRequest, restResponse, CatalogAPI.CHILD_RESOURCE_BOOKMARKS, "noSuchTool");
+            fail("DELETE on a tool which is not defiend should result in a NoSuchhandlerException");
+        } catch (NoSuchResourceException e) {
+            Message error = (Message) e.getPayload();
+            assertTrue("Exception message did not match expected 'CWWKX1001E:.*noSuchTool.*'",
+                       error.getMessage().matches("CWWKX1001E:.*noSuchTool.*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#deleteGrandchild(RESTRequest, RESTResponse, String, String}.
+     */
+    @Test
+    public void deleteGrandchild_definedTool() throws Exception {
+        final Bookmark myTool = new Bookmark("myName", "myURL", "myIcon", "myDescription");
+        final String toolId = myTool.getId();
+
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockCatalog).deleteBookmark(toolId);
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        Bookmark removedTool = (Bookmark) handler.deleteGrandchild(restRequest, restResponse, CatalogAPI.CHILD_RESOURCE_BOOKMARKS, toolId);
+        assertEquals("The returned (deleted) tool did not match the mock'd return",
+                     myTool, removedTool);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#deleteGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test(expected = MethodNotSupportedException.class)
+    public void deleteGrandchild_knownFeatureTool() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockCatalog).getFeatureTool("known");
+                will(returnValue(new FeatureTool("", "", "", "", "", "", "")));
+            }
+        });
+
+        handler.deleteGrandchild(restRequest, restResponse, "featureTools", "known");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.CatalogAPI#deleteGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void deleteGrandchild_unknownFeatureTool() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockCatalog).getFeatureTool("unknown");
+                will(returnValue(null));
+            }
+        });
+
+        handler.deleteGrandchild(restRequest, restResponse, "featureTools", "unknown");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/CatalogAPIWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/CatalogAPIWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.v1;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class CatalogAPIWithTraceTest extends CatalogAPITest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/ToolDataAPITest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/ToolDataAPITest.java
@@ -1,0 +1,561 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.v1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.ui.internal.rest.AdminCenterRestHandler.POSTResponse;
+import com.ibm.ws.ui.internal.rest.exceptions.NoSuchResourceException;
+import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
+import com.ibm.ws.ui.internal.v1.ITool;
+import com.ibm.ws.ui.internal.v1.IToolDataService;
+import com.ibm.ws.ui.internal.v1.IToolbox;
+import com.ibm.ws.ui.internal.v1.IToolboxService;
+import com.ibm.ws.ui.internal.v1.pojo.ToolEntry;
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class ToolDataAPITest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private static final String USER_ID = "bob_johnson";
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final RESTRequest restRequest = mock.mock(RESTRequest.class);
+    private final RESTResponse restResponse = mock.mock(RESTResponse.class);
+    private final Principal mockPrincipal = mock.mock(Principal.class);
+    private final IToolboxService mockToolboxService = mock.mock(IToolboxService.class);
+    private final IToolDataService mockToolDataService = mock.mock(IToolDataService.class);
+    private final IToolbox mockToolbox = mock.mock(IToolbox.class);
+    private ToolDataAPI handler;
+    private final String tool1 = "tool1-1.0-1.0.0";
+    private final String tool2 = "tool2-1.0-1.0.0";
+    private final String tool3 = "tool3-1.0-1.0.0";
+    private final ToolEntry toolEntry1 = new ToolEntry(tool1, ITool.TYPE_FEATURE_TOOL);
+    private final ToolEntry toolEntry2 = new ToolEntry(tool2, ITool.TYPE_FEATURE_TOOL);
+    private final ToolEntry toolEntry3 = new ToolEntry(tool3, ITool.TYPE_BOOKMARK);
+    private final String message = "{\"key\":\"value\"}";
+    private final String messageMD5 = "a7353f7cddce808de0032747a0b7be50";
+
+    private final String message2 = "{\"key\":\"value1\"}";
+    private final String message2MD5 = "9ecb15df65a2ceddcb3b2c726f5aa522";
+
+    private final String url = "ibm/api/adminCenter/v1/tooldata";
+    private final String createdURL = url + "/tool1";
+
+    @Before
+    public void setUp() {
+        // We always look up the user, just mock it once and let it happen
+        final List<ToolEntry> toolList = new ArrayList<ToolEntry>();
+        toolList.add(toolEntry1);
+        toolList.add(toolEntry3);
+        toolList.add(toolEntry2);
+
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getUserPrincipal();
+                will(returnValue(mockPrincipal));
+
+                allowing(mockPrincipal).getName();
+                will(returnValue(USER_ID));
+                allowing(mockToolboxService).getToolbox(USER_ID);
+                will(returnValue(mockToolbox));
+
+                allowing(mockToolbox).getToolEntries();
+                will(returnValue(toolList));
+
+            }
+        });
+
+        handler = new ToolDataAPI(mockToolDataService, mockToolboxService);
+    }
+
+    @After
+    public void tearDown() {
+        handler = null;
+
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Validates the setup of the object matches our expectations. This is a
+     * validation and not really a business logic test.
+     */
+    @Test
+    public void objectValidation() {
+        handler = new ToolDataAPI(mockToolDataService, mockToolboxService);
+        assertEquals("The handler's base URL was not what was expected",
+                     "/adminCenter/v1/tooldata", handler.baseURL());
+        assertTrue("The handler should expect to handle children",
+                   handler.hasChildren());
+    }
+
+    @Test
+    public void isKnownChildResource_unknown() throws Exception {
+        assertFalse("When the child is not known, isKnown should be false",
+                    handler.isKnownChildResource("unknown", restRequest));
+    }
+
+    @Test
+    public void isKnownChildResource_known() throws Exception {
+        assertTrue("'" + tool1 + "' should be a known child",
+                   handler.isKnownChildResource("tool1", restRequest));
+        assertTrue("'" + tool2 + "' should be a known child",
+                   handler.isKnownChildResource("tool2", restRequest));
+        assertFalse("'" + tool3 + "' should be an unknown child",
+                    handler.isKnownChildResource("tool3", restRequest));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void getChild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.getChild(restRequest, restResponse, "unknown");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_noData() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolDataService).promoteIfPossible(USER_ID, "tool1");
+
+                one(mockToolDataService).getToolData(USER_ID, "tool1");
+                will(returnValue(null));
+            }
+        });
+        try {
+            handler.getChild(restRequest, restResponse, "tool1");
+            fail("Get a non exist data should return RESTException");
+        } catch (RESTException e) {
+            assertEquals("Status should be 204 (no content)",
+                         204, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolDataService).promoteIfPossible(USER_ID, "tool1");
+
+                one(mockToolDataService).getToolData(USER_ID, "tool1");
+                will(returnValue(message));
+
+                one(restResponse).setResponseHeader("ETag", messageMD5);
+            }
+        });
+        assertSame("Did not get back the the same message which should have been returned by the mock",
+                   message, handler.getChild(restRequest, restResponse, "tool1"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void postChild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.postChild(restRequest, restResponse, "unknown");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_duplicateToolData() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolDataService).promoteIfPossible(USER_ID, "tool1");
+
+                one(mockToolDataService).exists(USER_ID, "tool1");
+                will(returnValue(true));
+            }
+        });
+        try {
+            handler.postChild(restRequest, restResponse, "tool1");
+            fail("Post to existing tool data should return RESTException");
+        } catch (RESTException e) {
+            assertEquals("Status should be 409 (conflict)",
+                         409, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_internalError() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolDataService).promoteIfPossible(USER_ID, "tool1");
+
+                one(mockToolDataService).exists(USER_ID, "tool1");
+                will(returnValue(false));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(message.getBytes("UTF-8"))));
+
+                one(mockToolDataService).addToolData(USER_ID, "tool1", message);
+                will(returnValue(null));
+            }
+        });
+        try {
+            handler.postChild(restRequest, restResponse, "tool1");
+            fail("Post data causes internal error should return RESTException");
+        } catch (RESTException e) {
+            assertEquals("Status should be 500 (internal error)",
+                         500, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolDataService).promoteIfPossible(USER_ID, "tool1");
+
+                one(mockToolDataService).exists(USER_ID, "tool1");
+                will(returnValue(false));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(message.getBytes("UTF-8"))));
+
+                one(mockToolDataService).addToolData(USER_ID, "tool1", message);
+                will(returnValue(message));
+
+                one(restRequest).getURL();
+                will(returnValue(url));
+
+                one(restResponse).setResponseHeader("ETag", messageMD5);
+            }
+        });
+        POSTResponse response = handler.postChild(restRequest, restResponse, "tool1");
+        assertEquals("did not get created url", createdURL, response.createdURL);
+        assertEquals("did not get created data", message, response.jsonPayload);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#putChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void putChild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.putChild(restRequest, restResponse, "unknown");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void putChild_preconditionNotSet() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getHeader("If-Match");
+                will(returnValue(null));
+            }
+        });
+        try {
+            handler.putChild(restRequest, restResponse, "tool1");
+            fail("Put data without If-Match header should return RESTException");
+        } catch (RESTException e) {
+            assertEquals("Status should be 412 (Pre-condition)",
+                         412, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void putChild_updateNonExistingData() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolDataService).exists(USER_ID, "tool1");
+                will(returnValue(false));
+
+                one(restRequest).getHeader("If-Match");
+                will(returnValue(messageMD5));
+            }
+        });
+        try {
+            handler.putChild(restRequest, restResponse, "tool1");
+            fail("Update non-existing tool data should return RESTException");
+        } catch (RESTException e) {
+            assertEquals("Status should be 404 (Not found)",
+                         404, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void putChild_checksumMismatch() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolDataService).getToolData(USER_ID, "tool1");
+                will(returnValue(message));
+
+                one(mockToolDataService).exists(USER_ID, "tool1");
+                will(returnValue(true));
+
+                one(restRequest).getHeader("If-Match");
+                will(returnValue("123"));
+            }
+        });
+        try {
+            handler.putChild(restRequest, restResponse, "tool1");
+        } catch (RESTException e) {
+            assertEquals("Should return HTTP_PRECONDITION_FAILED error message when checksums do not match", 412, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void putChild_internalError() throws Exception {
+        mock.checking(new Expectations() {
+            {
+
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getHeader("If-Match");
+                will(returnValue(messageMD5));
+
+                one(mockToolDataService).getToolData(USER_ID, "tool1");
+                will(returnValue(message));
+
+                one(mockToolDataService).exists(USER_ID, "tool1");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(message.getBytes("UTF-8"))));
+
+                one(mockToolDataService).addToolData(USER_ID, "tool1", message);
+                will(returnValue(null));
+            }
+        });
+        try {
+            handler.putChild(restRequest, restResponse, "tool1");
+            fail("Precondition mismatch should return RESTException");
+        } catch (RESTException e) {
+            assertEquals("Status should be 500 (internal error)",
+                         500, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void putChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getHeader("If-Match");
+                will(returnValue(messageMD5));
+
+                one(mockToolDataService).getToolData(USER_ID, "tool1");
+                will(returnValue(message));
+
+                one(mockToolDataService).exists(USER_ID, "tool1");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(message2.getBytes("UTF-8"))));
+
+                one(mockToolDataService).addToolData(USER_ID, "tool1", message2);
+                will(returnValue(message2));
+
+                one(restResponse).setResponseHeader("ETag", message2MD5);
+            }
+        });
+        Object obj = handler.putChild(restRequest, restResponse, "tool1");
+        assertEquals("did not get updated data", message2, obj);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#deleteChild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void deleteChild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.deleteChild(restRequest, restResponse, "unknown");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#deleteChild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void deleteChild_nonExisting() throws Exception {
+
+        mock.checking(new Expectations() {
+            {
+
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolDataService).exists(USER_ID, "tool1");
+                will(returnValue(false));
+
+            }
+        });
+        try {
+            handler.deleteChild(restRequest, restResponse, "tool1");
+        } catch (RESTException e) {
+            assertEquals("Status should be 404 (Not Found)",
+                         404, e.getStatus());
+
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#deleteChild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void deleteChild_failed() throws Exception {
+
+        mock.checking(new Expectations() {
+            {
+
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolDataService).exists(USER_ID, "tool1");
+                will(returnValue(true));
+                one(mockToolDataService).deleteToolData(USER_ID, "tool1");
+                will(returnValue(false));
+            }
+        });
+        try {
+            handler.deleteChild(restRequest, restResponse, "tool1");
+        } catch (RESTException e) {
+            assertEquals("Should return internal error message when delete failed", 500, e.getStatus());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolDataAPI#deleteChild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void deleteChild() throws Exception {
+
+        mock.checking(new Expectations() {
+            {
+
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolDataService).exists(USER_ID, "tool1");
+                will(returnValue(true));
+                one(mockToolDataService).deleteToolData(USER_ID, "tool1");
+                will(returnValue(true));
+            }
+        });
+        try {
+            handler.deleteChild(restRequest, restResponse, "tool1");
+        } catch (RESTException e) {
+            assertEquals("Should return 200 when delete succeeded", 200, e.getStatus());
+        }
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/ToolDataAPIWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/ToolDataAPIWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.v1;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class ToolDataAPIWithTraceTest extends ToolDataAPITest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/ToolboxAPITest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/ToolboxAPITest.java
@@ -1,0 +1,1263 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.v1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.InputStream;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.websphere.jsonsupport.JSON;
+import com.ibm.websphere.jsonsupport.JSONMarshallException;
+import com.ibm.ws.ui.internal.Filter;
+import com.ibm.ws.ui.internal.rest.AdminCenterRestHandler.POSTResponse;
+import com.ibm.ws.ui.internal.rest.HTTPConstants;
+import com.ibm.ws.ui.internal.rest.exceptions.BadRequestException;
+import com.ibm.ws.ui.internal.rest.exceptions.MethodNotSupportedException;
+import com.ibm.ws.ui.internal.rest.exceptions.NoSuchResourceException;
+import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
+import com.ibm.ws.ui.internal.v1.IToolbox;
+import com.ibm.ws.ui.internal.v1.IToolboxService;
+import com.ibm.ws.ui.internal.v1.pojo.Bookmark;
+import com.ibm.ws.ui.internal.v1.pojo.DuplicateException;
+import com.ibm.ws.ui.internal.v1.pojo.Message;
+import com.ibm.ws.ui.internal.v1.pojo.NoSuchToolException;
+import com.ibm.ws.ui.internal.v1.pojo.ToolEntry;
+import com.ibm.ws.ui.internal.validation.InvalidToolException;
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class ToolboxAPITest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private static final String USER_ID = "bob_johnson";
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final RESTRequest restRequest = mock.mock(RESTRequest.class);
+    private final RESTResponse restResponse = mock.mock(RESTResponse.class);
+    private final Principal mockPrincipal = mock.mock(Principal.class);
+    private final IToolboxService mockToolboxService = mock.mock(IToolboxService.class);
+    private final IToolbox mockToolbox = mock.mock(IToolbox.class);
+    private final JSON mockJson = mock.mock(JSON.class);
+    private final Filter mockFilter = mock.mock(Filter.class);
+
+    private ToolboxAPI handler;
+
+    @Before
+    public void setUp() {
+        // We always look up the user, just mock it once and let it happen
+        mock.checking(new Expectations() {
+            {
+                allowing(restRequest).getUserPrincipal();
+                will(returnValue(mockPrincipal));
+
+                allowing(mockPrincipal).getName();
+                will(returnValue(USER_ID));
+
+                allowing(mockToolboxService).getToolbox(USER_ID);
+                will(returnValue(mockToolbox));
+            }
+        });
+
+        handler = new ToolboxAPI(mockToolboxService, mockFilter, mockJson);
+    }
+
+    @After
+    public void tearDown() {
+        handler = null;
+
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Validates the setup of the object matches our expectations. This is a
+     * validation and not really a business logic test.
+     */
+    @Test
+    public void objectValidation() {
+        handler = new ToolboxAPI(mockToolboxService, mockFilter, mockJson);
+        assertEquals("The handler's base URL was not what was expected",
+                     "/adminCenter/v1/toolbox", handler.baseURL());
+        assertTrue("The handler should expect to handle children",
+                   handler.hasChildren());
+    }
+
+    @Test
+    public void isKnownChildResource_unknown() throws Exception {
+        assertFalse("When the child is not known, isKnown should be false",
+                    handler.isKnownChildResource("unknown", restRequest));
+    }
+
+    @Test
+    public void isKnownChildResource_known() throws Exception {
+        assertTrue("'bookmarks' should be a known child",
+                   handler.isKnownChildResource("bookmarks", restRequest));
+        assertTrue("'toolEntries' should be a known child",
+                   handler.isKnownChildResource("toolEntries", restRequest));
+        assertTrue("'_metadata' should be a known child",
+                   handler.isKnownChildResource("_metadata", restRequest));
+        assertTrue("'preferences' should be a known child",
+                   handler.isKnownChildResource("preferences", restRequest));
+    }
+
+    @Test
+    public void isKnownGrandchildResource_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockToolbox).getBookmark("unknown");
+                will(returnValue(null));
+
+                one(mockToolbox).getToolEntry("unknown");
+                will(returnValue(null));
+            }
+        });
+        assertFalse("When the child is not known, isKnown should be false",
+                    handler.isKnownGrandchildResource("unknown", "ignored", restRequest));
+        assertFalse("When the grandchild is not known, isKnown should be false",
+                    handler.isKnownGrandchildResource("bookmarks", "unknown", restRequest));
+        assertFalse("When the grandchild is not known, isKnown should be false",
+                    handler.isKnownGrandchildResource("toolEntries", "unknown", restRequest));
+    }
+
+    @Test
+    public void isKnownGrandchildResource_known() {
+        mock.checking(new Expectations() {
+            {
+                one(mockToolbox).getBookmark("known");
+                will(returnValue(new Bookmark("", "", "")));
+
+                one(mockToolbox).getToolEntry("known");
+                will(returnValue(new ToolEntry("", "")));
+            }
+        });
+        assertTrue("Any 'bookmarks' should be a known grandchild",
+                   handler.isKnownGrandchildResource("bookmarks", "known", restRequest));
+        assertTrue("Any 'toolEntries' should be a known grandchild",
+                   handler.isKnownGrandchildResource("toolEntries", "known", restRequest));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getBase(RESTRequest, RESTResponse)}.
+     */
+    @Test
+    public void getBase() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+                one(mockFilter).applyFieldFilter(null, mockToolbox);
+                will(returnValue(mockToolbox));
+            }
+        });
+
+        assertSame("Did not get Toolbox back",
+                   mockToolbox, handler.getBase(restRequest, restResponse));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void getChild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.getChild(restRequest, restResponse, "unknown");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_metadata() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolbox).get_metadata();
+                will(returnValue(Collections.EMPTY_MAP));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, Collections.EMPTY_MAP);
+                will(returnValue(Collections.EMPTY_MAP));
+            }
+        });
+
+        assertSame("Did not get back the EmptyMap which should have been returned by the mock",
+                   Collections.EMPTY_MAP, handler.getChild(restRequest, restResponse, "_metadata"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_preferences() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolbox).getPreferences();
+                will(returnValue(Collections.EMPTY_MAP));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, Collections.EMPTY_MAP);
+                will(returnValue(Collections.EMPTY_MAP));
+            }
+        });
+
+        assertSame("Did not get back the EmptyMap which should have been returned by the mock",
+                   Collections.EMPTY_MAP, handler.getChild(restRequest, restResponse, "preferences"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_toolEntries() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolbox).getToolEntries();
+                will(returnValue(Collections.EMPTY_LIST));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, Collections.EMPTY_LIST);
+                will(returnValue(Collections.EMPTY_LIST));
+            }
+        });
+
+        assertSame("Did not get back the EmptyMap which should have been returned by the mock",
+                   Collections.EMPTY_LIST, handler.getChild(restRequest, restResponse, "toolEntries"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_bookmarks() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolbox).getBookmarks();
+                will(returnValue(Collections.EMPTY_LIST));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, Collections.EMPTY_LIST);
+                will(returnValue(Collections.EMPTY_LIST));
+            }
+        });
+
+        assertSame("Did not get back the EmptyMap which should have been returned by the mock",
+                   Collections.EMPTY_LIST, handler.getChild(restRequest, restResponse, "bookmarks"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void getGrandchild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.getGrandchild(restRequest, restResponse, "unknown", "ignored");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void getGrandchild_toolDoesntExist() throws Exception {
+        final String toolId = "doesntExist";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                allowing(restRequest).getPath();
+                will(returnValue(V1Constants.TOOLBOX_PATH + "/" + toolId));
+
+                one(mockToolbox).getToolEntry(toolId);
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.getGrandchild(restRequest, restResponse, "toolEntries", toolId);
+            fail("Should have thrown a NoSuchhandlerException");
+        } catch (NoSuchResourceException e) {
+            Message error = (Message) e.getPayload();
+            System.out.println("error: " + error);
+            assertTrue("Thrown exception did not contain an ErrorMessage with the expected translated message",
+                       error.getMessage().matches("CWWKX1022E:.*" + toolId + ".*" + USER_ID + ".*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void getGrandchild_toolExists() throws Exception {
+        final String toolId = "myName-1.0";
+        final Bookmark myTool = new Bookmark("myName", "myURL", "myIcon");
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                allowing(restRequest).getPath();
+                will(returnValue(V1Constants.TOOLBOX_PATH + "/" + toolId));
+
+                one(mockToolbox).getToolEntry(toolId);
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        assertSame("Did not get back mock returned tool",
+                   myTool, handler.getGrandchild(restRequest, restResponse, "toolEntries", toolId));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void getGrandchild_toolIdWithSpaceExists() throws Exception {
+        final Bookmark myTool = new Bookmark("my Name", "myURL", "myIcon");
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolbox).getToolEntry("my Name");
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        assertSame("Did not get back mock returned tool",
+                   myTool, handler.getGrandchild(restRequest, restResponse, "toolEntries", "my Name"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void getGrandchild_bookmarkDoesntExist() throws Exception {
+        final String toolId = "doesntExist";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                allowing(restRequest).getPath();
+                will(returnValue(V1Constants.TOOLBOX_PATH + "/" + toolId));
+
+                one(mockToolbox).getBookmark(toolId);
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.getGrandchild(restRequest, restResponse, "bookmarks", toolId);
+            fail("Should have thrown a NoSuchhandlerException");
+        } catch (NoSuchResourceException e) {
+            Message error = (Message) e.getPayload();
+            assertTrue("Thrown exception did not contain an ErrorMessage with the expected translated message",
+                       error.getMessage().matches("CWWKX1022E:.*" + toolId + ".*" + USER_ID + ".*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void getGrandchild_bookmarkExists() throws Exception {
+        final String toolId = "myName-1.0";
+        final Bookmark myTool = new Bookmark("myName", "myURL", "myIcon");
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                allowing(restRequest).getPath();
+                will(returnValue(V1Constants.TOOLBOX_PATH + "/" + toolId));
+
+                one(mockToolbox).getBookmark(toolId);
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        assertSame("Did not get back mock returned tool",
+                   myTool, handler.getGrandchild(restRequest, restResponse, "bookmarks", toolId));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#getGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void getGrandchild_bookmarkIdWithSpaceExists() throws Exception {
+        final Bookmark myTool = new Bookmark("my Name", "myURL", "myIcon");
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolbox).getBookmark("my Name");
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        assertSame("Did not get back mock returned tool",
+                   myTool, handler.getGrandchild(restRequest, restResponse, "bookmarks", "my Name"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test(expected = MethodNotSupportedException.class)
+    public void postChild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.postChild(restRequest, restResponse, "unknown");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_noBookmarkPayload() throws Exception {
+        final InputStream mockInputStream = mock.mock(InputStream.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(mockInputStream));
+
+                one(mockInputStream).read(with(any(byte[].class)));
+                will(throwException(new EOFException("TestException")));
+
+                one(mockInputStream).close();
+            }
+        });
+
+        try {
+            handler.postChild(restRequest, restResponse, "bookmarks");
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertTrue("ErrorMessage message start with CWWKX1019E and contain Tool. Message: " + error.getMessage(),
+                       error.getMessage().matches("CWWKX1019E:.*Bookmark.*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_invalidBookmark() throws Exception {
+        final String mockPayload = "{\"name\":\"myName\",\"url\":\"myURL\",\"icon\":\"myIcon\"}";
+        final Bookmark mockBk = mock.mock(Bookmark.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, Bookmark.class);
+                will(returnValue(mockBk));
+
+                one(mockToolbox).addBookmark(with(any(Bookmark.class)));
+                will(throwException(new InvalidToolException("TestException")));
+            }
+        });
+
+        try {
+            handler.postChild(restRequest, restResponse, "bookmarks");
+            fail("Posting an invalid tool should result in a BadRequestException");
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertEquals("ErrorMessage message should be the exception message",
+                         "TestException", error.getMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_duplicateBookmark() throws Exception {
+        final String mockPayload = "{\"name\":\"myName\",\"url\":\"myURL\",\"icon\":\"myIcon\"}";
+        final Bookmark mockBk = mock.mock(Bookmark.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, Bookmark.class);
+                will(returnValue(mockBk));
+
+                one(mockToolbox).addBookmark(with(any(Bookmark.class)));
+                will(throwException(new DuplicateException("TestException")));
+            }
+        });
+
+        try {
+            handler.postChild(restRequest, restResponse, "bookmarks");
+            fail("Posting a duplicate tool should result in a RESTException");
+        } catch (RESTException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 409 (conflict)",
+                         409, error.getStatus());
+            assertEquals("ErrorMessage message should be the exception message",
+                         "TestException", error.getMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_validBookmark() throws Exception {
+        final String mockPayload = "{\"id\":\"myName\",\"type\":\"bookmark\",\"name\":\"myName\",\"url\":\"myURL\",\"icon\":\"myIcon\"}";
+        final Bookmark myTool = new Bookmark("myName", "myURL", "myIcon");
+        final String url = "ibm/api/adminCenter/v1/toolbox";
+        final String createdURL = url + "/" + myTool.getId();
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, Bookmark.class);
+                will(returnValue(myTool));
+
+                one(mockToolbox).addBookmark(with(any(Bookmark.class)));
+                will(returnValue(myTool));
+
+                one(restRequest).getURL();
+                will(returnValue(url));
+            }
+        });
+
+        POSTResponse response = handler.postChild(restRequest, restResponse, "bookmarks");
+        assertEquals("Did not get back the added tool",
+                     myTool, response.jsonPayload);
+        assertEquals("Did not get back the expected created URL",
+                     createdURL, response.createdURL);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_impliedBookmark() throws Exception {
+        final String mockPayload = "{\"name\":\"myName\",\"url\":\"myURL\",\"icon\":\"myIcon\"}";
+        final Bookmark myTool = new Bookmark("myName", "myURL", "myIcon");
+        final String url = "ibm/api/adminCenter/v1/toolbox";
+        final String createdURL = url + "/" + myTool.getId();
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, Bookmark.class);
+                will(returnValue(myTool));
+
+                one(mockToolbox).addBookmark(with(any(Bookmark.class)));
+                will(returnValue(myTool));
+
+                one(restRequest).getURL();
+                will(returnValue(url));
+            }
+        });
+
+        POSTResponse response = handler.postChild(restRequest, restResponse, "bookmarks");
+        assertEquals("Did not get back the added tool",
+                     myTool, response.jsonPayload);
+        assertEquals("Did not get back the expected created URL",
+                     createdURL, response.createdURL);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_noToolEntryPayload() throws Exception {
+        final InputStream mockInputStream = mock.mock(InputStream.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(mockInputStream));
+
+                one(mockInputStream).read(with(any(byte[].class)));
+                will(throwException(new EOFException("TestException")));
+
+                one(mockInputStream).close();
+            }
+        });
+
+        try {
+            handler.postChild(restRequest, restResponse, "toolEntries");
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertTrue("ErrorMessage message start with CWWKX1019E and contain Tool. Message: " + error.getMessage(),
+                       error.getMessage().matches("CWWKX1019E:.*ToolEntry.*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_invalidToolEntry() throws Exception {
+        final String mockPayload = "{\"id\":\"myId\",\"type\":\"myType\"}";
+        final ToolEntry mockTe = mock.mock(ToolEntry.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, ToolEntry.class);
+                will(returnValue(mockTe));
+
+                one(mockToolbox).addToolEntry(with(any(ToolEntry.class)));
+                will(throwException(new InvalidToolException("TestException")));
+            }
+        });
+
+        try {
+            handler.postChild(restRequest, restResponse, "toolEntries");
+            fail("Posting an invalid tool should result in a BadRequestException");
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertEquals("ErrorMessage message should be the exception message",
+                         "TestException", error.getMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_duplicateToolEntry() throws Exception {
+        final String mockPayload = "{\"id\":\"myId\",\"type\":\"myType\"}";
+        final ToolEntry mockTe = mock.mock(ToolEntry.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, ToolEntry.class);
+                will(returnValue(mockTe));
+
+                one(mockToolbox).addToolEntry(with(any(ToolEntry.class)));
+                will(throwException(new DuplicateException("TestException")));
+            }
+        });
+
+        try {
+            handler.postChild(restRequest, restResponse, "toolEntries");
+            fail("Posting a duplicate tool should result in a RESTException");
+        } catch (RESTException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 409 (conflict)",
+                         409, error.getStatus());
+            assertEquals("ErrorMessage message should be the exception message",
+                         "TestException", error.getMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_noSuchToolEntry() throws Exception {
+        final String mockPayload = "{\"id\":\"myId\",\"type\":\"myType\"}";
+        final ToolEntry mockTe = mock.mock(ToolEntry.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, ToolEntry.class);
+                will(returnValue(mockTe));
+
+                one(mockToolbox).addToolEntry(with(any(ToolEntry.class)));
+                will(throwException(new NoSuchToolException("TestException")));
+            }
+        });
+
+        try {
+            handler.postChild(restRequest, restResponse, "toolEntries");
+            fail("Posting an invalid tool should result in a BadRequestException");
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertEquals("ErrorMessage message should be the exception message",
+                         "TestException", error.getMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#postChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void postChild_validToolEntry() throws Exception {
+        final String mockPayload = "{\"id\":\"myId\",\"type\":\"myType\"}";
+        final ToolEntry toolEntry = new ToolEntry("myId", "myType");
+        final String url = "ibm/api/adminCenter/v1/toolbox";
+        final String createdURL = url + "/" + toolEntry.getId();
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, ToolEntry.class);
+                will(returnValue(toolEntry));
+
+                one(mockToolbox).addToolEntry(with(any(ToolEntry.class)));
+                will(returnValue(toolEntry));
+
+                one(restRequest).getURL();
+                will(returnValue(url));
+            }
+        });
+
+        POSTResponse response = handler.postChild(restRequest, restResponse, "toolEntries");
+        assertEquals("Did not get back the added tool",
+                     toolEntry, response.jsonPayload);
+        assertEquals("Did not get back the expected created URL",
+                     createdURL, response.createdURL);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#putChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test(expected = MethodNotSupportedException.class)
+    public void putChild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.putChild(restRequest, restResponse, "unknown");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#putChild(RESTRequest, RESTResponse, String)}.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void putChild_preferences() throws Exception {
+        final String mockPayload = "{}";
+        final Map mockMap = mock.mock(Map.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, Map.class);
+                will(returnValue(mockMap));
+
+                one(mockToolbox).updatePreferences(with(any(Map.class)));
+                will(returnValue(Collections.EMPTY_MAP));
+            }
+        });
+
+        assertSame("Did not get back the EmptyMap which should have been returned by the mock",
+                   Collections.EMPTY_MAP, handler.putChild(restRequest, restResponse, "preferences"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#putChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void putChild_preferencesNonStringKey() throws Exception {
+        final String mockPayload = "{123:\"abc\"}";
+        final Map<Object, Object> mockMap = mock.mock(Map.class);
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                one(mockJson).parse(mockPayload, Map.class);
+                will(throwException(new JSONMarshallException(("Unable to parse non-well-formed content"))));
+            }
+        });
+
+        try {
+            handler.putChild(restRequest, restResponse, "preferences");
+            fail("Expected BadRequestException to be thrown when the map's keys are non-String");
+        } catch (BadRequestException e) {
+            Message msg = (Message) e.getPayload();
+            assertEquals("FAIL: Even though the request did not complete, we want to response with 400",
+                         400, msg.getStatus());
+            assertTrue("FAIL: The NLS message CWWKX1020E was not the content of the message. Message: " + msg.getMessage(),
+                       msg.getMessage().startsWith("CWWKX1020E"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#putChild(RESTRequest, RESTResponse, String)}.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void putChild_toolEntriesIllegalArgumentException() throws Exception {
+        // The contents of the array is irrelevant. The mockToolbox drives the behaviour.
+        final String mockPayload = "[]";
+        final ToolEntry mockTe = mock.mock(ToolEntry.class);
+        final ToolEntry[] mockArray = { mockTe };
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                allowing(mockJson).parse(mockPayload, ToolEntry[].class);
+                will(returnValue(mockArray));
+
+                one(mockToolbox).updateToolEntries(with(any(List.class)));
+                will(throwException(new IllegalArgumentException("TestException")));
+            }
+        });
+
+        try {
+            handler.putChild(restRequest, restResponse, "toolEntries");
+            fail("Expected BadRequestException to be thrown when there is duplicate key in the tool entries list");
+        } catch (BadRequestException e) {
+            Message msg = (Message) e.getPayload();
+            assertEquals("FAIL: ErrorMessage status should be 400",
+                         400, msg.getStatus());
+            assertTrue("FAIL: Message payload did not contain the thrown exception message",
+                       msg.getMessage().contains("TestException"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#putChild(RESTRequest, RESTResponse, String)}.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void putChild_toolEntriesNoSuchToolException() throws Exception {
+        // The contents of the array is irrelevant. The mockToolbox drives the behaviour.
+        final String mockPayload = "[]";
+        final ToolEntry mockTe = mock.mock(ToolEntry.class);
+        final ToolEntry[] mockArray = { mockTe };
+
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                allowing(mockJson).parse(mockPayload, ToolEntry[].class);
+                will(returnValue(mockArray));
+
+                one(mockToolbox).updateToolEntries(with(any(List.class)));
+                will(throwException(new NoSuchToolException("TestException")));
+            }
+        });
+
+        try {
+            handler.putChild(restRequest, restResponse, "toolEntries");
+            fail("Expected BadRequestException to be thrown when list has non exist tool entry");
+        } catch (BadRequestException e) {
+            Message msg = (Message) e.getPayload();
+            assertEquals("FAIL: ErrorMessage status should be 400",
+                         400, msg.getStatus());
+            assertTrue("FAIL: Message payload did not contain the thrown exception message",
+                       msg.getMessage().contains("TestException"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#putChild(RESTRequest, RESTResponse, String)}.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void putChild_validToolEntries() throws Exception {
+        // The contents of the array is irrelevant. The mockToolbox drives the behaviour.
+        final String mockPayload = "[]";
+        final ToolEntry mockTe = mock.mock(ToolEntry.class);
+        final ToolEntry[] mockArray = { mockTe };
+
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getInputStream();
+                will(returnValue(new ByteArrayInputStream(mockPayload.getBytes("UTF-8"))));
+
+                allowing(mockJson).parse(mockPayload, ToolEntry[].class);
+                will(returnValue(mockArray));
+
+                one(mockToolbox).updateToolEntries(with(any(List.class)));
+            }
+        });
+
+        handler.putChild(restRequest, restResponse, "toolEntries");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#deleteBase(RESTRequest, RESTResponse)}.
+     */
+    @Test
+    public void deleteBase_noConfirmation() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getParameter("resetToolbox");
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.deleteBase(restRequest, restResponse);
+            fail("Expected BadRequestException to be thrown");
+        } catch (BadRequestException e) {
+            Message msg = (Message) e.getPayload();
+            assertEquals("FAIL: Even though the request did not complete, we want to response with 400",
+                         400, msg.getStatus());
+            assertTrue("FAIL: The NLS message CWWKX1028E was not the content of the message",
+                       msg.getMessage().startsWith("CWWKX1028E"));
+            assertNotNull("FAIL: The developer message was not set",
+                          msg.getDeveloperMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#deleteBase(RESTRequest, RESTResponse)}.
+     */
+    @Test
+    public void deleteBase_wrongConfirmation() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getParameter("resetToolbox");
+                will(returnValue("false"));
+            }
+        });
+
+        try {
+            handler.deleteBase(restRequest, restResponse);
+            fail("Expected BadRequestException to be thrown");
+        } catch (BadRequestException e) {
+            Message msg = (Message) e.getPayload();
+            assertEquals("FAIL: Even though the request did not complete, we want to response with 400",
+                         400, msg.getStatus());
+            assertTrue("FAIL: The NLS message CWWKX1028E was not the content of the message",
+                       msg.getMessage().startsWith("CWWKX1028E"));
+            assertNotNull("FAIL: The developer message was not set",
+                          msg.getDeveloperMessage());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#deleteBase(RESTRequest, RESTResponse)}.
+     */
+    @Test
+    public void deleteBase_goodConfirmation() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getParameter("resetToolbox");
+                will(returnValue("true"));
+
+                one(mockToolbox).reset();
+            }
+        });
+
+        Message msg = (Message) handler.deleteBase(restRequest, restResponse);
+        assertEquals("FAIL: Even though the request did not complete, we want to response with 200",
+                     200, msg.getStatus());
+        assertTrue("FAIL: The NLS message CWWKX1027I was not the content of the message",
+                   msg.getMessage().startsWith("CWWKX1027I"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#deleteGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test(expected = MethodNotSupportedException.class)
+    public void deleteGrandchild_unknown() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.deleteGrandchild(restRequest, restResponse, "unknown", "ignored");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#deleteGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void deleteGrandchild_noSuchBookmark() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolbox).deleteBookmark("noSuchTool");
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.deleteGrandchild(restRequest, restResponse, "bookmarks", "noSuchTool");
+            fail("DELETE on a tool which is not defiend should result in a NoSuchhandlerException");
+        } catch (NoSuchResourceException e) {
+            Message error = (Message) e.getPayload();
+            assertTrue("Exception message did not match expected 'CWWKX1022E:.*noSuchTool.*'",
+                       error.getMessage().matches("CWWKX1022E:.*noSuchTool.*" + USER_ID + ".*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#deleteGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void deleteGrandchild_definedBookmark() throws Exception {
+        final Bookmark myTool = new Bookmark("myName", "myURL", "myIcon");
+        final String toolId = myTool.getId();
+
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolbox).deleteBookmark(toolId);
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        Bookmark removedTool = (Bookmark) handler.deleteGrandchild(restRequest, restResponse, "bookmarks", toolId);
+        assertEquals("The returned (deleted) tool did not match the mock'd return",
+                     myTool, removedTool);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#deleteGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void deleteGrandchild_noSuchToolEntry() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolbox).deleteToolEntry("noSuchTool");
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.deleteGrandchild(restRequest, restResponse, "toolEntries", "noSuchTool");
+            fail("DELETE on a tool which is not defiend should result in a NoSuchhandlerException");
+        } catch (NoSuchResourceException e) {
+            Message error = (Message) e.getPayload();
+            assertTrue("Exception message did not match expected 'CWWKX1022E:.*noSuchTool.*'",
+                       error.getMessage().matches("CWWKX1022E:.*noSuchTool.*" + USER_ID + ".*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#deleteGrandchild(RESTRequest, RESTResponse, String, String)}.
+     */
+    @Test
+    public void deleteGrandchild_definedToolEntry() throws Exception {
+        final ToolEntry myTool = new ToolEntry("myName", "featureTool");
+        final String toolId = myTool.getId();
+
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockToolbox).deleteToolEntry(toolId);
+                will(returnValue(myTool));
+
+                one(restRequest).getParameter("fields");
+                will(returnValue(null));
+
+                one(mockFilter).applyFieldFilter(null, myTool);
+                will(returnValue(myTool));
+            }
+        });
+
+        ToolEntry removedTool = (ToolEntry) handler.deleteGrandchild(restRequest, restResponse, "toolEntries", toolId);
+        assertEquals("The returned (deleted) tool did not match the mock'd return",
+                     myTool, removedTool);
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/ToolboxAPIWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/ToolboxAPIWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.v1;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class ToolboxAPIWithTraceTest extends ToolboxAPITest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/V1RootTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/V1RootTest.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.v1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Map;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.ws.ui.internal.rest.HTTPConstants;
+import com.ibm.ws.ui.internal.rest.exceptions.NoSuchResourceException;
+import com.ibm.ws.ui.internal.rest.exceptions.RESTException;
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+/**
+ *
+ */
+public class V1RootTest {
+    private final Mockery mock = new JUnit4Mockery();;
+    private final RESTRequest restRequest = mock.mock(RESTRequest.class);
+    private final RESTResponse restResponse = mock.mock(RESTResponse.class);
+
+    private V1Root handler;
+
+    @Before
+    public void setUp() {
+        handler = new V1Root();
+    }
+
+    @After
+    public void tearDown() {
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Validates the setup of the object matches our expectations. This is a
+     * validation and not really a business logic test.
+     */
+    @Test
+    public void objectValidation() {
+        assertEquals("The handler's base URL was not what was expected",
+                     "/adminCenter/v1", handler.baseURL());
+        assertTrue("The handler should expect to handle children",
+                   handler.hasChildren());
+    }
+
+    @Test
+    public void isKnownChildResource_coffee() {
+        assertTrue("'coffee' should be a known child",
+                   handler.isKnownChildResource("coffee", null));
+    }
+
+    @Test
+    public void isKnownChildResource_other() {
+        assertFalse("'other' is not a known child",
+                    handler.isKnownChildResource("other", null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.V1Root#getBase(RESTRequest, RESTResponse)}.
+     */
+    @Test
+    public void getBase() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getURL();
+                will(returnValue("/adminCenter/v1"));
+            }
+        });
+
+        Map<String, String> obj = handler.getBase(restRequest, restResponse);
+
+        assertTrue("FAIL: the v1 JSON object did not contain a 'catalog' field",
+                   obj.containsKey("catalog"));
+        assertEquals("FAIL: the v1 'catalog' URL was incorrect",
+                     V1Constants.CATALOG_PATH,
+                     obj.get("catalog"));
+
+        assertTrue("FAIL: the v1 JSON object did not contain a 'toolbox' field",
+                   obj.containsKey("toolbox"));
+        assertEquals("FAIL: the v1 'toolbox' URL was incorrect",
+                     V1Constants.TOOLBOX_PATH,
+                     obj.get("toolbox"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.V1Root#getBase(RESTRequest, RESTResponse)}.
+     */
+    @Test
+    public void getBase_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getURL();
+                will(returnValue("/adminCenter/v1/"));
+            }
+        });
+
+        Map<String, String> obj = handler.getBase(restRequest, restResponse);
+
+        assertTrue("FAIL: the v1 JSON object did not contain a 'catalog' field",
+                   obj.containsKey("catalog"));
+        assertEquals("FAIL: the v1 'catalog' URL was incorrect",
+                     V1Constants.CATALOG_PATH,
+                     obj.get("catalog"));
+
+        assertTrue("FAIL: the v1 JSON object did not contain a 'toolbox' field",
+                   obj.containsKey("toolbox"));
+        assertEquals("FAIL: the v1 'toolbox' URL was incorrect",
+                     V1Constants.TOOLBOX_PATH,
+                     obj.get("toolbox"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.V1Root#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_coffee() throws Exception {
+        try {
+            handler.getChild(restRequest, restResponse, "coffee");
+            fail("Should have caught a RESTException");
+        } catch (RESTException e) {
+            assertEquals("FAIL: did not get back expected \"I'm a teapot\" status",
+                         418,
+                         e.getStatus());
+            assertEquals("FAIL: did not get back expected \"I'm a teapot\" entity",
+                         HTTPConstants.MEDIA_TYPE_TEXT_PLAIN,
+                         e.getContentType());
+            assertEquals("FAIL: did not get back expected \"I'm a teapot\" entity",
+                         "I'm a teapot!",
+                         e.getPayload());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.V1Root#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void getChild_undefinedChild() throws Exception {
+        handler.getChild(restRequest, restResponse, "other");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/utils/FeatureUtilsTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/utils/FeatureUtilsTest.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.v1.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.ws.ui.internal.v1.IFeatureToolService;
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+/**
+ *
+ */
+public class FeatureUtilsTest {
+    private final Mockery mock = new JUnit4Mockery();;
+    private final RESTRequest restRequest = mock.mock(RESTRequest.class);
+    private final RESTResponse restResponse = mock.mock(RESTResponse.class);
+    private final IFeatureToolService mockFeatureService = mock.mock(IFeatureToolService.class);
+
+    private FeatureUtils handler;
+
+    @Before
+    public void setUp() {
+        handler = new FeatureUtils(mockFeatureService);
+    }
+
+    @After
+    public void tearDown() {
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Validates the setup of the object matches our expectations. This is a
+     * validation and not really a business logic test.
+     */
+    @Test
+    public void objectValidation() {
+        assertEquals("The handler's base URL was not what was expected",
+                     "/adminCenter/v1/utils/feature", handler.baseURL());
+        assertTrue("The handler should expect to handle children",
+                   handler.hasChildren());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.URLUtils#getBase(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void getBase_root() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getURL();
+                will(returnValue("/adminCenter/v1/utils/feature"));
+            }
+        });
+
+        Map<String, String> obj = handler.getBase(restRequest, restResponse);
+
+        assertTrue("FAIL: the feature utils JSON object did not contain the expected base response",
+                   obj.containsKey("{featureName}"));
+        assertEquals("FAIL: the feature utils base response URL was incorrect",
+                     "/adminCenter/v1/utils/feature/{featureName}",
+                     obj.get("{featureName}"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.URLUtils#getBase(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void getBase_rootTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getURL();
+                will(returnValue("/adminCenter/v1/utils/feature/"));
+            }
+        });
+
+        Map<String, String> obj = handler.getBase(restRequest, restResponse);
+
+        assertTrue("FAIL: the feature utils JSON object did not contain the expected base response",
+                   obj.containsKey("{featureName}"));
+        assertEquals("FAIL: the feature utils base response URL was incorrect",
+                     "/adminCenter/v1/utils/feature/{featureName}",
+                     obj.get("{featureName}"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.URLUtils#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_provisionedFeature() throws Exception {
+        final String provisionedFeature = "provisioned-1.0";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockFeatureService).isFeatureProvisioned(provisionedFeature);
+                will(returnValue(true));
+            }
+        });
+
+        Map<String, Boolean> resp = handler.getChild(restRequest, restResponse, provisionedFeature);
+        assertTrue("FAIL: response did not contain the provisioned key",
+                   resp.containsKey("provisioned"));
+        assertTrue("FAIL: the response value for 'provisioned' should have been true",
+                   resp.get("provisioned"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.URLUtils#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_feature_not_provisioned() throws Exception {
+        final String notProvisionedFeature = "notProvisioned-1.0";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(mockFeatureService).isFeatureProvisioned(notProvisionedFeature);
+                will(returnValue(false));
+            }
+        });
+
+        Map<String, Boolean> resp = handler.getChild(restRequest, restResponse, notProvisionedFeature);
+        assertTrue("FAIL: response did not contain the provisioned key",
+                   resp.containsKey("provisioned"));
+        assertFalse("FAIL: the response value for 'provisioned' should have been false",
+                    resp.get("provisioned"));
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/utils/URLUtilsTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/utils/URLUtilsTest.java
@@ -1,0 +1,242 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.v1.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.Map;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.ws.ui.internal.rest.HTTPConstants;
+import com.ibm.ws.ui.internal.rest.exceptions.BadRequestException;
+import com.ibm.ws.ui.internal.rest.exceptions.NoSuchResourceException;
+import com.ibm.ws.ui.internal.v1.pojo.Message;
+import com.ibm.ws.ui.internal.v1.utils.URLUtility;
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+/**
+ *
+ */
+public class URLUtilsTest {
+    private final Mockery mock = new JUnit4Mockery();;
+    private final RESTRequest restRequest = mock.mock(RESTRequest.class);
+    private final RESTResponse restResponse = mock.mock(RESTResponse.class);
+    private final URLUtility mockUtils = mock.mock(URLUtility.class);
+
+    private URLUtils handler;
+
+    @Before
+    public void setUp() {
+        handler = new URLUtils(mockUtils);
+    }
+
+    @After
+    public void tearDown() {
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Validates the setup of the object matches our expectations. This is
+     * not really a business logic test.
+     */
+    @Test
+    public void objectValidation() {
+        assertEquals("The handler's base URL was not what was expected",
+                     "/adminCenter/v1/utils/url", handler.baseURL());
+        assertTrue("The handler should expect to handle children",
+                   handler.hasChildren());
+    }
+
+    @Test
+    public void isKnownChildResource_getTool() {
+        assertTrue("'getTool' should not be a known child",
+                   handler.isKnownChildResource("getTool", null));
+    }
+
+    @Test
+    public void isKnownChildResource_other() {
+        assertFalse("'other' should not be a known child",
+                    handler.isKnownChildResource("other", null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.URLUtils#getBase(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void getBase_root() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getURL();
+                will(returnValue("/adminCenter/v1/utils/url"));
+            }
+        });
+
+        Map<String, String> obj = handler.getBase(restRequest, restResponse);
+
+        assertTrue("FAIL: the URL utils JSON object did not contain a 'getTool' field",
+                   obj.containsKey("getTool"));
+        assertEquals("FAIL: the URL utils 'getTool' URL was incorrect",
+                     "/adminCenter/v1/utils/url/getTool",
+                     obj.get("getTool"));
+
+        assertTrue("FAIL: the URL utils JSON object did not contain a 'getTool' field",
+                   obj.containsKey("getTool"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.URLUtils#getBase(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void getBase_rootTrailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getURL();
+                will(returnValue("/adminCenter/v1/utils/url/"));
+            }
+        });
+
+        Map<String, String> obj = handler.getBase(restRequest, restResponse);
+
+        assertTrue("FAIL: the URL utils JSON object did not contain a 'getTool' field",
+                   obj.containsKey("getTool"));
+        assertEquals("FAIL: the URL utils 'getTool' URL was incorrect",
+                     "/adminCenter/v1/utils/url/getTool",
+                     obj.get("getTool"));
+
+        assertTrue("FAIL: the URL utils JSON object did not contain a 'getTool' field",
+                   obj.containsKey("getTool"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.URLUtils#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test(expected = NoSuchResourceException.class)
+    public void getChild_getStatus_undefinedChild() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+            }
+        });
+        handler.getChild(restRequest, restResponse, "other");
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.URLUtils#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_getTool_noURL() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getParameter("url");
+                will(returnValue(null));
+            }
+        });
+
+        try {
+            handler.getChild(restRequest, restResponse, "getTool");
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertTrue("ErrorMessage message start with CWWKX1017E and contain getTool",
+                       error.getMessage().matches("CWWKX1017E:.*getTool.*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.URLUtils#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_getTool_badURL() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getParameter("url");
+                will(returnValue("notAURL"));
+            }
+        });
+
+        try {
+            handler.getChild(restRequest, restResponse, "getTool");
+        } catch (BadRequestException e) {
+            assertEquals("Content type should be JSON",
+                         HTTPConstants.MEDIA_TYPE_APPLICATION_JSON, e.getContentType());
+
+            Message error = (Message) e.getPayload();
+            assertEquals("ErrorMessage status should be 400",
+                         400, error.getStatus());
+            assertTrue("ErrorMessage message start with CWWKX1018E and contain getTool",
+                       error.getMessage().matches("CWWKX1018E:.*getTool.*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.URLUtils#getChild(RESTRequest, RESTResponse, String)}.
+     */
+    @Test
+    public void getChild_getTool_invoked() throws Exception {
+        final String url = "http://www.ibm.com";
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getParameter("url");
+                will(returnValue(url));
+
+                // Test assertion
+                one(mockUtils).analyzeURL(with(any(URL.class)));
+            }
+        });
+
+        handler.getChild(restRequest, restResponse, "getTool");
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/utils/UtilsRootTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/utils/UtilsRootTest.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.rest.v1.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.wsspi.rest.handler.RESTRequest;
+import com.ibm.wsspi.rest.handler.RESTResponse;
+
+/**
+ *
+ */
+public class UtilsRootTest {
+    private final Mockery mock = new JUnit4Mockery();;
+    private final RESTRequest restRequest = mock.mock(RESTRequest.class);
+    private final RESTResponse restResponse = mock.mock(RESTResponse.class);
+
+    private UtilsRoot handler;
+
+    @Before
+    public void setUp() {
+        handler = new UtilsRoot();
+    }
+
+    @After
+    public void tearDown() {
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Validates the setup of the object matches our expectations. This is a
+     * validation and not really a business logic test.
+     */
+    @Test
+    public void objectValidation() {
+        assertEquals("The handler's base URL was not what was expected",
+                     "/adminCenter/v1/utils", handler.baseURL());
+        assertFalse("The handler should not expect to handle children",
+                    handler.hasChildren());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.UtilsRoot#getBase(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void getBase() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getURL();
+                will(returnValue("/adminCenter/v1/utils"));
+            }
+        });
+
+        Map<String, String> obj = handler.getBase(restRequest, restResponse);
+
+        assertTrue("FAIL: the v1 utils JSON object did not contain a 'url' field",
+                   obj.containsKey("url"));
+        assertEquals("FAIL: the v1 utils 'url' URL was incorrect",
+                     V1UtilsConstants.URL_UTILS_PATH,
+                     obj.get("url"));
+
+        assertTrue("FAIL: the v1 utils JSON object did not contain a 'feature' field",
+                   obj.containsKey("feature"));
+        assertEquals("FAIL: the v1 utils 'feature' URL was incorrect",
+                     V1UtilsConstants.FEATURE_UTILS_PATH,
+                     obj.get("feature"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.utils.UtilsRoot#getBase(com.ibm.wsspi.rest.handler.RESTRequest, com.ibm.wsspi.rest.handler.RESTResponse)}.
+     */
+    @Test
+    public void getBase_trailingSlash() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(restRequest).getMethod();
+                will(returnValue("GET"));
+                one(restRequest).isUserInRole("Administrator");
+                will(returnValue(true));
+
+                one(restRequest).getURL();
+                will(returnValue("/adminCenter/v1/utils/"));
+            }
+        });
+
+        Map<String, String> obj = handler.getBase(restRequest, restResponse);
+
+        assertTrue("FAIL: the v1 utils JSON object did not contain a 'url' field",
+                   obj.containsKey("url"));
+        assertEquals("FAIL: the v1 utils 'url' URL was incorrect",
+                     V1UtilsConstants.URL_UTILS_PATH,
+                     obj.get("url"));
+
+        assertTrue("FAIL: the v1 utils JSON object did not contain a 'feature' field",
+                   obj.containsKey("feature"));
+        assertEquals("FAIL: the v1 utils 'feature' URL was incorrect",
+                     V1UtilsConstants.FEATURE_UTILS_PATH,
+                     obj.get("feature"));
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/BookmarkTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/BookmarkTest.java
@@ -1,0 +1,1053 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.ui.internal.v1.ITool;
+import com.ibm.ws.ui.internal.v1.utils.LogRule;
+import com.ibm.ws.ui.internal.validation.InvalidToolException;
+import com.ibm.ws.ui.persistence.SelfValidatingPOJO;
+
+import test.common.JSONablePOJOTestCase;
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class BookmarkTest extends JSONablePOJOTestCase {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = new LogRule(outputMgr);
+    
+    private final String TOOL_ID = "myURL";
+    private final String TOOL_TYPE = ITool.TYPE_BOOKMARK;
+    private final String TOOL_NAME = "myURL";
+    private final String TOOL_URL = "ibm.com";
+    private final String TOOL_ICON = "icon.png";
+    private final String TOOL_DESCRIPTION = "a really great tool";
+
+    @Before
+    public void setUp() {
+        jsonablePojo = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        sourceJson = "{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}";
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#Bookmark(String, String, String, String, String, String)}.
+     */
+    @Test
+    public void getters() {
+        Bookmark tool = new Bookmark(TOOL_ID, TOOL_TYPE, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertEquals("FAIL: Bookmark did not return the expected ID",
+                     TOOL_ID, tool.getId());
+        assertEquals("FAIL: Bookmark did not return the expected type",
+                     TOOL_TYPE, tool.getType());
+        assertEquals("FAIL: Bookmark did not return the expected name",
+                     TOOL_NAME, tool.getName());
+        assertEquals("FAIL: Bookmark did not return the expected url",
+                     TOOL_URL, tool.getURL());
+        assertEquals("FAIL: Bookmark did not return the expected icon",
+                     TOOL_ICON, tool.getIcon());
+        assertEquals("FAIL: Bookmark did not return the expected description",
+                     TOOL_DESCRIPTION, tool.getDescription());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#Bookmark(String, String, String, String)}.
+     */
+    @Test
+    public void getters_implied() {
+        Bookmark tool = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertEquals("FAIL: Bookmark did not return the expected ID",
+                     TOOL_NAME, tool.getId());
+        assertEquals("FAIL: Bookmark did not return the expected type",
+                     ITool.TYPE_BOOKMARK, tool.getType());
+        assertEquals("FAIL: Bookmark did not return the expected name",
+                     TOOL_NAME, tool.getName());
+        assertEquals("FAIL: Bookmark did not return the expected icon",
+                     TOOL_ICON, tool.getIcon());
+        assertEquals("FAIL: Bookmark did not return the expected url",
+                     TOOL_URL, tool.getURL());
+        assertEquals("FAIL: Bookmark did not return the expected description",
+                     TOOL_DESCRIPTION, tool.getDescription());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Override
+    @Test
+    public void incompleteJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{}", Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id, type"));
+        }
+        assertFalse("FAIL: An incomplete Bookmark was considered to equal a valid Bookmark",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Bookmark should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Bookmark was considered to equal a valid Bookmark",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Bookmark should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":null,\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Bookmark was considered to equal a valid Bookmark",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Bookmark should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Bookmark was considered to equal a valid Bookmark",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Bookmark should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_wrongId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"otherId\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Bookmark was considered to equal a valid Bookmark",
+                    incompleteObj.equals(jsonablePojo));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("type"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":null,\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("type"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("type"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_incorrectType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"featureTool\"}", Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not match the expected format. Message: " + e.getMessage(),
+                       e.getMessage().matches(".*" + ITool.TYPE_BOOKMARK + ".*" + ITool.TYPE_FEATURE_TOOL + ".*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingName() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("name"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullName() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":null,\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("name"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyName() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("name"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingURL() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"myURL\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("url"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullURL() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":null,\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("url"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyURL() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("url"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingIcon() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\"}", Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("icon"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullIcon() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":null}",
+                                                  Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("icon"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyIcon() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"\"}", Bookmark.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("icon"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingDescription() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\"}",
+                                                  Bookmark.class);
+        incompleteObj.validateSelf();
+        // Pass - the description is allowed to be missing, null or empty
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullDescription() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":null}",
+                                                  Bookmark.class);
+        incompleteObj.validateSelf();
+        // Pass - the description is allowed to be missing, null or empty
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyDescription() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Bookmark incompleteObj = mapper.readValue("{\"id\":\"myURL\",\"type\":\"bookmark\",\"name\":\"myURL\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"\"}",
+                                                  Bookmark.class);
+        incompleteObj.validateSelf();
+        // Pass - the description is allowed to be missing, null or empty
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void validateSelf_featureTool() throws Exception {
+        final ITool tool = new Bookmark(TOOL_ID, ITool.TYPE_FEATURE_TOOL, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolException", e);
+            assertTrue("FAIL: InvalidToolException message did not match the expected format. Message: " + e.getMessage(),
+                       e.getMessage().matches(".*" + ITool.TYPE_BOOKMARK + ".*" + ITool.TYPE_FEATURE_TOOL + ".*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#validateSelf()}.
+     */
+    @Test
+    public void validateSelf_bookmark() throws Exception {
+        final ITool tool = new Bookmark(TOOL_ID, ITool.TYPE_BOOKMARK, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        tool.validateSelf();
+        // Should pass validation
+    }
+
+    @Test
+    public void validateSelf_absoluteURLsHTTP() {
+        final ITool tool = new Bookmark(TOOL_NAME, "http://cnn.com", "http://cnn.com/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: HTTP and HTTPS URLs are valid, regardless of case but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_russianResource() {
+        final ITool tool = new Bookmark(TOOL_NAME, "http://russian.co.ru/\u0420\u0430\u0437\u0432\u0435\u0440\u043d\u0443\u0442\u044c", "http://russian.co.ru/\u0420\u0430\u0437\u0432\u0435\u0440\u043d\u0443\u0442\u044c/icon.png", TOOL_DESCRIPTION);
+
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: HTTP and HTTPS URLs are valid, regardless of case but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_russianResourceWithCarats() {
+        final ITool tool = new Bookmark(TOOL_NAME, "http://russian.co.ru/\u0420\u0430\u0437\u0432\u0435\u0440\u043d\u0443\u0442<\u044c>", "http://russian.co.ru/\u0420\u0430\u0437\u0432\u0435\u0440\u043d\u0443\u0442<\u044c>/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+            fail("FAIL: A UTF-8 URL with <> characters was not considered invalid");
+        } catch (InvalidToolException e) {
+            // Pass
+        }
+    }
+
+    @Test
+    public void validateSelf_absoluteURLsHTTPS() {
+        final ITool tool = new Bookmark(TOOL_NAME, "https://cnn.com", "https://cnn.com/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: HTTP and HTTPS URLs are valid, regardless of case but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_absoluteURLsHTTPInCaps() {
+        final ITool tool = new Bookmark(TOOL_NAME, "HTTP://CNN.COM", "HTTP://CNN.COM/ICON.PNG", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: HTTP and HTTPS URLs are valid, regardless of case but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_absoluteURLsHTTPSInCaps() {
+        final ITool tool = new Bookmark(TOOL_NAME, "HTTPS://CNN.COM", "HTTPS://CNN.COM/ICON.PNG", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: HTTP and HTTPS URLs are valid, regardless of case but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_relativeServerURLs() {
+        final ITool tool = new Bookmark(TOOL_NAME, "/toolA", "/toolA/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: Server relative URLs are valid but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_relativePageURLs() {
+        final ITool tool = new Bookmark(TOOL_NAME, "toolB", "toolB/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: Page relative URLs are valid but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_relativePageURLsMoreDots() {
+        final ITool tool = new Bookmark(TOOL_NAME, "toolB/index...html", "toolB/icon....png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: Page relative URLs are valid (even with a lot of dots!) but validation failed");
+        }
+    }
+
+    @Ignore("For now, this is a pretty insane case. We need to be using a real library!")
+    @Test
+    public void validateSelf_relativePageURLsWackyResource() {
+        final ITool tool = new Bookmark(TOOL_NAME, "toolB/sub:/index.html", "toolB/sub:/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: Funky URLs should be considered valid, even when not encoded");
+        }
+    }
+
+    /**
+     * This scenario is really weird but it IS valid...
+     */
+    @Test
+    public void validateSelf_DoubleProtocol() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "http://ibm.com/http://localhost/index.html", "http://ibm.com/http://localhost/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_xssName() throws Exception {
+        final ITool tool = new Bookmark("CN<script>N", TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A tool with XSS in 'name' is not valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_xssURL() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "http://cnn.com?<script>alert('a')</script>", TOOL_ICON, TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A tool with XSS in 'url' is not valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_xssIcon() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, TOOL_URL, "http://i.cdn.turner.com/cnn/.e/<img src='abc'></img>", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A tool with XSS in 'icon' is not valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_xssDescription() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, "CNN<script src='abc'>");
+        tool.validateSelf();
+        fail("FAIL: A tool with XSS in 'name' is not valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_xssAll() throws Exception {
+        final ITool tool = new Bookmark("CNN<script src='abc'>", "http://cnn.com/<script>altert('hi')</script>", "http://i.cdn.turner.com/cnn/.e/<img src='abc'></img>", "CNN<script src='abc'>");
+        tool.validateSelf();
+        fail("FAIL: A tool with XSS in 'icon' is not valid");
+    }
+
+    @Test
+    public void validateSelf_nameChars() {
+        // test for valid and invalid characters in the name
+        // invalid chars are  ~ & : ; / \ ? {} < > []
+        String[] invalidChars = new String[] { "~", "&", ":", ";", "/", "\\", "?", "{", "}", "<", ">", "[", "]" };
+        String[] validChars = new String[] { "`", "!", "@", "#", "$", "%", "^", "*", "(", ")", "-", "_", "=", "+", "|", "\"", "'", ",", "." };
+        String toolName = null;
+        ITool tool;
+
+        for (int i = 0; i < validChars.length; i++) {
+            toolName = "CN" + validChars[i] + "N";
+            tool = new Bookmark(toolName, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+            try {
+                tool.validateSelf();
+                // no exception so pass
+            } catch (InvalidToolException e) {
+                fail("FAIL: A valid tool with " + validChars[i] + " in the 'name' is not valid");
+            }
+        }
+
+        for (int i = 0; i < invalidChars.length; i++) {
+            toolName = "CN" + invalidChars[i] + "N";
+            tool = new Bookmark(toolName, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+            try {
+                tool.validateSelf();
+                fail("FAIL: A tool with invalid char " + toolName + " in the 'name' is valid");
+            } catch (InvalidToolException e) {
+                // pass
+            }
+        }
+    }
+
+    @Test
+    public void validateSelf_descriptionChars() {
+        // test for valid and invalid characters in the name
+        // invalid chars are  ~ & : ; / \ ? {} < > []
+        String[] invalidChars = new String[] { "~", "&", ":", ";", "/", "\\", "?", "{", "}", "<", ">", "[", "]" };
+        String[] validChars = new String[] { "`", "!", "@", "#", "$", "%", "^", "*", "(", ")", "-", "_", "=", "+", "|", "\"", "'", ",", "." };
+        String toolDescription = null;
+        ITool tool;
+
+        for (int i = 0; i < validChars.length; i++) {
+            toolDescription = "CN" + validChars[i] + "N";
+            tool = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, toolDescription);
+            try {
+                tool.validateSelf();
+                // no exception so pass
+            } catch (InvalidToolException e) {
+                fail("FAIL: A valid tool with " + validChars[i] + " in the 'name' is not valid");
+            }
+        }
+
+        for (int i = 0; i < invalidChars.length; i++) {
+            toolDescription = "CN" + invalidChars[i] + "N";
+            tool = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, toolDescription);
+            try {
+                tool.validateSelf();
+                fail("FAIL: A tool with invalid char " + toolDescription + " in the 'name' is valid");
+            } catch (InvalidToolException e) {
+                // pass
+            }
+        }
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_FTP() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "ftp://ibm.com", "ftp://ibm.com/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with non-HTTP or HTTPS URL protocols was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_SSH() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "ssh://ibm.com", "ssh://ibm.com/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with non-HTTP or HTTPS URL protocols was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_FileURL() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "file:/ibm", "file:/ibm/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with non-HTTP or HTTPS URL protocols was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_MisspelledHTTP() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "htp://ibm.com", "htp://ibm.com/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with incorrectly spelled HTTP or HTTPS URL was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_MisspelledHTTPS() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "htps://ibm.com", "htps://ibm.com/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with incorrectly spelled HTTP or HTTPS URL was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_relativeSubPathURLs() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "../toolA", "../toolA/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with relative path elements was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_relativeSubPathURLs2() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "a/../toolA", "a/../toolA/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with relative path elements was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_relativeSubPathURLs3() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "..", "..", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with relative path elements was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_relativeSubPathURLs4() throws Exception {
+        final ITool tool = new Bookmark(TOOL_NAME, "/..", "/..", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with relative path elements was considered valid");
+    }
+
+    @Test
+    public void validateSelf_exploreAppURL() throws Exception {
+        final ITool tool = new Bookmark("explore server app URL", "https://localhost:9443/adminCenter/#explore/servers/localhost,/home/was/IBM/wlp/usr,server1/apps/lab", "prod.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+    }
+
+    @Test
+    public void validateSelf_exploreSearchURL() throws Exception {
+        final ITool tool = new Bookmark("explore search URL", "https://localhost:9443/adminCenter/#explore/search/?type=application&name=lab&tag=~eq~prod", "prod.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_twoPorts() throws Exception {
+        final ITool tool = new Bookmark("explore search URL", "https://localhost:9443:9000/adminCenter/#explore/search/?type=application&name=lab&tag=~eq~prod", "prod.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with relative path elements was considered valid");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void extraPojoMatchesSourceJSONChecks(SelfValidatingPOJO unmarshalledPojo) throws Exception {
+        unmarshalledPojo.validateSelf();
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameInstance() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertEquals("FAIL: The same Bookmark instance did not compare as equals=true",
+                     t1, t1);
+        assertEquals("FAIL: The same Bookmark instance did not compare hashCode as equals=true",
+                     t1.hashCode(), t1.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameValues() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertEquals("FAIL: Two equal Bookmark with only required fields did not compare as equals",
+                     t1, t2);
+        assertEquals("FAIL: Two equal Bookmark with only required fields did not compare hashCode as equals",
+                     t1.hashCode(), t2.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameValuesEmpty() {
+        final ITool t1 = new Bookmark();
+        final ITool t2 = new Bookmark();
+        assertEquals("FAIL: Two equal Bookmark with only required fields did not compare as equals",
+                     t1, t2);
+        assertEquals("FAIL: Two equal Bookmark with only required fields did not compare hashCode as equals",
+                     t1.hashCode(), t2.hashCode());
+    }
+
+    @Test
+    public void equalsNullThisId() {
+        final ITool t1 = new Bookmark(null, TOOL_TYPE, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'id' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatId() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(null, TOOL_TYPE, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'id' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchId() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark("yourURL", TOOL_TYPE, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'id' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisType() {
+        final ITool t1 = new Bookmark(TOOL_ID, null, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'type' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatType() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_ID, null, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'type' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchType() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_ID, ITool.TYPE_FEATURE_TOOL, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'type' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisName() {
+        final ITool t1 = new Bookmark(null, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'name' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatName() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(null, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'name' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchName() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark("yourURL", TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'name' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisURL() {
+        final ITool t1 = new Bookmark(TOOL_NAME, null, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'url' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatURL() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, null, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'url' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchURL() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, "google.com", TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'url' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisIcon() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, null, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatIcon() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, null, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchIcon() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, "other.png", TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisDescription() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, null);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatDescription() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, null);
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchDescription() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, "other desc");
+        assertFalse("FAIL: Two Bookmark considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNotABookmark() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: A non-Bookmark object was considered to equal a Bookmark",
+                    t1.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNull() {
+        final ITool t1 = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Null was conisdered to equal a Tool",
+                    t1.equals(null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#hashCode()}.
+     */
+    @Test
+    public void hashCode_nullId() {
+        final ITool tool = new Bookmark(null, TOOL_TYPE, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertEquals("FAIL: when the ID is null (which is not a valid case) hashcode should be 0",
+                     0, tool.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#hashCode()}.
+     */
+    @Test
+    public void hashCode_hasId() {
+        final ITool tool = new Bookmark(TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: when the ID is set hashcode should be non-zero",
+                    0 == tool.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#toString()}.
+     */
+    @Test
+    public void toString_emptyObject() {
+        final ITool tool = new Bookmark();
+        assertEquals("FAIL: the empty tool object did not return the expected toString",
+                     "Bookmark {\"id\":null,\"type\":null,\"name\":null,\"url\":null,\"icon\":null,\"description\":null}", tool.toString());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Bookmark#toString()}.
+     */
+    @Test
+    public void toString_validObject() {
+        assertEquals("FAIL: the valid tool object did not return the expected toString",
+                     "Bookmark " + sourceJson, jsonablePojo.toString());
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/BookmarkWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/BookmarkWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class BookmarkWithTraceTest extends BookmarkTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/CatalogTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/CatalogTest.java
@@ -1,0 +1,1050 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.websphere.jsonsupport.JSONMarshallException;
+import com.ibm.ws.ui.internal.v1.ICatalog;
+import com.ibm.ws.ui.internal.v1.IFeatureToolService;
+import com.ibm.ws.ui.internal.v1.ITool;
+import com.ibm.ws.ui.internal.v1.IToolbox;
+import com.ibm.ws.ui.internal.v1.IToolboxService;
+import com.ibm.ws.ui.internal.v1.utils.LogRule;
+import com.ibm.ws.ui.internal.validation.InvalidCatalogException;
+import com.ibm.ws.ui.internal.validation.InvalidToolException;
+import com.ibm.ws.ui.persistence.IPersistenceProvider;
+import com.ibm.ws.ui.persistence.SelfValidatingPOJO;
+
+import test.common.JSONablePOJOTestCase;
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class CatalogTest extends JSONablePOJOTestCase {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = new LogRule(outputMgr);
+
+    private final Mockery mock = new JUnit4Mockery();
+    private final IFeatureToolService mockFeatureToolService = mock.mock(IFeatureToolService.class);
+    private final IPersistenceProvider mockPersistence = mock.mock(IPersistenceProvider.class);
+    private final IToolboxService mockToolboxService = mock.mock(IToolboxService.class);
+    private Catalog catalog;
+
+    @Before
+    public void setUp() {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockFeatureToolService).getTools();
+                will(returnValue(Collections.EMPTY_SET));
+
+                allowing(mockFeatureToolService).getToolsForRequestLocale();
+                will(returnValue(Collections.EMPTY_LIST));
+
+                allowing(mockFeatureToolService).getToolForRequestLocale(with(any(String.class)));
+                will(returnValue(null));
+            }
+        });
+        jsonablePojo = new Catalog(mockPersistence, mockToolboxService, mockFeatureToolService);
+        sourceJson = "{\"_metadata\":{\"lastModified\":1,\"isDefault\":true},\"featureTools\":[],\"bookmarks\":[{\"name\":\"openliberty.io\",\"url\":\"https://openliberty.io\",\"description\":\"Open Liberty website.\",\"icon\":\"images/tools/Open_Liberty_square_142x142.png\",\"id\":\"openliberty.io\",\"type\":\"bookmark\"}]}";
+
+        catalog = new Catalog(mockPersistence, mockToolboxService, mockFeatureToolService);
+    }
+
+    @After
+    public void tearDown() {
+        catalog = null;
+
+        mock.assertIsSatisfied();
+    }
+
+    @Test
+    public void constructorDefautInitialization() {
+        assertNotNull("FAIL: Catalog tools should not be null",
+                      catalog.getFeatureTools());
+        assertEquals("FAIL: Catalog tools should be empty",
+                     0, catalog.getFeatureTools().size());
+
+        assertNotNull("FAIL: Catalog bookmarks should not be null",
+                      catalog.getBookmarks());
+        assertEquals("FAIL: Catalog bookmarks should be empty",
+                     1, catalog.getBookmarks().size());
+
+        assertNotNull("FAIL: Catalog metadata should not be null",
+                      catalog.get_metadata());
+        assertEquals("FAIL: Catalog metadata should not be empty",
+                     3, catalog.get_metadata().size());
+        assertTrue("FAIL: Catalog metadata should reflect isDefault=true",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * initialProcessFeatures should not cause a isDefault change or cause a store.
+     */
+    @Test
+    public void initialProcessFeatures_noFeatures() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                never(mockPersistence).store(Catalog.PERSIST_NAME, catalog);
+            }
+        });
+
+        assertTrue("FAIL: Catalog metadata should reflect isDefault=true before initialProcessFeatures",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        catalog.initialProcessFeatures();
+
+        assertTrue("FAIL: Catalog metadata should reflect isDefault=true after initialProcessFeatures",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * initialProcessFeatures should not cause a isDefault change or cause a store.
+     */
+    @Test
+    public void initialProcessFeatures_hasFeatures() throws Exception {
+        final IFeatureToolService newMockFeatureToolService = mock.mock(IFeatureToolService.class, "newMockFeatureToolService");
+        final Set<FeatureTool> featureTools = new HashSet<FeatureTool>();
+        FeatureTool featureTool = new FeatureTool("com.ibm.websphere.feature", "1.0", "tool-1.0", "FT", "ft.html", "ft.png", "A feature tool");
+        featureTools.add(featureTool);
+
+        mock.checking(new Expectations() {
+            {
+                allowing(newMockFeatureToolService).getTools();
+                will(returnValue(featureTools));
+
+                allowing(newMockFeatureToolService).getToolsForRequestLocale();
+                will(returnValue(new ArrayList<FeatureTool>(featureTools)));
+
+                never(mockPersistence).store(Catalog.PERSIST_NAME, catalog);
+            }
+        });
+
+        assertTrue("FAIL: Catalog metadata should reflect isDefault=true before initialProcessFeatures",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        catalog.setIFeatureToolService(newMockFeatureToolService);
+        catalog.initialProcessFeatures();
+
+        assertTrue("FAIL: Catalog metadata should reflect isDefault=true after initialProcessFeatures",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#get_metadata()}.
+     */
+    @Test
+    public void get_metadata_uninitialized() {
+        assertNull("FAIL: get_metadata() should return null when the object is not initialized",
+                   new Catalog().get_metadata());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#getFeatureTools()}.
+     */
+    @Test
+    public void getFeatureTools_uninitialized() {
+        assertNull("FAIL: getFeatureTools() should return null when the object is not initialized",
+                   new Catalog().getFeatureTools());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#getTools()}.
+     */
+    @Test
+    public void getFeatureTools() {
+        assertNotNull("FAIL: getTools() should never return null",
+                      catalog.getFeatureTools());
+        assertEquals("FAIL: should have no pre-defined feature tools",
+                     0, catalog.getFeatureTools().size());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#getTools()}.
+     */
+    @Test
+    public void getFeatureTools_availableFeatures() throws Exception {
+        final Set<FeatureTool> featureSet = new HashSet<FeatureTool>();
+        final FeatureTool featureTool = new FeatureTool("com.ibm.websphere.feature", "1.0", "tool-1.0", "FT", "ft.html", "ft.png", "A feature tool");
+        featureSet.add(featureTool);
+
+        final IFeatureToolService newMockFeatureToolService = mock.mock(IFeatureToolService.class, "newMockFeatureToolService");
+        mock.checking(new Expectations() {
+            {
+                allowing(newMockFeatureToolService).getTools();
+                will(returnValue(featureSet));
+
+                allowing(newMockFeatureToolService).getToolsForRequestLocale();
+                will(returnValue(new ArrayList<FeatureTool>(featureSet)));
+
+                allowing(newMockFeatureToolService).getToolForRequestLocale("com.ibm.websphere.feature-1.0");
+                will(returnValue(featureTool));
+            }
+        });
+
+        // Change the featureToolService to have a feature tool
+        catalog.setIFeatureToolService(newMockFeatureToolService);
+        setMockPersistStore();
+
+        assertNotNull("FAIL: getTools() should never return null",
+                      catalog.getFeatureTools());
+        assertEquals("FAIL: should have the now available feature tools",
+                     1, catalog.getFeatureTools().size());
+        assertTrue("FAIL: featureTools should contain the featureTool",
+                   catalog.getFeatureTools().contains(featureTool));
+        assertEquals("FAIL: featureTools should contain an exact match for the featureTool",
+                     featureTool, catalog.getTool(featureTool.getId()));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#getTools()}.
+     */
+    @Test
+    public void getFeatureTools_removesFeatures() throws Exception {
+        // Add in a tool - "com.ibm.websphere.feature-1.0"
+        getFeatureTools_availableFeatures();
+
+        // Change the featureToolService to have no tools
+        catalog.setIFeatureToolService(mockFeatureToolService);
+        setMockPersistStore();
+
+        assertNotNull("FAIL: getTools() should never return null",
+                      catalog.getFeatureTools());
+        assertEquals("FAIL: should have no pre-defined feature tools",
+                     0, catalog.getFeatureTools().size());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#getTools()}.
+     */
+    @Test
+    public void getFeatureTools_updatesChangedFeature() throws Exception {
+        // Add in a tool - "com.ibm.websphere.feature-1.0"
+        getFeatureTools_availableFeatures();
+
+        // CHANGE "com.ibm.websphere.feature-1.0" slightly. Update its URL.
+        final Set<FeatureTool> featureSet = new HashSet<FeatureTool>();
+        final FeatureTool featureTool = new FeatureTool("com.ibm.websphere.feature", "1.0", "FT", "tool-1.0", "ft-new.html", "ft.png", "A feature tool");
+        featureSet.add(featureTool);
+
+        final IFeatureToolService updatedMockFeatureToolService = mock.mock(IFeatureToolService.class, "updatedMockFeatureToolService");
+        mock.checking(new Expectations() {
+            {
+                allowing(updatedMockFeatureToolService).getTools();
+                will(returnValue(featureSet));
+
+                allowing(updatedMockFeatureToolService).getToolsForRequestLocale();
+                will(returnValue(new ArrayList<FeatureTool>(featureSet)));
+
+                allowing(updatedMockFeatureToolService).getToolForRequestLocale("com.ibm.websphere.feature-1.0");
+                will(returnValue(featureTool));
+            }
+        });
+
+        catalog.setIFeatureToolService(updatedMockFeatureToolService);
+        setMockPersistStore();
+
+        assertNotNull("FAIL: getTools() should never return null",
+                      catalog.getFeatureTools());
+        assertEquals("FAIL: should have the changed feature tools",
+                     1, catalog.getFeatureTools().size());
+        assertTrue("FAIL: should have the changed feature tools",
+                   catalog.getFeatureTools().contains(featureTool));
+        assertEquals("FAIL: the stored tool did not match the expected tool",
+                     featureTool, catalog.getTool(featureTool.getId()));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#getBookmarks()}.
+     */
+    @Test
+    public void getBookmarks_uninitialized() {
+        assertNull("FAIL: getBookmarks() should return null when the object is not initialized",
+                   new Catalog().getBookmarks());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#getTools()}.
+     */
+    @Test
+    public void getBookmarks() {
+        assertNotNull("FAIL: getBookmarks() should never return null",
+                      catalog.getBookmarks());
+        assertEquals("FAIL: should have 1 pre-defined URLs",
+                     1, catalog.getBookmarks().size());
+
+        Bookmark openlibertyio = catalog.getBookmarks().get(0);
+        assertEquals("The default openliberty.io bookmark did not have the right 'id'",
+                     "openliberty.io", openlibertyio.getId());
+        assertEquals("The default openliberty.io bookmark did not have the right 'id'",
+                     "bookmark", openlibertyio.getType());
+        assertEquals("The default openliberty.io bookmark did not have the right 'id'",
+                     "openliberty.io", openlibertyio.getName());
+        assertEquals("The default openliberty.io bookmark did not have the right 'id'",
+                     "https://openliberty.io", openlibertyio.getURL());
+        assertEquals("The default openliberty.io bookmark did not have the right 'id'",
+                     "images/tools/Open_Liberty_square_142x142.png", openlibertyio.getIcon());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#getTool(java.lang.String)}.
+     */
+    @Test
+    public void getTool_doesntExist() {
+        assertNull("FAIL: tool 'doesntExist' should not be defined",
+                   catalog.getTool("doesntExist"));
+    }
+
+    /**
+     * Establish the mock to expect a call to storage.
+     *
+     * @throws JSONMarshallException
+     */
+    private void setMockPersistStore() throws IOException, JSONMarshallException {
+        mock.checking(new Expectations() {
+            {
+                one(mockPersistence).store(Catalog.PERSIST_NAME, catalog);
+            }
+        });
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#addBookmark(com.ibm.ws.ui.internal.v1.pojo.FeatureTool)}.
+     */
+    @Test
+    public void addBookmark() throws Exception {
+        setMockPersistStore();
+
+        assertTrue("FAIL: The metadata isDefault should be true before any changes are made",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        int lCountBefore = catalog.getBookmarks().size();
+        long modBefore = (Long) catalog.get_metadata().get(ICatalog.METADATA_LAST_MODIFIED);
+
+        Bookmark featureTool = new Bookmark("Google Gmail", "https://mail.google.com/mail/u/0/?shva=1#inbox", "http://google.com/mail.ico", "Google Gmail desktop version");
+        catalog.addBookmark(featureTool);
+
+        int lCountAfter = catalog.getBookmarks().size();
+        long modAfter = (Long) catalog.get_metadata().get(ICatalog.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The tool count should be increased by 1 when a tool is added",
+                     lCountBefore + 1, lCountAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the add",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an add",
+                    (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#addBookmark(com.ibm.ws.ui.internal.v1.pojo.FeatureTool)}.
+     */
+    @Test
+    public void addBookmark_implied() throws Exception {
+        setMockPersistStore();
+
+        assertTrue("FAIL: The metadata isDefault should be true before any changes are made",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        int lCountBefore = catalog.getBookmarks().size();
+        long modBefore = (Long) catalog.get_metadata().get(ICatalog.METADATA_LAST_MODIFIED);
+
+        ObjectMapper mapper = new ObjectMapper();
+        Bookmark featureTool = mapper.readValue("{\"name\":\"b\",\"url\":\"ibm.com\",\"icon\":\"img.png\"}", Bookmark.class);
+        catalog.addBookmark(featureTool);
+
+        int lCountAfter = catalog.getBookmarks().size();
+        long modAfter = (Long) catalog.get_metadata().get(ICatalog.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The tool count should be increased by 1 when a tool is added",
+                     lCountBefore + 1, lCountAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the add",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an add",
+                    (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#addBookmark(com.ibm.ws.ui.internal.v1.pojo.FeatureTool)}.
+     */
+    @Test(expected = DuplicateException.class)
+    public void addBookmarkDuplicate() throws Exception {
+        setMockPersistStore();
+
+        Bookmark featureTool = new Bookmark("Google Gmail", "https://mail.google.com/mail/u/0/?shva=1#inbox", "https://google.com/mail.ico", "Google Gmail desktop version");
+        catalog.addBookmark(featureTool);
+
+        int lCountBefore = catalog.getBookmarks().size();
+
+        catalog.addBookmark(featureTool);
+
+        int lCountAfter = catalog.getBookmarks().size();
+        assertEquals("FAIL: The tool count should not change if the tool is not added",
+                     lCountBefore, lCountAfter);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addBookmark(com.ibm.ws.ui.internal.v1.pojo.FeatureTool)}.
+     */
+    @Test
+    public void addBookmarkInvalidTool() throws Exception {
+        Bookmark badTool = new Bookmark("Simple Action", "htt://www.abc.com/SimpleAction.html", "action-0.1/Action-icon.png", "A simple action");
+
+        int lCountBefore = catalog.getBookmarks().size();
+
+        try {
+            catalog.addBookmark(badTool);
+            fail("Expected a InvalidToolException to be thrown when adding a bad tool");
+        } catch (InvalidToolException e) {
+            // Pass
+        } ;
+
+        int lCountAfter = catalog.getBookmarks().size();
+        assertEquals("FAIL: The tool count should not change if the tool is not added",
+                     lCountBefore, lCountAfter);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#addBookmark(com.ibm.ws.ui.internal.v1.pojo.FeatureTool)}.
+     */
+    @Test
+    public void addBookmarkPersistenceError() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockPersistence).store(Catalog.PERSIST_NAME, catalog);
+                will(throwException(new IOException("TestException")));
+            }
+        });
+
+        assertTrue("FAIL: The metadata isDefault should be true before any changes are made",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        long modBefore = (Long) catalog.get_metadata().get(ICatalog.METADATA_LAST_MODIFIED);
+
+        Bookmark featureTool = new Bookmark("Google Gmail", "https://mail.google.com/mail/u/0/?shva=1#inbox", "http://google.com/mail.ico", "Google Gmail desktop version");
+        catalog.addBookmark(featureTool);
+
+        long modAfter = (Long) catalog.get_metadata().get(ICatalog.METADATA_LAST_MODIFIED);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the add",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an add",
+                    (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Persistence failed on add - did not produce expected CWWKX1012E",
+                   outputMgr.checkForMessages("CWWKX1012E:.*TestException"));
+    }
+
+    /**
+     * Check all futures for any exceptions.
+     *
+     * @param futureList
+     * @throws InterruptedException
+     */
+    private void checkFuturesForExceptions(List<Future<String>> futureList) throws InterruptedException {
+        try {
+            for (int i = 0; i < futureList.size(); i++) {
+                futureList.get(i).get();
+            }
+        } catch (ExecutionException ex) {
+            ex.printStackTrace();
+            fail("Thread ExecutionException: " + ex.getCause());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#addBookmark(com.ibm.ws.ui.internal.v1.pojo.FeatureTool)}.
+     */
+    @Test
+    public void addAndDeleteToolMultiThreads() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockPersistence).store(Catalog.PERSIST_NAME, catalog);
+
+                allowing(mockToolboxService).removeToolEntryFromAllToolboxes(with(any(String.class)));
+            }
+        });
+
+        // Spawn concurrent tool additions
+        int threadSize = 10;
+        int loops = 50;
+        int totalNewTools = loops * 100;
+        ExecutorService executor = Executors.newFixedThreadPool(threadSize);
+        List<Future<String>> futureList = new ArrayList<Future<String>>();
+
+        // Spawn writers
+        for (int t = 0; t < loops; t++) {
+            Callable<String> worker = new AddBookmarkWorker(catalog, "t" + t);
+            Future<String> future = executor.submit(worker);
+            futureList.add(future);
+        }
+
+        // Spawn readers
+        Future<String> reader = executor.submit(new GetCataloglWorker(catalog));
+        Future<String> metadataReader = executor.submit(new GetMetadataWorker(catalog));
+
+        executor.shutdown();
+        // Wait until all threads are finish (timeout 10 seconds)
+        executor.awaitTermination(10L, TimeUnit.SECONDS);
+
+        // Validation
+        List<Future<String>> validationList = new ArrayList<Future<String>>();
+        validationList.addAll(futureList);
+        validationList.add(reader);
+        validationList.add(metadataReader);
+        checkFuturesForExceptions(validationList);
+        assertEquals("FAIL: The catalog does not have the expected number of bookmarks",
+                     1 + totalNewTools, catalog.getBookmarks().size());
+
+        // Spawn concurrent tool removals
+        executor = Executors.newFixedThreadPool(threadSize);
+        List<Future<String>> futureDeleteList = new ArrayList<Future<String>>();
+
+        // Spawn writers
+        for (int t = 0; t < loops; t++) {
+            Callable<String> worker = new DeleteBookmarkWorker(catalog, futureList.get(t).get());
+            futureDeleteList.add(executor.submit(worker));
+        }
+        // Spawn readers
+        reader = executor.submit(new GetCataloglWorker(catalog));
+        metadataReader = executor.submit(new GetMetadataWorker(catalog));
+
+        executor.shutdown();
+        // Wait until all threads are finish (timeout 10 seconds)
+        executor.awaitTermination(10L, TimeUnit.SECONDS);
+
+        // Validation
+        validationList.clear();
+        validationList.addAll(futureList);
+        validationList.add(reader);
+        validationList.add(metadataReader);
+        checkFuturesForExceptions(validationList);
+        assertEquals("FAIL: The catalog bookmarks did not return to 1 bookmark",
+                     1, catalog.getBookmarks().size());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#deleteBookmark(java.lang.String)}.
+     */
+    @Test
+    public void deleteTool() throws Exception {
+        final String toolId = "Test+Bookmark";
+
+        setMockPersistStore();
+        catalog.addBookmark(new Bookmark("Test Bookmark", "ibm.com", "img.png"));
+
+        long modBefore = (Long) catalog.get_metadata().get(ICatalog.METADATA_LAST_MODIFIED);
+        int countBefore = catalog.getBookmarks().size();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockToolboxService).removeToolEntryFromAllToolboxes(toolId);
+            }
+        });
+        setMockPersistStore();
+
+        ITool deletedTool = catalog.deleteBookmark(toolId);
+        assertEquals("FAIL: The delete operation failed or it did not return the correct deleted Tool JSON",
+                     toolId, deletedTool.getId());
+
+        int countAfter = catalog.getBookmarks().size();
+        long modAfter = (Long) catalog.get_metadata().get(ICatalog.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The metadata count did not get decremented as part of the delete",
+                     countBefore - 1, countAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the delete",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an delete",
+                    (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#deleteBookmark(java.lang.String)}.
+     */
+    @Test
+    public void deleteToolTwice() throws Exception {
+        final String toolId = "Test+Bookmark";
+
+        setMockPersistStore();
+        catalog.addBookmark(new Bookmark("Test Bookmark", "ibm.com", "img.png"));
+
+        setMockPersistStore();
+        mock.checking(new Expectations() {
+            {
+                one(mockToolboxService).removeToolEntryFromAllToolboxes(toolId);
+            }
+        });
+
+        ITool t1 = catalog.deleteBookmark(toolId);
+        assertEquals("FAIL: The delete operation failed or it did not return the correct deleted Tool JSON",
+                     t1.getId(), toolId);
+
+        ITool t2 = catalog.deleteBookmark(toolId);
+        assertNull("FAIL: The delete operation did not return a null object when the tool did not exist", t2);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#deleteBookmark(java.lang.String)}.
+     *
+     * @throws JSONMarshallException
+     */
+    @Test
+    public void deleteToolWithInvalidIds() throws IOException, JSONMarshallException {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockPersistence).store(Catalog.PERSIST_NAME, catalog);
+            }
+        });
+
+        ITool deletedTool = catalog.deleteBookmark(null);
+        assertNull("FAIL: The delete operation did not return a null object when the toolId was null",
+                   deletedTool);
+        deletedTool = catalog.deleteBookmark("");
+        assertNull("FAIL: The delete operation did not return a null object when the toolId was empty",
+                   deletedTool);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#deleteBookmark(java.lang.String)}.
+     */
+    @Test
+    public void deleteToolPersistenceError() throws Exception {
+        final String toolId = "Test+Bookmark";
+
+        setMockPersistStore();
+        catalog.addBookmark(new Bookmark("Test Bookmark", "ibm.com", "img.png"));
+
+        int countBefore = catalog.getBookmarks().size();
+        long modBefore = (Long) catalog.get_metadata().get(ICatalog.METADATA_LAST_MODIFIED);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockToolboxService).removeToolEntryFromAllToolboxes(toolId);
+
+                one(mockPersistence).store(Catalog.PERSIST_NAME, catalog);
+                will(throwException(new IOException("TestException")));
+            }
+        });
+
+        catalog.deleteBookmark(toolId);
+
+        int countAfter = catalog.getBookmarks().size();
+        long modAfter = (Long) catalog.get_metadata().get(ICatalog.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The metadata count did not get decremented as part of the delete",
+                     countBefore - 1, countAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the delete",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after a delete",
+                    (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Persistence failed on add - did not produce expected CWWKX1012E",
+                   outputMgr.checkForMessages("CWWKX1012E:.*TestException"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Catalog#reset()}.
+     */
+    @Test
+    public void reset() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockToolboxService).removeToolEntryFromAllToolboxes("openliberty.io");
+            }
+        });
+
+        setMockPersistStore();
+        catalog.reset();
+        assertTrue("FAIL: The metadata isDefault should be true after a reset",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+        assertNull("Added Tool should no longer be present in the catalog",
+                   catalog.getTool("T"));
+    }
+
+    @Test
+    public void validateSelf() throws Exception {
+        catalog.validateSelf();
+    }
+
+    @Test
+    public void validateSelf_badFeatureTool() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Catalog incompleteToolDataCatalog = mapper.readValue(
+                                                             "{\"_metadata\":{\"lastModified\":1,\"isDefault\":true},\"featureTools\":[{\"id\":\"Feature+Tool\"}],\"bookmarks\":[]}",
+                                                             Catalog.class);
+        incompleteToolDataCatalog.validateSelf();
+        assertEquals("FAIL: Catalog tools should contain 0 tools after the tool was removed",
+                     0, incompleteToolDataCatalog.getBookmarks().size());
+
+        assertTrue("FAIL: Did not get expected catalog validation message CWWKX1013W",
+                   outputMgr.checkForMessages("CWWKX1013W:.*Feature\\+Tool.*"));
+    }
+
+    @Test
+    public void validateSelf_badBookmark() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Catalog incompleteToolDataCatalog = mapper.readValue(
+                                                             "{\"_metadata\":{\"lastModified\":1,\"isDefault\":true},\"featureTools\":[],\"bookmarks\":[{\"id\":\"Simple+Clock\"}]}",
+                                                             Catalog.class);
+        incompleteToolDataCatalog.validateSelf();
+        assertEquals("FAIL: Catalog tools should contain 0 tools after the tool was removed",
+                     0, incompleteToolDataCatalog.getBookmarks().size());
+
+        assertTrue("FAIL: Did not get expected catalog validation message CWWKX1013W",
+                   outputMgr.checkForMessages("CWWKX1013W:.*Simple\\+Clock.*"));
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameInstance() throws Exception {
+        final ICatalog c1 = new Catalog(mockPersistence, mockToolboxService, mockFeatureToolService);
+        assertEquals("FAIL: The same Catalog instance did not compare as equals=true",
+                     c1, c1);
+        assertEquals("FAIL: The same Catalog instance did not compare hashCode as equals=true",
+                     c1.hashCode(), c1.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsUninitializedTrue() {
+        final ICatalog c1 = new Catalog();
+        final ICatalog c2 = new Catalog();
+        assertEquals("FAIL: Two Catalogs with uninitialized required fields did not compare as equals",
+                     c1, c2);
+        assertEquals("FAIL: Two Catalogs with uninitialized required fields did not compare hashCode as equals",
+                     c1.hashCode(), c2.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsInitializedTrue() {
+        final ICatalog c1 = new Catalog(mockPersistence, mockToolboxService, mockFeatureToolService);
+        final ICatalog c2 = new Catalog(mockPersistence, mockToolboxService, mockFeatureToolService);
+        assertEquals("FAIL: Two Catalogs with initialized required fields did not compare as equals",
+                     c1, c2);
+        assertEquals("FAIL: Two Catalogs with initialized required fields did not compare hashCode as equals",
+                     c1.hashCode(), c2.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsMismatchTools() {
+        final ICatalog c1 = new Catalog();
+
+        final IFeatureToolService newMockFeatureToolService = mock.mock(IFeatureToolService.class, "newMockFeatureToolService");
+        final Set<FeatureTool> featureTools = new HashSet<FeatureTool>();
+        featureTools.add(new FeatureTool("", "", "", "", "", "", ""));
+        mock.checking(new Expectations() {
+            {
+                allowing(newMockFeatureToolService).getTools();
+                will(returnValue(featureTools));
+
+                allowing(newMockFeatureToolService).getToolsForRequestLocale();
+                will(returnValue(new ArrayList<FeatureTool>(featureTools)));
+            }
+        });
+        final Catalog c2 = new Catalog(mockPersistence, mockToolboxService, newMockFeatureToolService);
+        c2.initialProcessFeatures();
+        assertFalse("FAIL: Two unequal Catalogs compared as equal",
+                    c1.equals(c2));
+    }
+
+    @Test
+    public void equalsNotACatalog() {
+        assertFalse("FAIL: A non-Catalog object was considered to equal a Catalog",
+                    jsonablePojo.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNull() {
+        assertFalse("FAIL: Null was conisdered to equal a Catalog",
+                    jsonablePojo.equals(null));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Test
+    public void incompleteJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Catalog incompleteObj = mapper.readValue("{}", Catalog.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidCatalogException e) {
+            assertNotNull("FAIL: Should have caught an InvalidCatalogException", e);
+        }
+    }
+
+    @Test
+    public void incompleteJsonNoMetadata() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Catalog incompleteObj = mapper.readValue("{\"_metadata\":null,\"featureTools\":[],\"bookmarks\":[]}", Catalog.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidCatalogException e) {
+            assertNotNull("FAIL: Should have caught an InvalidCatalogException", e);
+            assertTrue("FAIL: Exception message did not contain the word '_metadata'. Message: " + e.getMessage(),
+                       e.getMessage().contains("_metadata"));
+        }
+    }
+
+    @Test
+    public void incompleteJsonNoMetaDataLastModified() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Catalog incompleteObj = mapper.readValue("{\"_metadata\":{\"isDefault\":true},\"featureTools\":[],\"bookmarks\":[]}", Catalog.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidCatalogException e) {
+            assertNotNull("FAIL: Should have caught an InvalidCatalogException", e);
+            assertTrue("FAIL: Exception message did not contain the word '" + ICatalog.METADATA_LAST_MODIFIED + "'",
+                       e.getMessage().contains(ICatalog.METADATA_LAST_MODIFIED));
+        }
+    }
+
+    @Test
+    public void incompleteJsonNoMetaDataIsDefault() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Catalog incompleteObj = mapper.readValue("{\"_metadata\":{\"lastModified\":0},\"featureTools\":[],\"bookmarks\":[]}", Catalog.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidCatalogException e) {
+            assertNotNull("FAIL: Should have caught an InvalidCatalogException", e);
+            assertTrue("FAIL: Exception message did not contain the word '" + ICatalog.METADATA_IS_DEFAULT + "'",
+                       e.getMessage().contains(ICatalog.METADATA_IS_DEFAULT));
+        }
+    }
+
+    @Test
+    public void incompleteJsonNoFeatureTools() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Catalog incompleteObj = mapper.readValue("{\"_metadata\":{\"lastModified\":1,\"isDefault\":true},\"featureTools\":null,\"bookmarks\":[]}",
+                                                 Catalog.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidCatalogException e) {
+            assertNotNull("FAIL: Should have caught an InvalidCatalogException", e);
+            assertTrue("FAIL: Exception message did not contain the word 'featureTools'",
+                       e.getMessage().contains("featureTools"));
+        }
+    }
+
+    @Test
+    public void incompleteJsonNoBookmarks() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Catalog incompleteObj = mapper.readValue("{\"_metadata\":{\"lastModified\":1,\"isDefault\":true},\"featureTools\":[],\"bookmarks\":null}",
+                                                 Catalog.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidCatalogException e) {
+            assertNotNull("FAIL: Should have caught an InvalidCatalogException", e);
+            assertTrue("FAIL: Exception message did not contain the word 'bookmarks'",
+                       e.getMessage().contains("bookmarks"));
+        }
+        assertFalse("FAIL: An incomplete Catalog was considered to equal a valid Catalog",
+                    incompleteObj.equals(jsonablePojo));
+    }
+
+    /** Valdiate Self! */
+    @Override
+    protected void extraPojoMatchesSourceJSONChecks(SelfValidatingPOJO unmarshalledPojo) throws Exception {
+        unmarshalledPojo.validateSelf();
+    }
+
+    /**
+     * Worker class to get the Catalog 100 times in the addAndDeleteToolMultiThreads test case
+     */
+    public static class GetCataloglWorker implements Callable<String> {
+
+        private final ICatalog catalog;
+
+        public GetCataloglWorker(ICatalog catalog) {
+            this.catalog = catalog;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String call() throws Exception {
+            int i = 0;
+            try {
+                // Each thread will get the catalog 100 times
+                for (; i < 100; i++) {
+                    for (Bookmark catalogTool : catalog.getBookmarks()) {
+                        // Iterate through to try and break things
+                        catalogTool.getId();
+                    }
+                }
+                return null;
+            } catch (Exception e) {
+                throw new Exception("Error while in getting catalog iteration " + i + ". Error:" + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Worker class to get the Catalog metadata 100 times in the addAndDeleteToolMultiThreads test case
+     */
+    public static class GetMetadataWorker implements Callable<String> {
+
+        private final ICatalog catalog;
+
+        public GetMetadataWorker(ICatalog catalog) {
+            this.catalog = catalog;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String call() throws Exception {
+            int i = 0;
+            try {
+                // Each thread will get the catalog 100 times
+                for (; i < 100; i++) {
+                    Map<String, Object> metadata = catalog.get_metadata();
+                    for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+                        // Iterate through to try and break things
+                        entry.getKey();
+                        entry.getValue();
+                    }
+                }
+                return null;
+            } catch (Exception e) {
+                throw new Exception("Error while in getting catalog metadata iteration " + i + ". Error:" + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Worker class to add 100 bookmarks in the addAndDeleteToolMultiThreads test case
+     */
+    public static class AddBookmarkWorker implements Callable<String> {
+
+        private final ICatalog catalog;
+        private final String namePrefix;
+
+        public AddBookmarkWorker(ICatalog catalog, String name) {
+            this.catalog = catalog;
+            this.namePrefix = name;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String call() throws Exception {
+            int i = 0;
+            try {
+                // Each thread will create 100 tools
+                for (; i < 100; i++) {
+                    Bookmark featureTool = new Bookmark(namePrefix + "-" + i, "http://www.ebay.com", "http://p.ebaystatic.com/aw/pics/globalheader/spr11.png", "eBay US store");
+                    catalog.addBookmark(featureTool);
+                }
+                return namePrefix;
+            } catch (Exception e) {
+                throw new Exception("Error while in adding tool " + namePrefix + ", iteration " + i + ". Error:" + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Worker class to delete 100 bookmarks in the addAndDeleteToolMultiThreads test case
+     */
+    public static class DeleteBookmarkWorker implements Callable<String> {
+
+        private final ICatalog catalog;
+        private final String namePrefix;
+
+        public DeleteBookmarkWorker(ICatalog catalog, String name) {
+            this.catalog = catalog;
+            this.namePrefix = name;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String call() throws Exception {
+            int i = 0;
+            try {
+                // Each thread will create 100 tools
+                for (; i < 100; i++) {
+                    catalog.deleteBookmark(namePrefix + "-" + i);
+                }
+                return namePrefix;
+            } catch (Exception e) {
+                throw new Exception("Error while in delete loop for " + namePrefix + ", iteration " + i + ". Error:" + e.getMessage(), e);
+            }
+        }
+    }
+
+    @Test
+    public void getMetadataAndgetTools_returnsSnapshot() throws Exception {
+        final Map<String, Object> firstMetadata = catalog.get_metadata();
+        final List<FeatureTool> firstTools = catalog.getFeatureTools();
+        final List<Bookmark> firstURLs = catalog.getBookmarks();
+
+        setMockPersistStore();
+        catalog.addBookmark(new Bookmark("T", "http://www.ebay.com", "http://p.ebaystatic.com/aw/pics/globalheader/spr11.png", "eBay US store"));
+
+        final Map<String, Object> secondMetadata = catalog.get_metadata();
+        final List<FeatureTool> secondTools = catalog.getFeatureTools();
+        final List<Bookmark> secondURLs = catalog.getBookmarks();
+
+        assertTrue("FAIL: the initial metadata should have a lower last modified compared to the second metadata",
+                   (Long) secondMetadata.get(IToolbox.METADATA_LAST_MODIFIED) >= (Long) firstMetadata.get(IToolbox.METADATA_LAST_MODIFIED));
+        assertEquals("FAIL: the initial feature tools list should be the same size as the second tools list",
+                     firstTools.size(), secondTools.size());
+        assertEquals("FAIL: the initial URL list should have one less count compared to the second tools list",
+                     firstURLs.size() + 1, secondURLs.size());
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/CatalogWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/CatalogWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class CatalogWithTraceTest extends CatalogTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/FeatureToolTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/FeatureToolTest.java
@@ -1,0 +1,1388 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.websphere.jsonsupport.JSON;
+import com.ibm.websphere.jsonsupport.JSONMarshallException;
+import com.ibm.ws.ui.internal.v1.ITool;
+import com.ibm.ws.ui.internal.v1.utils.LogRule;
+import com.ibm.ws.ui.internal.validation.InvalidToolException;
+import com.ibm.ws.ui.persistence.SelfValidatingPOJO;
+
+import test.common.JSONablePOJOTestCase;
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class FeatureToolTest extends JSONablePOJOTestCase {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = new LogRule(outputMgr);
+
+    private final String TOOL_ID = "com.ibm.websphere.feature-1.0";
+    private final String TOOL_TYPE = ITool.TYPE_FEATURE_TOOL;
+    private final String TOOL_FEATURE_NAME = "com.ibm.websphere.feature";
+    private final String TOOL_FEATURE_VERSION = "1.0";
+    private final String TOOL_FEATURE_SHORT_NAME = "tool-1.0";
+    private final String TOOL_NAME = "myFeature";
+    private final String TOOL_URL = "ibm.com";
+    private final String TOOL_ICON = "icon.png";
+    private final String TOOL_DESCRIPTION = "a really great tool";
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final JSON mockJson = mock.mock(JSON.class);
+
+    @Before
+    public void setUp() {
+        jsonablePojo = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        sourceJson = "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"featureShortName\":\"tool-1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}";
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#FeatureTool(java.lang.String, java.lang.String)}.
+     */
+    @Test
+    public void getters() {
+        FeatureTool tool = new FeatureTool(TOOL_ID, TOOL_TYPE, TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertEquals("FAIL: FeatureTool did not return the expected ID",
+                     TOOL_ID, tool.getId());
+        assertEquals("FAIL: FeatureTool did not return the expected type",
+                     TOOL_TYPE, tool.getType());
+        assertEquals("FAIL: FeatureTool did not return the expected name",
+                     TOOL_NAME, tool.getName());
+        assertEquals("FAIL: FeatureTool did not return the expected icon",
+                     TOOL_ICON, tool.getIcon());
+        assertEquals("FAIL: FeatureTool did not return the expected url",
+                     TOOL_URL, tool.getURL());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#FeatureTool(java.lang.String, java.lang.String)}.
+     */
+    @Test
+    public void getters_implied() {
+        FeatureTool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertEquals("FAIL: FeatureTool did not return the expected ID",
+                     TOOL_FEATURE_NAME + "-" + TOOL_FEATURE_VERSION, tool.getId());
+        assertEquals("FAIL: FeatureTool did not return the expected type",
+                     ITool.TYPE_FEATURE_TOOL, tool.getType());
+        assertEquals("FAIL: FeatureTool did not return the expected short name",
+                     TOOL_FEATURE_SHORT_NAME, tool.getFeatureShortName());
+        assertEquals("FAIL: FeatureTool did not return the expected name",
+                     TOOL_NAME, tool.getName());
+        assertEquals("FAIL: FeatureTool did not return the expected icon",
+                     TOOL_ICON, tool.getIcon());
+        assertEquals("FAIL: FeatureTool did not return the expected url",
+                     TOOL_URL, tool.getURL());
+    }
+
+    @Test
+    public void validateSelfAbsoluteURLsHTTP() {
+        FeatureTool featureTool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "http://cnn.com", "http://cnn.com/icon.png", "myDescription");
+        try {
+            featureTool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: HTTP and HTTPS URLs are valid, regardless of case but validation failed");
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Override
+    @Test
+    public void incompleteJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue("{}", FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id, type"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Toolbox should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Toolbox should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":null,\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Toolbox should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_wrongId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"wrongId\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Toolbox with an id should have a non-zero hashcode",
+                   0 != incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("type"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":null,\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("type"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("type"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_incorrectType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"bookmark\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the incorrect type. Message: " + e.getMessage(),
+                       e.getMessage().contains("featureTool"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingFeatureName() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("featureName"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullFeatureName() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":null,\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("featureName"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyFeatureName() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("featureName"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingFeatureVersion() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("featureVersion"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullFeatureVersion() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":null,\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("featureVersion"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyFeatureVersion() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("featureVersion"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingName() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("name"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullName() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":null,\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("name"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyName() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("name"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingURL() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("url"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullURL() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":null,\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("url"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyURL() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"\",\"icon\":\"icon.png\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("url"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingIcon() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("icon"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullIcon() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":null,\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("icon"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyIcon() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue(
+                                                     "{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"\",\"description\":\"a really great tool\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("icon"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingDescription() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue("{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("description"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullDescription() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue("{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":null}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("description"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyDescription() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue("{\"id\":\"com.ibm.websphere.feature-1.0\",\"type\":\"featureTool\",\"featureName\":\"com.ibm.websphere.feature\",\"featureVersion\":\"1.0\",\"name\":\"myFeature\",\"url\":\"ibm.com\",\"icon\":\"icon.png\",\"description\":\"\"}",
+                                                     FeatureTool.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("description"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void validateSelf_bookmark() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_ID, ITool.TYPE_BOOKMARK, TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not match the expected format. Message: " + e.getMessage(),
+                       e.getMessage().matches(".*" + ITool.TYPE_FEATURE_TOOL + ".*" + ITool.TYPE_BOOKMARK + ".*"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void validateSelf_featureToolWithoutShortName() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_ID, ITool.TYPE_FEATURE_TOOL, TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, null, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        tool.validateSelf();
+        // Should pass validation
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#validateSelf()}.
+     */
+    @Test
+    public void validateSelf_featureTool() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_ID, ITool.TYPE_FEATURE_TOOL, TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        tool.validateSelf();
+        // Should pass validation
+    }
+
+    @Test
+    public void validateSelf_absoluteURLsHTTP() {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "http://cnn.com", "http://cnn.com/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: HTTP and HTTPS URLs are valid, regardless of case but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_absoluteURLsHTTPS() {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "https://cnn.com", "https://cnn.com/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: HTTP and HTTPS URLs are valid, regardless of case but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_absoluteURLsHTTPInCaps() {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "HTTP://CNN.COM", "HTTP://CNN.COM/ICON.PNG", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: HTTP and HTTPS URLs are valid, regardless of case but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_absoluteURLsHTTPSInCaps() {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "HTTPS://CNN.COM", "HTTPS://CNN.COM/ICON.PNG", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: HTTP and HTTPS URLs are valid, regardless of case but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_relativeServerURLs() {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "/toolA", "/toolA/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: Server relative URLs are valid but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_relativePageURLs() {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "toolB", "toolB/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: Page relative URLs are valid but validation failed");
+        }
+    }
+
+    @Test
+    public void validateSelf_relativePageURLsMoreDots() {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "toolB/index...html", "toolB/icon....png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: Page relative URLs are valid (even with a lot of dots!) but validation failed");
+        }
+    }
+
+    @Ignore("For now, this is a pretty insane case. We need to be using a real library!")
+    @Test
+    public void validateSelf_relativePageURLsWackyResource() {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "toolB/sub:/index.html", "toolB/sub:/icon.png", TOOL_DESCRIPTION);
+        try {
+            tool.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: Funky URLs should be considered valid, even when not encoded");
+        }
+    }
+
+    /**
+     * This scenario is really weird but it IS valid...
+     */
+    @Test
+    public void validateSelf_DoubleProtocol() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "http://ibm.com/http://localhost/index.html", "http://ibm.com/http://localhost/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_xssName() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, "CN<script>N", TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A tool with XSS in 'name' is not valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_xssURL() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "http://cnn.com?<script>alert('a')</script>", TOOL_ICON, TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A tool with XSS in 'url' is not valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_xssIcon() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, "http://i.cdn.turner.com/cnn/.e/<img src='abc'></img>", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A tool with XSS in 'icon' is not valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_xssDescription() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, "CNN<script src='abc'>");
+        tool.validateSelf();
+        fail("FAIL: A tool with XSS in 'name' is not valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_xssAll() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, "CNN<script src='abc'>", "http://cnn.com/<script>altert('hi')</script>", "http://i.cdn.turner.com/cnn/.e/<img src='abc'></img>", "CNN<script src='abc'>");
+        tool.validateSelf();
+        fail("FAIL: A tool with XSS in 'icon' is not valid");
+    }
+
+    @Test
+    public void validateSelf_nameChars() {
+        // test for valid and invalid characters in the name
+        // invalid chars are  ~ & : ; / \ ? {} < > []
+        String[] invalidChars = new String[] { "~", "&", ":", ";", "/", "\\", "?", "{", "}", "<", ">", "[", "]" };
+        String[] validChars = new String[] { "`", "!", "@", "#", "$", "%", "^", "*", "(", ")", "-", "_", "=", "+", "|", "\"", "'", ",", "." };
+        String toolName = null;
+        ITool tool;
+
+        for (int i = 0; i < validChars.length; i++) {
+            toolName = "CN" + validChars[i] + "N";
+            tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, toolName, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+            try {
+                tool.validateSelf();
+                // no exception so pass
+            } catch (InvalidToolException e) {
+                fail("FAIL: A valid tool with " + validChars[i] + " in the 'name' is not valid");
+            }
+        }
+
+        for (int i = 0; i < invalidChars.length; i++) {
+            toolName = "CN" + invalidChars[i] + "N";
+            tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, toolName, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+            try {
+                tool.validateSelf();
+                fail("FAIL: A tool with invalid char " + toolName + " in the 'name' is valid");
+            } catch (InvalidToolException e) {
+                // pass
+            }
+        }
+    }
+
+    @Test
+    public void validateSelf_descriptionChars() {
+        // test for valid and invalid characters in the name
+        // invalid chars are  ~ & : ; / \ ? {} < > []
+        String[] invalidChars = new String[] { "~", "&", ":", ";", "/", "\\", "?", "{", "}", "<", ">", "[", "]" };
+        String[] validChars = new String[] { "`", "!", "@", "#", "$", "%", "^", "*", "(", ")", "-", "_", "=", "+", "|", "\"", "'", ",", "." };
+        String toolDescription = null;
+        ITool tool;
+
+        for (int i = 0; i < validChars.length; i++) {
+            toolDescription = "CN" + validChars[i] + "N";
+            tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, toolDescription);
+            try {
+                tool.validateSelf();
+                // no exception so pass
+            } catch (InvalidToolException e) {
+                fail("FAIL: A valid tool with " + validChars[i] + " in the 'name' is not valid");
+            }
+        }
+
+        for (int i = 0; i < invalidChars.length; i++) {
+            toolDescription = "CN" + invalidChars[i] + "N";
+            tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, toolDescription);
+            try {
+                tool.validateSelf();
+                fail("FAIL: A tool with invalid char " + toolDescription + " in the 'name' is valid");
+            } catch (InvalidToolException e) {
+                // pass
+            }
+        }
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_FTP() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "ftp://ibm.com", "ftp://ibm.com/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with non-HTTP or HTTPS URL protocols was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_SSH() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "ssh://ibm.com", "ssh://ibm.com/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with non-HTTP or HTTPS URL protocols was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_FileURL() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "file:/ibm", "file:/ibm/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with non-HTTP or HTTPS URL protocols was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_MisspelledHTTP() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "htp://ibm.com", "htp://ibm.com/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with incorrectly spelled HTTP or HTTPS URL was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_MisspelledHTTPS() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "htps://ibm.com", "htps://ibm.com/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with incorrectly spelled HTTP or HTTPS URL was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_relativeSubPathURLs() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "../toolA", "../toolA/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with relative path elements was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_relativeSubPathURLs2() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "a/../toolA", "a/../toolA/icon.png", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with relative path elements was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_relativeSubPathURLs3() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "..", "..", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with relative path elements was considered valid");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelf_relativeSubPathURLs4() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "/..", "/..", TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A URL with relative path elements was considered valid");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void extraPojoMatchesSourceJSONChecks(SelfValidatingPOJO unmarshalledPojo) throws Exception {
+        unmarshalledPojo.validateSelf();
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameInstance() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertEquals("FAIL: The same FeatureTool instance did not compare as equals=true",
+                     t1, t1);
+        assertEquals("FAIL: The same FeatureTool instance did not compare hashCode as equals=true",
+                     t1.hashCode(), t1.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameValues() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertEquals("FAIL: Two equal FeatureTool with only required fields did not compare as equals",
+                     t1, t2);
+        assertEquals("FAIL: Two equal FeatureTool with only required fields did not compare hashCode as equals",
+                     t1.hashCode(), t2.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameValuesEmpty() {
+        final ITool t1 = new FeatureTool();
+        final ITool t2 = new FeatureTool();
+        assertEquals("FAIL: Two equal FeatureTool with only required fields did not compare as equals",
+                     t1, t2);
+        assertEquals("FAIL: Two equal FeatureTool with only required fields did not compare hashCode as equals",
+                     t1.hashCode(), t2.hashCode());
+    }
+
+    @Test
+    public void equalsNullThisId() {
+        final ITool t1 = new FeatureTool(null, TOOL_FEATURE_SHORT_NAME, TOOL_TYPE, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'id' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatId() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(null, TOOL_FEATURE_SHORT_NAME, TOOL_TYPE, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'id' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchId() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool("yourURL", TOOL_FEATURE_SHORT_NAME, TOOL_TYPE, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'id' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisType() {
+        final ITool t1 = new FeatureTool(TOOL_ID, null, TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'type' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatType() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_ID, null, TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'type' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchType() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_ID, ITool.TYPE_BOOKMARK, TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'type' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisName() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, null, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'name' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatName() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, null, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'name' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchName() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, "yourURL", TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'name' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisShortName() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, null, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'name' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatShortName() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, null, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'name' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchShortName() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, "other-1.0", TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'name' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisURL() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, null, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'url' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatURL() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, null, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'url' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchURL() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, "google.com", TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'url' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisIcon() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, null, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatIcon() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, null, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchIcon() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, "other.png", TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisDescription() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, null);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatDescription() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, null);
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchDescription() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        final ITool t2 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, "other desc");
+        assertFalse("FAIL: Two FeatureTool considered equal when they have different 'icon' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNotAFeatureTool() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: A non-FeatureTool object was considered to equal a FeatureTool",
+                    t1.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNull() {
+        final ITool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: Null was conisdered to equal a Tool",
+                    t1.equals(null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#hashCode()}.
+     */
+    @Test
+    public void hashCode_nullId() {
+        final ITool tool = new FeatureTool(null, TOOL_TYPE, TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertEquals("FAIL: when the ID is null (which is not a valid case) hashcode should be 0",
+                     0, tool.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#hashCode()}.
+     */
+    @Test
+    public void hashCode_hasId() {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        assertFalse("FAIL: when the ID is set hashcode should be non-zero",
+                    0 == tool.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#getMyJson(JSON)}.
+     */
+    @Test
+    public void getMyJsonJsonGenerationException() throws Exception {
+        final FeatureTool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockJson).stringify(t1);
+                will(throwException(new JSONMarshallException("TestException")));
+            }
+        });
+
+        assertNull("FAIL: Mapper throwing an exception should result in null JSON",
+                   t1.getMyJson(mockJson));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#getMyJson(JSON)}.
+     */
+    @Test
+    public void getMyJsonJsonMappingException() throws Exception {
+        final FeatureTool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockJson).stringify(t1);
+                will(throwException(new JSONMarshallException("TestException")));
+            }
+        });
+
+        assertNull("FAIL: Mapper throwing an exception should result in null JSON",
+                   t1.getMyJson(mockJson));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#getMyJson(JSON)}.
+     */
+    @Test
+    public void getMyJsonIOException() throws Exception {
+        final FeatureTool t1 = new FeatureTool(TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockJson).stringify(t1);
+                will(throwException(new JSONMarshallException("TestException")));
+            }
+        });
+
+        assertNull("FAIL: Mapper throwing an exception should result in null JSON",
+                   t1.getMyJson(mockJson));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#toString()}.
+     */
+    @Test
+    public void toString_emptyObject() {
+        final ITool tool = new FeatureTool();
+        assertEquals("FAIL: the empty tool object did not return the expected toString",
+                     "FeatureTool {\"id\":null,\"type\":null,\"featureName\":null,\"featureVersion\":null,\"featureShortName\":null,\"name\":null,\"url\":null,\"icon\":null,\"description\":null}",
+                     tool.toString());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.FeatureTool#toString()}.
+     */
+    @Test
+    public void toString_validObject() {
+        assertEquals("FAIL: the valid tool object did not return the expected toString",
+                     "FeatureTool " + sourceJson, jsonablePojo.toString());
+    }
+
+    /**
+     * Second incomplete scenario as we have a different code path when no ID is defined.
+     */
+    @Test
+    public void incompleteJsonWithNoId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        FeatureTool incompleteObj = mapper.readValue("{\"name\": \"myName\"}", FeatureTool.class);
+
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: A Tool with a mismatched id was considered to be valid");
+        } catch (InvalidToolException e) {
+            // Pass
+        }
+        assertFalse("FAIL: An incomplete Tool was considered to equal a valid Tool",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Tool with no 'id' should have a zero hashcode",
+                   0 == incompleteObj.hashCode());
+    }
+
+    /**
+     * Third incomplete scenario as we have a different code path when a mismatched ID is defined.
+     */
+    @Test
+    public void validateSelfWithBadId() throws Exception {
+        FeatureTool badId = new FeatureTool("badId", ITool.TYPE_FEATURE_TOOL, TOOL_FEATURE_NAME, TOOL_FEATURE_VERSION, TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        try {
+            badId.validateSelf();
+            fail("FAIL: An incomplete Tool was considered to be valid");
+        } catch (InvalidToolException e) {
+            // Pass
+        }
+        assertFalse("FAIL: An incomplete Tool was considered to equal a valid Tool",
+                    badId.equals(jsonablePojo));
+    }
+
+    /**
+     * Third incomplete scenario as we have a different code path when a mismatched ID is defined.
+     */
+    @Test
+    public void validateSelfWithMajorVersion() throws Exception {
+        FeatureTool testMajorVersion = new FeatureTool(TOOL_FEATURE_NAME, "1", TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        try {
+            testMajorVersion.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: A version of 1 failed the validation but should have passed: " + e.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void validateSelfWithMajorMinorVersion() throws Exception {
+        FeatureTool testMajorMinorVersion = new FeatureTool(TOOL_FEATURE_NAME, "1.0", TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        try {
+            testMajorMinorVersion.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: A version of 1.0 failed the validation but should have passed: " + e.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void validateSelfWithMajorMinorMicroVersion() throws Exception {
+        FeatureTool testMajorMinorMicroVersion = new FeatureTool(TOOL_FEATURE_NAME, "1.0.0", TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        try {
+            testMajorMinorMicroVersion.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: A version of 1.0.0 failed the validation but should have passed: " + e.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void validateSelfWithMajorMinorMicroQualifierVersion() throws Exception {
+        FeatureTool testMajorMinorMicroQualifierVersion = new FeatureTool(TOOL_FEATURE_NAME, "1.0.0.20141028-1330", TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        try {
+            testMajorMinorMicroQualifierVersion.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: A version of 1.0.0.20141028-1330 failed the validation but should have passed: " + e.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void validateSelfWithMajorMinorMicroQualifierVersion2() throws Exception {
+        FeatureTool testMajorMinorMicroQualifierVersion = new FeatureTool(TOOL_FEATURE_NAME, "1.0.0.20141028_1330", TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        try {
+            testMajorMinorMicroQualifierVersion.validateSelf();
+        } catch (InvalidToolException e) {
+            fail("FAIL: A version of 1.0.0.20141028_1330 failed the validation but should have passed: " + e.getLocalizedMessage());
+        }
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelfwithInvalidVersion1() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, ITool.TYPE_FEATURE_TOOL, TOOL_FEATURE_NAME, "1.0.0.!!!!", TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A version containing invalid chars did not throw an InvalidToolException");
+    }
+
+    @Test(expected = InvalidToolException.class)
+    public void validateSelfwithInvalidVersion2() throws Exception {
+        final ITool tool = new FeatureTool(TOOL_FEATURE_NAME, ITool.TYPE_FEATURE_TOOL, TOOL_FEATURE_NAME, "1.a.0", TOOL_FEATURE_SHORT_NAME, TOOL_NAME, TOOL_URL, TOOL_ICON, TOOL_DESCRIPTION);
+        tool.validateSelf();
+        fail("FAIL: A version containing invalid chars did not throw an InvalidToolException");
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/FeatureToolWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/FeatureToolWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class FeatureToolWithTraceTest extends FeatureToolTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/MessageTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/MessageTest.java
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.ui.internal.v1.utils.LogRule;
+import com.ibm.ws.ui.persistence.InvalidPOJOException;
+import com.ibm.ws.ui.persistence.SelfValidatingPOJO;
+
+import test.common.JSONablePOJOTestCase;
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class MessageTest extends JSONablePOJOTestCase {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = new LogRule(outputMgr);
+
+    @Before
+    public void setUp() {
+        jsonablePojo = new Message(400, "myMessage");
+        sourceJson = "{\"status\":400,\"message\":\"myMessage\"}";
+    }
+
+    /**
+     * Ensure that the public constructor and all getter/setter operations
+     * work as expected. This is consolidated into one test method as this
+     * is a very basic validation.
+     */
+    @Test
+    public void constructorAndSetters() {
+        Message msg = new Message(400, "myMessage");
+
+        assertEquals("FAIL: The status was not the value set in the constructor",
+                     400, msg.getStatus());
+        assertEquals("FAIL: The message was not the value set in the constructor",
+                     "myMessage", msg.getMessage());
+        assertNull("FAIL: The userMessage should be null by default",
+                   msg.getUserMessage());
+        assertNull("FAIL: The developerMessage should be null by default",
+                   msg.getDeveloperMessage());
+
+        msg.setUserMessage("newUserMessage");
+        msg.setDeveloperMessage("newDeveloperMessage");
+
+        assertEquals("FAIL: The userMessage was not the value set",
+                     "newUserMessage", msg.getUserMessage());
+        assertEquals("FAIL: The developerMessage was not the value set",
+                     "newDeveloperMessage", msg.getDeveloperMessage());
+    }
+
+    @Test
+    public void validateSelf() throws Exception {
+        Message msg = new Message(400, "myMessage");
+        msg.validateSelf();
+    }
+
+    @Test(expected = InvalidPOJOException.class)
+    public void validateSelfInvalidStatus() throws Exception {
+        Message msg = new Message(-1, "myMessage");
+        msg.validateSelf();
+    }
+
+    @Test(expected = InvalidPOJOException.class)
+    public void validateSelfNullMessage() throws Exception {
+        Message msg = new Message(400, null);
+        msg.validateSelf();
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameInstance() {
+        final Message m1 = new Message(400, "myMessage");
+        assertEquals("FAIL: The same Tool instance did not compare as equals=true",
+                     m1, m1);
+        assertEquals("FAIL: The same Message instance did not compare hashCode as equals=true",
+                     m1.hashCode(), m1.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsRequiredTrue() {
+        final Message m1 = new Message(400, "myMessage");
+        final Message m2 = new Message(400, "myMessage");
+        assertEquals("FAIL: Two Tools with only required fields did not compare as equals",
+                     m1, m2);
+        assertEquals("FAIL: Two equal Tools with only required fields did not compare hashCode as equals",
+                     m1.hashCode(), m2.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsAllTrue() {
+        final String userMessage = "myUserMessage";
+        final String developerMessage = "myDeveloperMessage";
+
+        final Message m1 = new Message(400, "myMessage");
+        m1.setUserMessage(userMessage);
+        m1.setDeveloperMessage(developerMessage);
+
+        final Message m2 = new Message(400, "myMessage");
+        m2.setUserMessage(userMessage);
+        m2.setDeveloperMessage(developerMessage);
+
+        assertEquals("FAIL: Two Tools with all fields did not compare as equals",
+                     m1, m2);
+        assertEquals("FAIL: Two equal Tools with all fields did not compare hashCode as equals",
+                     m1.hashCode(), m2.hashCode());
+    }
+
+    @Test
+    public void equalsMismatchStatus() {
+        final Message m1 = new Message(400, "myMessage");
+        final Message m2 = new Message(401, "myMessage");
+        assertFalse("FAIL: Two Messages considered equal when they have different 'status' values",
+                    m1.equals(m2));
+    }
+
+    @Test
+    public void equalsMismatchMessage() {
+        final Message m1 = new Message(400, "myMessage");
+        final Message m2 = new Message(400, "myMessag");
+        assertFalse("FAIL: Two Messages considered equal when they have different 'message' values",
+                    m1.equals(m2));
+    }
+
+    @Test
+    public void equalsMismatchUserMessage() {
+        final Message m1 = new Message(400, "myMessage");
+        m1.setUserMessage("myUserMessage");
+        final Message m2 = new Message(400, "myMessage");
+        m2.setUserMessage("myUserMessag");
+        assertFalse("FAIL: Two Messages considered equal when they have different 'userMessage' values",
+                    m1.equals(m2));
+    }
+
+    @Test
+    public void equalsMismatchNullUserMessage() {
+        final Message m1 = new Message(400, "myMessage");
+        final Message m2 = new Message(400, "myMessage");
+        m2.setUserMessage("myUserMessage");
+        assertFalse("FAIL: Two Messages considered equal when they have different 'userMessage' values",
+                    m1.equals(m2));
+    }
+
+    @Test
+    public void equalsMismatchDeveloperMessage() {
+        final Message m1 = new Message(400, "myMessage");
+        m1.setDeveloperMessage("myDeveloperMessage");
+        final Message m2 = new Message(400, "myMessage");
+        m2.setDeveloperMessage("myDeveloperMessag");
+        assertFalse("FAIL: Two Messages considered equal when they have different 'developerMessage' values",
+                    m1.equals(m2));
+    }
+
+    @Test
+    public void equalsMismatchNullDeveloperMessage() {
+        final Message m1 = new Message(400, "myMessage");
+        final Message m2 = new Message(400, "myMessage");
+        m2.setDeveloperMessage("myDeveloperMessag");
+        assertFalse("FAIL: Two Messages considered equal when they have different 'developerMessage' values",
+                    m1.equals(m2));
+    }
+
+    @Test
+    public void equalsNotATool() {
+        assertFalse("FAIL: A non-Message object was considered to equal a Message",
+                    jsonablePojo.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNull() {
+        assertFalse("FAIL: Null was conisdered to equal an Message",
+                    jsonablePojo.equals(null));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Test
+    public void incompleteJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Message incompleteObj = mapper.readValue("{\"status\": 400}", Message.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidPOJOException e) {
+            assertNotNull("FAIL: Should have caught an InvalidPOJOException", e);
+        }
+        assertFalse("FAIL: An incomplete Message was considered to equal a valid Tool",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Message with no 'id' should have a zero hashcode",
+                   400 == incompleteObj.hashCode());
+    }
+
+    /** {@inheritDoc} */
+    @Test
+    public void incompleteJsonNoStatus() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Message incompleteObj = mapper.readValue("{\"message\": \"myMessage\"}", Message.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidPOJOException e) {
+            assertNotNull("FAIL: Should have caught an InvalidPOJOException", e);
+        }
+        assertFalse("FAIL: An incomplete Message was considered to equal a valid Tool",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Message with a 'message' should have a non-zero hashcode",
+                   0 != incompleteObj.hashCode());
+    }
+
+    /** {@inheritDoc} */
+    @Test
+    public void incompleteJsonNoRequiredFields() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Message incompleteObj = mapper.readValue("{\"userMessage\": \"myMessage\",\"developerMessage\": \"myMessage\"}", Message.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidPOJOException e) {
+            assertNotNull("FAIL: Should have caught an InvalidPOJOException", e);
+        }
+        assertFalse("FAIL: An incomplete Message was considered to equal a valid Tool",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Message with no 'id' should have a non-zero hashcode",
+                   0 == incompleteObj.hashCode());
+    }
+
+    /** Valdiate Self! */
+    @Override
+    protected void extraPojoMatchesSourceJSONChecks(SelfValidatingPOJO unmarshalledPojo) throws Exception {
+        unmarshalledPojo.validateSelf();
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/MessageWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/MessageWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class MessageWithTraceTest extends MessageTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/POJOLoaderServiceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/POJOLoaderServiceTest.java
@@ -1,0 +1,1282 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.websphere.jsonsupport.JSONMarshallException;
+import com.ibm.websphere.security.EntryNotFoundException;
+import com.ibm.websphere.security.UserRegistry;
+import com.ibm.ws.security.intfc.WSSecurityService;
+import com.ibm.ws.ui.internal.v1.ICatalog;
+import com.ibm.ws.ui.internal.v1.IFeatureToolService;
+import com.ibm.ws.ui.internal.v1.IToolbox;
+import com.ibm.ws.ui.internal.v1.utils.LogRule;
+import com.ibm.ws.ui.internal.validation.InvalidCatalogException;
+import com.ibm.ws.ui.internal.validation.InvalidToolboxException;
+import com.ibm.ws.ui.persistence.IPersistenceProvider;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class POJOLoaderServiceTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = new LogRule(outputMgr);
+
+    private static final String USER_ID = "bob_johnson";
+    private static final String ENCRYPTED_USER_ID = "Ym9iX2pvaG5zb24=";
+    private static final String USER_DISPLAY_NAME = "Bob Johnson";
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final WSSecurityService wsSecurityService = mock.mock(WSSecurityService.class);
+    private final UserRegistry mockUserRegistry = mock.mock(UserRegistry.class);
+    private final IFeatureToolService mockFeatureToolService = mock.mock(IFeatureToolService.class);
+    private final IPersistenceProvider mockFilePersistence = mock.mock(IPersistenceProvider.class, "mockFilePersistence");
+    private final IPersistenceProvider mockRepositoryPersistence = mock.mock(IPersistenceProvider.class, "mockRepositoryPersistence");
+    private final Catalog mockPersistedCatalog = mock.mock(Catalog.class);
+    private final Toolbox mockPersistedToolbox = mock.mock(Toolbox.class);
+    private POJOLoaderService loader;
+
+    @Before
+    public void setUp() {
+        loader = new POJOLoaderService();
+        loader.setWSSecurityService(wsSecurityService);
+        loader.setIPersistenceProviderFILE(mockFilePersistence);
+        loader.setIFeatureToolService(mockFeatureToolService);
+        loader.activate();
+    }
+
+    @After
+    public void tearDown() {
+        loader.deactive();
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        loader.unsetIPersistenceProviderFILE(mockFilePersistence);
+        loader.unsetIFeatureToolService(mockFeatureToolService);
+        loader.unsetWSSecurityService(wsSecurityService);
+        loader = null;
+
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#setIPersistenceProvider(org.osgi.framework.ServiceReference)}.
+     */
+    @Test
+    public void setIPersistenceProviderFILE_printsCorrectMessage() {
+        loader.setIPersistenceProviderFILE(mockFilePersistence);
+
+        assertTrue("FAIL: The FILE provider type was not reported correctly",
+                   outputMgr.checkForMessages("CWWKX1015I:.*FILE"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#setIPersistenceProvider(org.osgi.framework.ServiceReference)}.
+     */
+    @Test
+    public void setIPersistenceProviderCOLLECTIVE_printsCorrectMessage() {
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+
+        assertTrue("FAIL: The COLLECTIVE provider type was not reported correctly",
+                   outputMgr.checkForMessages("CWWKX1015I:.*COLLECTIVE"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#setIPersistenceProvider(org.osgi.framework.ServiceReference)}.
+     */
+    @Test
+    public void unsetIPersistenceProviderCOLLECTIVE_printsCorrectMessage() {
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+
+        assertTrue("FAIL: The FILE provider type was not reported correctly when COLLECTIVE is unset",
+                   outputMgr.checkForMessages("CWWKX1015I:.*FILE"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getCatalog_createDefault() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                exactly(1).of(mockFeatureToolService).getToolsForRequestLocale();
+                exactly(2).of(mockFeatureToolService).getTools();
+            }
+        });
+
+        ICatalog catalog = loader.getCatalog();
+
+        assertTrue("FAIL: expected default toolbox to be returned",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default catalog' message CWWKX1000I",
+                   outputMgr.checkForMessages("CWWKX1000I:.*"));
+
+        assertSame("FAIL: getCatalog() should return the same instance",
+                   catalog, loader.getCatalog());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getCatalog_badSyntax() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(throwException(new JSONMarshallException("Unable to parse non-well-formed content")));
+
+                exactly(1).of(mockFeatureToolService).getToolsForRequestLocale();
+                exactly(2).of(mockFeatureToolService).getTools();
+            }
+        });
+
+        ICatalog catalog = loader.getCatalog();
+
+        assertTrue("FAIL: expected default toolbox to be returned",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default catalog' message CWWKX1000I",
+                   outputMgr.checkForMessages("CWWKX1000I:.*"));
+
+        assertTrue("FAIL: Did not find the 'bad syntax' message CWWKX1002E",
+                   outputMgr.checkForMessages("CWWKX1002E:.*"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getCatalog_badContent() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(throwException(new JSONMarshallException("Fatal problems occurred while mapping content")));
+
+                exactly(1).of(mockFeatureToolService).getToolsForRequestLocale();
+                exactly(2).of(mockFeatureToolService).getTools();
+            }
+        });
+
+        ICatalog catalog = loader.getCatalog();
+
+        assertTrue("FAIL: expected default toolbox to be returned",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default catalog' message CWWKX1000I",
+                   outputMgr.checkForMessages("CWWKX1000I:.*"));
+
+        assertTrue("FAIL: Did not find the 'bad content' message CWWKX1003E",
+                   outputMgr.checkForMessages("CWWKX1003E:.*"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getCatalog_IOError() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                atMost(2).of(mockFilePersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(throwException(new IOException("Test Exception")));
+
+                exactly(1).of(mockFeatureToolService).getToolsForRequestLocale();
+                exactly(2).of(mockFeatureToolService).getTools();
+            }
+        });
+
+        ICatalog catalog = loader.getCatalog();
+
+        assertTrue("FAIL: expected default catalog to be returned",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default catalog' message CWWKX1000I",
+                   outputMgr.checkForMessages("CWWKX1000I:.*"));
+
+        assertTrue("FAIL: Did not find the 'io error' message CWWKX1004E",
+                   outputMgr.checkForMessages("CWWKX1004E:.*"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getCatalog_invalidCatalog() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(returnValue(mockPersistedCatalog));
+
+                one(mockPersistedCatalog).setIToolboxService(loader);
+
+                one(mockPersistedCatalog).setIPersistenceProvider(mockFilePersistence);
+
+                one(mockPersistedCatalog).setIFeatureToolService(mockFeatureToolService);
+
+                one(mockPersistedCatalog).initialProcessFeatures();
+
+                one(mockPersistedCatalog).validateSelf();
+                will(throwException(new InvalidCatalogException("TestException")));
+
+                exactly(1).of(mockFeatureToolService).getToolsForRequestLocale();
+                exactly(2).of(mockFeatureToolService).getTools();
+            }
+        });
+
+        ICatalog catalog = loader.getCatalog();
+
+        assertTrue("FAIL: expected default catalog to be returned",
+                   (Boolean) catalog.get_metadata().get(ICatalog.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default catalog' message CWWKX1000I",
+                   outputMgr.checkForMessages("CWWKX1000I:.*"));
+
+        assertTrue("FAIL: Did not find the 'not valid catalog' message CWWKX1005E",
+                   outputMgr.checkForMessages("CWWKX1005E:.*"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getCatalog_loadedCatalog() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(returnValue(mockPersistedCatalog));
+
+                one(mockPersistedCatalog).setIToolboxService(loader);
+
+                one(mockPersistedCatalog).setIPersistenceProvider(mockFilePersistence);
+
+                one(mockPersistedCatalog).setIFeatureToolService(mockFeatureToolService);
+
+                one(mockPersistedCatalog).initialProcessFeatures();
+
+                one(mockPersistedCatalog).validateSelf();
+            }
+        });
+
+        ICatalog catalog = loader.getCatalog();
+        assertSame("FAIL: Did not get back the mocked Catalog instance",
+                   mockPersistedCatalog, catalog);
+        assertTrue("FAIL: Did not find the 'loaded catalog' message CWWKX1006I",
+                   outputMgr.checkForMessages("CWWKX1006I:.*"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getCatalog_loadedCatalogFromCollective() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(returnValue(mockPersistedCatalog));
+
+                one(mockPersistedCatalog).setIToolboxService(loader);
+
+                one(mockPersistedCatalog).setIPersistenceProvider(mockRepositoryPersistence);
+
+                one(mockPersistedCatalog).setIFeatureToolService(mockFeatureToolService);
+
+                one(mockPersistedCatalog).initialProcessFeatures();
+
+                one(mockPersistedCatalog).validateSelf();
+
+                one(mockPersistedCatalog).get_metadata();
+                will(returnValue(Collections.singletonMap("isDefault", false)));
+
+                one(mockPersistedCatalog).getServerVersion();
+                will(returnValue("21.0.0.8"));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        ICatalog catalog = loader.getCatalog();
+        assertSame("FAIL: Did not get back the mocked Catalog instance",
+                   mockPersistedCatalog, catalog);
+        assertTrue("FAIL: Did not find the 'loaded catalog' message CWWKX1006I",
+                   outputMgr.checkForMessages("CWWKX1006I:.*"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     *
+     * Testing the path with default catalog created from an earlier server causing the default
+     * catalog to be recreated using the current server.
+     */
+    @Test
+    public void getCatalog_loadedCatalogFromCollectiveWithDefaultAndNoServerVersion() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(returnValue(mockPersistedCatalog));
+
+                one(mockPersistedCatalog).setIToolboxService(loader);
+
+                one(mockPersistedCatalog).setIPersistenceProvider(mockRepositoryPersistence);
+
+                one(mockPersistedCatalog).setIFeatureToolService(mockFeatureToolService);
+
+                one(mockPersistedCatalog).initialProcessFeatures();
+
+                one(mockPersistedCatalog).validateSelf();
+
+                one(mockPersistedCatalog).get_metadata();
+                will(returnValue(Collections.singletonMap("isDefault", true)));
+
+                one(mockPersistedCatalog).getServerVersion();
+                will(returnValue("21.0.0.8"));
+
+                one(mockRepositoryPersistence).delete("catalog");
+                will(returnValue(true));
+
+                one(mockFeatureToolService).getTools();
+
+                one(mockRepositoryPersistence).store(with(Catalog.PERSIST_NAME), with(any(Catalog.class)));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        ICatalog catalog = loader.getCatalog();
+        assertTrue("FAIL: Did not find the 'loaded catalog to the current server version' message CWWKX1070I",
+                   outputMgr.checkForMessages("CWWKX1070I:.*"));
+        assertTrue("FAIL: Did not find the 'loaded catalog' message CWWKX1006I",
+                   outputMgr.checkForMessages("CWWKX1006I:.*"));
+        assertTrue("FAIL: Did not find the 'loaded default catalog' message CWWKX1000I",
+                   outputMgr.checkForMessages("CWWKX1000I:.*"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     *
+     * Testing the path with default catalog created from the same server.
+     */
+    @Test
+    public void getCatalog_loadedCatalogFromCollectiveWithSameServerVersion() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(returnValue(mockPersistedCatalog));
+
+                one(mockPersistedCatalog).setIToolboxService(loader);
+
+                one(mockPersistedCatalog).setIPersistenceProvider(mockRepositoryPersistence);
+
+                one(mockPersistedCatalog).setIFeatureToolService(mockFeatureToolService);
+
+                one(mockPersistedCatalog).initialProcessFeatures();
+
+                one(mockPersistedCatalog).validateSelf();
+
+                one(mockPersistedCatalog).get_metadata();
+                will(returnValue(new HashMap<String, Object>() {
+                    {
+                        put("isDefault", true);
+                        put("serverVersion", "21.0.0.8");
+                    }
+                }));
+
+                one(mockPersistedCatalog).getServerVersion();
+                will(returnValue("21.0.0.8"));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        ICatalog catalog = loader.getCatalog();
+        assertFalse("FAIL: Should not find the 'loaded catalog to the current server version' message CWWKX1070I",
+                    outputMgr.checkForMessages("CWWKX1070I:.*"));
+        assertTrue("FAIL: Did not find the 'loaded catalog' message CWWKX1006I",
+                   outputMgr.checkForMessages("CWWKX1006I:.*"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getCatalog_loadedCatalogPromotedToCollective() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(throwException(new FileNotFoundException("TestException")));
+
+                one(mockFilePersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(returnValue(mockPersistedCatalog));
+
+                one(mockPersistedCatalog).setIToolboxService(loader);
+
+                one(mockPersistedCatalog).setIPersistenceProvider(mockRepositoryPersistence);
+
+                one(mockPersistedCatalog).setIFeatureToolService(mockFeatureToolService);
+
+                one(mockPersistedCatalog).initialProcessFeatures();
+
+                one(mockPersistedCatalog).validateSelf();
+
+                one(mockPersistedCatalog).storeCatalog();
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        ICatalog catalog = loader.getCatalog();
+        assertSame("FAIL: Did not get back the mocked Catalog instance",
+                   mockPersistedCatalog, catalog);
+        assertTrue("FAIL: Did not find the 'promoted catalog' message CWWKX1006I",
+                   outputMgr.checkForMessages("CWWKX1038I:.*FILE.*COLLECTIVE"));
+        assertTrue("FAIL: Did not find the 'loaded catalog' message CWWKX1006I",
+                   outputMgr.checkForMessages("CWWKX1006I:.*"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getCatalog_defaultCatalogStoredToCollective() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(throwException(new FileNotFoundException("TestException")));
+
+                one(mockFilePersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(throwException(new FileNotFoundException("TestException")));
+
+                one(mockFeatureToolService).getTools();
+
+                one(mockRepositoryPersistence).store(with(Catalog.PERSIST_NAME), with(any(Catalog.class)));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        loader.getCatalog();
+        assertTrue("FAIL: Did not find the 'loaded default catalog' message CWWKX1000I",
+                   outputMgr.checkForMessages("CWWKX1000I:.*"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getCatalog_changeProviderResetsCache() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(returnValue(mockPersistedCatalog));
+
+                one(mockPersistedCatalog).setIToolboxService(loader);
+
+                one(mockPersistedCatalog).setIPersistenceProvider(mockFilePersistence);
+
+                one(mockPersistedCatalog).setIFeatureToolService(mockFeatureToolService);
+
+                one(mockPersistedCatalog).initialProcessFeatures();
+
+                one(mockPersistedCatalog).validateSelf();
+            }
+        });
+
+        ICatalog catalog = loader.getCatalog();
+        assertSame("FAIL: Did not get back the mocked Catalog instance",
+                   mockPersistedCatalog, catalog);
+
+        // Set the COLLECTIVE provider, which should cause a cache clear
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(returnValue(mockPersistedCatalog));
+
+                one(mockPersistedCatalog).setIToolboxService(loader);
+
+                one(mockPersistedCatalog).setIPersistenceProvider(mockRepositoryPersistence);
+
+                one(mockPersistedCatalog).setIFeatureToolService(mockFeatureToolService);
+
+                one(mockPersistedCatalog).initialProcessFeatures();
+
+                one(mockPersistedCatalog).validateSelf();
+
+                one(mockPersistedCatalog).get_metadata();
+                will(returnValue(Collections.singletonMap("isDefault", false)));
+
+                one(mockPersistedCatalog).getServerVersion();
+                will(returnValue("21.0.0.8"));
+            }
+        });
+
+        catalog = loader.getCatalog();
+        assertSame("FAIL: Did not get back the mocked Catalog instance",
+                   mockPersistedCatalog, catalog);
+
+        // Unset the COLLECTIVE provider, which should cause a cache clear
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(returnValue(mockPersistedCatalog));
+
+                one(mockPersistedCatalog).setIToolboxService(loader);
+
+                one(mockPersistedCatalog).setIPersistenceProvider(mockFilePersistence);
+
+                one(mockPersistedCatalog).setIFeatureToolService(mockFeatureToolService);
+
+                one(mockPersistedCatalog).initialProcessFeatures();
+
+                one(mockPersistedCatalog).validateSelf();
+            }
+        });
+
+        catalog = loader.getCatalog();
+        assertSame("FAIL: Did not get back the mocked Catalog instance",
+                   mockPersistedCatalog, catalog);
+    }
+
+    private final void setLoadedCatalogFromProviderExpectations(final IPersistenceProvider provider) throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(provider).load(Catalog.PERSIST_NAME, Catalog.class);
+                will(returnValue(mockPersistedCatalog));
+
+                allowing(mockPersistedCatalog).setIToolboxService(loader);
+
+                allowing(mockPersistedCatalog).setIPersistenceProvider(provider);
+
+                allowing(mockPersistedCatalog).setIFeatureToolService(mockFeatureToolService);
+
+                allowing(mockPersistedCatalog).initialProcessFeatures();
+
+                allowing(mockPersistedCatalog).validateSelf();
+
+                allowing(mockPersistedCatalog).getFeatureTools();
+                will(returnValue(new ArrayList<FeatureTool>()));
+
+                allowing(mockPersistedCatalog).getBookmarks();
+                will(returnValue(new ArrayList<Bookmark>()));
+            }
+        });
+    }
+
+    /**
+     * Sets up the 'load catalog' expectations
+     *
+     * @throws Exception
+     */
+    private final void setLoadedCatalogExpectations() throws Exception {
+        setLoadedCatalogFromProviderExpectations(mockFilePersistence);
+    }
+
+    /**
+     * Sets up the 'load catalog' expectations
+     *
+     * @throws Exception
+     */
+    private final void setLoadedCatalogFromCollectiveExpectations() throws Exception {
+        setLoadedCatalogFromProviderExpectations(mockRepositoryPersistence);
+
+        mock.checking(new Expectations() {
+            {
+                allowing(mockPersistedCatalog).get_metadata();
+                will(returnValue(Collections.singletonMap("isDefault", false)));
+
+                allowing(mockPersistedCatalog).getServerVersion();
+                will(returnValue("21.0.0.8"));
+            }
+        });
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_createDefault() throws Exception {
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(wsSecurityService).getUserRegistry(null);
+                will(returnValue(mockUserRegistry));
+
+                one(mockUserRegistry).getUserDisplayName(USER_ID);
+                will(returnValue(USER_DISPLAY_NAME));
+            }
+        });
+
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+
+        assertTrue("FAIL: expected default toolbox to be returned",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default toolbox' message CWWKX1029I",
+                   outputMgr.checkForMessages("CWWKX1029I:.*" + USER_ID));
+
+        assertEquals("FAIL: getToolbox() should return a toolbox with the right user ID",
+                     USER_ID, toolbox.getOwnerId());
+
+        assertEquals("FAIL: getToolbox() should return a toolbox with the right user display name",
+                     USER_DISPLAY_NAME, toolbox.getOwnerDisplayName());
+
+        // Second get
+        assertSame("FAIL: getToolbox() should return the same instance",
+                   toolbox, loader.getToolbox(USER_ID));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_createDefaultNoDisplayName() throws Exception {
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(wsSecurityService).getUserRegistry(null);
+                will(returnValue(mockUserRegistry));
+
+                one(mockUserRegistry).getUserDisplayName(USER_ID);
+                will(throwException(new EntryNotFoundException("TestException")));
+            }
+        });
+
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+
+        assertTrue("FAIL: expected default toolbox to be returned",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'unable to determine display name' message CWWKX1016E",
+                   outputMgr.checkForMessages("CWWKX1016E:.*" + USER_ID));
+
+        assertTrue("FAIL: Did not find the 'loaded default toolbox' message CWWKX1029I",
+                   outputMgr.checkForMessages("CWWKX1029I:.*" + USER_ID));
+
+        assertEquals("FAIL: getToolbox() should return a toolbox with the right user ID",
+                     USER_ID, toolbox.getOwnerId());
+
+        assertEquals("FAIL: getToolbox() should return a toolbox with the user display name as the user ID because we could not resolve to a display name",
+                     USER_ID, toolbox.getOwnerDisplayName());
+
+        // Second get
+        assertSame("FAIL: getToolbox() should return the same instance",
+                   toolbox, loader.getToolbox(USER_ID));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_badSyntax() throws Exception {
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new JSONMarshallException("Unable to parse non-well-formed content")));
+
+                one(wsSecurityService).getUserRegistry(null);
+                will(returnValue(mockUserRegistry));
+
+                one(mockUserRegistry).getUserDisplayName(USER_ID);
+                will(returnValue(USER_DISPLAY_NAME));
+            }
+        });
+
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+
+        assertTrue("FAIL: expected default toolbox to be returned",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default toolbox' message CWWKX1029I",
+                   outputMgr.checkForMessages("CWWKX1029I:.*" + USER_ID));
+
+        assertTrue("FAIL: Did not find the 'bad syntax' message CWWKX1030E",
+                   outputMgr.checkForMessages("CWWKX1030E:.*" + USER_ID));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_badContent() throws Exception {
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new JSONMarshallException("Fatal problems occurred while mapping content")));
+
+                one(wsSecurityService).getUserRegistry(null);
+                will(returnValue(mockUserRegistry));
+
+                one(mockUserRegistry).getUserDisplayName(USER_ID);
+                will(returnValue(USER_DISPLAY_NAME));
+            }
+        });
+
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+
+        assertTrue("FAIL: expected default toolbox to be returned",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default toolbox' message CWWKX1029I",
+                   outputMgr.checkForMessages("CWWKX1029I:.*" + USER_ID));
+
+        assertTrue("FAIL: Did not find the 'bad content' message CWWKX1031E",
+                   outputMgr.checkForMessages("CWWKX1031E:.*" + USER_ID));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_IOError() throws Exception {
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new IOException("Test Exception")));
+
+                one(wsSecurityService).getUserRegistry(null);
+                will(returnValue(mockUserRegistry));
+
+                one(mockUserRegistry).getUserDisplayName(USER_ID);
+                will(returnValue(USER_DISPLAY_NAME));
+            }
+        });
+
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+
+        assertTrue("FAIL: expected default toolbox to be returned",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default toolbox' message CWWKX1029I",
+                   outputMgr.checkForMessages("CWWKX1029I:.*" + USER_ID));
+
+        assertTrue("FAIL: Did not find the 'io error' message CWWKX1032E",
+                   outputMgr.checkForMessages("CWWKX1032E:.*" + USER_ID));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_invalidToolbox() throws Exception {
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(returnValue(mockPersistedToolbox));
+
+                one(mockPersistedToolbox).setCatalog(mockPersistedCatalog);
+
+                one(mockPersistedToolbox).setPersistenceProvider(mockFilePersistence);
+
+                one(mockPersistedToolbox).validateSelf();
+                will(throwException(new InvalidToolboxException("TestException")));
+
+                one(wsSecurityService).getUserRegistry(null);
+                will(returnValue(mockUserRegistry));
+
+                one(mockUserRegistry).getUserDisplayName(USER_ID);
+                will(returnValue(USER_DISPLAY_NAME));
+
+            }
+        });
+
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+
+        assertTrue("FAIL: expected default toolbox to be returned",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default toolbox' message CWWKX1029I",
+                   outputMgr.checkForMessages("CWWKX1029I:.*" + USER_ID));
+
+        assertTrue("FAIL: Did not find the 'not valid toolbox' message CWWKX1033E",
+                   outputMgr.checkForMessages("CWWKX1033E:.*" + USER_ID));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_loadedToolbox() throws Exception {
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(returnValue(mockPersistedToolbox));
+
+                one(mockPersistedToolbox).setCatalog(mockPersistedCatalog);
+
+                one(mockPersistedToolbox).setPersistenceProvider(mockFilePersistence);
+
+                one(mockPersistedToolbox).validateSelf();
+            }
+        });
+
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+        assertSame("FAIL: Did not get back the mocked Toolbox instance",
+                   mockPersistedToolbox, toolbox);
+        assertTrue("FAIL: Did not find the 'loaded toolbox' message CWWKX1034I",
+                   outputMgr.checkForMessages("CWWKX1034I:.*" + USER_ID));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_loadedToolbox_promotedFromNonEncryptedToEncryptedName() throws Exception {
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + USER_ID, Toolbox.class);
+                will(returnValue(mockPersistedToolbox));
+
+                one(mockPersistedToolbox).setCatalog(mockPersistedCatalog);
+
+                one(mockPersistedToolbox).setPersistenceProvider(mockFilePersistence);
+
+                one(mockPersistedToolbox).validateSelf();
+
+                one(mockPersistedToolbox).storeToolbox();
+
+                one(mockFilePersistence).delete(Toolbox.PERSIST_NAME + "-" + USER_ID);
+                will(returnValue(true));
+            }
+        });
+
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+        assertSame("FAIL: Did not get back the mocked Toolbox instance",
+                   mockPersistedToolbox, toolbox);
+        assertTrue("FAIL: Did not find the 'loaded toolbox' message CWWKX1034I",
+                   outputMgr.checkForMessages("CWWKX1034I:.*" + USER_ID));
+        assertTrue("FAIL: Did not find the 'promoted toolbox' from non encrypted to encrypted name message CWWKX1068I",
+                   outputMgr.checkForMessages("CWWKX1068I:.*" + USER_ID));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_loadedToolboxFromCollective() throws Exception {
+        setLoadedCatalogFromCollectiveExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(returnValue(mockPersistedToolbox));
+
+                one(mockPersistedToolbox).setCatalog(mockPersistedCatalog);
+
+                one(mockPersistedToolbox).setPersistenceProvider(mockRepositoryPersistence);
+
+                one(mockPersistedToolbox).validateSelf();
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+        assertSame("FAIL: Did not get back the mocked Toolbox instance",
+                   mockPersistedToolbox, toolbox);
+        assertTrue("FAIL: Did not find the 'loaded toolbox' message CWWKX1034I",
+                   outputMgr.checkForMessages("CWWKX1034I:.*" + USER_ID));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_loadedToolboxFromCollective_promotedFromNonEncryptedToEncryptedName() throws Exception {
+        setLoadedCatalogFromCollectiveExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(mockRepositoryPersistence).load(Toolbox.PERSIST_NAME + "-" + USER_ID, Toolbox.class);
+                will(returnValue(mockPersistedToolbox));
+
+                one(mockPersistedToolbox).setCatalog(mockPersistedCatalog);
+
+                one(mockPersistedToolbox).setPersistenceProvider(mockRepositoryPersistence);
+
+                one(mockPersistedToolbox).validateSelf();
+
+                one(mockPersistedToolbox).storeToolbox();
+
+                one(mockRepositoryPersistence).delete(Toolbox.PERSIST_NAME + "-" + USER_ID);
+                will(returnValue(true));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+        assertSame("FAIL: Did not get back the mocked Toolbox instance",
+                   mockPersistedToolbox, toolbox);
+        assertTrue("FAIL: Did not find the 'loaded toolbox' message CWWKX1034I",
+                   outputMgr.checkForMessages("CWWKX1034I:.*" + USER_ID));
+        assertTrue("FAIL: Did not find the 'promoted toolbox' from non encrypted to encrypted name message CWWKX1068I",
+                   outputMgr.checkForMessages("CWWKX1068I:.*" + USER_ID));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_loadedToolboxPromotedFromFileToCollective() throws Exception {
+        setLoadedCatalogFromCollectiveExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("TestException")));
+
+                one(mockRepositoryPersistence).load(Toolbox.PERSIST_NAME + "-" + USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("TestException")));
+
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("TestException")));
+
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + USER_ID, Toolbox.class);
+                will(returnValue(mockPersistedToolbox));
+
+                one(mockPersistedToolbox).setCatalog(mockPersistedCatalog);
+
+                one(mockPersistedToolbox).setPersistenceProvider(mockRepositoryPersistence);
+
+                one(mockPersistedToolbox).validateSelf();
+
+                one(mockPersistedToolbox).storeToolbox();
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+        assertSame("FAIL: Did not get back the mocked Toolbox instance",
+                   mockPersistedToolbox, toolbox);
+        assertTrue("FAIL: Did not find the 'promoted toolbox' from file to collective persistence message CWWKX1039I",
+                   outputMgr.checkForMessages("CWWKX1039I:.*FILE.*COLLECTIVE"));
+        assertTrue("FAIL: Did not find the 'loaded toolbox' message CWWKX1034I",
+                   outputMgr.checkForMessages("CWWKX1034I:.*" + USER_ID));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getCatalog()}.
+     */
+    @Test
+    public void getToolbox_defaultToolboxStoredToCollective() throws Exception {
+        setLoadedCatalogFromCollectiveExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("TestException")));
+
+                one(mockRepositoryPersistence).load(Toolbox.PERSIST_NAME + "-" + USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("TestException")));
+
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("TestException")));
+
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("TestException")));
+
+                one(wsSecurityService).getUserRegistry(null);
+                will(returnValue(mockUserRegistry));
+
+                one(mockUserRegistry).getUserDisplayName(USER_ID);
+                will(returnValue(USER_DISPLAY_NAME));
+
+                one(mockRepositoryPersistence).store(with(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID), with(any(Toolbox.class)));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        loader.getToolbox(USER_ID);
+        assertTrue("FAIL: Did not find the 'loaded default toolbox' message CWWKX1029I",
+                   outputMgr.checkForMessages("CWWKX1029I:.*" + USER_ID));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox()}.
+     */
+    @Test
+    public void getToolbox_changeProviderResetsCache() throws Exception {
+        setLoadedCatalogExpectations();
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(returnValue(mockPersistedToolbox));
+
+                one(mockPersistedToolbox).setCatalog(mockPersistedCatalog);
+
+                one(mockPersistedToolbox).setPersistenceProvider(mockFilePersistence);
+
+                one(mockPersistedToolbox).validateSelf();
+            }
+        });
+
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+        assertSame("FAIL: Did not get back the mocked Toolbox instance",
+                   mockPersistedToolbox, toolbox);
+
+        // Set the COLLECTIVE provider, which should cause a cache clear
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+
+        setLoadedCatalogFromCollectiveExpectations();
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(returnValue(mockPersistedToolbox));
+
+                one(mockPersistedToolbox).setCatalog(mockPersistedCatalog);
+
+                one(mockPersistedToolbox).setPersistenceProvider(mockRepositoryPersistence);
+
+                one(mockPersistedToolbox).validateSelf();
+            }
+        });
+
+        toolbox = loader.getToolbox(USER_ID);
+        assertSame("FAIL: Did not get back the mocked Toolbox instance",
+                   mockPersistedToolbox, toolbox);
+
+        // Unset the COLLECTIVE provider, which should cause a cache clear
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+
+        setLoadedCatalogExpectations();
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(returnValue(mockPersistedToolbox));
+
+                one(mockPersistedToolbox).setCatalog(mockPersistedCatalog);
+
+                one(mockPersistedToolbox).setPersistenceProvider(mockFilePersistence);
+
+                one(mockPersistedToolbox).validateSelf();
+            }
+        });
+
+        toolbox = loader.getToolbox(USER_ID);
+        assertSame("FAIL: Did not get back the mocked Toolbox instance",
+                   mockPersistedToolbox, toolbox);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#getToolbox(java.lang.String)}.
+     * TODO: Should we behave this way? Right now we're documenting WHAT we do, but its not clear if we SHOULD
+     * behave this way.
+     */
+    @Test
+    public void getToolbox_nullUserId() throws Exception {
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                exactly(2).of(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-null", Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(wsSecurityService).getUserRegistry(null);
+                will(returnValue(mockUserRegistry));
+
+                one(mockUserRegistry).getUserDisplayName(null);
+                will(returnValue(null));
+            }
+        });
+
+        IToolbox toolbox = loader.getToolbox(null);
+
+        assertTrue("FAIL: expected default toolbox to be returned",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Did not find the 'loaded default toolbox' message CWWKX1029I",
+                   outputMgr.checkForMessages("CWWKX1029I:.*null"));
+
+        assertEquals("FAIL: getToolbox() should return a toolbox with the right user ID",
+                     null, toolbox.getOwnerId());
+
+        assertEquals("FAIL: getToolbox() should return a toolbox with the right user display name",
+                     null, toolbox.getOwnerDisplayName());
+
+        // Second get
+        assertSame("FAIL: getToolbox() should return the same instance",
+                   toolbox, loader.getToolbox(null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#setInstance(java.lang.String, com.ibm.ws.ui.internal.v1.IToolbox)}.
+     */
+    @Test
+    public void setInstance() {
+        loader.setToolbox(USER_ID, mockPersistedToolbox);
+        IToolbox toolbox = loader.getToolbox(USER_ID);
+        assertSame("FAIL: Did not get back the mocked persisted Toolbox",
+                   mockPersistedToolbox, toolbox);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#setInstance(java.lang.String, com.ibm.ws.ui.internal.v1.IToolbox)}.
+     */
+    @Test
+    public void setInstance_null() throws Exception {
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(wsSecurityService).getUserRegistry(null);
+                will(returnValue(mockUserRegistry));
+
+                one(mockUserRegistry).getUserDisplayName(USER_ID);
+                will(returnValue(USER_DISPLAY_NAME));
+            }
+        });
+
+        IToolbox toolbox1 = loader.getToolbox(USER_ID);
+
+        // Clear the catalog
+        loader.setToolbox(USER_ID, null);
+
+        // Do it again!
+        setLoadedCatalogExpectations();
+
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(mockFilePersistence).load(Toolbox.PERSIST_NAME + "-" + USER_ID, Toolbox.class);
+                will(throwException(new FileNotFoundException("Test Exception")));
+
+                one(wsSecurityService).getUserRegistry(null);
+                will(returnValue(mockUserRegistry));
+
+                one(mockUserRegistry).getUserDisplayName(USER_ID);
+                will(returnValue(USER_DISPLAY_NAME));
+            }
+        });
+        IToolbox toolbox2 = loader.getToolbox(USER_ID);
+        assertFalse("FAIL: Should get back a different instance of the toolbox",
+                    toolbox1 == toolbox2);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#resetAllToolboxes()}.
+     */
+    @Test
+    public void resetAllToolboxes_noToolboxes() {
+        loader.resetAllToolboxes();
+        // Nothing should blow up!
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#resetAllToolboxes()}.
+     */
+    @Test
+    public void resetAllToolboxes_withToolboxes() {
+        loader.setToolbox(USER_ID, mockPersistedToolbox);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockPersistedToolbox).reset();
+            }
+        });
+        loader.resetAllToolboxes();
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#removeToolEntryFromAllToolboxes(String)}.
+     */
+    @Test
+    public void removeToolFromAllToolboxes_noToolboxes() {
+        final String toolId = "Tool-1.0";
+        loader.removeToolEntryFromAllToolboxes(toolId);
+        // Nothing should blow up!
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.POJOLoaderService#removeToolEntryFromAllToolboxes(java.lang.String)}.
+     */
+    @Test
+    public void removeToolFromAllToolboxes() {
+        loader.setToolbox(USER_ID, mockPersistedToolbox);
+
+        final String toolId = "Tool-1.0";
+        mock.checking(new Expectations() {
+            {
+                one(mockPersistedToolbox).deleteToolEntry(toolId);
+            }
+        });
+        loader.removeToolEntryFromAllToolboxes(toolId);
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/POJOLoaderServiceWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/POJOLoaderServiceWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class POJOLoaderServiceWithTraceTest extends POJOLoaderServiceTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/PlainTextLoaderServiceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/PlainTextLoaderServiceTest.java
@@ -1,0 +1,521 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.ui.internal.v1.utils.LogRule;
+import com.ibm.ws.ui.persistence.IPersistenceProvider;
+
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class PlainTextLoaderServiceTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = new LogRule(outputMgr);
+
+    private static final String USER_ID = "bob_johnson";
+    private static final String ENCRYPTED_USER_ID = "Ym9iX2pvaG5zb24=";
+
+    private static final String TOOL_NAME = "tool";
+    private static final String TOOL_DATA = "{\"key\":\"value\"}";
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final IPersistenceProvider mockFilePersistence = mock.mock(IPersistenceProvider.class, "mockFilePersistence");
+    private final IPersistenceProvider mockRepositoryPersistence = mock.mock(IPersistenceProvider.class, "mockRepositoryPersistence");
+    private PlainTextLoaderService loader;
+
+    @Before
+    public void setUp() {
+        loader = new PlainTextLoaderService();
+        loader.setIPersistenceProviderFILE(mockFilePersistence);
+        loader.activate();
+    }
+
+    @After
+    public void tearDown() {
+        loader.deactive();
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        loader.unsetIPersistenceProviderFILE(mockFilePersistence);
+        loader = null;
+
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#setIPersistenceProvider(org.osgi.framework.ServiceReference)}.
+     */
+    @Test
+    public void setIPersistenceProviderFILE_printsCorrectMessage() {
+        loader.setIPersistenceProviderFILE(mockFilePersistence);
+
+        assertTrue("FAIL: The FILE provider type was not reported correctly",
+                   outputMgr.checkForMessages("CWWKX1063I:.*FILE"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#setIPersistenceProvider(org.osgi.framework.ServiceReference)}.
+     */
+    @Test
+    public void setIPersistenceProviderCOLLECTIVE_printsCorrectMessage() {
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+
+        assertTrue("FAIL: The COLLECTIVE provider type was not reported correctly",
+                   outputMgr.checkForMessages("CWWKX1063I:.*COLLECTIVE"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#setIPersistenceProvider(org.osgi.framework.ServiceReference)}.
+     */
+    @Test
+    public void unsetIPersistenceProviderCOLLECTIVE_printsCorrectMessage() {
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+
+        assertTrue("FAIL: The FILE provider type was not reported correctly when COLLECTIVE is unset",
+                   outputMgr.checkForMessages("CWWKX1063I:.*FILE"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#exists()}.
+     */
+    @Test
+    public void exists_filePersistence() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+            }
+        });
+
+        assertTrue("FAIL: expected true to be returned", loader.exists(USER_ID, TOOL_NAME));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#exists()}.
+     */
+    @Test
+    public void exists_RepoPersistence() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        assertTrue("FAIL: expected true to be returned", loader.exists(USER_ID, TOOL_NAME));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#promoteIfPossible()}.
+     */
+    @Test
+    public void promoteIfPossible_fileExist_noPromote() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        loader.promoteIfPossible(USER_ID, TOOL_NAME);
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#promoteIfPossible()}.
+     */
+    @Test
+    public void promoteIfPossible_noPromote() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(false));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(false));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(false));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        loader.promoteIfPossible(USER_ID, TOOL_NAME);
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#promoteIfPossible()}.
+     */
+    @Test
+    public void promoteIfPossible_fileFoundEncryptedName() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(false));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(TOOL_DATA));
+                one(mockRepositoryPersistence).storePlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID, TOOL_DATA);
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        loader.promoteIfPossible(USER_ID, TOOL_NAME);
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#promoteIfPossible()}.
+     */
+    @Test
+    public void promoteIfPossible_fileFoundNonEncryptedName() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(false));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(false));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(TOOL_DATA));
+                one(mockRepositoryPersistence).storePlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID, TOOL_DATA);
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        loader.promoteIfPossible(USER_ID, TOOL_NAME);
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#promoteIfPossible()}.
+     */
+    @Test
+    public void promoteIfPossible_filenotfoundException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(false));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(throwException(new FileNotFoundException("Test Exception")));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(false));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        loader.promoteIfPossible(USER_ID, TOOL_NAME);
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#promoteIfPossible()}.
+     */
+    @Test
+    public void promoteIfPossible_ioException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(false));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(false));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + USER_ID);
+                will(throwException(new IOException("Test Exception")));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        loader.promoteIfPossible(USER_ID, TOOL_NAME);
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#deleteToolData()}.
+     */
+    @Test
+    public void deleteToolData_IOE_FilePersistence() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+                one(mockRepositoryPersistence).delete(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(throwException(new IOException("Test Exception")));
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(true));
+                one(mockRepositoryPersistence).delete(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(true));
+
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).delete(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).delete(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(true));
+
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        assertFalse("Delete should be false", loader.deleteToolData(USER_ID, TOOL_NAME));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#deleteToolData()}.
+     */
+    @Test
+    public void deleteToolData_IOE_RepoPersistence() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(false));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(false));
+                one(mockRepositoryPersistence).delete(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).delete(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(throwException(new IOException("Test Exception")));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        assertFalse("Delete should be false", loader.deleteToolData(USER_ID, TOOL_NAME));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#getToolData()}.
+     */
+    @Test
+    public void getToolData_fromRepo_encryptedName() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).loadPlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(TOOL_DATA));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        assertEquals("Load from REPO using encrypted nmae should return '" + TOOL_DATA + "'", TOOL_DATA, loader.getToolData(USER_ID, TOOL_NAME));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#getToolData()}.
+     */
+    @Test
+    public void getToolData_fromRepo_nonEncryptedName() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).loadPlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(throwException(new FileNotFoundException()));
+                one(mockRepositoryPersistence).loadPlainText(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(TOOL_DATA));
+                one(mockRepositoryPersistence).exists(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(true));
+                one(mockRepositoryPersistence).delete(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(true));
+                one(mockRepositoryPersistence).storePlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID, TOOL_DATA);
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        assertEquals("Load from REPO using non encrypted name should return '" + TOOL_DATA + "'", TOOL_DATA, loader.getToolData(USER_ID, TOOL_NAME));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#getToolData()}.
+     */
+    @Test
+    public void getToolData_fromFILE_encryptedName() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(returnValue(TOOL_DATA));
+            }
+        });
+
+        assertEquals("Load from FILE using encrypted name should return '" + TOOL_DATA + "'", TOOL_DATA, loader.getToolData(USER_ID, TOOL_NAME));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#getToolData()}.
+     */
+    @Test
+    public void getToolData_fromFILE_nonEncryptedName() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(throwException(new FileNotFoundException()));
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(TOOL_DATA));
+                one(mockFilePersistence).exists(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).delete(TOOL_NAME + "/" + USER_ID);
+                will(returnValue(true));
+                one(mockFilePersistence).storePlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID, TOOL_DATA);
+            }
+        });
+
+        assertEquals("Load from FILE using non encrypted name should return '" + TOOL_DATA + "'", TOOL_DATA, loader.getToolData(USER_ID, TOOL_NAME));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#getToolData()}.
+     */
+    @Test
+    public void getToolData_FNFException() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(throwException(new FileNotFoundException()));
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + USER_ID);
+                will(throwException(new FileNotFoundException()));
+            }
+        });
+
+        assertEquals("Load from FILE should return null.", null, loader.getToolData(USER_ID, TOOL_NAME));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#getToolData()}.
+     */
+    @Test
+    public void getToolData_IOException_encryptedName() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(throwException(new IOException()));
+            }
+        });
+
+        assertEquals("Load from FILE using encryption name with IO Exception should return null.", null, loader.getToolData(USER_ID, TOOL_NAME));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#getToolData()}.
+     */
+    @Test
+    public void getToolData_IOException_nonEncryptedName() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID);
+                will(throwException(new FileNotFoundException()));
+                one(mockFilePersistence).loadPlainText(TOOL_NAME + "/" + USER_ID);
+                will(throwException(new IOException()));
+            }
+        });
+
+        assertEquals("Load from FILE using non encryption name with IO Exception should return null.", null, loader.getToolData(USER_ID, TOOL_NAME));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#addToolData()}.
+     */
+    @Test
+    public void addToolData_fromFILE() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).storePlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID, TOOL_DATA);
+            }
+        });
+
+        assertEquals("add to FILE should return '" + TOOL_DATA + "'", TOOL_DATA, loader.addToolData(USER_ID, TOOL_NAME, TOOL_DATA));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#addToolData()}.
+     */
+    @Test
+    public void addToolData_fromFile_IOE() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockFilePersistence).storePlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID, TOOL_DATA);
+                will(throwException(new IOException()));
+            }
+        });
+
+        assertEquals("add to FILE should return null", null, loader.addToolData(USER_ID, TOOL_NAME, TOOL_DATA));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#addToolData()}.
+     */
+    @Test
+    public void addToolData_fromRepo() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).storePlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID, TOOL_DATA);
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        assertEquals("post to Repository should return '" + TOOL_DATA + "'", TOOL_DATA, loader.addToolData(USER_ID, TOOL_NAME, TOOL_DATA));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.PlainTextLoaderService#addToolData()}.
+     */
+    @Test
+    public void addToolData_fromRepo_IOE() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockRepositoryPersistence).storePlainText(TOOL_NAME + "/" + ENCRYPTED_USER_ID, TOOL_DATA);
+                will(throwException(new IOException()));
+            }
+        });
+
+        loader.setIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+        assertEquals("post to Repository should return null", null, loader.addToolData(USER_ID, TOOL_NAME, TOOL_DATA));
+        loader.unsetIPersistenceProviderCOLLECTIVE(mockRepositoryPersistence);
+    }
+
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/PlainTextLoaderServiceWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/PlainTextLoaderServiceWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class PlainTextLoaderServiceWithTraceTest extends PlainTextLoaderServiceTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/ToolEntryTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/ToolEntryTest.java
@@ -1,0 +1,387 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.ui.internal.v1.ITool;
+import com.ibm.ws.ui.internal.v1.utils.LogRule;
+import com.ibm.ws.ui.internal.validation.InvalidToolException;
+import com.ibm.ws.ui.persistence.SelfValidatingPOJO;
+
+import test.common.JSONablePOJOTestCase;
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class ToolEntryTest extends JSONablePOJOTestCase {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = new LogRule(outputMgr);
+
+    private final String TOOL_ID = "tool-1.0";
+    private final String TOOL_TYPE = ITool.TYPE_FEATURE_TOOL;
+
+    @Before
+    public void setUp() {
+        jsonablePojo = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        sourceJson = "{\"id\":\"tool-1.0\",\"type\":\"featureTool\"}";
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#ToolEntry(java.lang.String, java.lang.String)}.
+     */
+    @Test
+    public void getters() {
+        final ITool tool = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        assertEquals("FAIL: ToolEntry did not return the expected ID",
+                     TOOL_ID, tool.getId());
+        assertEquals("FAIL: ToolEntry did not return the expected type",
+                     TOOL_TYPE, tool.getType());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#validateSelf()}.
+     */
+    @Override
+    @Test
+    public void incompleteJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ToolEntry incompleteObj = mapper.readValue("{}", ToolEntry.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id, type"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Toolbox should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ToolEntry incompleteObj = mapper.readValue("{\"type\":\"featureTool\"}", ToolEntry.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Toolbox should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ToolEntry incompleteObj = mapper.readValue("{\"id\":null,\"type\":\"featureTool\"}", ToolEntry.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Toolbox should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ToolEntry incompleteObj = mapper.readValue("{\"id\":\"\",\"type\":\"featureTool\"}", ToolEntry.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("id"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Toolbox should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_missingType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ToolEntry incompleteObj = mapper.readValue("{\"id\":\"tool-1.0\"}", ToolEntry.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("type"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_nullType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ToolEntry incompleteObj = mapper.readValue("{\"id\":\"tool-1.0\",\"type\":null}", ToolEntry.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("type"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_emptyType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ToolEntry incompleteObj = mapper.readValue("{\"id\":\"tool-1.0\",\"type\":\"\"}", ToolEntry.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("type"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#validateSelf()}.
+     */
+    @Test
+    public void incompleteJson_incorrectType() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ToolEntry incompleteObj = mapper.readValue("{\"id\":\"tool-1.0\",\"type\":\"wrongType\"}", ToolEntry.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: InvalidToolException should have been thrown");
+        } catch (InvalidToolException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: InvalidToolException message did not contain the missing fields. Message: " + e.getMessage(),
+                       e.getMessage().contains("wrongType"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#validateSelf()}.
+     */
+    @Test
+    public void validateSelf_featureTool() throws Exception {
+        final ITool tool = new ToolEntry(TOOL_ID, ITool.TYPE_FEATURE_TOOL);
+        tool.validateSelf();
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#validateSelf()}.
+     */
+    @Test
+    public void validateSelf_bookmark() throws Exception {
+        final ITool tool = new ToolEntry(TOOL_ID, ITool.TYPE_BOOKMARK);
+        tool.validateSelf();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void extraPojoMatchesSourceJSONChecks(SelfValidatingPOJO unmarshalledPojo) throws Exception {
+        unmarshalledPojo.validateSelf();
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameInstance() {
+        final ITool t1 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        assertEquals("FAIL: The same ToolEntry instance did not compare as equals=true",
+                     t1, t1);
+        assertEquals("FAIL: The same ToolEntry instance did not compare hashCode as equals=true",
+                     t1.hashCode(), t1.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameValues() {
+        final ITool t1 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        final ITool t2 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        assertEquals("FAIL: Two equal ToolEntry with only required fields did not compare as equals",
+                     t1, t2);
+        assertEquals("FAIL: Two equal ToolEntry with only required fields did not compare hashCode as equals",
+                     t1.hashCode(), t2.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameValuesEmpty() {
+        final ITool t1 = new ToolEntry();
+        final ITool t2 = new ToolEntry();
+        assertEquals("FAIL: Two equal ToolEntry with only required fields did not compare as equals",
+                     t1, t2);
+        assertEquals("FAIL: Two equal ToolEntry with only required fields did not compare hashCode as equals",
+                     t1.hashCode(), t2.hashCode());
+    }
+
+    @Test
+    public void equalsNullThisId() {
+        final ITool t1 = new ToolEntry(null, TOOL_TYPE);
+        final ITool t2 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        assertFalse("FAIL: Two ToolEntry considered equal when they have different 'id' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatId() {
+        final ITool t1 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        final ITool t2 = new ToolEntry(null, TOOL_TYPE);
+        assertFalse("FAIL: Two ToolEntry considered equal when they have different 'id' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchId() {
+        final ITool t1 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        final ITool t2 = new ToolEntry("tool-2.0", TOOL_TYPE);
+        assertFalse("FAIL: Two ToolEntry considered equal when they have different 'id' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThisType() {
+        final ITool t1 = new ToolEntry(TOOL_ID, null);
+        final ITool t2 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        assertFalse("FAIL: Two ToolEntry considered equal when they have different 'type' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNullThatType() {
+        final ITool t1 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        final ITool t2 = new ToolEntry(TOOL_ID, null);
+        assertFalse("FAIL: Two ToolEntry considered equal when they have different 'type' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsMismatchType() {
+        final ITool t1 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        final ITool t2 = new ToolEntry(TOOL_ID, ITool.TYPE_BOOKMARK);
+        assertFalse("FAIL: Two ToolEntry considered equal when they have different 'type' values",
+                    t1.equals(t2));
+    }
+
+    @Test
+    public void equalsNotAToolEntry() {
+        final ITool t1 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        assertFalse("FAIL: A non-ToolEntry object was considered to equal a ToolEntry",
+                    t1.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNull() {
+        final ITool t1 = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        assertFalse("FAIL: Null was conisdered to equal a Tool",
+                    t1.equals(null));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#hashCode()}.
+     */
+    @Test
+    public void hashCode_nullId() {
+        final ITool tool = new ToolEntry(null, TOOL_TYPE);
+        assertEquals("FAIL: when the ID is null (which is not a valid case) hashcode should be 0",
+                     0, tool.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#hashCode()}.
+     */
+    @Test
+    public void hashCode_hasId() {
+        final ITool tool = new ToolEntry(TOOL_ID, TOOL_TYPE);
+        assertFalse("FAIL: when the ID is set hashcode should be non-zero",
+                    0 == tool.hashCode());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#toString()}.
+     */
+    @Test
+    public void toString_emptyObject() {
+        final ITool tool = new ToolEntry();
+        assertEquals("FAIL: the empty tool object did not return the expected toString",
+                     "ToolEntry {\"id\":null,\"type\":null}", tool.toString());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.ToolEntry#toString()}.
+     */
+    @Test
+    public void toString_validObject() {
+        assertEquals("FAIL: the valid tool object did not return the expected toString",
+                     "ToolEntry " + sourceJson, jsonablePojo.toString());
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/ToolEntryWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/ToolEntryWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class ToolEntryWithTraceTest extends ToolEntryTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/ToolboxTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/ToolboxTest.java
@@ -1,0 +1,1733 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import com.ibm.websphere.jsonsupport.JSONMarshallException;
+import com.ibm.ws.ui.internal.v1.ICatalog;
+import com.ibm.ws.ui.internal.v1.ITool;
+import com.ibm.ws.ui.internal.v1.IToolbox;
+import com.ibm.ws.ui.internal.v1.utils.LogRule;
+import com.ibm.ws.ui.internal.validation.InvalidToolException;
+import com.ibm.ws.ui.internal.validation.InvalidToolboxException;
+import com.ibm.ws.ui.persistence.IPersistenceProvider;
+import com.ibm.ws.ui.persistence.SelfValidatingPOJO;
+import org.osgi.service.component.ComponentContext;
+
+import test.common.JSONablePOJOTestCase;
+import test.common.SharedOutputManager;
+
+/**
+ *
+ */
+public class ToolboxTest extends JSONablePOJOTestCase {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = new LogRule(outputMgr);
+
+    private static final String USER_ID = "bob_johnson";
+    private static final String ENCRYPTED_USER_ID = "Ym9iX2pvaG5zb24=";
+    private static final String USER_DISPLAY_NAME = "Bob Johnson";
+    private static final String USER_ID_2 = "luke_skywalker";
+    private static final String ENCRYPTED_USER_ID_2 = "bHVrZV9za3l3YWxrZXI=";
+    private static final String USER_DISPLAY_NAME_2 = "Luke Skywalker";
+
+    private final Mockery mock = new JUnit4Mockery();
+    private final ICatalog mockCatalog = mock.mock(ICatalog.class);
+
+    // Mocks for RegistryHelper
+    final ComponentContext cc = mock.mock(ComponentContext.class);
+    private final IPersistenceProvider mockPersistence = mock.mock(IPersistenceProvider.class);
+
+    private final List<FeatureTool> featureTools = new ArrayList<FeatureTool>();
+    private final FeatureTool featureTool = new FeatureTool("com.ibm.websphere.featureTool", "1.0", "tool-1.0", "myFeatureTool", "feature/tool.html", "feature/icon.png", "Feature Tool");
+
+    private final List<Bookmark> bookmarks = new ArrayList<Bookmark>();
+    private final Bookmark bookmark = new Bookmark("myBookmark", "catalog/url.html", "catalog/icon.png", "Catalog URL");
+    private Toolbox toolbox;
+
+    @Before
+    public void setUp() throws Exception {
+        featureTools.add(featureTool);
+        bookmarks.add(bookmark);
+
+        final Map<String, Object> catalogMetadata = new HashMap<String, Object>();
+        catalogMetadata.put(ICatalog.METADATA_IS_DEFAULT, false);
+        catalogMetadata.put(ICatalog.METADATA_LAST_MODIFIED, 123L);
+        mock.checking(new Expectations() {
+            {
+                allowing(mockCatalog).getFeatureTools();
+                will(returnValue(featureTools));
+
+                allowing(mockCatalog).getBookmarks();
+                will(returnValue(bookmarks));
+
+                allowing(mockCatalog).get_metadata();
+                will(returnValue(catalogMetadata));
+            }
+        });
+
+        jsonablePojo = new Toolbox(mockCatalog, mockPersistence, USER_ID, USER_DISPLAY_NAME);
+        sourceJson = "{\"_metadata\":{\"lastModified\":123,\"isDefault\":true},\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\"" + USER_DISPLAY_NAME
+                     + "\",\"preferences\":{},\"toolEntries\":[{\"id\":\""
+                     + featureTool.getId() + "\",\"type\":\"" + featureTool.getType() + "\"},{\"id\":\"" + bookmark.getId()
+                     + "\",\"type\":\"" + bookmark.getType() + "\"}],\"bookmarks\":[]}";
+
+        toolbox = new Toolbox(mockCatalog, mockPersistence, USER_ID, USER_DISPLAY_NAME);
+    }
+
+    @After
+    public void tearDown() {
+        toolbox = null;
+        mock.assertIsSatisfied();
+    }
+
+    @Test
+    public void constructorDefautInitialization() {
+        Toolbox tb = new Toolbox(mockCatalog, mockPersistence, USER_ID_2, USER_DISPLAY_NAME_2);
+        assertNotNull("FAIL: Toolbox instance was null",
+                      tb);
+        assertEquals("FAIL: Toolbox did not have the correct user ID",
+                     USER_ID_2, tb.getOwnerId());
+        assertEquals("FAIL: Toolbox did not have the correct user display name",
+                     USER_DISPLAY_NAME_2, tb.getOwnerDisplayName());
+
+        assertFalse("FAIL: Catalog metadata should reflect isDefault=false when cataog is not default",
+                    (Boolean) mockCatalog.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+        assertTrue("FAIL: Toolbox metadata should reflect isDefault=true when toolbox is default",
+                   (Boolean) tb.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: The feature tool was not in the list of tool entries",
+                   tb.getToolEntries().contains(new ToolEntry(featureTool.getId(), featureTool.getType())));
+        assertTrue("FAIL: The catalog URL was not in the list of tool entries",
+                   tb.getToolEntries().contains(new ToolEntry(bookmark.getId(), bookmark.getType())));
+    }
+
+    @Test
+    public void constructorDefautInitialization2() {
+        final FeatureTool featureTool2 = new FeatureTool("com.ibm.websphere.featureTool", "tool-2.0", "2.0", "FeatureTool", "feature/tool.html", "feature/icon.png", "Feature Tool");
+        featureTools.add(featureTool2);
+
+        final Bookmark Bookmark2 = new Bookmark("Bookmark2", "catalog/url.html", "catalog/icon.png", "Catalog URL");
+        bookmarks.add(Bookmark2);
+
+        Toolbox tb = new Toolbox(mockCatalog, mockPersistence, USER_ID_2, USER_DISPLAY_NAME_2);
+        assertNotNull("FAIL: Toolbox instance was null",
+                      tb);
+        assertEquals("FAIL: Toolbox did not have the correct user ID",
+                     USER_ID_2, tb.getOwnerId());
+        assertEquals("FAIL: Toolbox did not have the correct user display name",
+                     USER_DISPLAY_NAME_2, tb.getOwnerDisplayName());
+
+        assertFalse("FAIL: Catalog metadata should reflect isDefault=false when cataog is not default",
+                    (Boolean) mockCatalog.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+        assertTrue("FAIL: Toolbox metadata should reflect isDefault=true when toolbox is default",
+                   (Boolean) tb.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: The feature tool was not in the list of tool entries",
+                   tb.getToolEntries().contains(new ToolEntry(featureTool.getId(), featureTool.getType())));
+        assertTrue("FAIL: The feature tool 2 was not in the list of tool entries",
+                   tb.getToolEntries().contains(new ToolEntry(featureTool2.getId(), featureTool2.getType())));
+        assertTrue("FAIL: The catalog URL was not in the list of tool entries",
+                   tb.getToolEntries().contains(new ToolEntry(bookmark.getId(), bookmark.getType())));
+        assertTrue("FAIL: The catalog URL 2 was not in the list of tool entries",
+                   tb.getToolEntries().contains(new ToolEntry(Bookmark2.getId(), Bookmark2.getType())));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#getPreferences()}.
+     */
+    @Test
+    public void getPreferences() {
+        assertNotNull("FAIL: getPreferences() should never return null",
+                      toolbox.getPreferences());
+        assertEquals("FAIL: Toolbox preferences should contain 0 tool entries by default",
+                     0, toolbox.getPreferences().size());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#updatePreferences(Map)}.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void updatePreferences_null() {
+        toolbox.updatePreferences(null);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#updatePreferences(Map)}.
+     */
+    @Test
+    public void updatePreferences_valid() throws Exception {
+        Map<String, Object> newPreferences = new HashMap<String, Object>();
+        newPreferences.put("pref1", true);
+
+        setMockPersistStore();
+        Map<String, Object> oldPrefs = toolbox.updatePreferences(newPreferences);
+
+        assertNotNull("FAIL: updatePreferences() should never return null",
+                      oldPrefs);
+        assertEquals("FAIL: Toolbox default preferences should contain 0 tool entries by default",
+                     0, oldPrefs.size());
+
+        assertEquals("FAIL: should have 1 preference defined",
+                     1, toolbox.getPreferences().size());
+        assertEquals("FAIL: pref1 did not have the correct value",
+                     true, toolbox.getPreferences().get("pref1"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#updatePreferences(Map)}.
+     */
+    @Test
+    public void updatePreferences_malicious() throws Exception {
+        Map<String, Object> newPreferences = new HashMap<String, Object>();
+        newPreferences.put("malicious", "<script>alert('hi');</script>");
+
+        setMockPersistStore();
+        toolbox.updatePreferences(newPreferences);
+        assertEquals("FAIL: should have 0 preference defined since the input was malicious",
+                     0, toolbox.getPreferences().size());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#getToolEntries()}.
+     */
+    @Test
+    public void getToolEntries() {
+        List<ToolEntry> featureTools = toolbox.getToolEntries();
+        assertNotNull("FAIL: getTools() should never return null",
+                      featureTools);
+        assertEquals("FAIL: should have 2 pre-defined tools because Catalog does",
+                     2, featureTools.size());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#updateToolEntries(List<ToolEntry> toolEntries)}.
+     */
+    @Test
+    public void updateToolEntries_emptyList() throws Exception {
+        final List<ToolEntry> toolEntries = toolbox.getToolEntries();
+        assertEquals("FAIL: The default tool entries should be 2 length",
+                     2, toolEntries.size());
+
+        final List<ToolEntry> toolEntriestoUpdate = new ArrayList<ToolEntry>();
+
+        try {
+            toolbox.updateToolEntries(toolEntriestoUpdate);
+            fail("Expected IllegalArgumentException to be thrown when the tool entries list to be update is empty");
+        } catch (IllegalArgumentException e) {
+            assertTrue("FAIL: The IllegalArgumentException message did not contain CWWKX1044E. Message: " + e.getMessage(),
+                       e.getMessage().contains("CWWKX1043E"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#updateToolEntries(List<ToolEntry> toolEntries)}.
+     */
+    @Test
+    public void updateToolEntries_duplicateToolEntries() throws Exception {
+        final List<ToolEntry> toolEntries = toolbox.getToolEntries();
+        assertEquals("FAIL: The default tool entries should be 2 length",
+                     2, toolEntries.size());
+
+        final List<ToolEntry> toolEntriestoUpdate = new ArrayList<ToolEntry>();
+        toolEntriestoUpdate.add(toolEntries.get(0));
+        toolEntriestoUpdate.add(toolEntries.get(0));
+
+        try {
+            toolbox.updateToolEntries(toolEntriestoUpdate);
+            fail("Expected IllegalArgumentException to be thrown when there is duplicate key in the tool entries list");
+        } catch (IllegalArgumentException e) {
+            assertTrue("FAIL: The IllegalArgumentException message did not contain CWWKX1044E. Message: " + e.getMessage(),
+                       e.getMessage().contains("CWWKX1044E"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#updateToolEntries(List<ToolEntry> toolEntries)}.
+     */
+    @Test
+    public void updateToolEntries_invalidToolEntry() throws Exception {
+        final List<ToolEntry> toolEntries = toolbox.getToolEntries();
+        assertEquals("FAIL: The default tool entries should be 2 length",
+                     2, toolEntries.size());
+
+        final List<ToolEntry> toolEntriestoUpdate = new ArrayList<ToolEntry>();
+        toolEntriestoUpdate.add(toolEntries.get(0));
+        toolEntriestoUpdate.add(new ToolEntry("invalidTool", "bookmark"));
+
+        try {
+            toolbox.updateToolEntries(toolEntriestoUpdate);
+            fail("Expected NoSuchToolException to be thrown when there is invalid key in the tool entries list");
+        } catch (NoSuchToolException e) {
+            assertTrue("FAIL: The NoSuchToolException message did not contain CWWKX1045E. Message: " + e.getMessage(),
+                       e.getMessage().contains("CWWKX1045E"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#updateToolEntries(List<ToolEntry> toolEntries)}.
+     */
+    @Test
+    public void updateToolEntries_invalidListTooManyEntries() throws Exception {
+        final List<ToolEntry> toolEntries = toolbox.getToolEntries();
+        assertEquals("FAIL: The default tool entries should be 2 length",
+                     2, toolEntries.size());
+
+        final List<ToolEntry> toolEntriestoUpdate = new ArrayList<ToolEntry>();
+        toolEntriestoUpdate.addAll(toolEntries);
+        toolEntriestoUpdate.add(new ToolEntry("myTool", "bookmark"));
+
+        try {
+            toolbox.updateToolEntries(toolEntriestoUpdate);
+            fail("Expected IllegalArgumentException to be thrown when the number of tools to be update is not the same as the number of tools in the toolbox");
+        } catch (IllegalArgumentException e) {
+            assertTrue("FAIL: The IllegalArgumentException message did not contain CWWKX1043E. Message: " + e.getMessage(),
+                       e.getMessage().contains("CWWKX1043E"));
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.rest.v1.ToolboxAPI#updateToolEntries(List<ToolEntry> toolEntries)}.
+     */
+    @Test
+    public void updateToolEntries_validToolEntries() throws Exception {
+        final List<ToolEntry> toolEntries = toolbox.getToolEntries();
+        assertEquals("FAIL: The default tool entries should be 2 length",
+                     2, toolEntries.size());
+
+        final List<ToolEntry> toolEntriestoUpdate = new ArrayList<ToolEntry>(2);
+        toolEntriestoUpdate.add(toolEntries.get(1));
+        toolEntriestoUpdate.add(toolEntries.get(0));
+
+        setMockPersistStore();
+        toolbox.updateToolEntries(toolEntriestoUpdate);
+
+        List<ToolEntry> getToolEntriesAfterUpdate = toolbox.getToolEntries();
+        assertEquals("Original 1th should now be in the 0th element",
+                     toolEntries.get(1), getToolEntriesAfterUpdate.get(0));
+        assertEquals("Original 0th should now be in the 1th element",
+                     toolEntries.get(0), getToolEntriesAfterUpdate.get(1));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#getTools()}.
+     */
+    @Test
+    public void getBookmarks() {
+        List<Bookmark> bookmarks = toolbox.getBookmarks();
+        assertNotNull("FAIL: getBookmarks() should never return null",
+                      bookmarks);
+        assertEquals("FAIL: should have 0 pre-defined bookmarks",
+                     0, bookmarks.size());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#getToolEntry(java.lang.String)}.
+     */
+    @Test
+    public void getTool() {
+        final String doesntExist = "doesntExist";
+        mock.checking(new Expectations() {
+            {
+                one(mockCatalog).getTool(featureTool.getId());
+                will(returnValue(bookmark));
+            }
+        });
+        assertNull("FAIL: tool 'doesntExist' should not be defined",
+                   toolbox.getToolEntry(doesntExist));
+
+        assertNotNull("FAIL: tool '" + featureTool.getId() + "' should be pre-defined",
+                      toolbox.getToolEntry(featureTool.getId()));
+    }
+
+    /**
+     * Establish the mock to expect a call to storage.
+     *
+     * @throws JSONMarshallException
+     */
+    private void setMockPersistStore() throws IOException, JSONMarshallException {
+        mock.checking(new Expectations() {
+            {
+                one(mockPersistence).store(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, toolbox);
+            }
+        });
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addToolEntry(ToolEntry)}.
+     */
+    @Test
+    public void addTool_ToolEntry() throws Exception {
+        final Bookmark Bookmark = new Bookmark("T1", "t1/url.html", "t1/icon.png", "T1 URL");
+        mock.checking(new Expectations() {
+            {
+                allowing(mockCatalog).getTool("T1");
+                will(returnValue(Bookmark));
+            }
+        });
+
+        setMockPersistStore();
+
+        assertTrue("FAIL: The metadata isDefault should be true before any changes are made",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        int lCountBefore = toolbox.getToolEntries().size();
+        long modBefore = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+
+        assertNull("The Tool has not been added yet, we should get back null",
+                   toolbox.getToolEntry("T1"));
+
+        ToolEntry entry = new ToolEntry("T1", "bookmark");
+        ITool added = toolbox.addToolEntry(entry);
+        assertEquals("FAIL: The added tool was not added",
+                     added, entry);
+
+        assertEquals("The Tool has been added and the backing Bookmark should be returned",
+                     Bookmark, toolbox.getToolEntry("T1"));
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        long modAfter = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The tool entries count should be increased by 1 when a tool is added",
+                     lCountBefore + 1, lCountAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the add",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an add",
+                    (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addToolEntry(ToolEntry)}.
+     */
+    @Test
+    public void addTool_ToolEntry_duplicate() throws Exception {
+        final Bookmark Bookmark = new Bookmark("T1", "t1/url.html", "t1/icon.png", "T1 URL");
+        mock.checking(new Expectations() {
+            {
+                allowing(mockCatalog).getTool("T1");
+                will(returnValue(Bookmark));
+            }
+        });
+
+        setMockPersistStore();
+
+        ToolEntry entry = new ToolEntry("T1", "bookmark");
+        toolbox.addToolEntry(entry);
+
+        int lCountBefore = toolbox.getToolEntries().size();
+
+        try {
+            toolbox.addToolEntry(entry);
+            fail("Re-adding the tool entry should result in a DuplicateException");
+        } catch (DuplicateException e) {
+            assertTrue("FAIL: The DuplicateException message did not contain CWWKX1025E and the tool id. Message: " + e.getMessage(),
+                       e.getMessage().matches("CWWKX1025E:.*" + entry.getId() + ".*"));
+        }
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        assertEquals("FAIL: The tool entries count should not change if the tool is not added",
+                     lCountBefore, lCountAfter);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addToolEntry(ToolEntry)}.
+     */
+    @Test
+    public void addTool_ToolEntry_noSuchFeatureToolInCatalog() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockCatalog).getTool("noSuchFeatureTool");
+                will(returnValue(null));
+            }
+        });
+
+        ToolEntry entry = new ToolEntry("noSuchFeatureTool", "featureTool");
+
+        int lCountBefore = toolbox.getToolEntries().size();
+
+        try {
+            toolbox.addToolEntry(entry);
+            fail("Expected a NoSuchToolException to be thrown when adding a tool which is not in the catalog");
+        } catch (NoSuchToolException e) {
+            assertTrue("FAIL: The DuplicateException message did not contain CWWKX1001E and the tool id. Message: " + e.getMessage(),
+                       e.getMessage().matches("CWWKX1001E:.*" + entry.getId() + ".*"));
+        } ;
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        assertEquals("FAIL: The tool entries count should not change if the tool is not added",
+                     lCountBefore, lCountAfter);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addToolEntry(ToolEntry)}.
+     */
+    @Test
+    public void addTool_ToolEntry_noSuchBookmarkInCatalog() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockCatalog).getTool("noSuchBookmark");
+                will(returnValue(null));
+            }
+        });
+
+        ToolEntry entry = new ToolEntry("noSuchBookmark", "bookmark");
+
+        int lCountBefore = toolbox.getToolEntries().size();
+
+        try {
+            toolbox.addToolEntry(entry);
+            fail("Expected a NoSuchToolException to be thrown when adding a tool which is not in the catalog");
+        } catch (NoSuchToolException e) {
+            assertTrue("FAIL: The DuplicateException message did not contain CWWKX1001E and the tool id. Message: " + e.getMessage(),
+                       e.getMessage().matches("CWWKX1001E:.*" + entry.getId() + ".*"));
+        } ;
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        assertEquals("FAIL: The tool entries count should not change if the tool is not added",
+                     lCountBefore, lCountAfter);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addToolEntry(ToolEntry)}.
+     */
+    @Test
+    public void addTool_ToolEntry_idAndTypeMismatch() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockPersistence).store(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, toolbox);
+            }
+        });
+        toolbox.deleteToolEntry(featureTool.getId());
+
+        final Bookmark Bookmark = new Bookmark("T1", "t1/url.html", "t1/icon.png", "T1 URL");
+        mock.checking(new Expectations() {
+            {
+                allowing(mockCatalog).getTool("T1");
+                will(returnValue(Bookmark));
+            }
+        });
+
+        ToolEntry entry = new ToolEntry("T1", "featureTool");
+
+        int lCountBefore = toolbox.getToolEntries().size();
+
+        try {
+            toolbox.addToolEntry(entry);
+            fail("Expected a NoSuchToolException to be thrown when adding a tool which is not in the catalog");
+        } catch (NoSuchToolException e) {
+            assertTrue("FAIL: The DuplicateException message did not contain CWWKX1041E and the tool id and type. Message: " + e.getMessage(),
+                       e.getMessage().matches("CWWKX1041E:.*" + entry.getId() + ".*" + entry.getType() + ".*"));
+        } ;
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        assertEquals("FAIL: The tool entries count should not change if the tool is not added",
+                     lCountBefore, lCountAfter);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addToolEntry(ToolEntry)}.
+     */
+    @Test
+    public void addTool_ToolEntry_invalidTool() throws Exception {
+        ToolEntry entry = new ToolEntry("id", "type");
+
+        int lCountBefore = toolbox.getToolEntries().size();
+
+        try {
+            toolbox.addToolEntry(entry);
+            fail("Expected a InvalidToolException to be thrown when adding a bad tool");
+        } catch (InvalidToolException e) {
+            assertTrue("FAIL: The DuplicateException message did not contain assCWWKX1026E. Message: " + e.getMessage(),
+                       e.getMessage().matches("CWWKX1026E:.*"));
+        } ;
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        assertEquals("FAIL: The tool entries count should not change if the tool is not added",
+                     lCountBefore, lCountAfter);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addToolEntry(ToolEntry)}.
+     */
+    @Test
+    public void addTool_ToolEntry_persistenceError() throws Exception {
+        final Bookmark Bookmark = new Bookmark("T1", "t1/url.html", "t1/icon.png", "T1 URL");
+        mock.checking(new Expectations() {
+            {
+                allowing(mockCatalog).getTool("T1");
+                will(returnValue(Bookmark));
+            }
+        });
+
+        mock.checking(new Expectations() {
+            {
+                one(mockPersistence).store(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, toolbox);
+                will(throwException(new IOException("TestException")));
+            }
+        });
+
+        assertTrue("FAIL: The metadata isDefault should be true before any changes are made",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        long modBefore = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+
+        ToolEntry entry = new ToolEntry("T1", "bookmark");
+        toolbox.addToolEntry(entry);
+
+        long modAfter = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the add",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an add",
+                    (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Persistence failed on add - did not produce expected CWWKX1036E",
+                   outputMgr.checkForMessages("CWWKX1036E:.*" + USER_ID + ".*TestException"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addBookmark(Bookmark)}.
+     */
+    @Test
+    public void addTool_Bookmark() throws Exception {
+        setMockPersistStore();
+
+        assertTrue("FAIL: The metadata isDefault should be true before any changes are made",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        int lCountBefore = toolbox.getToolEntries().size();
+        int uCountBefore = toolbox.getBookmarks().size();
+        long modBefore = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+
+        assertNull("The Tool has not been added yet, we should get back null",
+                   toolbox.getToolEntry("T1"));
+
+        Bookmark bookmark = new Bookmark("T1", "t1.com", "t1.com/icon.png");
+        ITool added = toolbox.addBookmark(bookmark);
+        assertEquals("FAIL: The added tool was not added",
+                     added, bookmark);
+        assertEquals("The Tool has been added and the Bookmark should be returned",
+                     bookmark, toolbox.getToolEntry("T1"));
+        assertTrue("FAIL: Did NOT find the tool in tool entries",
+                   toolbox.getToolEntries().contains(new ToolEntry(bookmark.getId(), bookmark.getType())));
+        assertFalse("FAIL: Should NOT find the whole tool in tool entries",
+                    toolbox.getToolEntries().contains(bookmark));
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        int uCountAfter = toolbox.getBookmarks().size();
+        long modAfter = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The tool entries count should be increased by 1 when a tool is added",
+                     lCountBefore + 1, lCountAfter);
+        assertEquals("FAIL: The bookmark count should be increased by 1 when a tool is added",
+                     uCountBefore + 1, uCountAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the add",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an add",
+                    (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addBookmark(Bookmark)}.
+     */
+    @Test
+    public void addTool_Bookmark_implied() throws Exception {
+        setMockPersistStore();
+
+        assertTrue("FAIL: The metadata isDefault should be true before any changes are made",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        int lCountBefore = toolbox.getToolEntries().size();
+        int uCountBefore = toolbox.getBookmarks().size();
+        long modBefore = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+
+        assertNull("The Tool has not been added yet, we should get back null",
+                   toolbox.getToolEntry("T1"));
+
+        Bookmark completeTool = new Bookmark("T1", "t1.com", "t1.com/icon.png");
+        Bookmark incomplete = new Bookmark(null, null, "T1", "t1.com", "t1.com/icon.png", null);
+
+        ITool added = toolbox.addBookmark(incomplete);
+        assertEquals("FAIL: The added tool was not added as a complete Bookmark",
+                     completeTool, added);
+        assertEquals("The Tool has been added and the complete Bookmark should be returned",
+                     completeTool, toolbox.getToolEntry("T1"));
+        assertTrue("FAIL: Did NOT find the tool in tool entries",
+                   toolbox.getToolEntries().contains(new ToolEntry(completeTool.getId(), completeTool.getType())));
+        assertFalse("FAIL: Should NOT find the whole tool in tool entries",
+                    toolbox.getToolEntries().contains(completeTool));
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        int uCountAfter = toolbox.getBookmarks().size();
+        long modAfter = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The tool entries count should be increased by 1 when a tool is added",
+                     lCountBefore + 1, lCountAfter);
+        assertEquals("FAIL: The bookmark count should be increased by 1 when a tool is added",
+                     uCountBefore + 1, uCountAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the add",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an add",
+                    (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addBookmark(Bookmark)}.
+     */
+    @Test
+    public void addTool_Bookmark_duplicate() throws Exception {
+        setMockPersistStore();
+
+        Bookmark bookmark = new Bookmark("T1", "t1.com", "t1.com/icon.png");
+        toolbox.addBookmark(bookmark);
+
+        int lCountBefore = toolbox.getToolEntries().size();
+        int uCountBefore = toolbox.getBookmarks().size();
+
+        try {
+            toolbox.addBookmark(bookmark);
+            fail("Expected a DuplicateException to be thrown when adding a duplicate tool");
+        } catch (DuplicateException e) {
+            assertTrue("FAIL: The DuplicateException message did not contain CWWKX1025E and the tool id. Message: " + e.getMessage(),
+                       e.getMessage().matches("CWWKX1025E:.*" + bookmark.getId() + ".*"));
+        } ;
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        int uCountAfter = toolbox.getBookmarks().size();
+        assertEquals("FAIL: The tool entries count should not change if the tool is not added",
+                     lCountBefore, lCountAfter);
+        assertEquals("FAIL: The bookmark count should not change if the tool is not added",
+                     uCountBefore, uCountAfter);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addBookmark(Bookmark)}.
+     */
+    @Test
+    public void addTool_Bookmark_invalidTool() throws Exception {
+        Bookmark bookmark = new Bookmark(null, "https://mail.google.com/mail/u/0/?shva=1#inbox", "http://google.com/mail.ico");
+
+        int lCountBefore = toolbox.getToolEntries().size();
+        int uCountBefore = toolbox.getBookmarks().size();
+
+        try {
+            toolbox.addBookmark(bookmark);
+            fail("Expected a InvalidToolException to be thrown when adding a bad tool");
+        } catch (InvalidToolException e) {
+            assertTrue("FAIL: The DuplicateException message did not contain CWWKX1026E. Message: " + e.getMessage(),
+                       e.getMessage().matches("CWWKX1026E:.*"));
+        } ;
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        int uCountAfter = toolbox.getBookmarks().size();
+        assertEquals("FAIL: The tool entries count should not change if the tool is not added",
+                     lCountBefore, lCountAfter);
+        assertEquals("FAIL: The bookmark count should not change if the tool is not added",
+                     uCountBefore, uCountAfter);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addBookmark(Bookmark)}.
+     */
+    @Test
+    public void addTool_Bookmark_persistenceError() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockPersistence).store(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, toolbox);
+                will(throwException(new IOException("TestException")));
+            }
+        });
+
+        assertTrue("FAIL: The metadata isDefault should be true before any changes are made",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        int lCountBefore = toolbox.getToolEntries().size();
+        int uCountBefore = toolbox.getBookmarks().size();
+        long modBefore = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+
+        Bookmark bookmark = new Bookmark("T1", "t1.com", "t1.com/icon.png");
+        toolbox.addBookmark(bookmark);
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        int uCountAfter = toolbox.getBookmarks().size();
+        long modAfter = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The tool entries count should be increased by 1 when a tool is added",
+                     lCountBefore + 1, lCountAfter);
+        assertEquals("FAIL: The bookmark count should be increased by 1 when a tool is added",
+                     uCountBefore + 1, uCountAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the add",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an add",
+                    (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Persistence failed on add - did not produce expected CWWKX1036E",
+                   outputMgr.checkForMessages("CWWKX1036E:.*" + USER_ID + ".*TestException"));
+    }
+
+    /**
+     * Check all futures for any exceptions.
+     *
+     * @param futureList
+     * @throws InterruptedException
+     */
+    private void checkFuturesForExceptions(List<Future<String>> futureList) throws InterruptedException {
+        try {
+            for (int i = 0; i < futureList.size(); i++) {
+                futureList.get(i).get();
+            }
+        } catch (ExecutionException ex) {
+            ex.printStackTrace();
+            fail("Thread ExecutionException: " + ex.getCause());
+        }
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#addBookmark(Bookmark)}.
+     */
+    @Test
+    public void addAndDeleteBookmarkMultiThreads() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockPersistence).store(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, toolbox);
+            }
+        });
+
+        int countBefore = toolbox.getToolEntries().size();
+
+        // Spawn concurrent tool additions
+        int threadSize = 10;
+        int loops = 50;
+        int totalNewTools = loops * 100;
+        ExecutorService executor = Executors.newFixedThreadPool(threadSize);
+        List<Future<String>> futureList = new ArrayList<Future<String>>();
+
+        // Spawn writers
+        for (int t = 0; t < loops; t++) {
+            Callable<String> worker = new AddBookmarkWorker(toolbox, "t" + t);
+            Future<String> future = executor.submit(worker);
+            futureList.add(future);
+        }
+        // Spawn readers
+        Future<String> reader = executor.submit(new GetToolboxWorker(toolbox));
+        Future<String> metadataReader = executor.submit(new GetMetadataWorker(toolbox));
+
+        executor.shutdown();
+        // Wait until all threads are finish (timeout 10 seconds)
+        executor.awaitTermination(10L, TimeUnit.SECONDS);
+
+        // Validation
+        List<Future<String>> validationList = new ArrayList<Future<String>>();
+        validationList.addAll(futureList);
+        validationList.add(reader);
+        validationList.add(metadataReader);
+        checkFuturesForExceptions(validationList);
+        assertEquals("FAIL: The toolbox does not have the expected number of tool entries",
+                     countBefore + totalNewTools, toolbox.getToolEntries().size());
+        assertEquals("FAIL: The toolbox does not have the expected number of bookmarks",
+                     totalNewTools, toolbox.getBookmarks().size());
+
+        // Spawn concurrent tool removals
+        executor = Executors.newFixedThreadPool(threadSize);
+        List<Future<String>> futureDeleteList = new ArrayList<Future<String>>();
+
+        // Spawn writers
+        for (int t = 0; t < loops; t++) {
+            Callable<String> worker = new DeleteBookmarkWorker(toolbox, futureList.get(t).get());
+            Future<String> future = executor.submit(worker);
+            futureDeleteList.add(future);
+        }
+        // Spawn readers
+        reader = executor.submit(new GetToolboxWorker(toolbox));
+        metadataReader = executor.submit(new GetMetadataWorker(toolbox));
+
+        executor.shutdown();
+        // Wait until all threads are finish (timeout 10 seconds)
+        executor.awaitTermination(10L, TimeUnit.SECONDS);
+
+        // Validation
+        validationList.clear();
+        validationList.addAll(futureList);
+        validationList.add(reader);
+        validationList.add(metadataReader);
+        checkFuturesForExceptions(validationList);
+        assertEquals("FAIL: The toolbox did not return to the beginning tool entries",
+                     countBefore, toolbox.getToolEntries().size());
+        assertEquals("FAIL: The toolbox did not return to zero bookmarks",
+                     0, toolbox.getBookmarks().size());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#deleteToolEntry(java.lang.String)}.
+     */
+    @Test
+    public void deleteToolEntry_withInvalidIds() throws IOException {
+        ITool deletedTool = toolbox.deleteToolEntry(null);
+        assertNull("FAIL: The delete operation did not return a null object when the toolId was null",
+                   deletedTool);
+
+        deletedTool = toolbox.deleteToolEntry("");
+        assertNull("FAIL: The delete operation did not return a null object when the toolId was empty",
+                   deletedTool);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#deleteToolEntry(java.lang.String)}.
+     *
+     * @throws IOException
+     * @throws JSONMarshallException
+     *
+     */
+    @Test
+    public void deleteToolEntry() throws IOException, JSONMarshallException {
+        setMockPersistStore();
+
+        assertTrue("FAIL: The metadata isDefault should be true before any changes are made",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        int lCountBefore = toolbox.getToolEntries().size();
+        int uCountBefore = toolbox.getBookmarks().size();
+        long modBefore = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+
+        ITool deletedTool = toolbox.deleteToolEntry(featureTool.getId());
+        assertEquals("FAIL: The delete operation failed or it did not return the correct deleted Tool JSON",
+                     deletedTool.getId(), featureTool.getId());
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        int uCountAfter = toolbox.getBookmarks().size();
+        long modAfter = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The tool entries count did not get decremented as part of the ToolEntry delete",
+                     lCountBefore - 1, lCountAfter);
+        assertEquals("FAIL: The bookmarks count should not be decremented as part of a ToolEntry delete",
+                     uCountBefore, uCountAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the delete",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an delete",
+                    (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#deleteToolEntry(java.lang.String)}.
+     *
+     * @throws IOException
+     * @throws JSONMarshallException
+     *
+     */
+    @Test
+    public void deleteToolEntry_twice() throws IOException, JSONMarshallException {
+        setMockPersistStore();
+
+        ITool deletedTool = toolbox.deleteToolEntry(featureTool.getId());
+        assertEquals("FAIL: The delete operation failed or it did not return the correct deleted Tool JSON",
+                     deletedTool.getId(), featureTool.getId());
+
+        deletedTool = toolbox.deleteToolEntry(featureTool.getId());
+        assertNull("FAIL: The delete operation did not return a null object when the tool did not exist",
+                   deletedTool);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#deleteToolEntry(java.lang.String)}.
+     */
+    @Test
+    public void deleteToolEntry_Bookmark() throws Exception {
+        Bookmark bookmark = new Bookmark("T1", "t1.com", "t1.com/icon.png");
+        setMockPersistStore();
+        toolbox.addBookmark(bookmark);
+
+        int lCountBefore = toolbox.getToolEntries().size();
+        int uCountBefore = toolbox.getBookmarks().size();
+        long modBefore = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+
+        setMockPersistStore();
+        ITool deletedTool = toolbox.deleteToolEntry(bookmark.getId());
+        assertEquals("FAIL: The delete operation failed or it did not return the correct deleted Tool JSON",
+                     bookmark.getId(), deletedTool.getId());
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        int uCountAfter = toolbox.getBookmarks().size();
+        long modAfter = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The tool entries count did not get decremented as part of the Bookmark delete",
+                     lCountBefore - 1, lCountAfter);
+        assertEquals("FAIL: The bookmarks count did not get decremented as part of the Bookmark delete",
+                     uCountBefore - 1, uCountAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the delete",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an delete",
+                    (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#deleteToolEntry(java.lang.String)}.
+     */
+    @Test
+    public void deleteToolEntry_Bookmark_twice() throws Exception {
+        Bookmark bookmark = new Bookmark("T1", "t1.com", "t1.com/icon.png");
+        setMockPersistStore();
+        toolbox.addBookmark(bookmark);
+
+        setMockPersistStore();
+        ITool deletedTool = toolbox.deleteToolEntry(bookmark.getId());
+        assertEquals("FAIL: The delete operation failed or it did not return the correct deleted Tool JSON",
+                     deletedTool.getId(), bookmark.getId());
+
+        deletedTool = toolbox.deleteToolEntry(bookmark.getId());
+        assertNull("FAIL: The delete operation did not return a null object when the tool did not exist",
+                   deletedTool);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#deleteToolEntry(java.lang.String)}.
+     */
+    @Test
+    public void deleteToolEntry_persistenceError() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockPersistence).store(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, toolbox);
+                will(throwException(new IOException("TestException")));
+            }
+        });
+
+        assertTrue("FAIL: The metadata isDefault should be true before any changes are made",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        int countBefore = toolbox.getToolEntries().size();
+        long modBefore = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+
+        toolbox.deleteToolEntry(featureTool.getId());
+
+        int countAfter = toolbox.getToolEntries().size();
+        long modAfter = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The metadata count did not get decremented as part of the delete",
+                     countBefore - 1, countAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the delete",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after a delete",
+                    (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Persistence failed on add - did not produce expected CWWKX1036E",
+                   outputMgr.checkForMessages("CWWKX1036E:.*" + USER_ID + ".*TestException"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#deleteBookmark(java.lang.String)}.
+     */
+    @Test
+    public void deleteBookmark_withInvalidIds() throws IOException {
+        ITool deletedTool = toolbox.deleteBookmark(null);
+        assertNull("FAIL: The delete operation did not return a null object when the toolId was null",
+                   deletedTool);
+
+        deletedTool = toolbox.deleteBookmark("");
+        assertNull("FAIL: The delete operation did not return a null object when the toolId was empty",
+                   deletedTool);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#deleteBookmark(java.lang.String)}.
+     */
+    @Test
+    public void deleteBookmark() throws Exception {
+        Bookmark bookmark = new Bookmark("T1", "t1.com", "t1.com/icon.png");
+        setMockPersistStore();
+        toolbox.addBookmark(bookmark);
+
+        int lCountBefore = toolbox.getToolEntries().size();
+        int uCountBefore = toolbox.getBookmarks().size();
+        long modBefore = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+
+        setMockPersistStore();
+        ITool deletedTool = toolbox.deleteBookmark(bookmark.getId());
+        assertEquals("FAIL: The delete operation failed or it did not return the correct deleted Tool JSON",
+                     bookmark.getId(), deletedTool.getId());
+
+        int lCountAfter = toolbox.getToolEntries().size();
+        int uCountAfter = toolbox.getBookmarks().size();
+        long modAfter = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The tool entries count did not get decremented as part of the Bookmark delete",
+                     lCountBefore - 1, lCountAfter);
+        assertEquals("FAIL: The bookmarks count did not get decremented as part of the Bookmark delete",
+                     uCountBefore - 1, uCountAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the delete",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after an delete",
+                    (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#deleteBookmark(java.lang.String)}.
+     */
+    @Test
+    public void deleteBookmark_twice() throws Exception {
+        Bookmark bookmark = new Bookmark("T1", "t1.com", "t1.com/icon.png");
+        setMockPersistStore();
+        toolbox.addBookmark(bookmark);
+
+        setMockPersistStore();
+        ITool deletedTool = toolbox.deleteBookmark(bookmark.getId());
+        assertEquals("FAIL: The delete operation failed or it did not return the correct deleted Tool JSON",
+                     deletedTool.getId(), bookmark.getId());
+
+        deletedTool = toolbox.deleteBookmark(bookmark.getId());
+        assertNull("FAIL: The delete operation did not return a null object when the tool did not exist",
+                   deletedTool);
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#deleteBookmark(java.lang.String)}.
+     */
+    @Test
+    public void deleteBookmark_persistenceError() throws Exception {
+        Bookmark bookmark = new Bookmark("T1", "t1.com", "t1.com/icon.png");
+        setMockPersistStore();
+        toolbox.addBookmark(bookmark);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockPersistence).store(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID, toolbox);
+                will(throwException(new IOException("TestException")));
+            }
+        });
+
+        int countBefore = toolbox.getToolEntries().size();
+        long modBefore = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+
+        toolbox.deleteBookmark(bookmark.getId());
+
+        int countAfter = toolbox.getToolEntries().size();
+        long modAfter = (Long) toolbox.get_metadata().get(IToolbox.METADATA_LAST_MODIFIED);
+        assertEquals("FAIL: The metadata count did not get decremented as part of the delete",
+                     countBefore - 1, countAfter);
+        assertTrue("FAIL: The metadata lastModified did not get set as part of the delete",
+                   modAfter >= modBefore);
+        assertFalse("FAIL: The metadata isDefault should be false after a delete",
+                    (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+
+        assertTrue("FAIL: Persistence failed on add - did not produce expected CWWKX1036E",
+                   outputMgr.checkForMessages("CWWKX1036E:.*" + USER_ID + ".*TestException"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.pojo.Toolbox#reset()}.
+     */
+    @Test
+    public void reset() throws Exception {
+        Bookmark bookmark = new Bookmark("T", "http://ibm.com/", "default.png");
+
+        setMockPersistStore();
+        toolbox.addBookmark(bookmark);
+        // No need to check if addTool worked, we already know from previous tests
+
+        setMockPersistStore();
+        toolbox.reset();
+        assertTrue("FAIL: The metadata isDefault should be true after a reset",
+                   (Boolean) toolbox.get_metadata().get(IToolbox.METADATA_IS_DEFAULT));
+        assertNull("Added Tool should no longer be present in the toolbox",
+                   toolbox.getToolEntry("T-1"));
+    }
+
+    @Test
+    public void validateSelf() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockCatalog).getTool(featureTool.getId());
+                will(returnValue(featureTool));
+
+                one(mockCatalog).getTool(bookmark.getId());
+                will(returnValue(bookmark));
+            }
+        });
+
+        toolbox.validateSelf();
+
+        assertTrue("FAIL: Validation should not have produced any messages",
+                   outputMgr.isEmptyMessageLog());
+    }
+
+    @Test
+    public void validateSelf_featureToolRemovedFromCatalog() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockCatalog).getTool(featureTool.getId());
+                will(returnValue(null));
+
+                one(mockCatalog).getTool(bookmark.getId());
+                will(returnValue(bookmark));
+            }
+        });
+
+        toolbox.validateSelf();
+
+        assertTrue("FAIL: Did not get expected tool no longer available message CWWKX1037W",
+                   outputMgr.checkForMessages("CWWKX1037W:.*" + featureTool.getId() + ".*" + USER_ID));
+    }
+
+    @Test
+    public void validateSelf_BookmarkRemovedFromCatalog() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockCatalog).getTool(featureTool.getId());
+                will(returnValue(featureTool));
+
+                one(mockCatalog).getTool(bookmark.getId());
+                will(returnValue(null));
+            }
+        });
+
+        toolbox.validateSelf();
+
+        assertTrue("FAIL: Did not get expected tool no longer available message CWWKX1037W",
+                   outputMgr.checkForMessages("CWWKX1037W:.*" + bookmark.getId() + ".*" + USER_ID));
+    }
+
+    @Test
+    public void validateSelf_BookmarkNotRemoved() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockCatalog).getTool(featureTool.getId());
+                will(returnValue(featureTool));
+
+                one(mockCatalog).getTool(bookmark.getId());
+                will(returnValue(bookmark));
+            }
+        });
+
+        setMockPersistStore();
+        toolbox.addBookmark(new Bookmark("T1", "t1.com/", "default.png"));
+        toolbox.validateSelf();
+
+        assertTrue("FAIL: Validation should not have produced any messages",
+                   outputMgr.isEmptyMessageLog());
+    }
+
+    /**
+     * @return
+     * @throws Exception
+     */
+    private Toolbox deserializeToolbox(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        Toolbox tb = mapper.readValue(json, Toolbox.class);
+        tb.setCatalog(mockCatalog);
+        return tb;
+    }
+
+    @Test
+    public void validateSelf_badPeferencesEntry() throws Exception {
+        Toolbox toolbox = deserializeToolbox("{\"_metadata\":{\"lastModified\":123,\"isDefault\":true},\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\""
+                                             + USER_DISPLAY_NAME
+                                             + "\",\"preferences\":{\"malicious\":\"<script>alert('hi');</script>\"},\"toolEntries\":[{\"id\":\"badEntry\"}],\"bookmarks\":[]}");
+        toolbox.validateSelf();
+
+        assertEquals("FAIL: Toolbox preferences should contain 0 tool entries because the one entry was malicious",
+                     0, toolbox.getPreferences().size());
+    }
+
+    @Test
+    public void validateSelf_badToolEntry() throws Exception {
+        Toolbox toolbox = deserializeToolbox("{\"_metadata\":{\"lastModified\":123,\"isDefault\":true},\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\""
+                                             + USER_DISPLAY_NAME + "\",\"preferences\":{},\"toolEntries\":[{\"id\":\"badEntry\"}],\"bookmarks\":[]}");
+        toolbox.validateSelf();
+        assertEquals("FAIL: Toolbox tools should contain 0 tool entries",
+                     0, toolbox.getToolEntries().size());
+        assertEquals("FAIL: Toolbox tools should contain 0 bookmarks",
+                     0, toolbox.getBookmarks().size());
+        assertNull("FAIL: Bad tool was not removed from the catalog after validation",
+                   toolbox.getToolEntry("badEntry"));
+
+        assertTrue("FAIL: Did not get expected toolbox validation message CWWKX1035W",
+                   outputMgr.checkForMessages("CWWKX1035W:.*badEntry.*" + USER_ID + ".*"));
+    }
+
+    @Test
+    public void validateSelf_badBookmark() throws Exception {
+        Toolbox toolbox = deserializeToolbox("{\"_metadata\":{\"lastModified\":123,\"isDefault\":true},\"ownerId\":\""
+                                             + USER_ID
+                                             + "\",\"ownerDisplayName\":\""
+                                             + USER_DISPLAY_NAME
+                                             + "\",\"preferences\":{},\"toolEntries\":[{\"id\":\"badBookmark\",\"type\":\"bookmark\"}],\"bookmarks\":[{\"id\":\"badBookmark\",\"name\":\"badBookmark\"}]}");
+        assertNotNull("FAIL: Bad tool is not bad of the toolbox before validation",
+                      toolbox.getToolEntry("badBookmark"));
+
+        toolbox.validateSelf();
+        assertEquals("FAIL: Toolbox tools should contain 0 tool entries",
+                     0, toolbox.getToolEntries().size());
+        assertEquals("FAIL: Toolbox tools should contain 0 bookmarks",
+                     0, toolbox.getBookmarks().size());
+        assertNull("FAIL: Bad tool was not removed from the catalog after validation",
+                   toolbox.getToolEntry("badBookmark"));
+    }
+
+    @Test
+    public void validateSelf_bookmarkEntryNotInURLs() throws Exception {
+        Toolbox toolbox = deserializeToolbox("{\"_metadata\":{\"lastModified\":123,\"isDefault\":true},\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\""
+                                             + USER_DISPLAY_NAME + "\",\"preferences\":{},\"toolEntries\":[{\"id\":\"badBookmark\",\"type\":\"bookmark\"}],\"bookmarks\":[]}");
+        mock.checking(new Expectations() {
+            {
+                one(mockCatalog).getTool("badBookmark");
+                will(returnValue(null));
+            }
+        });
+        toolbox.validateSelf();
+        assertEquals("FAIL: Toolbox tools should contain 0 tool entries",
+                     0, toolbox.getToolEntries().size());
+        assertEquals("FAIL: Toolbox tools should contain 0 bookmarks",
+                     0, toolbox.getBookmarks().size());
+        assertNull("FAIL: Bad tool was not removed from the catalog after validation",
+                   toolbox.getToolEntry("badBookmark"));
+    }
+
+    @Test
+    public void validateSelf_bookmarkNotInEntries() throws Exception {
+        Toolbox toolbox = deserializeToolbox("{\"_metadata\":{\"lastModified\":123,\"isDefault\":true},\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\""
+                                             + USER_DISPLAY_NAME + "\",\"preferences\":{},\"toolEntries\":[],\"bookmarks\":[{\"id\":\"badBookmark\",\"name\":\"badBookmark\"}]}");
+        assertNotNull("FAIL: Bad tool is not bad of the toolbox before validation",
+                      toolbox.getToolEntry("badBookmark"));
+
+        toolbox.validateSelf();
+        assertEquals("FAIL: Toolbox tools should contain 0 tool entries",
+                     0, toolbox.getToolEntries().size());
+        assertEquals("FAIL: Toolbox tools should contain 0 bookmarks",
+                     0, toolbox.getBookmarks().size());
+        assertNull("FAIL: Bad tool was not removed from the catalog after validation",
+                   toolbox.getToolEntry("badBookmark"));
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsSameInstance() throws Exception {
+        final IToolbox c1 = new Toolbox(mockCatalog, mockPersistence, USER_ID, USER_DISPLAY_NAME);
+        assertEquals("FAIL: The same Toolbox instance did not compare as equals=true",
+                     c1, c1);
+        assertEquals("FAIL: The same Toolbox instance did not compare hashCode as equals=true",
+                     c1.hashCode(), c1.hashCode());
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsMismatchUsers() {
+        final IToolbox c1 = new Toolbox(mockCatalog, mockPersistence, USER_ID, USER_DISPLAY_NAME);
+        final IToolbox c2 = new Toolbox(mockCatalog, mockPersistence, USER_ID_2, USER_DISPLAY_NAME_2);
+        assertFalse("FAIL: Two unequal Toolboxes compared as equal",
+                    c1.equals(c2));
+    }
+
+    /**
+     * Test equivalence across .equals() and .hashCode().
+     */
+    @Test
+    public void equalsMismatchPreferences() throws Exception {
+        final IToolbox c1 = new Toolbox(mockCatalog, mockPersistence, USER_ID, USER_DISPLAY_NAME);
+        final IToolbox c2 = new Toolbox(mockCatalog, mockPersistence, USER_ID_2, USER_DISPLAY_NAME_2);
+        Map<String, Object> newPreferences = new HashMap<String, Object>();
+        newPreferences.put("pref1", true);
+
+        mock.checking(new Expectations() {
+            {
+                one(mockPersistence).store(Toolbox.PERSIST_NAME + "-" + ENCRYPTED_USER_ID_2, c2);
+            }
+        });
+        c2.updatePreferences(newPreferences);
+        assertFalse("FAIL: Two unequal Toolboxes compared as equal",
+                    c1.equals(c2));
+    }
+
+    @Test
+    public void equalsNotAToolbox() {
+        assertFalse("FAIL: A non-Toolbox object was considered to equal a Toolbox",
+                    jsonablePojo.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNull() {
+        assertFalse("FAIL: Null was conisdered to equal a Toolbox",
+                    jsonablePojo.equals(null));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Test
+    public void incompleteJson() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Toolbox incompleteObj = mapper.readValue("{}", Toolbox.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidToolboxException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertEquals("FAIL: An incomplete Toolbox should have a zero hashcode",
+                     0, incompleteObj.hashCode());
+    }
+
+    @Test
+    public void incompleteJsonEmptyMetadata() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Toolbox incompleteObj = mapper.readValue("{\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\"" + USER_DISPLAY_NAME
+                                                 + "\",\"preferences\":{},\"toolEntries\":[],\"bookmarks\":[]}",
+                                                 Toolbox.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidToolboxException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: Exception message did not contain the word '_metadata'. Message: " + e.getMessage(),
+                       e.getMessage().contains("_metadata"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Toolbox with toolEntries should have a non-zero hashcode",
+                   0 != incompleteObj.hashCode());
+    }
+
+    @Test
+    public void incompleteJsonNoMetaDataLastModified() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Toolbox incompleteObj = mapper.readValue("{\"_metadata\":{\"isDefault\":true},\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\"" + USER_DISPLAY_NAME
+                                                 + "\",\"preferences\":{},\"toolEntries\":[],\"bookmarks\":[]}",
+                                                 Toolbox.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidToolboxException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: Exception message did not contain the word '" + IToolbox.METADATA_LAST_MODIFIED + "'. Message: " + e.getMessage(),
+                       e.getMessage().contains(IToolbox.METADATA_LAST_MODIFIED));
+        }
+        assertFalse("FAIL: An incomplete Toolbox should not be considered equal to a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Toolbox with toolEntries should have a non-zero hashcode",
+                   0 != incompleteObj.hashCode());
+    }
+
+    @Test
+    public void incompleteJsonNoMetaDataIsDefault() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Toolbox incompleteObj = mapper.readValue("{\"_metadata\":{\"lastModified\":0},\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\""
+                                                 + USER_DISPLAY_NAME + "\",\"preferences\":{},\"toolEntries\":[],\"bookmarks\":[]}", Toolbox.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidToolboxException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: Exception message did not contain the word '" + IToolbox.METADATA_IS_DEFAULT + "'. Message: " + e.getMessage(),
+                       e.getMessage().contains(IToolbox.METADATA_IS_DEFAULT));
+        }
+        assertFalse("FAIL: An incomplete Toolbox should not be considered equal to a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Toolbox with toolEntries should have a non-zero hashcode",
+                   0 != incompleteObj.hashCode());
+    }
+
+    @Test
+    public void incompleteJsonNoPreferences() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Toolbox incompleteObj = mapper.readValue("{\"_metadata\":{\"lastModified\":0,\"isDefault\":true},\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\""
+                                                 + USER_DISPLAY_NAME + "\",\"toolEntries\":[]}",
+                                                 Toolbox.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidToolboxException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: Exception message did not contain the word 'bookmarks'. Message: " + e.getMessage(),
+                       e.getMessage().contains("bookmarks"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertFalse("FAIL: An incomplete Catalog with toolEntries should have a non-zero hashcode",
+                    0 == incompleteObj.hashCode());
+    }
+
+    @Test
+    public void incompleteJsonNoOwnerId() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Toolbox incompleteObj = mapper.readValue("{\"_metadata\":{\"lastModified\":123,\"isDefault\":true},\"ownerDisplayName\":\"bob\",\"preferences\":{},\"toolEntries\":[],\"bookmarks\":[]}",
+                                                 Toolbox.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidToolboxException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: Exception message did not contain the word 'ownerId'. Message: " + e.getMessage(),
+                       e.getMessage().contains("ownerId"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox should not be considered equal to a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Toolbox with toolEntries should have a non-zero hashcode",
+                   0 != incompleteObj.hashCode());
+    }
+
+    @Test
+    public void incompleteJsonNoOwnerDisplayname() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Toolbox incompleteObj = mapper.readValue("{\"_metadata\":{\"lastModified\":123,\"isDefault\":true},\"ownerId\":\"bob\",\"preferences\":{},\"toolEntries\":[],\"bookmarks\":[]}",
+                                                 Toolbox.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidToolboxException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: Exception message did not contain the word 'ownerDisplayName'. Message: " + e.getMessage(),
+                       e.getMessage().contains("ownerDisplayName"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox should not be considered equal to a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Toolbox with toolEntries should have a non-zero hashcode",
+                   0 != incompleteObj.hashCode());
+    }
+
+    @Test
+    public void incompleteJsonNoToolEntries() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Toolbox incompleteObj = mapper.readValue("{\"_metadata\":{\"lastModified\":0,\"isDefault\":true},\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\""
+                                                 + USER_DISPLAY_NAME + "\",\"preferences\":{},\"bookmarks\":[]}",
+                                                 Toolbox.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidToolboxException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: Exception message did not contain the word 'tools'. Message: " + e.getMessage(),
+                       e.getMessage().contains("toolEntries"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertTrue("FAIL: An incomplete Catalog with no toolEntries should have a zero hashcode",
+                   0 == incompleteObj.hashCode());
+    }
+
+    @Test
+    public void incompleteJsonNoBookmarks() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Toolbox incompleteObj = mapper.readValue("{\"_metadata\":{\"lastModified\":0,\"isDefault\":true},\"ownerId\":\"" + USER_ID + "\",\"ownerDisplayName\":\""
+                                                 + USER_DISPLAY_NAME + "\",\"preferences\":{},\"toolEntries\":[]}",
+                                                 Toolbox.class);
+        try {
+            incompleteObj.validateSelf();
+            fail("FAIL: Validation should have failed");
+        } catch (InvalidToolboxException e) {
+            assertNotNull("FAIL: Should have caught an InvalidToolboxException", e);
+            assertTrue("FAIL: Exception message did not contain the word 'bookmarks'. Message: " + e.getMessage(),
+                       e.getMessage().contains("bookmarks"));
+        }
+        assertFalse("FAIL: An incomplete Toolbox was considered to equal a valid Toolbox",
+                    incompleteObj.equals(jsonablePojo));
+        assertFalse("FAIL: An incomplete Catalog with toolEntries should have a non-zero hashcode",
+                    0 == incompleteObj.hashCode());
+    }
+
+    /** Valdiate Self! */
+    @Override
+    protected void extraPojoMatchesSourceJSONChecks(SelfValidatingPOJO unmarshalledPojo) throws Exception {
+        mock.checking(new Expectations() {
+            {
+                one(mockCatalog).getTool(featureTool.getId());
+                will(returnValue(featureTool));
+
+                one(mockCatalog).getTool(bookmark.getId());
+                will(returnValue(bookmark));
+            }
+        });
+
+        Toolbox toolbox = ((Toolbox) unmarshalledPojo);
+        toolbox.setCatalog(mockCatalog);
+        toolbox.setPersistenceProvider(mockPersistence);
+        unmarshalledPojo.validateSelf();
+    }
+
+    /**
+     * Worker class to get the Toolbox 100 times in the addAndDeleteBookmarkMultiThreads test case
+     */
+    public static class GetToolboxWorker implements Callable<String> {
+
+        private final IToolbox toolbox;
+
+        public GetToolboxWorker(IToolbox toolbox) {
+            this.toolbox = toolbox;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String call() throws Exception {
+            int i = 0;
+            try {
+                // Each thread will get the toolbox 100 times
+                for (; i < 100; i++) {
+                    for (Bookmark bookmark : toolbox.getBookmarks()) {
+                        // Iterate through to try and break things
+                        bookmark.getId();
+                    }
+                }
+                return null;
+            } catch (Exception e) {
+                throw new Exception("Error while in getting toolbox iteration " + i + ". Error:" + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Worker class to get the Toolbox metadata 100 times in the addAndDeleteBookmarkMultiThreads test case
+     */
+    public static class GetMetadataWorker implements Callable<String> {
+
+        private final IToolbox toolbox;
+
+        public GetMetadataWorker(IToolbox toolbox) {
+            this.toolbox = toolbox;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String call() throws Exception {
+            int i = 0;
+            try {
+                // Each thread will get the toolbox 100 times
+                for (; i < 100; i++) {
+                    Map<String, Object> metadata = toolbox.get_metadata();
+                    for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+                        // Iterate through to try and break things
+                        entry.getKey();
+                        entry.getValue();
+                    }
+                }
+                return null;
+            } catch (Exception e) {
+                throw new Exception("Error while in getting toolbox metadata iteration " + i + ". Error:" + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Worker class to add 100 bookmarks in the addAndDeleteBookmarkMultiThreads test case
+     */
+    public static class AddBookmarkWorker implements Callable<String> {
+
+        private final IToolbox toolbox;
+        private final String namePrefix;
+
+        public AddBookmarkWorker(IToolbox toolbox, String name) {
+            this.toolbox = toolbox;
+            this.namePrefix = name;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String call() throws Exception {
+            int i = 0;
+            try {
+                // Each thread will create 100 tools
+                String name = namePrefix;
+                for (; i < 100; i++) {
+                    Bookmark featureTool = new Bookmark(name + "-" + i, "http://www.ebay.com", "http://p.ebaystatic.com/aw/pics/globalheader/spr11.png");
+                    toolbox.addBookmark(featureTool);
+                }
+                return name;
+            } catch (Exception e) {
+                throw new Exception("Error while in adding tool " + namePrefix + ", iteration " + i + ". Error:" + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Worker class to delete 100 bookmarks in the addAndDeleteBookmarkMultiThreads test case
+     */
+    public static class DeleteBookmarkWorker implements Callable<String> {
+
+        private final IToolbox toolbox;
+        private final String name;
+
+        public DeleteBookmarkWorker(IToolbox toolbox, String name) {
+            this.toolbox = toolbox;
+            this.name = name;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String call() throws Exception {
+            int i = 0;
+            try {
+                // Each thread will create 100 tools
+                for (; i < 100; i++) {
+                    String toolId = name + "-" + i;
+                    this.toolbox.deleteBookmark(toolId);
+                }
+                return name;
+            } catch (Exception e) {
+                throw new Exception("Error while in delete loop for " + name + ", iteration " + i + ". Error:" + e.getMessage(), e);
+            }
+        }
+    }
+
+    @Test
+    public void getMetadataAndgetTools_returnsSnapshot() throws Exception {
+        List<ToolEntry> firstToolEntries = toolbox.getToolEntries();
+        List<Bookmark> firstBookmarks = toolbox.getBookmarks();
+
+        setMockPersistStore();
+        toolbox.addBookmark(new Bookmark("T", "ibm.com", "ibm.png", "desc"));
+
+        List<ToolEntry> secondToolEntries = toolbox.getToolEntries();
+        List<Bookmark> secondBookmarks = toolbox.getBookmarks();
+
+        assertEquals("FAIL: the initial tool entriess list should have one less count compared to the second tools list",
+                     firstToolEntries.size() + 1, secondToolEntries.size());
+        assertEquals("FAIL: the initial bookmarks list should have one less count compared to the second tools list",
+                     firstBookmarks.size() + 1, secondBookmarks.size());
+    }
+
+    @Test
+    public void test_toString() {
+        assertEquals("FAIL: Toolbox toString did not respond with the user name",
+                     "Toolbox(" + USER_ID + ")", toolbox.toString());
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/ToolboxWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/pojo/ToolboxWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.pojo;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class ToolboxWithTraceTest extends ToolboxTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/ContextAwarePrintStreamFilter.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/ContextAwarePrintStreamFilter.java
@@ -1,0 +1,254 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.utils;
+
+import java.io.PrintStream;
+import java.util.Locale;
+
+/**
+ * A PrintStream wrapper that will forward print() calls except for those
+ * which originate (directly or indirectly) from a particular package. This
+ * stream can be used to silence noisy 3rd party components that write
+ * unconditionally to System.out and System.err.
+ */
+public final class ContextAwarePrintStreamFilter extends PrintStream {
+
+    private final PrintStream out;
+    private final String packageName;
+
+    /**
+     * @param out
+     */
+    public ContextAwarePrintStreamFilter(PrintStream out, String packageName) {
+        super(out);
+        this.out = out;
+        this.packageName = packageName + '.';
+    }
+
+    @Override
+    public PrintStream append(char c) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.append(c);
+        }
+        return this;
+    }
+
+    @Override
+    public PrintStream append(CharSequence csq) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.append(csq);
+        }
+        return this;
+    }
+
+    @Override
+    public PrintStream append(CharSequence csq, int start, int end) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.append(csq, start, end);
+        }
+        return this;
+    }
+
+    @Override
+    public PrintStream format(Locale l, String format, Object... args) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.format(l, format, args);
+        }
+        return this;
+    }
+
+    @Override
+    public PrintStream format(String format, Object... args) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.format(format, args);
+        }
+        return this;
+    }
+
+    @Override
+    public void print(boolean x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.print(x);
+        }
+    }
+
+    @Override
+    public void print(char x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.print(x);
+        }
+    }
+
+    @Override
+    public void print(char[] x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.print(x);
+        }
+    }
+
+    @Override
+    public void print(double x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.print(x);
+        }
+    }
+
+    @Override
+    public void print(float x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.print(x);
+        }
+    }
+
+    @Override
+    public void print(int x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.print(x);
+        }
+    }
+
+    @Override
+    public void print(long x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.print(x);
+        }
+    }
+
+    @Override
+    public void print(Object x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.print(x);
+        }
+    }
+
+    @Override
+    public void print(String x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.print(x);
+        }
+    }
+
+    @Override
+    public PrintStream printf(Locale l, String format, Object... args) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.printf(l, format, args);
+        }
+        return this;
+    }
+
+    @Override
+    public PrintStream printf(String format, Object... args) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.printf(format, args);
+        }
+        return this;
+    }
+
+    @Override
+    public void println() {
+        if (!isCalledFromForbiddenPackage()) {
+            out.println();
+        }
+    }
+
+    @Override
+    public void println(boolean x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.println(x);
+        }
+    }
+
+    @Override
+    public void println(char x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.println(x);
+        }
+    }
+
+    @Override
+    public void println(char[] x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.println(x);
+        }
+    }
+
+    @Override
+    public void println(double x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.println(x);
+        }
+    }
+
+    @Override
+    public void println(float x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.println(x);
+        }
+    }
+
+    @Override
+    public void println(int x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.println(x);
+        }
+    }
+
+    @Override
+    public void println(long x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.println(x);
+        }
+    }
+
+    @Override
+    public void println(Object x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.println(x);
+        }
+    }
+
+    @Override
+    public void println(String x) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.println(x);
+        }
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.write(buf, off, len);
+        }
+    }
+
+    @Override
+    public void write(int b) {
+        if (!isCalledFromForbiddenPackage()) {
+            out.write(b);
+        }
+    }
+
+    /**
+     * Returns true if one of the ancestor calls on the stack originates
+     * from any class from the specified package or any of its sub-packages.
+     */
+    private boolean isCalledFromForbiddenPackage() {
+        for (final StackTraceElement ste : Thread.currentThread().getStackTrace()) {
+            final String className = ste.getClassName();
+            if (className != null && className.startsWith(packageName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/LogRule.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/LogRule.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.utils;
+
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * This somehow is setting up the console output so that it can be read by the unit tests
+ */
+public class LogRule implements TestRule {
+
+    private final TestRule outerRule;
+
+    public LogRule(TestRule outerRule) {
+        this.outerRule = outerRule;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.junit.rules.TestRule#apply(org.junit.runners.model.Statement, org.junit.runner.Description)
+     */
+    @Override
+    public Statement apply(final Statement stmt, final Description desc) {
+        try {
+            final Method m = outerRule.getClass().getDeclaredMethod("apply", Statement.class, Description.class);
+            m.setAccessible(true);
+            final Statement innerRule = new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    PrintStream systemOut = System.out;
+                    PrintStream systemErr = System.err;
+                    if (systemOut != null) {
+                        System.setOut(systemOut);
+                        systemOut = null;
+                    }
+                    if (systemErr != null) {
+                        System.setErr(systemErr);
+                        systemErr = null;
+                    }
+
+                }
+            };
+            return (Statement) m.invoke(outerRule, innerRule, desc);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/URLUtilityImplTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/URLUtilityImplTest.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Map;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import test.common.SharedOutputManager;
+
+import com.ibm.ws.ui.internal.v1.pojo.Bookmark;
+
+public class URLUtilityImplTest {
+    static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    private final Mockery mock = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private final HttpURLConnection mockHTTPConnection = mock.mock(HttpURLConnection.class);
+
+    private static final String DEFAULT_ICON_URL = "images/tools/defaultTool_142x142.png";
+    private static final String EXPECTED_URL = "http://www.ibm.com";
+
+    private URLUtility utils;
+    private URL mockURL;
+
+    @Before
+    public void setUp() throws Exception {
+        utils = new URLUtilityImpl();
+
+        mock.checking(new Expectations() {
+            {
+                allowing(mockHTTPConnection).disconnect();
+            }
+        });
+
+        mockURL = new URL("http", "www.ibm.com", -1, "", new URLStreamHandler() {
+            @Override
+            protected URLConnection openConnection(URL u) throws IOException {
+                return mockHTTPConnection;
+            }
+        });
+    }
+
+    @After
+    public void tearDown() {
+        utils = null;
+        mock.assertIsSatisfied();
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.utils.URLUtilityImpl#analyzeURL(java.net.URL)}.
+     */
+    @Test
+    public void analyzeURL() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockHTTPConnection).getInputStream();
+                will(returnValue(new ByteArrayInputStream("<title>aaa WebPage</title>/n<meta name=\"description\" content=\"This is the aaaa Website\"".getBytes())));
+            }
+        });
+
+        Map<String, Object> ret = utils.analyzeURL(mockURL);
+
+        assertTrue("FAIL: URL should be reachable",
+                   (Boolean) ret.get("urlReachable"));
+        Bookmark bookmark = (Bookmark) ret.get("tool");
+        assertEquals("FAIL: tool didn't have a name of \"aaa WebPage\"",
+                     "aaa WebPage", bookmark.getName());
+        assertEquals("FAIL: tool didn't have a url entry of " + EXPECTED_URL,
+                     EXPECTED_URL, bookmark.getURL());
+        assertEquals("FAIL: tool didn't have an icon entry of " + DEFAULT_ICON_URL,
+                     DEFAULT_ICON_URL, bookmark.getIcon());
+        assertEquals("FAIL: tool didn't have a description of \"This is the aaaa Website\"",
+                     "This is the aaaa Website", bookmark.getDescription());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.utils.URLUtilityImpl#analyzeURL(java.net.URL)}.
+     */
+    @Test
+    public void analyzeURL_noMetadata() throws Exception {
+        mock.checking(new Expectations() {
+            {
+                allowing(mockHTTPConnection).getInputStream();
+                will(returnValue(new ByteArrayInputStream("<notitle/><nodesc/>/n".getBytes())));
+            }
+        });
+
+        Map<String, Object> ret = utils.analyzeURL(mockURL);
+
+        assertTrue("FAIL: URL should be reachable",
+                   (Boolean) ret.get("urlReachable"));
+
+        Bookmark bookmark = (Bookmark) ret.get("tool");
+        assertTrue("FAIL: tool didn't have an empty name",
+                   bookmark.getName().isEmpty());
+        assertEquals("FAIL: tool didn't have a url entry of " + EXPECTED_URL,
+                     EXPECTED_URL, bookmark.getURL());
+        assertEquals("FAIL: tool didn't have an icon entry of " + DEFAULT_ICON_URL,
+                     DEFAULT_ICON_URL, bookmark.getIcon());
+        assertTrue("FAIL: tool didn't have an empty description",
+                   bookmark.getDescription().isEmpty());
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.ui.internal.v1.utils.URLUtilityImpl#analyzeURL(java.net.URL)}.
+     */
+    @Test
+    public void analyzeURL_invalidURL() throws Exception {
+        mock.checking(new Expectations() {
+            {
+
+                allowing(mockHTTPConnection).getInputStream();
+                will(throwException(new IOException("Unable to find Invalid Website")));
+            }
+        });
+
+        Map<String, Object> ret = utils.analyzeURL(mockURL);
+
+        assertFalse("FAIL: URL should be not reachable",
+                    (Boolean) ret.get("urlReachable"));
+
+        Bookmark bookmark = (Bookmark) ret.get("tool");
+        assertTrue("FAIL: tool didn't have an empty name",
+                   bookmark.getName().isEmpty());
+        assertEquals("FAIL: tool didn't have a url entry of " + EXPECTED_URL,
+                     EXPECTED_URL, bookmark.getURL());
+        assertEquals("FAIL: tool didn't have an icon entry of " + DEFAULT_ICON_URL,
+                     DEFAULT_ICON_URL, bookmark.getIcon());
+        assertTrue("FAIL: tool didn't have an empty description",
+                   bookmark.getDescription().isEmpty());
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/URLUtilityImplWithTraceTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/URLUtilityImplWithTraceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.utils;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * Drives the extended JUnit tests but with all trace enabled.
+ * Used to drive out any lingering bugs which may only be discovered
+ * when tracing is enabled.
+ */
+public class URLUtilityImplWithTraceTest extends URLUtilityImplTest {
+    @BeforeClass
+    public static void traceSetUp() {
+        outputMgr.trace("*=all");
+    }
+
+    @AfterClass
+    public static void traceTearDown() {
+        outputMgr.trace("*=all=disabled");
+    }
+}

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/UtilsTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/UtilsTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ui.internal.v1.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.net.MalformedURLException;
+
+import org.junit.Test;
+
+/**
+ * 
+ */
+public class UtilsTest {
+
+    @Test
+    public void urlEncoded() {
+        assertEquals("Drives Utils.urlEncoded for happy path coverage... this test is here because we care about coverage and no other real reason",
+                     "encodeMe", Utils.urlEncode("encodeMe"));
+    }
+
+    @Test
+    public void urlEncoded_null() {
+        assertNull("Drives Utils.urlEncoded for happy path coverage...",
+                   Utils.urlEncode(null));
+    }
+
+    @Test
+    public void getURL() throws Exception {
+        assertNotNull("Drives Utils.getURL for happy path coverage... this test is here because we care about coverage and no other real reason",
+                      Utils.getURL("http://www.ibm.com"));
+    }
+
+    @Test(expected = MalformedURLException.class)
+    public void getURL_badURL() throws Exception {
+        Utils.getURL("tp:/.ibm.com");
+    }
+
+    @Test
+    public void md5Test() {
+        assertEquals("MD5 encoding not working", "9EC5C2C0F355B0B1EA8319C9FCD6E44F".toLowerCase(), Utils.getMD5String("Test MD5 String"));
+    }
+}

--- a/dev/com.ibm.ws.ui/test/test/common/JSONablePOJOTestCase.java
+++ b/dev/com.ibm.ws.ui/test/test/common/JSONablePOJOTestCase.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+
+import com.ibm.ws.ui.persistence.SelfValidatingPOJO;
+
+/**
+ * Common root class for any JSON-able POJO unit test.
+ */
+public abstract class JSONablePOJOTestCase {
+    protected Object jsonablePojo;
+    protected String sourceJson;
+
+    /**
+     * Tests that the Object Under Test is JSONable using Jackson.
+     * This simply drives a Jackon marshall / unmarshall to check
+     * that the flow back and forth works. It does not test the
+     * correctness of the resulting JSON.
+     */
+    @Test
+    public void isJSONable() throws Exception {
+        assertNotNull("FAIL: test development error.\nPlease set the 'jsonablePojo' field to an object instance.\nThis is normally done in setUp.",
+                      jsonablePojo);
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Step 1: Marshall (aka serialize) the Java object to JSON format using Jackson's ObjectMapper
+        String json = mapper.writeValueAsString(jsonablePojo);
+        System.out.println("Jackson JSON represetation: " + json);
+        System.out.println(mapper.defaultPrettyPrintingWriter().writeValueAsString(jsonablePojo));
+
+        // Step 2: Unmarshall (aka deserialize) the JSON into a Java Object
+        Object unmarshalledPojo = mapper.readValue(json, jsonablePojo.getClass());
+        System.out.println("Deserialized to object: " + unmarshalledPojo);
+        System.out.println(mapper.defaultPrettyPrintingWriter().writeValueAsString(unmarshalledPojo));
+
+        assertEquals("FAIL: The unmarshedlled POJO from the JSON does not equal the original POJO",
+                     jsonablePojo, unmarshalledPojo);
+    }
+
+    /**
+     * Extension point for additional checks. Must be implemented by caller
+     * even if it does no work. It is recommended that unmarshalledPojo.validateSelf
+     * is minimally invoked, because it has a high probability of uncovering NPEs.
+     * 
+     * @param unmarshalledPojo
+     * @throws Exception
+     */
+    abstract protected void extraPojoMatchesSourceJSONChecks(SelfValidatingPOJO unmarshalledPojo) throws Exception;
+
+    /**
+     * Tests that the Object Under Test is JSONable using Jackson.
+     */
+    @Test
+    public void pojoMatchesSourceJSON() throws Exception {
+        assertNotNull("FAIL: test development error.\nPlease set the 'jsonablePojo' field to an object instance.\nThis is normally done in setUp.",
+                      jsonablePojo);
+        assertNotNull("FAIL: test development error.\nPlease set the 'expectedJson' field to the expected JSON String for 'jsonablePojo'.\nThis is normally done in setUp.",
+                      sourceJson);
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        String json = mapper.writeValueAsString(jsonablePojo);
+        System.out.println("Jackson JSON represetation: " + json);
+
+        Object unmarshalledPojo = mapper.readValue(sourceJson, jsonablePojo.getClass());
+        extraPojoMatchesSourceJSONChecks((SelfValidatingPOJO) unmarshalledPojo);
+        System.out.println("Deserialized to object: " + unmarshalledPojo);
+        System.out.println(mapper.defaultPrettyPrintingWriter().writeValueAsString(unmarshalledPojo));
+
+        assertEquals("FAIL: The unmarshedlled POJO from the JSON does not equal the original POJO",
+                     jsonablePojo, unmarshalledPojo);
+    }
+
+    /**
+     * Reminder for test case writers to implement at least some form of incomplete
+     * JSON representation test. Because these are POJOs, the JSON could be incomplete
+     * and result in an 'invalid' POJO. The definition of a valid POJO is up to the
+     * POJO itself.
+     * <p>
+     * It is recommended that tests will drive o.equals(), o.hashCode() and o.validateSelf().
+     * Note that we do not need to test incorrect JSON. Jackson handles that. Jackson does not
+     * understand what an incomplete Object means however, which is why we have these tests.
+     */
+    @Test
+    public void incompleteJson() throws Exception {
+        fail("FAIL: test development error.\nPlease override this method.\nImplement at least one test method to validate that the POJO can detect if it is incomplete.");
+    }
+}


### PR DESCRIPTION
For https://github.com/OpenLiberty/open-liberty/issues/32522, 
convert WL unit test project `com.ibm.ws.ui_test` to OL `test` folder in `com.ibm.ws.ui`.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
