### PR TITLE
Set maximum java level for OpenAPI proxy support tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ProxySupportTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ProxySupportTest.java
@@ -25,6 +25,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.ws.microprofile.openapi.fat.utils.OpenAPIConnection;
 import com.ibm.ws.microprofile.openapi.fat.utils.OpenAPITestUtil;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.RepeatTests;
@@ -137,6 +138,8 @@ public class ProxySupportTest extends FATServletClient {
      * @throws Exception
      */
     @Test
+    @MaximumJavaLevel(javaLevel = 23) // On JAVA 24 many JDKs are setting the Host variable to localhost despite its
+                                      // explicit definition
     public void testRefererSamePort() throws Exception {
         String referer = "http://openliberty.io:" + server.getHttpDefaultPort() + "/openapi";
         String openapi = OpenAPIConnection.openAPIDocsConnection(server, false).header(REFERER, referer).download();
@@ -181,6 +184,8 @@ public class ProxySupportTest extends FATServletClient {
      * @throws Exception
      */
     @Test
+    @MaximumJavaLevel(javaLevel = 23) // On JAVA 24 many JDKs are setting the Host variable to localhost despite its
+                                      // explicit definition
     public void testForwardedDifferentPort() throws Exception {
         String openapi = OpenAPIConnection.openAPIDocsConnection(server, false)
             .header(HOST, "openliberty.io")
@@ -231,6 +236,8 @@ public class ProxySupportTest extends FATServletClient {
      * @throws Exception
      */
     @Test
+    @MaximumJavaLevel(javaLevel = 23) // On JAVA 24 many JDKs are setting the Host variable to localhost despite its
+                                      // explicit definition
     public void testForwadedSamePortOtherScheme() throws Exception {
         String openapi = OpenAPIConnection.openAPIDocsConnection(server, false)
             .header(HOST, "openliberty.io:" + server.getHttpDefaultPort())


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Resovles https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=305715&tab=com.ibm.team.workitem.tab.links

On many JDKs at 24, the Host header was set to localhost even though the test explicitly sets it to io.openliberty causing the test to fail 

https://github.com/OpenLiberty/open-liberty/issues/32587 is also associated with this