### PR TITLE
Override virtual=true on ManagedScheduledExecutor

### DIFF
--- a/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent/resources/com/ibm/ws/concurrent/resources/CWWKCMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2012, 2020 IBM Corporation and others.
+# Copyright (c) 2012, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -61,6 +61,12 @@ CWWKC1102.listener.failed.useraction=Correct the cause of the failure and decide
 CWWKC1103.skip.run.failed=CWWKC1103E: Execution of task {0}, which was submitted to executor service {1}, is skipped because the Trigger.skipRun operation failed with the following error: {2}.
 CWWKC1103.skip.run.failed.explanation=The skipRun operation for the Trigger has failed, causing the current execution attempt for the task to be skipped.
 CWWKC1103.skip.run.failed.useraction=Correct the cause of the failure and decide whether or not to resubmit the task.
+
+CWWKC1108.override.virtual=CWWKC1108I: The {0} managed thread factory will create \
+ platform threads because virtual thread creation by the Liberty server is disabled.
+CWWKC1108.override.virtual.explanation=The ThreadTypeOverride SPI disabled \
+ creation of virtual threads by the Liberty server.
+CWWKC1108.override.virtual.useraction=No action is necessary.
 
 CWWKC1110.task.canceled=CWWKC1110I: The {0} task, which was submitted to the {1} executor service, is canceled.
 CWWKC1110.task.canceled.explanation=The task was canceled.

--- a/dev/com.ibm.ws.concurrent_fat_no_vt/fat/src/test/concurrent/no/vt/ConcurrentVirtualThreadsDisabledTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_no_vt/fat/src/test/concurrent/no/vt/ConcurrentVirtualThreadsDisabledTest.java
@@ -12,6 +12,11 @@
  *******************************************************************************/
 package test.concurrent.no.vt;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -36,6 +41,24 @@ public class ConcurrentVirtualThreadsDisabledTest extends FATServletClient {
                  contextRoot = "ConcurrentNoVTWeb")
     public static LibertyServer server;
 
+    /**
+     * Asserts that a String within the list contains the substring.
+     *
+     * @param substring text to search for.
+     * @param list      strings to search.
+     */
+    private static void assertContains(String substring, List<String> list) {
+        boolean found = false;
+        for (String item : list)
+            if (item.contains(substring)) {
+                found = true;
+                break;
+            }
+
+        if (!found)
+            fail("Expected item with substring " + substring + " in " + list);
+    }
+
     @BeforeClass
     public static void setUp() throws Exception {
         WebArchive ConcurrentNoVTWeb = ShrinkHelper
@@ -50,6 +73,36 @@ public class ConcurrentVirtualThreadsDisabledTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        try {
+            List<String> mtfMessages = server.findStringsInLogs("CWWKC1108I");
+
+            assertContains("concurrent/ServerXMLThreadFactoryToOverride",
+                           mtfMessages);
+            assertContains("java:comp/concurrent/WebXMLThreadFactoryToOverride",
+                           mtfMessages);
+            assertContains("java:module/concurrent/AnnoThreadFactoryToOverride",
+                           mtfMessages);
+
+            assertEquals(mtfMessages.toString(), 3, mtfMessages.size());
+
+            List<String> policyMessages = server.findStringsInLogs("CWWKE1208I");
+
+            assertContains("application[ConcurrentNoVTWeb]/managedScheduledExecutorService[java:app/concurrent/AnnoScheduledExecutorToOverride]/concurrencyPolicy",
+                           policyMessages);
+            assertContains("application[ConcurrentNoVTWeb]/module[ConcurrentNoVTWeb.war]/managedExecutorService[java:comp/concurrent/AnnoExecutorToOverride]/concurrencyPolicy",
+                           policyMessages);
+            assertContains("application[ConcurrentNoVTWeb]/module[ConcurrentNoVTWeb.war]/managedScheduledExecutorService[java:module/concurrent/WebXMLScheduledExecutorToOverride]/concurrencyPolicy",
+                           policyMessages);
+            assertContains("managedExecutorService[executorToOverride]/concurrencyPolicy[default-0]",
+                           policyMessages);
+            assertContains("managedExecutorService[java:global/concurrent/WebXMLExecutorToOverride]/concurrencyPolicy",
+                           policyMessages);
+            assertContains("virtualThreadPolicyToOverride",
+                           policyMessages);
+
+            assertEquals(policyMessages.toString(), 6, policyMessages.size());
+        } finally {
+            server.stopServer();
+        }
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_no_vt/publish/servers/com.ibm.ws.concurrent.fat.no.vt/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_no_vt/publish/servers/com.ibm.ws.concurrent.fat.no.vt/server.xml
@@ -23,11 +23,24 @@
 
   <application location="ConcurrentNoVTWeb.war"/>
 
-  <managedExecutorService jndiName="concurrent/ServerXMLExecutorToOverride"
-                          virtual="true"/>
+  <concurrencyPolicy
+    id="virtualThreadPolicyToOverride"
+    max="3"
+    virtual="true"/>
 
-  <managedThreadFactory jndiName="concurrent/ServerXMLThreadFactoryToOverride"
-                        virtual="true"/>
+  <managedExecutorService
+    id="executorToOverride"
+    jndiName="concurrent/ServerXMLExecutorToOverride">
+    <concurrencyPolicy virtual="true"/>
+  </managedExecutorService>
+
+  <managedScheduledExecutorService
+    jndiName="concurrent/ServerXMLScheduledExecutorToOverride"
+    concurrencyPolicyRef="virtualThreadPolicyToOverride"/>
+
+  <managedThreadFactory
+    jndiName="concurrent/ServerXMLThreadFactoryToOverride"
+    virtual="true"/>
 
   <!-- allows application to shut down a pool of unmanaged threads -->
   <javaPermission codebase="${server.config.dir}/apps/ConcurrentNoVTWeb.war"

--- a/dev/com.ibm.ws.threading/resources/com/ibm/ws/threading/internal/resources/ThreadingMessages.nlsprops
+++ b/dev/com.ibm.ws.threading/resources/com/ibm/ws/threading/internal/resources/ThreadingMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015 IBM Corporation and others.
+# Copyright (c) 2015,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -65,3 +65,9 @@ CWWKE1206.quiesce.timeout.not.valid.useraction=Edit the 'server.xml' file and ch
 CWWKE1207.threads.hung.pool.cannot.grow=CWWKE1207W:  All threads in the Liberty default executor appear to be hung, and no more threads can be added because the pool size has reached its limit.  The current pool size is {0}.
 CWWKE1207.threads.hung.pool.cannot.grow.explanation=All default executor threads are busy, the threads have not completed any tasks recently, and tasks are waiting in queue. No more threads can be added because the pool size has reached its limit.  
 CWWKE1207.threads.hung.pool.cannot.grow.useraction=Determine if there is a bottleneck, such as a locked database table, that might prevent threads from completing their tasks. If there is no bottleneck and the server just needs more threads, adjust the coreThreads and maxThreads attributes of the executor configuration element.
+
+CWWKE1208.override.virtual=CWWKE1208I: The {0} concurrency policy will create \
+ platform threads because virtual thread creation by the Liberty server is disabled.
+CWWKE1208.override.virtual.explanation=The ThreadTypeOverride SPI disabled \
+ creation of virtual threads by the Liberty server.
+CWWKE1208.override.virtual.useraction=No action is necessary.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -1548,6 +1548,11 @@ public class PolicyExecutorImpl implements PolicyExecutor {
                 throw new IllegalArgumentException("virtual: true");
             } else if (!virtualThreadOps.isVirtualThreadCreationEnabled()) {
                 useVirtualThreads = false;
+                String identifierProp = props.containsKey("config.parentPID") //
+                                ? "config.displayId" //
+                                : "id";
+                Tr.info(tc, "CWWKE1208.override.virtual",
+                        props.get(identifierProp));
             }
         }
 


### PR DESCRIPTION
The SPI to override virtual thread creation should apply to ManagedScheduledExecutor.
A second commit covers the requirement to log an informational message when overriding the virtual=true setting.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
