### PR TITLE
Do not include local.sharedLib for Open Liberty FAT classpath

### DIFF
--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -291,11 +291,6 @@
 				<include name="com.ibm.ws.componenttest.jar" />
 			</fileset>
 
-			<!-- shared libraries from bootstrapping.properties -->
-			<fileset dir="${local.sharedLib}" erroronmissingdir="false">
-				<include name="**/*.jar" />
-			</fileset>
-
 			<!-- java libraries for secure SSH authentication -->
 			<fileset dir="${local.java}/lib/" erroronmissingdir="false">
 				<include name="*.jar" />


### PR DESCRIPTION
- The local.sharedLib directory's jars are not needed on the classpath for Open Liberty FATs and as such can be removed from launch.xml.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
