### PR TITLE
Remove the experimental updateBy pattern

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1550,11 +1550,11 @@ public class DataTestServlet extends FATServlet {
         // Update embeddable attributes
 
         assertEquals(true, houses
-                        .updateByParcelIdSetGarageAddAreaAddKitchenLengthSetNumBedrooms("TestEmbeddable-304-3655-30",
-                                                                                        null,
-                                                                                        180,
-                                                                                        2,
-                                                                                        4));
+                        .updateHomeInfo("TestEmbeddable-304-3655-30",
+                                        null,
+                                        180,
+                                        2,
+                                        4));
 
         h = houses.findById("TestEmbeddable-304-3655-30");
         assertEquals("TestEmbeddable-304-3655-30", h.parcelId);
@@ -4885,7 +4885,7 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Use repository updateBy methods with multiplication and division,
+     * Use repository Query methods with multiplication and division,
      */
     @Test
     public void testRepositoryUpdateMethodsMultiplyAndDivide() {
@@ -4936,7 +4936,7 @@ public class DataTestServlet extends FATServlet {
         packages.saveAll(List.of(p1, p2, p3, p4, p5, p6));
 
         // multiply, divide, and add within same update
-        assertEquals(true, packages.updateByIdAddHeightMultiplyLengthDivideWidth(990003, 1.0f, 0.95f, 1.05f));
+        assertEquals(true, packages.increaseHeightAndLengthReduceWidth(990003, 1.0f, 0.95f, 1.05f));
 
         Package p = packages.findById(990003).get();
         assertEquals(11.4f, p.length, 0.01f);
@@ -4944,7 +4944,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(10.2f, p.height, 0.01f);
 
         // perform same type of update to multiple columns
-        packages.updateByIdDivideLengthDivideWidthDivideHeight(990005, 1.2f, 1.15f, 1.1375f);
+        packages.reduceDimensions(990005, 1.2f, 1.15f, 1.1375f);
 
         p = packages.findById(990005).get();
         assertEquals(4.0f, p.length, 0.01f);
@@ -4952,7 +4952,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(24.0f, p.height, 0.01f);
 
         // multiple conditions and multiple updates
-        assertEquals(2L, packages.updateByLengthLessThanEqualAndHeightBetweenMultiplyLengthMultiplyWidthSetHeight(7.1f, 18.4f, 19.4f, 1.1f, 1.2f, 19.5f));
+        assertEquals(2L, packages.increaseLengthAndWidthAssignHeight(7.1f, 18.4f, 19.4f, 1.1f, 1.2f, 19.5f));
 
         List<Package> results = packages.findByHeightBetween(19.4999f, 19.5001f);
         assertEquals(results.toString(), 2, results.size());
@@ -4968,7 +4968,7 @@ public class DataTestServlet extends FATServlet {
         assertEquals(19.5f, p.height, 0.01f);
 
         // divide width and append to description via query by method name
-        assertEquals(true, packages.updateByIdDivideWidthAddDescription(990003, 2, " halved"));
+        assertEquals(true, packages.reduceWidthAppendDescription(990003, 2, " halved"));
 
         p = packages.findById(990003).orElseThrow();
         assertEquals(11.4f, p.length, 0.01f);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Houses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -87,5 +87,17 @@ public interface Houses {
     @Save
     List<House> save(House... h);
 
-    boolean updateByParcelIdSetGarageAddAreaAddKitchenLengthSetNumBedrooms(String parcel, Garage updatedGarage, int addedArea, int addedKitchenLength, int newNumBedrooms);
+    @Query("""
+                    UPDATE House
+                       SET garage=?2,
+                           area=area+?3,
+                           kitchen.length=kitchen.length+?4,
+                           numBedrooms=?5
+                     WHERE o.parcelId=?1
+                    """)
+    boolean updateHomeInfo(String parcel,
+                           Garage updatedGarage,
+                           int addedArea,
+                           int addedKitchenLength,
+                           int newNumBedrooms);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -104,6 +104,49 @@ public interface Packages extends BasicRepository<Package, Integer> {
     @OrderBy(ID)
     List<Integer> findIdByWidthRounded(int width);
 
+    @Query("""
+                    UPDATE Package
+                       SET height=height+?2,
+                           length=length*?3,
+                           width=width/?4
+                     WHERE (id=?1)
+                    """)
+    boolean increaseHeightAndLengthReduceWidth(int id,
+                                               float heightToAdd,
+                                               float lengthMultiplier,
+                                               float widthDivisor);
+
+    @Query("""
+                    UPDATE Package
+                       SET length=length*?4,
+                           width=width*?5,
+                           height=?6
+                     WHERE length<=?1 AND height BETWEEN ?2 AND ?3
+                    """)
+    long increaseLengthAndWidthAssignHeight(float maxLength,
+                                            float minHeight,
+                                            float maxHeight,
+                                            float lengthMultiplier,
+                                            float widthMultiplier,
+                                            float newHeight);
+
+    @Query("""
+                    UPDATE Package o
+                       SET o.length=o.length/?2,
+                           o.width=o.width/?3,
+                           o.height=o.height/?4
+                     WHERE o.id=?1
+                    """)
+    void reduceDimensions(int id, float lengthDivisor, float widthDivisor, float heightDivisor);
+
+    @Query("""
+                    UPDATE Package
+                       SET width=width/?2,
+                           description=CONCAT(description,?3)
+                     WHERE id=?1
+                    """)
+    boolean reduceWidthAppendDescription(int id, int widthDivisor, String additionalDescription);
+
     @Delete
     @OrderBy(value = "length", descending = true)
     List<Integer> removeIfDescriptionMatches(String description, Limit limit);
@@ -117,15 +160,6 @@ public interface Packages extends BasicRepository<Package, Integer> {
     @Delete
     @OrderBy("width")
     List<Package> takeOrdered(String description);
-
-    boolean updateByIdAddHeightMultiplyLengthDivideWidth(int id, float heightToAdd, float lengthMultiplier, float widthDivisor);
-
-    void updateByIdDivideLengthDivideWidthDivideHeight(int id, float lengthDivisor, float widthDivisor, float heightDivisor);
-
-    boolean updateByIdDivideWidthAddDescription(int id, int widthDivisor, String additionalDescription);
-
-    long updateByLengthLessThanEqualAndHeightBetweenMultiplyLengthMultiplyWidthSetHeight(float maxLength, float minHeight, float maxHeight,
-                                                                                         float lengthMultiplier, float widthMultiplier, float newHeight);
 
     @Query("SELECT p FROM Package p WHERE (p.length * p.width * p.height >= ?1 AND p.length * p.width * p.height <= ?2)")
     @OrderBy(value = "width", descending = true)

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -64,6 +64,7 @@ public interface Vehicles {
     @Save
     Iterable<Vehicle> save(Iterable<Vehicle> v);
 
+    @Query("UPDATE Vehicle SET price=price+?2 WHERE (vinId=?1)")
     boolean updateByVinIdAddPrice(String vin, float priceIncrease);
 
     @Query("WHERE LOWER(ID(THIS)) = ?1")

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -1522,10 +1522,10 @@ public class DataExperimentalServlet extends FATServlet {
     }
 
     /**
-     * Use repository updateBy methods.
+     * Use repository Query methods that perform assignment operations.
      */
     @Test
-    public void testRepositoryUpdateMethods() {
+    public void testRepositoryQueryMethodsAssignment() {
         ZoneOffset CDT = ZoneOffset.ofHours(-5);
 
         // remove data that other tests previously inserted to the same table
@@ -1570,7 +1570,7 @@ public class DataExperimentalServlet extends FATServlet {
         reservations.saveAll(List.of(r1, r2, r3, r4));
 
         // Update by primary key
-        assertEquals(true, reservations.updateByMeetingIDSetHost(1012004, "testRepositoryUpdateMethods-host2@example.org"));
+        assertEquals(true, reservations.setHost(1012004, "testRepositoryUpdateMethods-host2@example.org"));
 
         // See if the updated entry is found
         List<Long> found = new ArrayList<>();
@@ -1578,9 +1578,9 @@ public class DataExperimentalServlet extends FATServlet {
         assertEquals(List.of(1012004L), found);
 
         // Update multiple by various conditions
-        assertEquals(2, reservations.updateByHostAndLocationSetLocation("testRepositoryUpdateMethods-host1@example.org",
-                                                                        "050-2 A101",
-                                                                        "050-2 H115"));
+        assertEquals(2, reservations.setLocation("testRepositoryUpdateMethods-host1@example.org",
+                                                 "050-2 A101",
+                                                 "050-2 H115"));
         assertEquals(List.of(1012001L, 1012003L),
                      reservations.findByLocationContainsOrderByMeetingID("H115")
                                      .stream()

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/Reservations.java
@@ -55,9 +55,11 @@ import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Select;
+import jakarta.data.repository.Update;
 
 import io.openliberty.data.repository.function.ElementCount;
 import io.openliberty.data.repository.function.Extract;
+import io.openliberty.data.repository.update.Assign;
 
 /**
  * Covers various patterns that are extensions to Jakarta Data, such as
@@ -180,6 +182,15 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
 
     int removeByHostNotIn(Collection<String> hosts);
 
+    @Update
+    boolean setHost(@By("meetingID") long id,
+                    @Assign("host") String newHost);
+
+    @Update
+    int setLocation(@By("host") String host,
+                    @By("location") String currentLocation,
+                    @Assign("location") String newLocation);
+
     @Find
     @Select("meetingId")
     @OrderBy("host")
@@ -203,10 +214,6 @@ public interface Reservations extends BasicRepository<Reservation, Long> {
     List<Long> startsWithinHoursWithMinute(@By("start") @Extract(HOUR) @Is(AtLeast.class) int minHour,
                                            @By("start") @Extract(HOUR) @Is(AtMost.class) int maxHour,
                                            @By("start") @Extract(MINUTE) int minute);
-
-    int updateByHostAndLocationSetLocation(String host, String currentLocation, String newLocation);
-
-    boolean updateByMeetingIDSetHost(long meetingID, String newHost);
 
     @Find
     @OrderBy(ID)

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -109,8 +109,16 @@ public interface Counties {
         EntityManager emOuter1 = getEntityManager();
         EntityManager emInner = getAutoClosedEntityManager();
         EntityManager emOuter2 = getEntityManager();
-        return new Object[] { emOuter1, emOuter2, emOuter1.isOpen(), emOuter2.isOpen(), emInner.isOpen() };
+        return new Object[] {
+                              emOuter1,
+                              emOuter2,
+                              emOuter1.isOpen(),
+                              emOuter2.isOpen(),
+                              emInner.isOpen()
+        };
     }
 
-    boolean updateByNameSetZipCodes(String name, int... zipcodes);
+    @Query("UPDATE County SET zipcodes=?2 WHERE name=?1")
+    boolean setZipCodesFor(String name,
+                           int... zipcodes);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -4635,7 +4635,7 @@ public class DataJPATestServlet extends FATServlet {
             Thread.sleep(Duration.ofMillis(1).toMillis());
 
         dodgeZipCodes = new int[] { 55917, 55924, 55927, 55940, 55944, 55955, 55963, 55985 };
-        assertEquals(true, counties.updateByNameSetZipCodes("Dodge", dodgeZipCodes));
+        assertEquals(true, counties.setZipCodesFor("Dodge", dodgeZipCodes));
 
         // Try to update with outdated version/LocalDateTime:
         try {
@@ -4809,7 +4809,7 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(false, counties.findZipCodesByPopulationLessThanEqual(1).hasNext());
 
         // update array value to empty
-        assertEquals(true, counties.updateByNameSetZipCodes("Wabasha", new int[0]));
+        assertEquals(true, counties.setZipCodesFor("Wabasha", new int[0]));
 
         // query on array value
         assertEquals(Arrays.toString(new int[0]),
@@ -4817,7 +4817,7 @@ public class DataJPATestServlet extends FATServlet {
 
         // update array value to non-empty
         int[] wabashaZipCodesDescending = new int[] { 55991, 55981, 55968, 55964, 55957, 55956, 55945, 55932, 55910, 55041 };
-        assertEquals(true, counties.updateByNameSetZipCodes("Wabasha", wabashaZipCodesDescending));
+        assertEquals(true, counties.setZipCodesFor("Wabasha", wabashaZipCodesDescending));
 
         // query on array value
         assertEquals(Arrays.toString(wabashaZipCodesDescending),

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Creatures.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/Creatures.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.List;
 
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -36,5 +37,6 @@ public interface Creatures extends BasicRepository<@Valid Creature, @Positive Lo
                                                                   @Positive float minWeight,
                                                                   @Positive float maxWeight);
 
-    boolean updateByIdSetWeight(long id, float newWeight);
+    @Query("UPDATE Creature SET weight=?2 WHERE id=?1")
+    boolean setWeight(long id, float newWeight);
 }

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
@@ -270,7 +270,7 @@ public class DataValidationTestServlet extends FATServlet {
         creatures.save(c);
 
         // Validation does not apply to updates made in ways that do not involve the class
-        assertEquals(true, creatures.updateByIdSetWeight(800L, -0.823f));
+        assertEquals(true, creatures.setWeight(800L, -0.823f));
 
         // Validation does not apply to find operations.
         c = creatures.findById(800l).orElseThrow();
@@ -311,7 +311,7 @@ public class DataValidationTestServlet extends FATServlet {
                         459.2f));
 
         // Validation does not apply to updates made in ways that do not involve the class
-        assertEquals(true, creatures.updateByIdSetWeight(900L, -452.9f));
+        assertEquals(true, creatures.setWeight(900L, -452.9f));
 
         // Validation does not apply to find operations.
         Creature c = creatures.findById(900l).orElseThrow();

--- a/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_validation/test-applications/DataValidationTestApp/src/test/jakarta/data/validation/web/DataValidationTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2024 IBM Corporation and others.
+ * Copyright (c) 2023,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Remove the code where we tried out updateBy, which was not included in Jakarta Data 1.0, nor is there any expectation it will be added in a future release. Adjust test cases that were relying on it to either switch to an UPDATE Query method or the Update annotation.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
