### PR TITLE
fix NullPointerException in PolicyAndExecutor

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/PolicyAndExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/PolicyAndExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,7 +56,7 @@ class PolicyAndExecutor {
             b.append(policy.getClass().getName()).append('@') //
                             .append(Integer.toHexString(policy.hashCode()));
         b.append(", ");
-        if (policy == null)
+        if (executor == null)
             b.append("null");
         else
             b.append(executor.getClass().getName()).append('@')//


### PR DESCRIPTION
NullPointerException observed in internal trace, when invoking PolicyAndExecutor.toString on an instance that has a null `executor` field. It is not known that there is any way for users to directly invoke the toString on this instance and the failure that occurs indirectly appears to be caught be Liberty trace rather than being surfaced to the user.

```
[8/20/25, 14:37:13:064 PDT] 0000002d id=e9a52c83 com.ibm.ws.concurrent.internal.ManagedExecutorServiceImpl    > getNormalPolicyExecutor Entry  
                                                                                                               <Exception java.lang.NullPointerException: Cannot invoke "java.lang.Object.getClass()" because "this.executor" is null caught while calling toString() on object java.util.concurrent.atomic.AtomicReference@743e25a6>
```

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
