### PR TITLE
Update Java 25 FAT with GA WAR

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -66,7 +66,7 @@ io.openliberty:java-apps:21.0.0
 io.openliberty:java-apps:22.1.0
 io.openliberty:java-apps:23.1.0
 io.openliberty:java-apps:24.1.0
-io.openliberty:java-apps:25.0.0
+io.openliberty:java-apps:25.1.0
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0

--- a/dev/io.openliberty.java.internal_fat/build.gradle
+++ b/dev/io.openliberty.java.internal_fat/build.gradle
@@ -32,7 +32,7 @@ configurations {
     app22 'io.openliberty:java-apps:22.1.0'
     app23 'io.openliberty:java-apps:23.1.0'
     app24 'io.openliberty:java-apps:24.1.0'
-    app25 'io.openliberty:java-apps:25.0.0'
+    app25 'io.openliberty:java-apps:25.1.0'
  }
 
 task copyKernelService(type: Copy) {


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

The Java 25 specific FAT was compiled against the EA version of Java 25.  Once Java 25 becomes GA, we need to recompile the WAR file used in the FAT with the GA version of Java 25 and update the WAR file in our repositories.

Note:
```
io.openliberty:java-apps:25.0.0 -> WAR file compiled with EA version of Java 25
io.openliberty:java-apps:25.1.0 -> WAR file compiled with GA version of Java 25
```

Previous request for Java 24 for reference -> https://github.com/OpenLiberty/open-liberty/pull/31029