### PR TITLE
Fips fattest simplicity envvar updates

### DIFF
--- a/dev/build.sharedResources/usrShared/resources/security/semeruFips140_3CustomProfile.properties
+++ b/dev/build.sharedResources/usrShared/resources/security/semeruFips140_3CustomProfile.properties
@@ -20,3 +20,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {SecretKeyFactory, PBEWithMD5AndDES, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Cipher, PBEWithHmacSHA256AndAES_256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}, \
     {Mac, HmacPBESHA256, *, ModuleAndFullClassName:java.base/sun.security.pkcs12.PKCS12KeyStore}]
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.5 = com.ibm.ws.collective.security.internal.provider.CollectiveProvider

--- a/dev/cnf/resources/bin/tool
+++ b/dev/cnf/resources/bin/tool
@@ -278,14 +278,25 @@ if [ -z "${JAVA_HOME}" ]; then
   JAVA_PATH_FROM_PATH=$(command -v java)
   if [ -n "${JAVA_PATH_FROM_PATH}" ] ; then
     JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $JAVA_PATH_FROM_PATH))/lib/modules
+    IBM_SDK_FIPS140_3_FILE_LOCATION=$(dirname "$(dirname "${JAVA_PATH_FROM_PATH}")")/jre/fips140-3
   fi
 else
   JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
+  IBM_SDK_FIPS140_3_FILE_LOCATION="${JAVA_HOME}/fips140-3"
 fi
 
 # If this is a Java 9 JDK, add some JDK 9 workarounds to the JVM_ARGS
 if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
   JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED ${JVM_ARGS}"
+fi
+
+# If ENABLE_FIPS140_3 is set by the user then add appropiate FIPS140-3 JVM options
+if [ -n "${ENABLE_FIPS140_3+set}" ]; then
+  if [ -d "${IBM_SDK_FIPS140_3_FILE_LOCATION}" ]; then
+    JVM_ARGS="-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS ${JVM_ARGS}"
+  else
+    JVM_ARGS="-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Custom -Djava.security.properties=${WLP_INSTALL_DIR}/lib/security/fips140-3/fips140_3Liberty.properties ${JVM_ARGS}"
+  fi
 fi
 
 # Prevent the Java invocation appearing as an application on a mac

--- a/dev/cnf/resources/bin/tool.bat
+++ b/dev/cnf/resources/bin/tool.bat
@@ -56,6 +56,23 @@ if NOT defined JAVA_HOME (
 @REM If this is a Java 9 JDK, add some JDK 9 workarounds to the JVM_ARGS
 if exist "%JAVA_HOME%\lib\modules" set JVM_ARGS=--add-opens java.base/java.lang=ALL-UNNAMED !JVM_ARGS!
 
+@REM If ENABLE_FIPS140_3 is specified and has a value, add FIPS140-3
+if defined ENABLE_FIPS140_3 (
+    @REM determine if we are using IBM SDK 8 with FIPS140-3 support
+    if exist "%JAVA_HOME%\fips140-3" set IBM_SDK_8=true
+    if NOT defined IBM_SDK_8 (
+      if exist "%JRE_HOME%\fips140-3" set IBM_SDK_8=true
+      if NOT defined IBM_SDK_8 (
+        if exist "%WLP_DEFAULT_JAVA_HOME%\jre\fips140-3" set IBM_SDK_8=true
+      )
+    )
+    if defined IBM_SDK_8 (
+        set JVM_ARGS=-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS !JVM_ARGS!
+    ) else (
+        set JVM_ARGS=-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Custom -Djava.security.properties=!WLP_INSTALL_DIR!\lib\security\fips140-3\fips140_3Liberty.properties !JVM_ARGS!
+    )
+)
+
 set JVM_ARGS=-Djava.awt.headless=true !JVM_ARGS!
 set TOOL_JAVA_CMD_QUOTED=!JAVA_CMD_QUOTED! !JVM_ARGS! -jar "!WLP_INSTALL_DIR!\bin\@TOOL_JAR@"
 

--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
@@ -391,27 +391,6 @@ clientEnvDefaults()
     fi
   fi
 
-  # If ENABLE_FIPS140_3 is set by the user then add appropiate FIPS140-3 JVM options
-  if [ -n "${ENABLE_FIPS140_3+set}" ]; then
-    # Inspect Java install to determine if IBM SDK 8 or Semeru
-    if [[ -d "${JAVA_HOME}/jre/fips140-3" || -d "${JAVA_HOME}/fips140-3" || -d "$(dirname $(dirname $(command -v java)))/jre/fips140-3" ]]; then
-      JVM_ARGS="${JVM_ARGS} -Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
-    else
-      # Retrieve the profile name from the last file in the property
-      regex='RestrictedSecurity\.([a-zA-Z0-9\.-]*)\.extends\s*?=.*'
-      files=(${ENABLE_FIPS140_3//:/ })
-      for file in $files; do
-        profileFile=$file
-      done
-      while read l; do
-        if [[ $l =~ $regex ]]; then
-          profile="${BASH_REMATCH[1]}"
-        fi
-      done < $profileFile
-      JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.properties=${ENABLE_FIPS140_3}"
-    fi
-  fi
-
   clientUmask
 }
 
@@ -462,6 +441,8 @@ clientEnvAndJVMOptions()
     mergeJVMOptions "${WLP_INSTALL_DIR}/lib/platform/java/java9.options"
   fi
 
+  enableFIPS140_3
+
   return $rc
 }
 
@@ -486,6 +467,29 @@ mergeJVMOptions()
         fi
       done
       IFS=$saveIFS
+    fi
+}
+
+enableFIPS140_3()
+{
+    if [ -n "${ENABLE_FIPS140_3+set}" ]; then
+      if [ -d "${JAVA_HOME}/jre/fips140-3" ] || [ -d "${JAVA_HOME}/fips140-3" ] || [ -d "$(dirname $(dirname $(command -v java)))/jre/fips140-3" ]; then
+        JVM_ARGS="${JVM_ARGS} -Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
+      else
+        saveIFS=$IFS
+        IFS=":"
+        for file in $ENABLE_FIPS140_3; do
+          profileFile=$file
+        done
+        IFS=$saveIFS
+        while read l; do
+          match=$(echo "$l" | sed -n 's/.*RestrictedSecurity\.\([a-zA-Z0-9\.-]*\)\.extends[[:space:]]*=.*/\1/p')
+          if [ -n "$match" ]; then
+            profile=$match
+          fi
+        done < $profileFile
+        JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.properties=${ENABLE_FIPS140_3}"
+      fi
     fi
 }
 

--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
@@ -390,7 +390,28 @@ clientEnvDefaults()
       JVM_ARGS="${JVM_ARGS} -Dfile.encoding=$defaultFileEncoding"
     fi
   fi
-  
+
+  # If ENABLE_FIPS140_3 is set by the user then add appropiate FIPS140-3 JVM options
+  if [ -n "${ENABLE_FIPS140_3+set}" ]; then
+    # Inspect Java install to determine if IBM SDK 8 or Semeru
+    if [[ -d "${JAVA_HOME}/jre/fips140-3" || -d "${JAVA_HOME}/fips140-3" || -d "$(dirname $(dirname $(command -v java)))/jre/fips140-3" ]]; then
+      JVM_ARGS="${JVM_ARGS} -Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
+    else
+      # Retrieve the profile name from the last file in the property
+      regex='RestrictedSecurity\.([a-zA-Z0-9\.-]*)\.extends\s*?=.*'
+      files=(${ENABLE_FIPS140_3//:/ })
+      for file in $files; do
+        profileFile=$file
+      done
+      while read l; do
+        if [[ $l =~ $regex ]]; then
+          profile="${BASH_REMATCH[1]}"
+        fi
+      done < $profileFile
+      JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.properties=${ENABLE_FIPS140_3}"
+    fi
+  fi
+
   clientUmask
 }
 

--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client.bat
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client.bat
@@ -175,6 +175,8 @@ goto:eof
   if %RC% == 2 goto:eof
 
   call:clientWorkingDirectory
+  call:checkForFIPS1403
+
   !JAVA_CMD_QUOTED! !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED!
   set RC=%errorlevel%
   call:javaCmdResult
@@ -260,7 +262,6 @@ goto:eof
     if exist "%JAVA_HOME%\jre\bin\java.exe" set JAVA_HOME=!JAVA_HOME!\jre
     set JAVA_CMD_QUOTED="!JAVA_HOME!\bin\java"
   )
-
 goto:eof
 
 @REM
@@ -302,7 +303,9 @@ goto:eof
   )
   
   set JVM_OPTIONS=!JVM_OPTIONS!%JVM_TEMP_OPTIONS%
-  
+
+  echo !JVM_OPTIONS!
+
 goto:eof
 
 @REM
@@ -349,6 +352,44 @@ goto:eof
   if not exist "%CLIENT_OUTPUT_DIR%" mkdir "%CLIENT_OUTPUT_DIR%"
   cd /d "%CLIENT_OUTPUT_DIR%"
 goto:eof
+
+@REM Check if the ENABLE_FIPS140_3 variable has been set by the user
+@REM If ENABLE_FIPS140_3 is set, determine the correct JVM options depending on the version of Java to be used and add to list
+@REM The version of java is determined to correctly set IBM SDK 8 or Semeru FIPS140-3 flags
+:checkForFIPS1403
+  @REM CHeck if FIPS140-3 is enabled for the client
+  if defined ENABLE_FIPS140_3 (
+    @REM determine if we are using IBM SDK 8 with FIPS140-3 support
+    if exist "%JAVA_HOME%\fips140-3" set IBM_SDK_8=true
+    if NOT defined IBM_SDK_8 (
+      if exist "%JRE_HOME%\fips140-3" set IBM_SDK_8=true
+      if NOT defined IBM_SDK_8 (
+        if exist "%WLP_DEFAULT_JAVA_HOME%\jre\fips140-3" set IBM_SDK_8=true
+      )
+    )
+
+    if defined IBM_SDK_8 (
+      set JVM_OPTIONS=-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS !JVM_OPTIONS!
+    ) else (
+      @REM Retrieve name of Semeru FIPS140-3 profile from the last file in provided paths
+      for %%i in ("!ENABLE_FIPS140_3:;=";"!") do (
+          set "file=%%~i"
+      )
+      for /f "delims== " %%l in (!file!) do (
+        set line=%%l
+        if /i "!line:~0,18!" == "RestrictedSecurity" (
+          set "line=!line:~19!"
+          if "!line:~-7!" == "extends" (
+            set profileName=!line:~0,-8!
+          )
+        )
+      )
+      set JVM_OPTIONS=-Dsemeru.fips=true -Dsemeru.customprofile=!profileName! -Djava.security.properties=!ENABLE_FIPS140_3! !JVM_OPTIONS!
+    )
+  )
+
+goto:eof
+
 
 @REM
 @REM Check the result of a Java command.

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -480,27 +480,6 @@ serverEnvDefaults()
     fi
   fi
 
-  # If ENABLE_FIPS140_3 is set by the user then add appropiate FIPS140-3 JVM options
-  if [ -n "${ENABLE_FIPS140_3+set}" ]; then
-    # Inspect Java install to determine if IBM SDK 8 or Semeru
-    if [[ -d "${JAVA_HOME}/jre/fips140-3" || -d "${JAVA_HOME}/fips140-3" || -d "$(dirname $(dirname $(command -v java)))/jre/fips140-3" ]]; then
-      JVM_ARGS="${JVM_ARGS} -Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
-    else
-      # Retrieve the profile name from the last file in the property
-      regex='RestrictedSecurity\.([a-zA-Z0-9\.-]*)\.extends\s*?=.*'
-      files=(${ENABLE_FIPS140_3//:/ })
-      for file in $files; do
-        profileFile=$file
-      done
-      while read l; do
-      if [[ $l =~ $regex ]]; then
-        profile="${BASH_REMATCH[1]}"
-      fi
-      done < $profileFile
-      JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.properties=${ENABLE_FIPS140_3}"
-    fi
-  fi
-
   serverUmask
 }
 
@@ -545,7 +524,7 @@ serverEnvAndJVMOptions()
   mergeJVMOptions "${WLP_USER_DIR}/shared/jvm.options"
   if [ $rc -ne 0 ]; then
     return $rc
-  fi  
+  fi
   # This location is intentionally not documented  but removing might break existing installations
   mergeJVMOptions "${WLP_INSTALL_DIR}/usr/shared/jvm.options"
   if [ $rc -ne 0 ]; then
@@ -577,7 +556,7 @@ serverEnvAndJVMOptions()
     # JAVA_HOME not set.  Locate java using the PATH.
     JAVA_PATH=$(command -v java)
     if [ -n "${JAVA_PATH}" ] ; then
-      
+
       # Resolve symlinks.  JAVA_HOME is parent of parent of 'java'
       REAL_JAVA_PATH=$(findRealPath "${JAVA_PATH}")
       JAVA_HOME=$(dirname "${REAL_JAVA_PATH}")/..
@@ -607,11 +586,13 @@ serverEnvAndJVMOptions()
   # If there is a lib/modules directory under JAVA_HOME, then it is at least Java 9.   Ensure java9.options gets loaded.
   if [ -n "${JAVA_HOME}" ]; then
     JPMS_MODULE_FILE_LOCATION=${JAVA_HOME}/lib/modules
-  
+
     if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
        mergeJVMOptions "${WLP_INSTALL_DIR}/lib/platform/java/java9.options"
     fi
   fi
+
+  enableFIPS140_3
 
   return $rc
 }
@@ -630,13 +611,13 @@ findRealPath() {
 
       resolvedPath=$(realpath "${path}" 2>/dev/null)
     fi
-  
+
     # If unsuccessful, try readlink -e
     if [ -z "${resolvedPath}" ] && command -v readlink >/dev/null; then
       resolvedPath=$(readlink -e "${path}" 2>/dev/null)
     fi
 
-    # If unsuccessful, try cd -P command. 
+    # If unsuccessful, try cd -P command.
     if [ -z "${resolvedPath}" ]; then
       resolvedPath=$(unset CDPATH; cd -P "${path}" >/dev/null 2>&1 && pwd)
     fi
@@ -644,10 +625,10 @@ findRealPath() {
   fi
 
   # If none of those methods work, try a more basic approach
-  if [ -z "${resolvedPath}" ]; then 
+  if [ -z "${resolvedPath}" ]; then
     symLinkCount=0
 
-    # Loop ends when resolvedPath does not contain any symlinks  
+    # Loop ends when resolvedPath does not contain any symlinks
     while true; do
 
       resolvedPath=""
@@ -656,7 +637,7 @@ findRealPath() {
       set -- $path
       pathContainsSymLink="false"
       for component; do
-	  
+
         if [ -z "$component" ]; then
           continue # Skip empty components
         fi
@@ -678,7 +659,7 @@ findRealPath() {
         if [ -L "$resolvedPath" ]; then
           pathContainsSymLink="true"
           symLinkCount=$((symLinkCount + 1))
-		  
+
           # Get the target of the symbolic link
           target=$(ls -l "$resolvedPath" | awk '{print $NF}')
           # The line above might have problems with special characters. Possible replacement to consider and test:
@@ -696,7 +677,7 @@ findRealPath() {
 
           # Save the prefix up one level from the symlink
           savePrefix=$(cd "$(dirname "$resolvedPath")" && pwd)
-		  
+
           case "$target" in
           /*)
             # Absolute path case
@@ -740,11 +721,11 @@ mergeJVMOptions()
     READ_ETC=0
     saveIFS=$IFS
     IFS=$newline
-    
+
     for option in $(readNativeFile "$jvmOptions" '[#-]' | LC_ALL=C tr -d '\r'); do
       if [ -n "$option" ]; then
         case $option in
-          \#*) 
+          \#*)
               ;;
           *)
               escapeForEval "${option}"
@@ -790,7 +771,7 @@ readServerEnv()
           # characters. Only accept alphanumeric variable names to avoid eval complexities.
           if [ "$uname" != "SunOS" ] && [ "$uname" != "OS/390" ]; then
 
-            # This is the preferred pattern, because it handles characters 
+            # This is the preferred pattern, because it handles characters
             # from multiple languages, but it doesn't work on Solaris.
             var=$(safeEcho "$line" | sed -n -e 's/^\([_[:alpha:]][_[:alnum:]]*\)=.*/\1/p')
 
@@ -812,7 +793,7 @@ readServerEnv()
               then
                  eval "export ${var}"
               else
-                 # Variable expansion is not enabled.  Just set the variable to whatever is on the right side 
+                 # Variable expansion is not enabled.  Just set the variable to whatever is on the right side
                  # of the assignment and export it.  If a later line enables variable expansion, the source
                  # command will reassign the variable (which is already exported) to the resolved value.
                  extractValueAndEscapeForEval "${line}"
@@ -882,7 +863,7 @@ serverWorkingDirectory()
     case "${SERVER_WORKING_DIR}" in
       /*) len=${#SERVER_WORKING_DIR}
           if [ $len -eq 1 ]; then
-            SERVER_WORKING_DIR=$SERVER_OUTPUT_DIR 
+            SERVER_WORKING_DIR=$SERVER_OUTPUT_DIR
           fi ;;
       *) SERVER_WORKING_DIR="${SERVER_OUTPUT_DIR}/${SERVER_WORKING_DIR}" ;;
     esac
@@ -929,7 +910,7 @@ javaCmd()
 {
   JAVA_CMD_LOG=$1
   shift
-  
+
   # Filter all of the -D and -X arguments off of the argument line and add them to $JVM_OPTIONS_QUOTED
   REMAINING_ARGS=""
   for option in "$@"; do
@@ -946,13 +927,13 @@ javaCmd()
           REMAINING_ARGS="$option"
         else
           REMAINING_ARGS="$REMAINING_ARGS $option"
-        fi  
+        fi
       fi
     else
       REMAINING_ARGS="$REMAINING_ARGS $option"
     fi
   done
-  
+
   if [ $ACTION = "checkpoint" ]; then
     if [ -z "$CHECKPOINT_AT" ]; then
       CHECKPOINT_AT="beforeAppStart"
@@ -976,7 +957,7 @@ javaCmd()
       JVM_OPTIONS_QUOTED="$JVM_OPTIONS_QUOTED -Dio.openliberty.checkpoint.criu.unprivileged=true"
     fi
     if [ -n "$CRIU_LOG_LEVEL" ]; then
-      # A system property is used here to avoid having to read env on the 
+      # A system property is used here to avoid having to read env on the
       # checkpoint side. If reading the env from the Java checkpoint side we need
       # to make the env an immutable value but we don't want to force the
       # same CRIU_LOG_LEVEL on both the checkpoint and restore side here.
@@ -984,7 +965,7 @@ javaCmd()
     fi
     criuEnvDefaults
   fi
-  
+
   # Set all the parameters for the java command.  We use eval so that each line
   # in jvm.options is treated as a distinct argument.
   eval "set -- ${JAVA_AGENT_QUOTED} ${JVM_OPTIONS_QUOTED} ${JAVA_DEBUG} ${JVM_ARGS} -jar ${WLP_INSTALL_DIR_QUOTED}/bin/tools/ws-server.jar ""$REMAINING_ARGS"
@@ -993,11 +974,11 @@ javaCmd()
   if [ $ACTION = "checkpoint" ]; then
     if [ -d "${SERVER_OUTPUT_DIR}/workarea/checkpoint" ]; then
       rm -rf ${SERVER_OUTPUT_DIR}/workarea/checkpoint
-      rc=$? 
+      rc=$?
       if [ $rc -ne 0 ]; then
          issueMessage --message:error.checkpoint.delete "${SERVER_OUTPUT_DIR}/workarea/checkpoint"
          return $rc
-      fi   
+      fi
     fi
   fi
 
@@ -1051,7 +1032,7 @@ javaCmd()
       fi
     fi
     kill $TAIL_PID
-    # Above JAVA_CMD should terminate after a criu dump and SIGKILL. 
+    # Above JAVA_CMD should terminate after a criu dump and SIGKILL.
     # Check for expected return code of 137 from the KILL.
     if [ $rc -eq 137 ]; then
       backupWorkarea
@@ -1170,7 +1151,7 @@ serverCmd()
 
   SAVE_JVM_OPTIONS_QUOTED=${JVM_OPTIONS_QUOTED}
   JVM_OPTIONS_QUOTED=${SERVER_JVM_OPTIONS_QUOTED}
-  
+
   SAVE_IBM_JAVA_OPTIONS=${IBM_JAVA_OPTIONS}
   IBM_JAVA_OPTIONS=${SERVER_IBM_JAVA_OPTIONS}
   SAVE_OPENJ9_JAVA_OPTIONS=${OPENJ9_JAVA_OPTIONS}
@@ -1261,14 +1242,14 @@ serverCmd()
         fi
       fi
 
-  
+
   else
     X_CMD="${JAVA_CMD} ${ARGS}"
     export X_CMD
 
     javaCmd "${SERVER_CMD_BACKGROUND_LOG}" "${SERVER_NAME}" "$@"
     rc=$?
-      
+
     PID=$!
 
     JVM_OPTIONS_QUOTED=${SAVE_JVM_OPTIONS_QUOTED}
@@ -1282,7 +1263,7 @@ serverCmd()
       # write the pid file if return is OK or UNKNOWN
       if [ $rc = 0 -o $rc = $SERVER_UNKNOWN_STATUS ]; then
           safeEcho "${PID}" > "${X_PID_FILE}"
-      fi        
+      fi
     fi
   fi
   return $rc
@@ -1367,12 +1348,12 @@ criuRestore()
   if [ $rc -ne 0 ]; then
     issueMessage --message:error.checkpoint.workarea.restore "${SERVER_OUTPUT_DIR}/workarea/checkpoint/workarea"
     return $rc
-  fi 
+  fi
 
   BACKGROUND_RESTORE=$1
   if [ -z "${CRIU_LOG_LEVEL}" ]; then
     CRIU_LOG_LEVEL=2
-  fi  
+  fi
 
   checkCriuUnprivileged
   if [ $DO_CRIU_UNPRIVILEGED = true ]; then
@@ -1407,7 +1388,7 @@ criuRestore()
       if [ $rc = 0 -o $rc = $SERVER_UNKNOWN_STATUS ]; then
         safeEcho "${PID}" > "${X_PID_FILE}"
       fi
-    fi        
+    fi
   else
     # For checkpoint we always write to the log file.
     # Use tail to bring the content to the console output
@@ -1449,18 +1430,18 @@ restoreServer()
   done
 
   # restore artifacts and environment prior to checkpoint here
-    
+
   # no good way to check for criu support since fast startup is imperative
   #   just let criu invocation fail with a hopefully informative error message.
   mkdirs ${X_LOG_DIR}/checkpoint
 
-  # save off the log during checkpoint and start fresh from restore 
+  # save off the log during checkpoint and start fresh from restore
   RESTORE_CONSOLE_LOG="${X_LOG_DIR}/${X_LOG_FILE}"
   CHECKPOINT_CONSOLE_LOG="${X_LOG_DIR}/checkpoint-${X_LOG_FILE}"
   backupIfNeededOrRemove $RESTORE_CONSOLE_LOG $CHECKPOINT_CONSOLE_LOG
   mkdirs "${X_LOG_DIR}"
   touchIfNotExist "${RESTORE_CONSOLE_LOG}"
- 
+
   # record the start of restoreTime
   echo `date +%s%3N` > ${SERVER_OUTPUT_DIR}/workarea/checkpoint/restoreTime
 
@@ -1481,7 +1462,7 @@ restoreServer()
   env | grep -E "^[^\=]*.=" > ${SERVER_OUTPUT_DIR}/workarea/checkpoint/.env.properties
 
   rm -f ${SERVER_OUTPUT_DIR}/workarea/checkpoint/.restoreFailedMarker
-  
+
   criuRestore $BACKGROUND_RESTORE
   rc=$?
   if [ -f "${SERVER_OUTPUT_DIR}/workarea/checkpoint/.restoreFailedMarker" ]; then
@@ -1528,12 +1509,12 @@ defineEscapeForEvalFunctions()
       {
         escapeForEvalResult=\\'\${1//\\'/\\'\\\"\\'\\\"\\'}\\'
       }
-  
+
       extractValueAndEscapeForEval()
       {
         escapeForEval \"\${1#*=}\"
       }
-  
+
       substitutePrefixVar()
       {
         case \$1 in
@@ -1551,7 +1532,7 @@ defineEscapeForEvalFunctions()
     {
       escapeForEvalResult=\'$(safeEcho "$1" | sed s/\'/\'\"\'\"\'/g)\'
     }
-  
+
     ##
     ## extractValueAndEscapeForEval: Extract the value of a var=value string,
     ##                               and set escapeForEvalResult with the result.
@@ -1560,7 +1541,7 @@ defineEscapeForEvalFunctions()
     {
       escapeForEvalResult=\'`safeEcho "$1" | sed -e 's/[^=]*=//' -e s/\'/\'\"\'\"\'/g`\'
     }
-  
+
     ##
     ## substitutePrefixVar: If $1 has a prefix @$2@, set substitutePrefixVarResult
     ##                      to $1 with the prefix replaced by $3.  Otherwise, set
@@ -1575,6 +1556,31 @@ defineEscapeForEvalFunctions()
   fi
 }
 
+enableFIPS140_3()
+{
+    if [ -n "${ENABLE_FIPS140_3+set}" ]; then
+      if [ -d "${JAVA_HOME}/jre/fips140-3" ] || [ -d "${JAVA_HOME}/fips140-3" ] || [ -d "$(dirname $(dirname $(command -v java)))/jre/fips140-3" ]; then
+        JVM_ARGS="${JVM_ARGS} -Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
+      else
+        saveIFS=$IFS
+        IFS=":"
+        for file in "${ENABLE_FIPS140_3}"; do
+          profileFile=$file
+        done
+        IFS=$saveIFS
+        while read l; do
+          match=$(echo "$l" | sed -n 's/.*RestrictedSecurity\.\([a-zA-Z0-9\.-]*\)\.extends[[:space:]]*=.*/\1/p')
+          if [ -n "$match" ]; then
+            profile=$match
+          fi
+        done < $profileFile
+        JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.properties=${ENABLE_FIPS140_3}"
+      fi
+    fi
+
+    echo $JVM_ARGS
+}
+
 # ########################################################################### #
 # main()                                                                      #
 # ########################################################################### #
@@ -1584,9 +1590,9 @@ SERVER_UNKNOWN_STATUS=5
 ##
 ## Determine the platform and absolute path of the installation directory.
 ##
-## IMPORTANT: Be cautious when updating WLP_INSTALL_DIR as it affects the process name of the 
-## Liberty server shown by the Linux 'ps' command. Changes introducing ".." to the path 
-## may break users' ability to find the Liberty process based on the normalized path. The pwd 
+## IMPORTANT: Be cautious when updating WLP_INSTALL_DIR as it affects the process name of the
+## Liberty server shown by the Linux 'ps' command. Changes introducing ".." to the path
+## may break users' ability to find the Liberty process based on the normalized path. The pwd
 ## command normalizes the path.
 ##
 case $OSTYPE in
@@ -1621,12 +1627,12 @@ case $OSTYPE in
 
     case $uname in
       CYGWIN_*)
-        # This is a very unlikely path. 
+        # This is a very unlikely path.
         WLP_INSTALL_DIR=$(cygpath -ma "$(findRealPath "$0" | sed 's|\\|/|g' | sed 's|/[^/]*$||')"/..)
         ;;
 
       *)
-        # The directory of this script (the server script) 
+        # The directory of this script (the server script)
         scriptDir="$(dirname "$0")"
 
         # Get absolute path.  Needed because "." (current directory) never tests positive as a symbolic link, even if it is.
@@ -1639,7 +1645,7 @@ case $OSTYPE in
         # Else the directory containing this script is a symbolic link.
         # Must find the real path in order to find the installation directory (The parent of scriptDir).
         else
-          resolvedScriptDir=$(findRealPath "${scriptDir}")             
+          resolvedScriptDir=$(findRealPath "${scriptDir}")
           WLP_INSTALL_DIR=$(unset CDPATH; cd "${resolvedScriptDir}/.." && pwd)
         fi
     esac
@@ -1762,11 +1768,11 @@ case "$ACTION" in
 
     if [ -d "${SERVER_OUTPUT_DIR}/workarea/checkpoint/image" ] && [ ${ACTION} != "checkpoint" ]; then
       # Avoid call to restoreServer below if server already running.
-      # If there is no checkpoint, then maintain legacy behavior of 
+      # If there is no checkpoint, then maintain legacy behavior of
       # allowing server launch to check for already running instance.
       if serverStatus false --status:starting; then
         exit 0
-      fi  
+      fi
     fi
 
     serverWorkingDirectory
@@ -1805,21 +1811,21 @@ case "$ACTION" in
       fi
 
       # WLP_JAR_CYGWIN is used only in support of java -jar startup of a Liberty server.
-      # When WLP_JAR_CYGWIN=true (or synonym) is specified, the PID of the launching 
+      # When WLP_JAR_CYGWIN=true (or synonym) is specified, the PID of the launching
       # process (i.e. parent of server process) is determined and stored in the PID file
-      # for use by the java -jar shutdown hook to ensure termination of the launching 
+      # for use by the java -jar shutdown hook to ensure termination of the launching
       # process. This is necessary because the launching process does not terminate on
       # its own under cygwin and if left behind holds file locks that prevent cleanup
-      # of the java -jar extraction directory. 
+      # of the java -jar extraction directory.
       if [ "$WLP_JAR_CYGWIN" = "true" -o "$WLP_JAR_CYGWIN" = "1" -o "$WLP_JAR_CYGWIN" = "TRUE" -o "$WLP_JAR_CYGWIN" = "True" ]
-      then 
+      then
 	      serverCmd '' "$@" &
 	      PID=$!
 	      mkdirs "${X_PID_DIR}"
-	      # find parent PID and store it 
+	      # find parent PID and store it
 	      SPID=`ps -ef | while read l; do grep $PID | awk -v PID=$PID '{ if ( $3 == PID ) print $2 }'; done`
 	      safeEcho "${SPID}" > "${X_PID_FILE}"
-	      wait "${PID}" # wait because this 
+	      wait "${PID}" # wait because this
 	      rc=$?
       else
 	      serverCmd '' "$@"
@@ -1830,9 +1836,9 @@ case "$ACTION" in
       exit 2
     fi
   ;;
-   
+
   # Start the server in the background
-  start)    
+  start)
 
     if serverEnvAndJVMOptions
     then
@@ -1896,7 +1902,7 @@ case "$ACTION" in
       exit $rc
     else
       exit 2
-    fi    
+    fi
   ;;
 
   create)
@@ -1904,8 +1910,8 @@ case "$ACTION" in
     createServer "$@"
     exit $rc
   ;;
-  
-  # Stop the server. 
+
+  # Stop the server.
   stop)
     serverEnv
     if checkServer true
@@ -1932,7 +1938,7 @@ case "$ACTION" in
       exit 2
     fi
   ;;
-  
+
   # Check if server is running
   status)
     serverEnv
@@ -1971,19 +1977,19 @@ case "$ACTION" in
     else
      exit $?
     fi
-    
+
     # Check to see if the server exists
     if checkServer true
     then
       serverPIDStatus
-      JVM_OPTIONS_QUOTED=${SERVER_JVM_OPTIONS_QUOTED} 
+      JVM_OPTIONS_QUOTED=${SERVER_JVM_OPTIONS_QUOTED}
       javaCmd '' "${SERVER_NAME}" --pid="${PID}" --package "$@"
       exit $?
     else
       exit 2
-    fi    
+    fi
   ;;
-  
+
 
   # dump the server's configs/logs/status to a zip file
   dump)
@@ -1991,11 +1997,11 @@ case "$ACTION" in
     # Check to see if the server exists
     if checkServer true
     then
-      javaCmd '' "${SERVER_NAME}" --dump "$@" 
+      javaCmd '' "${SERVER_NAME}" --dump "$@"
       exit $?
     else
       exit 2
-    fi    
+    fi
   ;;
 
   # dump JVM status
@@ -2009,18 +2015,18 @@ case "$ACTION" in
       exit 2
     fi
   ;;
-  
+
   # pause the server
   pause)
     serverEnv
     # Check to see if the server exists
     if checkServer true
     then
-      javaCmd '' "${SERVER_NAME}" --pause "$@" 
+      javaCmd '' "${SERVER_NAME}" --pause "$@"
       exit $?
     else
       exit 2
-    fi    
+    fi
   ;;
 
   # resume the server
@@ -2029,33 +2035,33 @@ case "$ACTION" in
     # Check to see if the server exists
     if checkServer true
     then
-      javaCmd '' "${SERVER_NAME}" --resume "$@" 
+      javaCmd '' "${SERVER_NAME}" --resume "$@"
       exit $?
     else
       exit 2
-    fi    
+    fi
   ;;
 
   version)
     serverEnv
     javaCmd '' --version
-  ;;  
-  
+  ;;
+
   list)
     installEnv
     javaCmd '' --list
-  ;;  
-  
+  ;;
+
   help)
     installEnv
     javaCmd '' --help ${SERVER_NAME}
-  ;;  
+  ;;
 
   help:usage)
     installEnv
     javaCmd '' --help:usage
   ;;
-  
+
   *)
     installEnv
     javaCmd '' --help:actions:${ACTION}

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -480,6 +480,27 @@ serverEnvDefaults()
     fi
   fi
 
+  # If ENABLE_FIPS140_3 is set by the user then add appropiate FIPS140-3 JVM options
+  if [ -n "${ENABLE_FIPS140_3+set}" ]; then
+    # Inspect Java install to determine if IBM SDK 8 or Semeru
+    if [[ -d "${JAVA_HOME}/jre/fips140-3" || -d "${JAVA_HOME}/fips140-3" || -d "$(dirname $(dirname $(command -v java)))/jre/fips140-3" ]]; then
+      JVM_ARGS="${JVM_ARGS} -Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS"
+    else
+      # Retrieve the profile name from the last file in the property
+      regex='RestrictedSecurity\.([a-zA-Z0-9\.-]*)\.extends\s*?=.*'
+      files=(${ENABLE_FIPS140_3//:/ })
+      for file in $files; do
+        profileFile=$file
+      done
+      while read l; do
+      if [[ $l =~ $regex ]]; then
+        profile="${BASH_REMATCH[1]}"
+      fi
+      done < $profileFile
+      JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.properties=${ENABLE_FIPS140_3}"
+    fi
+  fi
+
   serverUmask
 }
 

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -277,6 +277,7 @@ goto:eof
   set OPENJ9_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
 
   call:checkForVerboseGC
+  call:checkForFIPS1403
 
   !JAVA_CMD_QUOTED! !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED!
   set RC=%errorlevel%
@@ -298,6 +299,7 @@ goto:eof
   set OPENJ9_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
 
   call:checkForVerboseGC
+  call:checkForFIPS1403
 
   !JAVA_CMD_QUOTED! !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED!
   set RC=%errorlevel%
@@ -348,6 +350,7 @@ goto:eof
     set OPENJ9_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
 	
     call:checkForVerboseGC
+    call:checkForFIPS1403
 
     @REM Use javaw so command windows can be closed.
     start /min /b "" !JAVA_CMD_QUOTED!w !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED! >> "%X_LOG_DIR%\%X_LOG_FILE%" 2>&1
@@ -741,6 +744,44 @@ goto:eof
     )
 
     set OPENJ9_JAVA_OPTIONS="-Xverbosegclog:!X_LOG_DIR!\verbosegc.%%seq.log,10,1024" !OPENJ9_JAVA_OPTIONS!
+goto:eof
+
+@REM Check if the ENABLE_FIPS140_3 variable has been set by the user
+@REM If ENABLE_FIPS140_3 is set, determine the correct JVM options depending on the version of Java to be used and add to list
+@REM The version of java is determined to correctly set IBM SDK 8 or Semeru FIPS140-3 flags
+:checkForFIPS1403
+
+  if defined ENABLE_FIPS140_3 (
+    @REM determine if we are using IBM SDK 8 with FIPS140-3 support
+    if exist "%JAVA_HOME%\fips140-3\" set IBM_SDK_8=true
+    if NOT defined IBM_SDK_8 (
+      if exist "%JRE_HOME%\fips140-3\" set IBM_SDK_8=true
+      if NOT defined IBM_SDK_8 (
+        if exist "%WLP_DEFAULT_JAVA_HOME%\jre\fips140-3\" set IBM_SDK_8=true
+      )
+    )
+
+    if defined IBM_SDK_8 (
+      set JVM_OPTIONS=-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS !JVM_OPTIONS!
+    ) else (
+      if exist !ENABLE_FIPS140_3! (
+        @REM Retrieve name of Semeru FIPS140-3 profile from the last file in provided paths
+        for %%i in ("!ENABLE_FIPS140_3:;=";"!") do (
+            set "file=%%~i"
+        )
+        for /f "delims== " %%l in (!file!) do (
+          set line=%%l
+          if /i "!line:~0,18!" == "RestrictedSecurity" (
+            set "line=!line:~19!"
+            if "!line:~-7!" == "extends" (
+              set profileName=!line:~0,-8!
+            )
+          )
+        )
+        set JVM_OPTIONS=-Dsemeru.fips=true -Dsemeru.customprofile=!profileName! -Djava.security.properties=!ENABLE_FIPS140_3! !JVM_OPTIONS!
+      )
+    )
+  )
 goto:eof
 
 @REM

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -685,19 +685,13 @@ public class LibertyClient {
                     Log.info(c, "startClientWithArgs", "FIPS 140-3 global build properties is set for Client " + getClientName()
                                                        + " with IBM Java " + javaInfo.majorVersion() + ", adding required JVM arguments to run with FIPS 140-3 enabled");
 
-                    JVM_ARGS += " -Dsemeru.fips=true";
-                    JVM_ARGS += " -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Custom";
-                    JVM_ARGS += " -Djava.security.properties=" + getSemeruFips140_3CustomProfileLocationAndPrintFileContents();
-                    JVM_ARGS += " -Dcom.ibm.fips.mode=140-3";
+                    envVars.setProperty("ENABLE_FIPS140_3",getSemeruFips140_3CustomProfileLocationAndPrintFileContents());
                     // JVM_ARGS += " -Djavax.net.debug=all";  // Uncomment as needed for additional debugging
                 } else if (javaInfo.majorVersion() == 8) {
                     Log.info(c, "startClientWithArgs", "FIPS 140-3 global build properties is set for Client " + getClientName()
                                                        + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
 
-                    JVM_ARGS += " -Xenablefips140-3";
-                    JVM_ARGS += " -Dcom.ibm.jsse2.usefipsprovider=true";
-                    JVM_ARGS += " -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS";
-                    JVM_ARGS += " -Dcom.ibm.fips.mode=140-3";
+                    envVars.setProperty("ENABLE_FIPS140_3", "");
                     // JVM_ARGS += " -Djavax.net.debug=all";  // Uncomment as needed for additional debugging
                 }
             }

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1737,7 +1737,7 @@ public class LibertyServer implements LogMonitorClient {
         // if we have FIPS 140-3 enabled, and the matched java/platform, add JVM Arg
         if (isFIPS140_3EnabledAndSupported(info) || isFIPS140_2EnabledAndSupported(info)) {
             if (!GLOBAL_ENHANCED_ALGO) {
-                JVM_ARGS += getJvmArgString(this.getFipsJvmOptions(info, false));
+                JVM_ARGS += getJvmArgString(this.getFipsJvmOptions(info, useEnvVars, false));
             } else {
                 JVM_ARGS += getJvmArgString(this.getEnhancedAlgorithmOptions());
             }
@@ -8153,24 +8153,31 @@ public class LibertyServer implements LogMonitorClient {
         configureLTPAKeys(JavaInfo.forServer(this));
     }
 
-    private Map<String, String> getFipsJvmOptions(JavaInfo info, boolean includeGlobalArgs) throws Exception, IOException {
+    private Map<String, String> getFipsJvmOptions(JavaInfo info, Properties useEnvVars, boolean includeGlobalArgs) throws Exception, IOException {
         Map<String, String> opts = new HashMap<>();
         if (isFIPS140_3EnabledAndSupported(info, false)) {
             if (info.majorVersion() >= 11) {
                 Log.info(c, "getFipsJvmOptions",
                          "FIPS 140-3 global build properties is set for server " + getServerName()
                                                  + " with IBM Java " + info.majorVersion() + ", adding required JVM arguments to run with FIPS 140-3 enabled");
-                opts.put("-Dsemeru.fips", "true");
-                opts.put("-Dsemeru.customprofile", "OpenJCEPlusFIPS.FIPS140-3-Custom");
-                opts.put("-Djava.security.properties", getSemeruFips140_3CustomProfileLocationAndPrintFileContents());
+                if(useEnvVars == null) {
+                    opts.put("-Dsemeru.fips", "true");
+                    opts.put("-Dsemeru.customprofile", "OpenJCEPlusFIPS.FIPS140-3-Custom");
+                    opts.put("-Djava.security.properties", getSemeruFips140_3CustomProfileLocationAndPrintFileContents());
+                } else {
+                    useEnvVars.setProperty("ENABLE_FIPS140_3",getSemeruFips140_3CustomProfileLocationAndPrintFileContents());
+                }
             } else if (info.majorVersion() == 8) {
                 Log.info(c, "getFipsJvmOptions", "FIPS 140-3 global build properties is set for server "
                                                  + getServerName()
                                                  + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
+                if(useEnvVars == null){
                 opts.put("-Xenablefips140-3", null);
                 opts.put("-Dcom.ibm.jsse2.usefipsprovider", "true");
                 opts.put("-Dcom.ibm.jsse2.usefipsProviderName", "IBMJCEPlusFIPS");
-
+                } else {
+                    useEnvVars.setProperty("ENABLE_FIPS140_3","");
+                }
             }
             if (includeGlobalArgs) {
                 opts.put("-Dglobal.fips_140-3", "true");
@@ -8221,7 +8228,7 @@ public class LibertyServer implements LogMonitorClient {
             Map<String, String> jvm_opts = this.getJvmOptionsAsMap();
             // Use LinkedHashMap to ensure entry ordering to not break --add-module entries
             Map<String, String> combined = new LinkedHashMap(jvm_opts);
-            combined.putAll(this.getFipsJvmOptions(info, true));
+            combined.putAll(this.getFipsJvmOptions(info, null,true));
             if (!combined.isEmpty() && !combined.equals(jvm_opts)) {
                 this.setJvmOptions(combined);
             }


### PR DESCRIPTION
Change Fattest.simplicity server and client FIPS settings from adding the options to adding an envvar picked up by the respective `server` and `client` scripts to set the FIPS140-3 settings. FIPS140-2 is left as is.

- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

