### PR TITLE
Tests enablement and minor fixes in JPA 3.2 FAT

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/County.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/County.java
@@ -11,15 +11,13 @@ package io.openliberty.jpa.data.tests.models;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Version;
 
-/**
- * Add the @Entity annotation when enabling testOLGH30534.
- */
-
+@Entity
 public class County {
 
     @Id
@@ -30,6 +28,10 @@ public class County {
 
     @Version
     private LocalDateTime lastUpdated;
+    
+    public County() {
+        
+    }
 
     public County(String name) {
         this.name = name;

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -2247,8 +2247,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
             assertEquals(4, h1.getNumBedrooms());
 
         } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException();
+            throw e;
         }
     }
 

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -2283,8 +2283,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/31558")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/31558
     public void testOLGH31558() throws Exception {
+        deleteCollectionTable("ShippingAddress_RECIPIENTINFO");
         deleteAllEntities(ShippingAddress.class);
 
         ShippingAddress a1 = new ShippingAddress();
@@ -2346,6 +2347,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
     @Test
     @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/31559")
     public void testOLGH31559() throws Exception {
+        deleteCollectionTable("ShippingAddress_RECIPIENTINFO");
         deleteAllEntities(ShippingAddress.class);
 
         ShippingAddress a1 = new ShippingAddress();
@@ -2495,5 +2497,17 @@ public class JakartaDataRecreateServlet extends FATServlet {
                         .executeUpdate();
         tx.commit();
     }
+    
+    /**
+     * Deletes all rows from the specified collection table using native SQL.
+     *
+     * @param tableName the exact name of the table to delete from (e.g., "ShippingAddress_RECIPIENTINFO")
+     */
+    private void deleteCollectionTable(String tableName) throws Exception{
+        tx.begin();
+        em.createNativeQuery("DELETE FROM " + tableName).executeUpdate();
+        tx.commit();
+    }
+
 
 }

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -453,7 +453,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28931")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28931
     public void testOLGH28931() throws Exception {
         Business ibmRoc = Business.of(44.05887f, -92.50355f, "Rochester", "Minnesota", 55901, 2800, "37th St", "NW",
                                       "IBM Rochester");

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -2074,7 +2074,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/30534")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/30534
     public void testOLGH30534() throws Exception {
 
         County county1 = new County("CountyA");

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -1788,6 +1788,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
 
     @Test
     @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/30501")
+    //Issue closed. Error is valid and now provides a meaningful message
     public void testOLGH30501() throws Exception{
         deleteAllEntities(Prime.class); 
 
@@ -1815,7 +1816,8 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }   
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/29475")
+    //Original issue: https://github.com/OpenLiberty/open-liberty/issues/29475
+    @Ignore("Additional issue: https://github.com/OpenLiberty/open-liberty/issues/28589")
     public void testOLGH29475() throws Exception {
         Rating.Reviewer jimmy = Rating.Reviewer.of("Jimothy", "Scramble", "J.Scramble@example.com");
         Rating.Item blueBerry = Rating.Item.of("BlueBerry 10", 299.99f);
@@ -2174,7 +2176,8 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
     
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/30789")
+    //Original issue: https://github.com/OpenLiberty/open-liberty/issues/30789
+    @Ignore("Additional issue: https://github.com/OpenLiberty/open-liberty/issues/28925")
     public void testOLGH30789() throws Exception {
         try {
             deleteAllEntities(House.class);
@@ -2253,6 +2256,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
 
     @Test
     @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/32263")
+    //Issue closed. Error is valid and now provides a meaningful message
     public void testOLGH32263() throws Exception {
         deleteAllEntities(TaxPayer.class);
 
@@ -2436,6 +2440,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
     
     @Test
     @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/32246") 
+    //Error due to valid behavioural change introduced in B09. Passes for B08 and below.
     public void testOLGH32246() throws Exception {
         deleteAllEntities(Student.class);
 

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -797,7 +797,6 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
-    @Ignore
     //Reference issue : https://github.com/OpenLiberty/open-liberty/issues/30444
     public void testOLGH30444() throws Exception {
         deleteAllEntities(Package.class); 
@@ -814,7 +813,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
 
         tx.begin();
         try {
-            results = em.createQuery("SELECT ID FROM Package ORDER BY WIDTH DESC", Integer.class)
+            results = em.createQuery("SELECT id FROM Package ORDER BY width DESC", Integer.class)
                             .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                             .setMaxResults(1)
                             .getResultList();

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -1453,7 +1453,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28905")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28905
     public void testOLGH28905() throws Exception {
         Triangle t1_0 = Triangle.of((byte) 13, (byte) 84, (byte) 85);
 
@@ -1473,11 +1473,12 @@ public class JakartaDataRecreateServlet extends FATServlet {
                             .setParameter(3, (short) (198))
                             .executeUpdate();
 
+            tx.commit();
+            
             t1_1 = em.createQuery("SELECT o FROM Triangle o WHERE o.distinctKey=?1", Triangle.class)
-                            .setParameter(0, t1_0.distinctKey)
+                            .setParameter(1, t1_0.distinctKey)
                             .getSingleResult();
 
-            tx.commit();
         } catch (Exception e) {
             tx.rollback();
             /*

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -892,6 +892,9 @@ public class JakartaPersistenceServlet extends FATServlet {
      */
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/31802
+    @SkipIfSysProp({
+        DB_SQLServer //Failing on SQLServer (No mention of NULLS FIRST/LAST keywords in Documentation)
+    })
     public void testExtractYearFromLocalData() throws Exception {
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2022, 06, 07), LocalTime.of(12, 0), LocalDateTime.of(2022, 06, 07, 12, 0));
@@ -916,9 +919,9 @@ public class JakartaPersistenceServlet extends FATServlet {
         List<Integer> result = em.createQuery(criteriaQuery).getResultList();
         assertEquals(4, result.size());
         assertEquals(null, result.get(0));
-        assertEquals("Extracted Year should be 2021", Integer.valueOf(2021), result.get(1));
-        assertEquals("Extracted Year should be 2020", Integer.valueOf(2020), result.get(2));
-        assertEquals("Extracted Year should be 2022", Integer.valueOf(2022), result.get(3));
+        assertEquals("Extracted Year should be 2021", 2021, ((Number) result.get(1)).intValue());
+        assertEquals("Extracted Year should be 2020", 2020, ((Number) result.get(2)).intValue());
+        assertEquals("Extracted Year should be 2022", 2022, ((Number) result.get(3)).intValue());
 
     }
 
@@ -929,6 +932,9 @@ public class JakartaPersistenceServlet extends FATServlet {
      */
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/31802
+    @SkipIfSysProp({
+        DB_SQLServer //Failing on SQLServer (No mention of NULLS FIRST/LAST keywords in Documentation)
+    })
     public void testExtractQuarterFromLocalData() throws Exception {
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2022, 06, 07), LocalTime.of(12, 0), LocalDateTime.of(2022, 06, 07, 12, 0));
@@ -953,9 +959,9 @@ public class JakartaPersistenceServlet extends FATServlet {
         List<Integer> result = em.createQuery(criteriaQuery).getResultList();
         assertEquals(4, result.size());
         assertEquals(null, result.get(0));
-        assertEquals("Extracted Quarter should be 1", Integer.valueOf(1), result.get(1));
-        assertEquals("Extracted Quarter should be 4", Integer.valueOf(4), result.get(2));
-        assertEquals("Extracted Quarter should be 2", Integer.valueOf(2), result.get(3));
+        assertEquals("Extracted Quarter should be 1", 1, ((Number) result.get(1)).intValue());
+        assertEquals("Extracted Quarter should be 4", 4, ((Number) result.get(2)).intValue());
+        assertEquals("Extracted Quarter should be 2", 2, ((Number) result.get(3)).intValue());
 
     }
 

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -891,7 +891,7 @@ public class JakartaPersistenceServlet extends FATServlet {
      * @throws Exception
      */
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/31802")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/31802
     public void testExtractYearFromLocalData() throws Exception {
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2022, 06, 07), LocalTime.of(12, 0), LocalDateTime.of(2022, 06, 07, 12, 0));
@@ -928,7 +928,7 @@ public class JakartaPersistenceServlet extends FATServlet {
      * @throws Exception
      */
     @Test
-    @Ignore("Reference issue : https://github.com/OpenLiberty/open-liberty/issues/31802")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/31802
     public void testExtractQuarterFromLocalData() throws Exception {
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2022, 06, 07), LocalTime.of(12, 0), LocalDateTime.of(2022, 06, 07, 12, 0));


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This PR enables tests in JPA 3.2 FAT, which were disabled due to issues which are currently fixed now. It also makes some minor refactoring in the FAT.