### PR TITLE
Remove java.base/sun.security.action=ALL-UNNAMED from java9.options

### DIFF
--- a/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
@@ -1,7 +1,7 @@
 ### Exports
 # for com.ibm.crypto.ibmkeycert.jar
---add-exports
-java.base/sun.security.action=ALL-UNNAMED
+#--add-exports
+#java.base/sun.security.action=ALL-UNNAMED
 # for com.ibm.ws.jndi.internal.WASInitialContextFactoryBuilder
 --add-exports
 java.naming/com.sun.jndi.ldap=ALL-UNNAMED


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

When running Liberty on Java 24+, you will see the following warning in the console.log file:
```
WARNING: package sun.security.action not in java.base
```

This is because of the entry
```
--add-exports
java.base/sun.security.action=ALL-UNNAMED
```
in the [java9.options](https://github.com/OpenLiberty/open-liberty/blob/release/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options) file.

If that entry is no longer needed for Liberty to run, then the simple fix would be to remove it.  Otherwise, we need to work around that requirement if we want to prevent that warning from showing up in the console.log file.