### PR TITLE
Fix Jwt InvalidKeyException occurring in IBM JDK 8 FIPS 140-3 tests

### DIFF
--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
@@ -2151,9 +2151,9 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
     @Test
     public void JwtBuilderAPIConfigTests_encryption_invalidKeyMgmtKeyAlg_goodAlias_goodContentEncryptAlg() throws Exception {
 
-        String builderId = builderServer.isFIPS140_3EnabledAndSupported() ? "key_encrypt_good_ES256_bad_keyMgmtKey" : "key_encrypt_good_RS256_bad_keyMgmtKey";
-        String keyMgmtKeyAlg = builderServer.isFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.KEY_MGMT_KEY_ALG_ES : JWTBuilderConstants.DEFAULT_KEY_MGMT_KEY_ALG;
-        String sigAlg = builderServer.isFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.SIGALG_ES256 : JWTBuilderConstants.SIGALG_RS256;
+        String builderId = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? "key_encrypt_good_ES256_bad_keyMgmtKey" : "key_encrypt_good_RS256_bad_keyMgmtKey";
+        String keyMgmtKeyAlg = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.KEY_MGMT_KEY_ALG_ES : JWTBuilderConstants.DEFAULT_KEY_MGMT_KEY_ALG;
+        String sigAlg = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.SIGALG_ES256 : JWTBuilderConstants.SIGALG_RS256;
 
         JSONObject expectationSettings = BuilderHelpers.setDefaultClaimsWithEncryption(keyMgmtKeyAlg, JWTBuilderConstants.DEFAULT_CONTENT_ENCRYPT_ALG);
 
@@ -2186,9 +2186,9 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
     @Test
     public void JwtBuilderAPIConfigTests_encryption_missingKeyMgmtKeyAlg_goodAlias_goodContentEncryptAlg() throws Exception {
 
-        String builderId = builderServer.isFIPS140_3EnabledAndSupported() ? "key_encrypt_good_ES256_missing_keyMgmtKey" : "key_encrypt_good_RS256_missing_keyMgmtKey";
-        String keyMgmtKeyAlg = builderServer.isFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.KEY_MGMT_KEY_ALG_ES : JWTBuilderConstants.DEFAULT_KEY_MGMT_KEY_ALG;
-        String sigAlg = builderServer.isFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.SIGALG_ES256 : JWTBuilderConstants.SIGALG_RS256;
+        String builderId = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? "key_encrypt_good_ES256_missing_keyMgmtKey" : "key_encrypt_good_RS256_missing_keyMgmtKey";
+        String keyMgmtKeyAlg = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.KEY_MGMT_KEY_ALG_ES : JWTBuilderConstants.DEFAULT_KEY_MGMT_KEY_ALG;
+        String sigAlg = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.SIGALG_ES256 : JWTBuilderConstants.SIGALG_RS256;
 
         JSONObject expectationSettings = BuilderHelpers.setDefaultClaimsWithEncryption(keyMgmtKeyAlg, JWTBuilderConstants.DEFAULT_CONTENT_ENCRYPT_ALG);
 

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderApiBasicTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderApiBasicTests.java
@@ -7026,8 +7026,8 @@ public class JwtBuilderApiBasicTests extends CommonSecurityFat {
     public void JwtBuilderAPIBasicTests_encryptWith_nullKeyMgmtKeyAlg_publicKey_A256GCM() throws Exception {
 
         String builderId = "jwt1";
-        String keyMgmtKeyAlg = builderServer.isFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.KEY_MGMT_KEY_ALG_ES : JWTBuilderConstants.DEFAULT_KEY_MGMT_KEY_ALG;
-        String sigAlg = builderServer.isFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.SIGALG_ES256 : JWTBuilderConstants.SIGALG_RS256;
+        String keyMgmtKeyAlg = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.KEY_MGMT_KEY_ALG_ES : JWTBuilderConstants.DEFAULT_KEY_MGMT_KEY_ALG;
+        String sigAlg = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.SIGALG_ES256 : JWTBuilderConstants.SIGALG_RS256;
         Log.info(thisClass, "Key Management", "key management alg:" + keyMgmtKeyAlg);
 
         JSONObject expectationSettings = BuilderHelpers.setDefaultClaimsWithEncryption(keyMgmtKeyAlg, JWTBuilderConstants.DEFAULT_CONTENT_ENCRYPT_ALG);
@@ -7055,9 +7055,9 @@ public class JwtBuilderApiBasicTests extends CommonSecurityFat {
     @Test
     public void JwtBuilderAPIBasicTests_encryptWith_nullKeyMgmtKeyAlg_goodBuilderConfig() throws Exception {
 
-        String builderId = builderServer.isFIPS140_3EnabledAndSupported() ? "encryptJwtES256" : "encryptJwtRS256";
-        String keyMgmtKeyAlg = builderServer.isFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.KEY_MGMT_KEY_ALG_ES : JWTBuilderConstants.DEFAULT_KEY_MGMT_KEY_ALG;
-        String sigAlg = builderServer.isFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.SIGALG_ES256 : JWTBuilderConstants.SIGALG_RS256;
+        String builderId = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? "encryptJwtES256" : "encryptJwtRS256";
+        String keyMgmtKeyAlg = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.KEY_MGMT_KEY_ALG_ES : JWTBuilderConstants.DEFAULT_KEY_MGMT_KEY_ALG;
+        String sigAlg = builderServer.isSemeruFIPS140_3EnabledAndSupported() ? JWTBuilderConstants.SIGALG_ES256 : JWTBuilderConstants.SIGALG_RS256;
         JSONObject expectationSettings = BuilderHelpers.setDefaultClaimsWithEncryption(keyMgmtKeyAlg, JWTBuilderConstants.DEFAULT_CONTENT_ENCRYPT_ALG);
 
         // create settings that will be passed to the test app as well as used to create what to expect in the results

--- a/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.commonTest/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/noOP/NoOPEncryptionRSServerTests.java
+++ b/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.commonTest/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/noOP/NoOPEncryptionRSServerTests.java
@@ -794,11 +794,13 @@ public class NoOPEncryptionRSServerTests extends MangleJWTTestTools {
     @Test
     public void NoOPEncryption1ServerTests_consumeTokenThatWasEncryptedUsingOtherContentEncryptionAlg() throws Exception {
 
+        String sigAlg = testOPServer.getServer().isSemeruFIPS140_3EnabledAndSupported() ? JwtConstants.SIGALG_ES256 : JwtConstants.SIGALG_RS256;
+
         List<NameValuePair> parms = new ArrayList<NameValuePair>();
         parms.add(new NameValuePair(JwtConstants.PARAM_CONTENT_ENCRYPT_ALG, JwtConstants.CONTENT_ENCRYPT_ALG_192));
-        parms.add(new NameValuePair(JwtConstants.PARAM_ENCRYPT_KEY, JwtKeyTools.getComplexPublicKeyForSigAlg(testOPServer.getServer(), JwtConstants.SIGALG_RS256)));
+        parms.add(new NameValuePair(JwtConstants.PARAM_ENCRYPT_KEY, JwtKeyTools.getComplexPublicKeyForSigAlg(testOPServer.getServer(), sigAlg)));
 
-        genericEncryptTest(Constants.SIGALG_RS256, Constants.SIGALG_RS256, parms);
+        genericEncryptTest(sigAlg, sigAlg, parms);
     }
 
     /**

--- a/dev/com.ibm.ws.security.social_fat/fat/src/com/ibm/ws/security/social/fat/commonTests/Social_EncryptionTests.java
+++ b/dev/com.ibm.ws.security.social_fat/fat/src/com/ibm/ws/security/social/fat/commonTests/Social_EncryptionTests.java
@@ -765,13 +765,13 @@ public class Social_EncryptionTests extends SocialCommonTest {
      * @throws Exception
      */
     @Test
-    public void Social_EncryptionTests_consumeTokenThatWasEncryptedUsingOtherContentEncryptionAlg() throws Exception {
+	public void Social_EncryptionTests_consumeTokenThatWasEncryptedUsingOtherContentEncryptionAlg() throws Exception {
+		String sigAlg = testOPServer.getServer().isSemeruFIPS140_3EnabledAndSupported() ? JwtConstants.SIGALG_ES256 : JwtConstants.SIGALG_RS256;
+		List<endpointSettings> parms = eSettings.addEndpointSettingsIfNotNull(null, JwtConstants.PARAM_CONTENT_ENCRYPT_ALG, JwtConstants.CONTENT_ENCRYPT_ALG_192);
+		parms = eSettings.addEndpointSettingsIfNotNull(parms, JwtConstants.PARAM_ENCRYPT_KEY, JwtKeyTools.getComplexPublicKeyForSigAlg(testOPServer.getServer(), sigAlg));
 
-        List<endpointSettings> parms = eSettings.addEndpointSettingsIfNotNull(null, JwtConstants.PARAM_CONTENT_ENCRYPT_ALG, JwtConstants.CONTENT_ENCRYPT_ALG_192);
-        parms = eSettings.addEndpointSettingsIfNotNull(parms, JwtConstants.PARAM_ENCRYPT_KEY, JwtKeyTools.getComplexPublicKeyForSigAlg(testOPServer.getServer(), JwtConstants.SIGALG_RS256));
-
-        genericEncryptTest(SocialConstants.SIGALG_RS256, SocialConstants.SIGALG_RS256, parms);
-    }
+		genericEncryptTest(sigAlg, sigAlg, parms);
+	}
 
     /**
      * Show that the Social Client can accept a token built specifying RSA_OAEP_256 (instead of RSA-OAEP) in the


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

----

**Description**
- Mismatch between the FIPS check in engine and in test code
- In the engine, CryptoUtils.isFips140_3EnabledWithBetaGuard() is used to set the default key management algorithm
- In the test case, LibertyServer.isFIPS140_3EnabledAndSupported is used to get the key
- With FIPS 140-3 enabled on IBM JDK 8 the engine returns false due to the beta guard (returning RSA-OAEP), but the test case tries to use an EC key due to FIPS enabled check.

**Solution**
- Update test case to use LibertyServer.isSemeruFIPS140_3EnabledAndSupported() which will set EC key only if running IBM Semeru.
