### PR TITLE
Re-enable GC event tests on zOS

### DIFF
--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -507,10 +507,7 @@ public class LogstashSSLTest extends LogstashCollectorTest {
             || System.getProperty("java.vendor.url").toLowerCase().contains("sun") || !healthCenterInstalled) {
             return true;
         }
-        // Skip zOS temporary as zOS JDK has a bug that does not return any GC information.
-        if (os.contains("os/390") || os.contains("z/os") || os.contains("zos")) {
-            return true;
-        }
+
         return false;
     }
 


### PR DESCRIPTION
fixes #15454

Re-enables GC event tests on z/OS by removing the temporary skip that was added in PR #15439

The z/OS JDK has now been upgraded to JDK8 SR5 FP30, which fixes the bug that was causing GC event tests to fail on z/OS. 
