### PR TITLE
Fix Netty websocket regression

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -51,6 +51,7 @@ import com.ibm.ws.http.netty.NettyHttpConstants;
 import com.ibm.ws.http.netty.NettyVirtualConnectionImpl;
 import com.ibm.ws.http.netty.message.NettyRequestMessage;
 import com.ibm.ws.http.netty.pipeline.RemoteIpHandler;
+import com.ibm.ws.http.netty.pipeline.inbound.LibertyHttpRequestHandler;
 import com.ibm.ws.netty.upgrade.NettyServletUpgradeHandler;
 import com.ibm.ws.transport.access.TransportConnectionAccess;
 import com.ibm.ws.transport.access.TransportConstants;
@@ -232,6 +233,10 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
                 nettyContext.channel().pipeline().addLast("ServletUpgradeHandler", upgradeHandler);
             } else { // In HTTP2
                 nettyContext.channel().pipeline().addBefore(nettyContext.channel().pipeline().context(http2Handler).name(), "ServletUpgradeHandler", upgradeHandler);
+            }
+            // In an upgrade, we don't expect to keep the request handler running so will remove this because it is HTTP 1.1 specific
+            if(nettyContext.channel().pipeline().get(LibertyHttpRequestHandler.class) != null){
+                nettyContext.channel().pipeline().remove(LibertyHttpRequestHandler.class);
             }
         }
     }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpRequestHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpRequestHandler.java
@@ -69,7 +69,15 @@ public class LibertyHttpRequestHandler extends SimpleChannelInboundHandler<FullH
         context.channel().attr(NettyHttpConstants.HANDLING_REQUEST).set(false);
         requestHandlerContext = context;
     }
-                  
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext context) {
+        FullHttpRequest request;
+        while ((request = requestQueue.poll()) != null) {
+            ReferenceCountUtil.safeRelease(request);
+        }
+    }
+
     @Override
     public void channelInactive(ChannelHandlerContext context) throws Exception{
         FullHttpRequest request;

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/TransportHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/TransportHandler.java
@@ -10,6 +10,7 @@
 package io.openliberty.http.netty.channel;
 
 import com.ibm.ws.http.netty.NettyHttpConstants;
+import com.ibm.ws.http.netty.pipeline.inbound.LibertyHttpRequestHandler;
 import com.ibm.ws.netty.upgrade.NettyServletUpgradeHandler;
 
 import io.netty.channel.ChannelDuplexHandler;
@@ -70,6 +71,7 @@ public final class TransportHandler extends ChannelDuplexHandler{
                 pipeline.remove(TransportHandler.this);
                 removeIfPresent(pipeline, HttpServerCodec.class);
                 removeIfPresent(pipeline, TimeoutHandler.class);
+                removeIfPresent(pipeline, LibertyHttpRequestHandler.class);
 
                 if(pipeline.get(NettyServletUpgradeHandler.class) == null){
                     pipeline.addLast(new NettyServletUpgradeHandler(context.channel()));


### PR DESCRIPTION
Added fix for websocket on peer connection closed for http 1.1 pipelining changes introduced in https://github.com/OpenLiberty/open-liberty/pull/32443