### PR TITLE
Outbound SSL Hostname should not append aliases

### DIFF
--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/OutboundSSLSelections.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/OutboundSSLSelections.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -94,48 +94,49 @@ public class OutboundSSLSelections {
                 String key = null;
                 String host = (String) outboundEntry.get("host");
 
+                String currentSslCfgAlias = sslCfgAlias;
                 String certAlias = (String) outboundEntry.get("clientCertificate");
                 if (certAlias != null) {
-                    sslCfgAlias = sslCfgAlias + ":" + certAlias;
+                    currentSslCfgAlias = currentSslCfgAlias + ":" + certAlias;
                 }
 
                 Integer port = (Integer) outboundEntry.get("port");
                 if (port != null) {
                     key = host + "," + port.toString();
                     if (dynamicHostPortSelections.containsKey(key)) {
-                        if (!dynamicHostPortSelections.get(key).equals(sslCfgAlias)) {
+                        if (!dynamicHostPortSelections.get(key).equals(currentSslCfgAlias)) {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                                Tr.debug(tc, "loadOutboundConnectionInfo", "Existing " + key + " : " + dynamicHostPortSelections.get(key) + ",  trying to add " + sslCfgAlias);
+                                Tr.debug(tc, "loadOutboundConnectionInfo", "Existing " + key + " : " + dynamicHostPortSelections.get(key) + ",  trying to add " + currentSslCfgAlias);
                             }
                             issueConflictWarning(host, port.toString(), dynamicHostPortSelections.get(key));
                         }
                     } else {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "loadOutboundConnectionInfo", "Adding " + key + " to the host port list, sslCfgAlias " + sslCfgAlias);
+                            Tr.debug(tc, "loadOutboundConnectionInfo", "Adding " + key + " to the host port list, sslCfgAlias " + currentSslCfgAlias);
                         }
-                        dynamicHostPortSelections.put(key, sslCfgAlias);
+                        dynamicHostPortSelections.put(key, currentSslCfgAlias);
                     }
                 } else {
                     // special check for host "*" and port "*"
                     if (host.equals("*")) {
-                        if (!warningIssued && isDefaultOutboundRefSet(sslCfgAlias))
+                        if (!warningIssued && isDefaultOutboundRefSet(currentSslCfgAlias))
                             continue;
                     }
 
                     key = host + ",*";
                     if (dynamicHostSelections.containsKey(key)) {
-                        if (!dynamicHostSelections.get(key).equals(sslCfgAlias))
+                        if (!dynamicHostSelections.get(key).equals(currentSslCfgAlias))
                             issueConflictWarning(host, "*", dynamicHostSelections.get(key));
                     } else {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Tr.debug(tc, "loadOutboundConnectionInfo", "Adding " + key + " to the host list");
                         }
-                        dynamicHostSelections.put(key, sslCfgAlias);
+                        dynamicHostSelections.put(key, currentSslCfgAlias);
                     }
                 }
 
                 newConnectionInfo.add(key);
-                dynamicSelections.put(key, sslCfgAlias);
+                dynamicSelections.put(key, currentSslCfgAlias);
             }
         }
 


### PR DESCRIPTION
It has been found that when multiple hostnames are specified, the alias are getting appended.


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
