### PR TITLE
Added FIPS justifications for csvi2

### DIFF
--- a/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/security/csiv2/config/ssl/SSLConfig.java
+++ b/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/security/csiv2/config/ssl/SSLConfig.java
@@ -195,6 +195,9 @@ public class SSLConfig {
 
     //static final Pattern p = Pattern.compile("(?:(SSL)|(TLS))_([A-Z0-9]*)(_anon)?(_[a-zA-Z0-9]*)??(_EXPORT)?_WITH_([A-Z0-9]*)(?:_(\\d*))?([_a-zA-Z0-9]*)?_(?:(?:(SHA)(\\d*))|(MD5))");
     //Made "WITH" as optional in the above pattern to accommodate ciphers without the substring "WITH" in their cipher-names
+
+    // FIPS 140-3: The following was assessed for FIPS 140-3 compliance and no changes were required.
+    // since the encryption and hashing algorithms are only being used to set filter criteria and in both cases the filter criteria aren't used (Options.strong is never set)
     static final Pattern p = Pattern.compile("(?:(SSL)|(TLS))_([A-Z0-9]*)?(_anon)?(_[a-zA-Z0-9]*)??(_EXPORT)?(_WITH_)?(AES|RC4|DES40|3DES|NULL)(?:_(\\d*))?([_a-zA-Z0-9]*)?_(?:(?:(SHA)(\\d*))|(MD5))");
     //[1 null, 2 TLS, 3 ECDHE, 4 null, 5 _ECDSA, 6 null, 8 AES, 9 128, 10 _CBC, 11 SHA, 12 256, 13 null]
     

--- a/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/asn1/pkcs/PKCSObjectIdentifiers.java
+++ b/dev/com.ibm.ws.security.csiv2.common/src/com/ibm/ws/transport/iiop/asn1/pkcs/PKCSObjectIdentifiers.java
@@ -69,6 +69,10 @@ public interface PKCSObjectIdentifiers
     // md2 OBJECT IDENTIFIER ::=
     //      {iso(1) member-body(2) US(840) rsadsi(113549) digestAlgorithm(2) 2}
     //
+
+    //We reviewed this as part of the FIPS 140-3: Algorithm assessment; no changes required.
+    //Older algorithms are not used because of spec requirements.
+
     static final DERObjectIdentifier    md2                     = new DERObjectIdentifier(digestAlgorithm + ".2");
 
     //


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

For the MD5 der object referenced, older algorithms are not used because of the spec requirements.

I removed older algorithm references in PKCSObjectIdentifier and everything seemed to build successful (csiv2 and ejb tests). However, we are unsure of the impact of removing those sections. For now though, we still believe it is dead code.

For the SSL pattern reference:
@jacobwdv's Analysis
getOptions returns a set which can contain all or some of the following 'Options' enum values
1. Options.integrity
2. Options.tls
3. Options.establishTrustInTarget
4. Options.noexport
5. Options.confidentiality
6. Options.strong
Options.strong is only set if there is a cipher suite that has an encryption key length >= 128 and a hash key length >= 128
However, this method is called to filter out requested cipher suites in 'filter()' which simply issues a warning if cipher suites were requested that dont match the required Options.
Required options EnumSet is created by `toOptions()`
    private EnumSet<Options> toOptions(short flags, boolean supports) {
        //TODO strong from MEDIUM/HIGH setting?
        EnumSet<Options> options = supports? EnumSet.of(Options.noexport, Options.tls) : EnumSet.noneOf(Options.class);
        if ((flags & Integrity.value) == Integrity.value)
            options.add(Options.integrity);
        if ((flags & Confidentiality.value) == Confidentiality.value)
            options.add(Options.confidentiality);
        if ((flags & EstablishTrustInTarget.value) == EstablishTrustInTarget.value)
            options.add(Options.establishTrustInTarget);
        return options;
    }
You can see that for now, there is a todo for checking for Options.strong, but it has not been done and isn't used by the filter.
In conclusion, the values for encryption algorithm/keysize and hash algorithm / keysize are only considered when setting Options.strong which is not implemented anywhere. For this reason, I don't see a reason to make a change here since the encryption and hashing algorithms are only being used to set filter criteria and in both cases the filter criteria aren't used. 

################################################################################################


