### PR TITLE
MCP: remove trailing space from bnd.bnd

### DIFF
--- a/dev/io.openliberty.mcp.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.mcp.internal_fat/bnd.bnd
@@ -16,7 +16,7 @@ javac.target: 17
 src: \
     fat/src
 
-fat.project: true 
+fat.project: true
 
 
 tested.features: \


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This trailing space causes part of the build to treat the FAT project as a product bundle, which then fails because it doesn't find the corresponding jar for it in the product.