### PR TITLE
Replace `SHA256` with SHA-256 for JPA

### DIFF
--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/class_scanner/ano/EntityMappingsScannerResults.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/class_scanner/ano/EntityMappingsScannerResults.java
@@ -32,7 +32,7 @@ import com.ibm.ws.jpa.diagnostics.class_scanner.ano.jaxb.classinfo10.ClassInform
 import com.ibm.ws.common.crypto.CryptoUtils;
 
 public class EntityMappingsScannerResults {
-    private final String shaDigestAlg = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    private final String shaDigestAlg = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
     public static final String KEY_SHA256HASH = "SHA256HASH"; // Value is a String
     public static final String KEY_CITXML = "CITXML";   // Value is byte[]
     

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/ormparser/Constants.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/ormparser/Constants.java
@@ -17,7 +17,7 @@ import com.ibm.ws.common.crypto.CryptoUtils;
 
 public final class Constants {
     public final static String JVM_Property_ORMXML_DIGEST_ALGORITHM = "jpaormviewer.ormxml.digest.algorithm";
-    public final static String DEFAULT_DIGEST_ALGORITHM = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    public final static String DEFAULT_DIGEST_ALGORITHM = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
 
     public final static String JPA_10_JAXB_PACKAGE = "com.ibm.ws.jpa.diagnostics.ormparser.jaxb.orm10xml";
     public final static String JPA_20_JAXB_PACKAGE = "com.ibm.ws.jpa.diagnostics.ormparser.jaxb.orm20xml";

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puparser/Constants.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/puparser/Constants.java
@@ -17,7 +17,7 @@ import com.ibm.ws.common.crypto.CryptoUtils;
 
 public final class Constants {
     public final static String JVM_Property_PXML_DIGEST_ALGORITHM = "jpaormviewer.pxml.digest.algorithm";
-    public final static String DEFAULT_DIGEST_ALGORITHM = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    public final static String DEFAULT_DIGEST_ALGORITHM = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
 
     public final static String JPA_10_JAXB_PACKAGE = "com.ibm.ws.jpa.diagnostics.puparser.jaxb.puxml10";
     public final static String JPA_20_JAXB_PACKAGE = "com.ibm.ws.jpa.diagnostics.puparser.jaxb.puxml20";

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/utils/encapsulation/EncapsulatedData.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics/src/com/ibm/ws/jpa/diagnostics/utils/encapsulation/EncapsulatedData.java
@@ -44,9 +44,9 @@ import com.ibm.ws.common.crypto.CryptoUtils;
 import com.ibm.ws.common.crypto.CryptoUtils;
 
 public class EncapsulatedData {
-    private final String shaDigestAlg = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
+    private final String shaDigestAlg = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
     public static EncapsulatedData createEncapsulatedData(String name, String id, byte[] data) throws Exception {
-        return createEncapsulatedData(name, id, CompressionType.GZIP, CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256, data);
+        return createEncapsulatedData(name, id, CompressionType.GZIP, CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256, data);
     }
 
     public static EncapsulatedData createEncapsulatedData(String name, String id, CompressionType ct,


### PR DESCRIPTION
In Open JDK 8 distributions (IBM and Oracle Java 8 distributions are unaffected) `SHA256` does not seem to be an available alias for `SHA-256`

Java 11 onwards has it as an alias in every distribution.

For Defect [305270](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=305270)
 
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
