### PR TITLE
Log Server Channel Closing and Cookie Update Test

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WCSameSiteCookieAttributeTests.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WCSameSiteCookieAttributeTests.java
@@ -532,7 +532,7 @@ public class WCSameSiteCookieAttributeTests {
                         splitSameSiteHeaderFound = true;
                     }
                 }
-
+                client.close(); // close connection now. The waitForStringInTraceUsingMark times out (forces connection to remain open)
                 assertNull("The Channel Framework incorrectly added the Secure attribute.",
                            sameSiteServer.waitForStringInTraceUsingMark("Setting the Secure attribute for SameSite=None"));
                 assertTrue("The response did not contain the expected Servlet output: " + expectedResponse,
@@ -1825,7 +1825,7 @@ public class WCSameSiteCookieAttributeTests {
                         splitSameSiteHeaderFound = true;
                     }
                 }
-
+                client.close(); // close connection now. The waitForStringInTraceUsingMark times out (forces connection to remain open)
                 assertNull("The Channel Framework incorrectly added the Secure attribute.",
                            sameSiteServer.waitForStringInTraceUsingMark("Setting the Secure attribute for SameSite=None"));
                 assertTrue("The response did not contain the expected Servlet output: " + expectedResponse,
@@ -1835,6 +1835,7 @@ public class WCSameSiteCookieAttributeTests {
                 assertFalse("The response contained a split SameSite Set-Cookie header and it should not have.", splitSameSiteHeaderFound);
             }
         } finally {
+            
             sameSiteServer.setMarkToEndOfLog();
             sameSiteServer.restoreServerConfiguration();
             sameSiteServer.waitForConfigUpdateInLogUsingMark(Collections.singleton(APP_NAME_SAMESITE), false, "CWWKT0016I:.*SameSiteTest.*");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

For #32755

To debug ` java.net.BindException: Address already in use` error in Netty.
