### PR TITLE
Update SHA512 message digest alg - com.ibm.ws.ui, ui_rest_fat

### DIFF
--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/utils/Utils.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/utils/Utils.java
@@ -33,6 +33,7 @@ import com.ibm.wsspi.rest.handler.RESTRequest;
 
 /**
  * This class is designed to hold utility methods that different parts of the server side UI will need to use.
+ * The algorithm assessment of FIPS 140-3 by updating SHA512 message digest algorithm is based on slack discussion with component SMEs.
  */
 public class Utils {
     private static final TraceComponent tc = Tr.register(Utils.class);
@@ -40,7 +41,7 @@ public class Utils {
 
     static {
         try {
-            messagedigest = CryptoUtils.isFips140_3EnabledWithBetaGuard() ? MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256) : MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_MD5);
+            messagedigest = MessageDigest.getInstance(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_512);
         } catch (NoSuchAlgorithmException e) {
             //should not happen
             throw new RuntimeException(e);
@@ -118,12 +119,12 @@ public class Utils {
     }
 
     /**
-     * Generates the md5 checksum of the given string
+     * Generates the sha512 checksum of the given string
      *
      * @param str The input string
-     * @return The MD5 checksum of the given string.
+     * @return The SHA512 checksum of the given string.
      */
-    public synchronized static String getMD5String(String str) {
+    public synchronized static String getSHA512String(String str) {
         byte[] hash;
         try {
             hash = messagedigest.digest(str.getBytes(StandardCharsets.UTF_8));

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/ToolDataAPITest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/rest/v1/ToolDataAPITest.java
@@ -47,7 +47,7 @@ import com.ibm.wsspi.rest.handler.RESTResponse;
 import test.common.SharedOutputManager;
 
 /**
- *
+ * The algorithm assessment of FIPS 140-3 by updating SHA512 checksum is based on slack discussion with component SMEs.
  */
 public class ToolDataAPITest {
     static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
@@ -76,10 +76,10 @@ public class ToolDataAPITest {
     private final ToolEntry toolEntry2 = new ToolEntry(tool2, ITool.TYPE_FEATURE_TOOL);
     private final ToolEntry toolEntry3 = new ToolEntry(tool3, ITool.TYPE_BOOKMARK);
     private final String message = "{\"key\":\"value\"}";
-    private final String messageMD5 = "a7353f7cddce808de0032747a0b7be50";
+    private final String messageSHA512 = "0213f898602b6a489de25f20d8d32c3dbf3d6fee0fbe468f89ac803874ac846f8cd239294a78c2bddf3e0988acb8cd3d00e067a981c9c7933b43a42d3b273eae";
 
     private final String message2 = "{\"key\":\"value1\"}";
-    private final String message2MD5 = "9ecb15df65a2ceddcb3b2c726f5aa522";
+    private final String message2SHA512 = "30a9c1549c94169bc284e21ea24d49084b1d661d01a8f6c194b7823bcad429da2aafae945b6a1573994234806fb6000ca092718e8b92c02b062223650e6817e1";
 
     private final String url = "ibm/api/adminCenter/v1/tooldata";
     private final String createdURL = url + "/tool1";
@@ -201,7 +201,7 @@ public class ToolDataAPITest {
                 one(mockToolDataService).getToolData(USER_ID, "tool1");
                 will(returnValue(message));
 
-                one(restResponse).setResponseHeader("ETag", messageMD5);
+                one(restResponse).setResponseHeader("ETag", messageSHA512);
             }
         });
         assertSame("Did not get back the the same message which should have been returned by the mock",
@@ -302,7 +302,7 @@ public class ToolDataAPITest {
                 one(restRequest).getURL();
                 will(returnValue(url));
 
-                one(restResponse).setResponseHeader("ETag", messageMD5);
+                one(restResponse).setResponseHeader("ETag", messageSHA512);
             }
         });
         POSTResponse response = handler.postChild(restRequest, restResponse, "tool1");
@@ -361,7 +361,7 @@ public class ToolDataAPITest {
                 will(returnValue(false));
 
                 one(restRequest).getHeader("If-Match");
-                will(returnValue(messageMD5));
+                will(returnValue(messageSHA512));
             }
         });
         try {
@@ -412,7 +412,7 @@ public class ToolDataAPITest {
                 will(returnValue(true));
 
                 one(restRequest).getHeader("If-Match");
-                will(returnValue(messageMD5));
+                will(returnValue(messageSHA512));
 
                 one(mockToolDataService).getToolData(USER_ID, "tool1");
                 will(returnValue(message));
@@ -448,7 +448,7 @@ public class ToolDataAPITest {
                 will(returnValue(true));
 
                 one(restRequest).getHeader("If-Match");
-                will(returnValue(messageMD5));
+                will(returnValue(messageSHA512));
 
                 one(mockToolDataService).getToolData(USER_ID, "tool1");
                 will(returnValue(message));
@@ -462,7 +462,7 @@ public class ToolDataAPITest {
                 one(mockToolDataService).addToolData(USER_ID, "tool1", message2);
                 will(returnValue(message2));
 
-                one(restResponse).setResponseHeader("ETag", message2MD5);
+                one(restResponse).setResponseHeader("ETag", message2SHA512);
             }
         });
         Object obj = handler.putChild(restRequest, restResponse, "tool1");

--- a/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/UtilsTest.java
+++ b/dev/com.ibm.ws.ui/test/com/ibm/ws/ui/internal/v1/utils/UtilsTest.java
@@ -48,8 +48,11 @@ public class UtilsTest {
         Utils.getURL("tp:/.ibm.com");
     }
 
+   /**
+    * The algorithm assessment of FIPS 140-3 by updating SHA512 checksum is based on slack discussion with component SMEs. 
+    */
     @Test
-    public void md5Test() {
-        assertEquals("MD5 encoding not working", "9EC5C2C0F355B0B1EA8319C9FCD6E44F".toLowerCase(), Utils.getMD5String("Test MD5 String"));
+    public void sha512Test() {
+        assertEquals("SHA512 encoding not working", "298bd4e66fec7b0c116bb0ab9858e450b176c07f8b151fdfa083bf775cc258668e93fc8e2ae412939a35062aa712ee484b307690d043ee59d489d27ca0dcddc9".toLowerCase(), Utils.getSHA512String("Test SHA512 String"));
     }
 }

--- a/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/TooldataAPIv1Test.java
+++ b/dev/com.ibm.ws.ui_rest_fat/fat/src/com/ibm/ws/ui/fat/rest/v1/TooldataAPIv1Test.java
@@ -39,7 +39,7 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 /**
- *
+ * The algorithm assessment of FIPS 140-3 by updating SHA512 checksum is based on slack discussion with component SMEs.
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
@@ -50,8 +50,8 @@ public class TooldataAPIv1Test extends CommonRESTTest implements APIConstants {
     private final String tooldataExploreEntryURL = API_V1_TOOLDATA + "/com.ibm.websphere.appserver.adminCenter.tool.explore";
     private final String dataString = "{\"key\":\"value\"}";
     private final String dataString1 = "{\"key\":\"value1\"}";
-    private final String etagCheckSum1 = isFIPSEnabledOnServer() ? "e43abcf3375244839c012f9633f95862d232a95b00d5bc7348b3098b9fed7f32" : "a7353f7cddce808de0032747a0b7be50";
-    private final String etagCheckSum2 = isFIPSEnabledOnServer() ? "dfada72ccc2244e8c7aef8f0dbe7c026a6553bc5bda3f7654f3d0b94dd51a23b" : "9ecb15df65a2ceddcb3b2c726f5aa522";
+    private final String etagCheckSum1 = "0213f898602b6a489de25f20d8d32c3dbf3d6fee0fbe468f89ac803874ac846f8cd239294a78c2bddf3e0988acb8cd3d00e067a981c9c7933b43a42d3b273eae";
+    private final String etagCheckSum2 = "30a9c1549c94169bc284e21ea24d49084b1d661d01a8f6c194b7823bcad429da2aafae945b6a1573994234806fb6000ca092718e8b92c02b062223650e6817e1";
 
     public TooldataAPIv1Test() {
         super(c);
@@ -265,20 +265,6 @@ public class TooldataAPIv1Test extends CommonRESTTest implements APIConstants {
 
         // make sure etag is correct
         assertEquals("Unexpected etag value.", expectedETagValue, list.get(0));
-    }
-
-    /**
-     * Determine if FIPS is enabled and supported on the test server
-     * Determines which etag checksum will be used for validation:
-     * MD5 when FIPS 140-3 is disabled, and SHA256 when FIPS 140-3 is enabled
-     */
-    private boolean isFIPSEnabledOnServer() {
-        try {
-            return FATSuite.server.isFIPS140_3EnabledAndSupported();
-        } catch (IOException e) {
-            e.printStackTrace();
-            return false;
-        }
     }
 
 }


### PR DESCRIPTION
Update with message digest hash algorithm (SHA512), which works for both FIPS enabled and No-FIPS.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).


