### PR TITLE
Use Java EE name application name for applicationStopped

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/DataProvider.java
@@ -381,7 +381,10 @@ public class DataProvider implements //
             Tr.entry(this, tc, "applicationStopped" + appInfo.getDeploymentName() +
                                " (" + appInfo.getName() + ')');
 
-        String appName = appInfo.getName();
+        // Prefer deployment name (from J2EEName)
+        String appName = appInfo.getDeploymentName();
+        if (appName == null) // fall back to generated name
+            appName = appInfo.getName();
 
         // Try to order removals based on dependencies, so that we remove first
         // what might depend on the others.


### PR DESCRIPTION
DataProvider is inconsistent on application name that is used as as key.  When inserting and accessing elsewhere, the Java EE name application name is used.   The applicationStopped is inconsistent with that and will not behave correctly if the application names differ.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
