### PR TITLE
 Increase app undeploy timeout in io.openliberty.jakarta.validation.3.1_fat_tck

### DIFF
--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
@@ -14,6 +14,7 @@ package io.openliberty.jakarta.validation.tck;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.time.Duration;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -103,6 +104,7 @@ public class ValidationTckLauncher {
                         .withPlatfromVersion("11")
                         .withSuiteFileName("tck-tests.xml")
                         .withAdditionalMvnProps(additionalProps)
+                        .withAppUndeployTimeout(Duration.ofSeconds(120))
                         .runTCK();
     }
 }

--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
 			<property name="httpPort">${tck_port}</property>
 			<property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
 			<property name="appDeployTimeout">${tck_appDeployTimeout}</property>
-			<property name="appUndeployTimeout">${tck_appUndeployTimeout}</property>
+			<property name="appUndeployTimeout">120</property>
 			<property name="allowConnectingToRunningServer">true</property>
 		</configuration>
 	</container>

--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
 			<property name="httpPort">${tck_port}</property>
 			<property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
 			<property name="appDeployTimeout">${tck_appDeployTimeout}</property>
-			<property name="appUndeployTimeout">120</property>
+			<property name="appUndeployTimeout">${tck_appUndeployTimeout}</property>
 			<property name="allowConnectingToRunningServer">true</property>
 		</configuration>
 	</container>


### PR DESCRIPTION
Increasing app undeploy timeout


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Issue https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=302022

arquillianAfterClass:org.jboss.arquillian.container.spi.client.container.DeploymentException: Exception while undeploying application.

Fix: Increasing app undeploy timeout in io.openliberty.jakarta.validation.3.1_fat_tck