### PR TITLE
Mcp cancellation test reliability

### DIFF
--- a/dev/io.openliberty.mcp.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.mcp.internal_fat/bnd.bnd
@@ -25,6 +25,7 @@ tested.features: \
 
 -buildpath: \
 	io.openliberty.jakarta.cdi.4.0;version=latest,\
+	io.openliberty.jakarta.servlet.6.0;version=latest,\
 	io.openliberty.mcp;version=latest,\
 	org.json:json;version=20080701,\
 	org.skyscreamer:jsonassert,\

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/CancellationTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/CancellationTest.java
@@ -32,6 +32,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpRequest;
 import io.openliberty.mcp.internal.fat.tool.cancellationApp.CancellationTools;
 import io.openliberty.mcp.internal.fat.utils.HttpTestUtils;
 
@@ -104,8 +105,8 @@ public class CancellationTest extends FATServletClient {
         //make sure the tool call request has started
         latch.await();
 
-        //wait to make sure the tool call is registered before trying to cancel it
-        TimeUnit.MILLISECONDS.sleep(1000);
+        // Call AwaitToolServlet to wait for the tool to start running
+        new HttpRequest(server, "/cancellationTest/awaitTool").run(String.class);
 
         HttpTestUtils.callMCPNotification(server, "/cancellationTest", cancellationRequestNotification);
 

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/CancellationTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/CancellationTest.java
@@ -32,7 +32,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
-import io.openliberty.mcp.internal.fat.tool.basicToolApp.BasicTools;
+import io.openliberty.mcp.internal.fat.tool.cancellationApp.CancellationTools;
 import io.openliberty.mcp.internal.fat.utils.HttpTestUtils;
 
 @RunWith(FATRunner.class)
@@ -44,7 +44,7 @@ public class CancellationTest extends FATServletClient {
 
     @BeforeClass
     public static void setup() throws Exception {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "toolTest.war").addPackage(BasicTools.class.getPackage());
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "cancellationTest.war").addPackage(CancellationTools.class.getPackage());
 
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
 
@@ -55,8 +55,12 @@ public class CancellationTest extends FATServletClient {
 
     @AfterClass
     public static void teardown() throws Exception {
-        executor.shutdown();
         server.stopServer();
+    }
+
+    @AfterClass
+    public static void shutdownExecutor() {
+        executor.shutdown();
     }
 
     @Test
@@ -79,7 +83,7 @@ public class CancellationTest extends FATServletClient {
                                 """;
                 //make sure this tread executes first
                 latch.countDown();
-                return HttpTestUtils.callMCP(server, "/toolTest", request);
+                return HttpTestUtils.callMCP(server, "/cancellationTest", request);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -103,7 +107,7 @@ public class CancellationTest extends FATServletClient {
         //wait to make sure the tool call is registered before trying to cancel it
         TimeUnit.MILLISECONDS.sleep(1000);
 
-        HttpTestUtils.callMCPNotification(server, "/toolTest", cancellationRequestNotification);
+        HttpTestUtils.callMCPNotification(server, "/cancellationTest", cancellationRequestNotification);
 
         String response = future.get(10, TimeUnit.SECONDS);
 
@@ -128,7 +132,7 @@ public class CancellationTest extends FATServletClient {
                         }
                         """;
 
-        String response = HttpTestUtils.callMCP(server, "/toolTest", request);
+        String response = HttpTestUtils.callMCP(server, "/cancellationTest", request);
 
         String expectedResponseString = """
                         {"id":"3","jsonrpc":"2.0","result":{"content":[{"type":"text", "text": "If this String is returned, then the tool was not cancelled"}],"isError":false}}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/CancellationTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/CancellationTest.java
@@ -119,7 +119,7 @@ public class CancellationTest extends FATServletClient {
         String request = """
                           {
                           "jsonrpc": "2.0",
-                          "id": "2",
+                          "id": "3",
                           "method": "tools/call",
                           "params": {
                             "name": "cancellationToolNoWait",
@@ -131,7 +131,7 @@ public class CancellationTest extends FATServletClient {
         String response = HttpTestUtils.callMCP(server, "/toolTest", request);
 
         String expectedResponseString = """
-                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"type":"text", "text": "If this String is returned, then the tool was not cancelled"}],"isError":false}}
+                        {"id":"3","jsonrpc":"2.0","result":{"content":[{"type":"text", "text": "If this String is returned, then the tool was not cancelled"}],"isError":false}}
                         """;
         JSONAssert.assertEquals(expectedResponseString, response, true);
     }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
@@ -926,26 +926,6 @@ public class ToolTest extends FATServletClient {
                                       "description": "A tool that does not have a title"
                                     },
                                     {
-                                        "inputSchema": {
-                                          "properties": {},
-                                          "required": [],
-                                          "type": "object"
-                                        },
-                                        "name": "cancellationTool",
-                                        "title": "Cancellable tool",
-                                        "description": "A tool that waits to be cancelled"
-                                    },
-                                    {
-                                        "inputSchema": {
-                                          "properties": {},
-                                          "required": [],
-                                          "type": "object"
-                                        },
-                                        "name": "cancellationToolNoWait",
-                                        "title": "Cancellable tool NoWait",
-                                        "description": "A tool that does not waits to be cancelled"
-                                    },
-                                    {
                                       "inputSchema": {
                                         "type": "object",
                                         "properties": {

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/basicToolApp/BasicTools.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/basicToolApp/BasicTools.java
@@ -10,8 +10,6 @@
 package io.openliberty.mcp.internal.fat.tool.basicToolApp;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import io.openliberty.mcp.annotations.Tool;
 import io.openliberty.mcp.annotations.Tool.Annotations;
@@ -20,8 +18,6 @@ import io.openliberty.mcp.content.AudioContent;
 import io.openliberty.mcp.content.Content;
 import io.openliberty.mcp.content.ImageContent;
 import io.openliberty.mcp.content.TextContent;
-import io.openliberty.mcp.messaging.Cancellation;
-import io.openliberty.mcp.messaging.Cancellation.OperationCancellationException;
 import io.openliberty.mcp.tools.ToolResponse;
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -30,7 +26,6 @@ import jakarta.enterprise.context.ApplicationScoped;
  */
 @ApplicationScoped
 public class BasicTools {
-    private static final Logger LOG = Logger.getLogger(BasicTools.class.getName());
 
     @Tool(name = "mixedContentTool", title = "Mixed Content Tool", description = "Returns Text, Audio or Image Content")
     public ToolResponse mixedContentTool(@ToolArg(name = "input", description = "input to echo") String input) {
@@ -294,36 +289,5 @@ public class BasicTools {
     @Tool(name = "testToolArgIsNotRequired", title = "ToolArgNotRequired", description = "ToolArgNotRequired")
     public boolean testToolArgNotRequired(@ToolArg(name = "value", description = "boolean value", required = false) boolean value) {
         return false;
-    }
-
-
-    @Tool(name = "cancellationTool", title = "Cancellable tool", description = "A tool that waits to be cancelled")
-    public String cancellationTool(Cancellation cancellation) throws InterruptedException {
-        LOG.info("Cancelling Request");
-        int counter = 0;
-        while (counter++ < 20) {
-            TimeUnit.MILLISECONDS.sleep(500);
-            LOG.info("Checking if tool is cancelled");
-            if (cancellation.check().isRequested()) {
-                LOG.info("tool is cancelled");
-                throw new OperationCancellationException();
-            }
-        }
-        LOG.info("the tool was not cancelled");
-        return "If this String is returned, then the tool was not cancelled";
-    }
-
-    @Tool(name = "cancellationToolNoWait", title = "Cancellable tool NoWait", description = "A tool that does not waits to be cancelled")
-    public String cancellationToolNoWait(Cancellation cancellation) {
-        LOG.info("Cancelling Request");
-        int counter = 0;
-        while (counter++ < 5) {
-            if (cancellation.check().isRequested()) {
-                LOG.info("Checking if tool is cancelled");
-                throw new OperationCancellationException();
-            }
-        }
-        LOG.info("the tool was not cancelled");
-        return "If this String is returned, then the tool was not cancelled";
     }
 }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/cancellationApp/AwaitToolServlet.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/cancellationApp/AwaitToolServlet.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.tool.cancellationApp;
+
+import java.io.IOException;
+
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Allows the test to wait for a tool to start running, so that it can be cancelled
+ */
+@SuppressWarnings("serial")
+@WebServlet("/awaitTool")
+public class AwaitToolServlet extends HttpServlet {
+
+    @Inject
+    private ToolStatus toolStatus;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            toolStatus.awaitRunning();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e.toString(), e);
+        }
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/cancellationApp/CancellationTools.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/cancellationApp/CancellationTools.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.tool.cancellationApp;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import io.openliberty.mcp.annotations.Tool;
+import io.openliberty.mcp.messaging.Cancellation;
+import io.openliberty.mcp.messaging.Cancellation.OperationCancellationException;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Tools for CancellationTest
+ */
+@ApplicationScoped
+public class CancellationTools {
+
+    private static final Logger LOG = Logger.getLogger(CancellationTools.class.getName());
+
+    @Tool(name = "cancellationTool", title = "Cancellable tool", description = "A tool that waits to be cancelled")
+    public String cancellationTool(Cancellation cancellation) throws InterruptedException {
+        LOG.info("Cancelling Request");
+        int counter = 0;
+        while (counter++ < 20) {
+            TimeUnit.MILLISECONDS.sleep(500);
+            LOG.info("Checking if tool is cancelled");
+            if (cancellation.check().isRequested()) {
+                LOG.info("tool is cancelled");
+                throw new OperationCancellationException();
+            }
+        }
+        LOG.info("the tool was not cancelled");
+        return "If this String is returned, then the tool was not cancelled";
+    }
+
+    @Tool(name = "cancellationToolNoWait", title = "Cancellable tool NoWait", description = "A tool that does not waits to be cancelled")
+    public String cancellationToolNoWait(Cancellation cancellation) {
+        LOG.info("Cancelling Request");
+        int counter = 0;
+        while (counter++ < 5) {
+            if (cancellation.check().isRequested()) {
+                LOG.info("Checking if tool is cancelled");
+                throw new OperationCancellationException();
+            }
+        }
+        LOG.info("the tool was not cancelled");
+        return "If this String is returned, then the tool was not cancelled";
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/cancellationApp/CancellationTools.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/cancellationApp/CancellationTools.java
@@ -31,32 +31,33 @@ public class CancellationTools {
 
     @Tool(name = "cancellationTool", title = "Cancellable tool", description = "A tool that waits to be cancelled")
     public String cancellationTool(Cancellation cancellation) throws InterruptedException {
-        LOG.info("Cancelling Request");
+        LOG.info("[cancellationTool] Starting");
         toolStatus.setRunning();
         int counter = 0;
         while (counter++ < 20) {
             TimeUnit.MILLISECONDS.sleep(500);
-            LOG.info("Checking if tool is cancelled");
+            LOG.info("[cancellationTool] Checking if tool is cancelled");
             if (cancellation.check().isRequested()) {
-                LOG.info("tool is cancelled");
+                LOG.info("[cancellationTool] tool is cancelled");
                 throw new OperationCancellationException();
             }
         }
-        LOG.info("the tool was not cancelled");
+        LOG.info("[cancellationTool] the tool was not cancelled");
         return "If this String is returned, then the tool was not cancelled";
     }
 
     @Tool(name = "cancellationToolNoWait", title = "Cancellable tool NoWait", description = "A tool that does not waits to be cancelled")
     public String cancellationToolNoWait(Cancellation cancellation) {
-        LOG.info("Cancelling Request");
+        LOG.info("[cancellationToolNoWait] Starting");
         int counter = 0;
         while (counter++ < 5) {
+            LOG.info("[cancellationToolNoWait] Checking if tool is cancelled");
             if (cancellation.check().isRequested()) {
-                LOG.info("Checking if tool is cancelled");
+                LOG.info("[cancellationToolNoWait] tool is cancelled");
                 throw new OperationCancellationException();
             }
         }
-        LOG.info("the tool was not cancelled");
+        LOG.info("[cancellationToolNoWait] the tool was not cancelled");
         return "If this String is returned, then the tool was not cancelled";
     }
 

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/cancellationApp/CancellationTools.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/cancellationApp/CancellationTools.java
@@ -16,6 +16,7 @@ import io.openliberty.mcp.annotations.Tool;
 import io.openliberty.mcp.messaging.Cancellation;
 import io.openliberty.mcp.messaging.Cancellation.OperationCancellationException;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * Tools for CancellationTest
@@ -25,9 +26,13 @@ public class CancellationTools {
 
     private static final Logger LOG = Logger.getLogger(CancellationTools.class.getName());
 
+    @Inject
+    private ToolStatus toolStatus;
+
     @Tool(name = "cancellationTool", title = "Cancellable tool", description = "A tool that waits to be cancelled")
     public String cancellationTool(Cancellation cancellation) throws InterruptedException {
         LOG.info("Cancelling Request");
+        toolStatus.setRunning();
         int counter = 0;
         while (counter++ < 20) {
             TimeUnit.MILLISECONDS.sleep(500);

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/cancellationApp/ToolStatus.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/cancellationApp/ToolStatus.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.tool.cancellationApp;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ */
+@ApplicationScoped
+public class ToolStatus {
+
+    private CountDownLatch latch = new CountDownLatch(1);
+
+    public void setRunning() {
+        latch.countDown();
+    }
+
+    public void awaitRunning() throws InterruptedException {
+        boolean toolStarted = latch.await(10, TimeUnit.SECONDS);
+        if (!toolStarted) {
+            throw new RuntimeException("Tool did not start");
+        }
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

CI showed a couple of reliability problems with `CancellationTest`:
- Both tests use the same id, which means if one fails it can call the other one to fail because there's already a tool execution with that id running
- It's possible for the cancellation request to be processed before the tool execution starts, likely due to startup classloading coupled with poor performance of the CI VM. We need to add a servlet to allow us to wait for the tool execution to start.