### PR TITLE
Update fats to indicate they require Java 11

### DIFF
--- a/dev/com.ibm.ws.transaction.cloud_fat.db2.6/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.db2.6/bnd.bnd
@@ -18,6 +18,9 @@ src: \
 
 fat.project: true
 
+# The FATSuite does EE 10 repeat which requires Java 11
+fat.minimum.java.level=11
+
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.6/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.6/bnd.bnd
@@ -18,6 +18,9 @@ src: \
 
 fat.project: true
 
+# The FATSuite does EE 10 repeat which requires Java 11
+fat.minimum.java.level=11
+
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\

--- a/dev/com.ibm.ws.transaction.cloud_fat.oracle.6/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.oracle.6/bnd.bnd
@@ -18,6 +18,9 @@ src: \
 
 fat.project: true
 
+# The FATSuite does EE 10 repeat which requires Java 11
+fat.minimum.java.level=11
+
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\

--- a/dev/com.ibm.ws.transaction.cloud_fat.postgresql.6/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.postgresql.6/bnd.bnd
@@ -18,6 +18,9 @@ src: \
 
 fat.project: true
 
+# The FATSuite does EE 10 repeat which requires Java 11
+fat.minimum.java.level=11
+
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\

--- a/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.6/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.6/bnd.bnd
@@ -18,6 +18,9 @@ src: \
 
 fat.project: true
 
+# The FATSuite does EE 10 repeat which requires Java 11
+fat.minimum.java.level=11
+
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, servlet-4.0 is added programmatically at runtime by the RepeatTests rule.
 tested.features:\


### PR DESCRIPTION
- The fat buckets only do a EE 10 repeat which requires Java 11.  Since the property is not set to say minimum Java as being 11, it will still try to run on Java 8 and run 0 tests which is not allowed

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".