### PR TITLE
32555 jsonrpc missing method test

### DIFF
--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
@@ -146,6 +146,9 @@ public class McpServlet extends HttpServlet {
     @FFDCIgnore({ JSONRPCException.class, InvocationTargetException.class, IllegalAccessException.class, IllegalArgumentException.class })
     private void callTool(McpRequest request, Writer writer) {
         McpToolCallParams params = request.getParams(McpToolCallParams.class, jsonb);
+        if (params.getMetadata() == null) {
+            throw new JSONRPCException(JSONRPCErrorCode.INVALID_PARAMS, List.of("Method " + request.params().getString("name") + " not found"));
+        }
         CreationalContext<Object> cc = bm.createCreationalContext(null);
         Object bean = bm.getReference(params.getBean(), params.getBean().getBeanClass(), cc);
         McpResponse mcpResponse;

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolRegistry.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolRegistry.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import io.openliberty.mcp.annotations.Tool;
 import jakarta.enterprise.inject.spi.CDI;
@@ -42,9 +41,6 @@ public class ToolRegistry {
 
     public ToolMetadata getTool(String name) {
         ToolMetadata result = tools.get(name);
-        if (result == null) {
-            throw new NoSuchElementException(name);
-        }
         return result;
     }
 

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/McpToolCallParams.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/McpToolCallParams.java
@@ -33,6 +33,14 @@ public class McpToolCallParams {
     private Jsonb jsonb;
     private String name;
     private ToolMetadata metadata;
+
+    /**
+     * @return the metadata
+     */
+    public ToolMetadata getMetadata() {
+        return metadata;
+    }
+
     private JsonObject arguments;
     private Object[] parsedArguments;
 

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
@@ -588,6 +588,40 @@ public class ToolTest extends FATServletClient {
     }
 
     @Test
+    public void testToolNotFoundError() throws Exception {
+        String request = """
+                          {
+                          "jsonrpc": "2.0",
+                          "id": 2,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "privateEchoMissing",
+                            "arguments": {
+                              "input": "Hello",
+                              "repeat": 4
+                            }
+                          }
+                        }
+                        """;
+
+        String response = HttpTestUtils.callMCP(server, "/toolTest", request);
+        String expectedResponseString = """
+                        {
+                            "id": 2,
+                            "jsonrpc": "2.0",
+                            "error": {
+                                "code": -32602,
+                                "data": [
+                                    "Method privateEchoMissing not found"
+                                ],
+                                "message": "Invalid params"
+                            }
+                        }
+                        """;
+        JSONAssert.assertEquals(expectedResponseString, response, true);
+    }
+
+    @Test
     public void testAddWithIntegerInputArgs() throws Exception {
         String request = """
                           {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes Resolves #xxxxx .
- [x] If this PR resolves an external Known Issue (including APARS), the description includes Resolves #xxxxx.

`ToolRegistry.getTool` no longer throws `NoSuchItemException`, instead  `McpServlet.callTool` method will check if `McpToolCallsParams.metadata` is null and throw a `JSONRPCException` if it is.

Resolves #32555