### PR TITLE
Updates after EclipseLink beta 10

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/RomanNumeral.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/RomanNumeral.java
@@ -10,17 +10,15 @@
  *******************************************************************************/
 package test.jakarta.data.web;
 
-import java.util.ArrayList;
-
 /**
  * A record to use as a result type for selecting attributes of the Prime entity.
+ * EclipseLink decided to disallow collection attributes such as
+ * ArrayList<String> romanNumeralSymbols
+ * so it is omitted from from this record.
  */
 public record RomanNumeral(
                 String name,
-                String romanNumeral
-// , TODO enable once EclipseLink bug #30501 is fixed
-// ArrayList<String> romanNumeralSymbols
-) {
+                String romanNumeral) {
 
     /**
      * Format in an easy way for tests to compare results.
@@ -30,9 +28,9 @@ public record RomanNumeral(
         StringBuilder s = new StringBuilder();
         s.append(name).append(" ");
         s.append(romanNumeral).append(" ( ");
+        // If collection attributes are ever allowed, the following could become
+        // for (String symbol : romanNumeralSymbols)
         for (char symbol : romanNumeral.toCharArray())
-        // TODO replace the above with the following once EclipseLink bug #30501 is fixed
-        //for (String symbol : romanNumeralSymbols)
             s.append(symbol).append(' ');
         s.append(")");
         return s.toString();

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2014,8 +2014,7 @@ public class DataJPATestServlet extends FATServlet {
     /**
      * Verify that JPQL can be used to EXTRACT the DATE from a LocalDateTime.
      */
-    // TODO enable once EclipseLink bug #31802 is fixed
-    //@Test
+    @Test
     public void testExtractDate() {
         rebates.reset();
 
@@ -2138,8 +2137,7 @@ public class DataJPATestServlet extends FATServlet {
     /**
      * Verify that JPQL can be used to EXTRACT the TIME from a LocalDateTime.
      */
-    // TODO enable once EclipseLink bug #31802 is fixed
-    //@Test
+    @Test
     public void testExtractTime() {
         rebates.reset();
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1332,20 +1332,27 @@ public class DataJPATestServlet extends FATServlet {
                                              .map(a -> a.houseNumber + " " + a.streetName)
                                              .collect(Collectors.toList()));
 
-        // TODO Enable once EclipseLink bug #31558 is fixed:
-        // List<ShippingAddress> found = shippingAddresses
-        //                .findByStreetAddressRecipientInfoNotEmpty();
+        List<ShippingAddress> found = shippingAddresses
+                        .findByStreetAddressRecipientInfoNotEmpty();
+        ShippingAddress a = null;
+        for (ShippingAddress s : found) {
+            if (a1.id.equals(s.id))
+                a = s;
+        }
+        // TODO Replace above for loop with the following once EclipseLink bug #31559 is fixed
         // assertEquals(1, found.size());
-        // ShippingAddress a = found.get(0);
-        // assertEquals(a1.id, a.id);
-        // assertEquals(a1.city, a.city);
-        // assertEquals(a1.state, a.state);
-        // assertEquals(a1.zipCode, a.zipCode);
-        // assertEquals(a1.streetAddress.houseNumber, a.streetAddress.houseNumber);
-        // assertEquals(a1.streetAddress.streetName, a.streetAddress.streetName);
-        // assertEquals(a1.streetAddress.recipientInfo, a.streetAddress.recipientInfo);
+        // a = found.get(0);
+        assertEquals(a1.id, a.id);
+        assertEquals(a1.city, a.city);
+        assertEquals(a1.state, a.state);
+        assertEquals(a1.zipCode, a.zipCode);
+        assertEquals(a1.streetAddress.houseNumber, a.streetAddress.houseNumber);
+        assertEquals(a1.streetAddress.streetName, a.streetAddress.streetName);
+        assertEquals(a1.streetAddress.recipientInfo, a.streetAddress.recipientInfo);
 
-        // assertEquals(3L, shippingAddresses.countByStreetAddressRecipientInfoEmpty());
+        long count = shippingAddresses.countByStreetAddressRecipientInfoEmpty();
+        // TODO Enable once EclipseLink bug #31559 is fixed:
+        // assertEquals(3L, count);
 
         // [EclipseLink-4002] Internal Exception: java.sql.SQLIntegrityConstraintViolationException:
         //                    DELETE on table 'SHIPPINGADDRESS' caused a violation of foreign key constraint 'SHPPNGSHPPNGDDRSSD' for key (1001)

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1446,13 +1446,15 @@ public class DataJPATestServlet extends FATServlet {
                                                  .map(t -> t.ssn)
                                                  .collect(Collectors.toList()));
 
-        // TODO enable once issue #31558 and
-        // TODO subsequently #32263 is fixed in EclipseLink
-        if (false)
-            assertIterableEquals(List.of(789007890L),
-                                 taxpayers.findByBankAccountsNotEmpty()
-                                                 .map(t -> t.ssn)
-                                                 .collect(Collectors.toList()));
+        assertEquals(List.of(123001230L,
+                             234002340L,
+                             345003450L,
+                             456004560L,
+                             567005670L,
+                             678006780L),
+                     taxpayers.findByBankAccountsNotEmpty()
+                                     .map(t -> t.ssn)
+                                     .collect(Collectors.toList()));
 
         taxpayers.delete();
     }


### PR DESCRIPTION
Updates to enable tests and eliminate workarounds after EclipseLink beta 10 fixed several issues.

EclipseLink beta 10 fixes #31558
EclipseLink beta 10 fixes #30501 by disallowing the capability
EclipseLink beta 10 fixes #31802
EclipseLink beta 10 fixes #32263

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
