### PR TITLE
Add xml-apis to the list of required libs

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.spnego/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.client_fat.spnego/build.gradle
@@ -41,7 +41,8 @@ dependencies {
                'org.apache.httpcomponents:httpclient:4.1.2',
                'org.apache.httpcomponents:httpcore:4.1.2',
                'org.apache.httpcomponents:httpmime:4.3.1',
-               'org.eclipse.birt.runtime.3_7_1:org.apache.xml.serializer:2.7.1'
+               'org.eclipse.birt.runtime.3_7_1:org.apache.xml.serializer:2.7.1',
+               'xml-apis:xml-apis:1.4.01'
 }
 
 configurations {


### PR DESCRIPTION
When the tests were updated to remove transitive = true for the requiredLibs, the gathering of xml-apis no longer was being gathered as a required lib.  xerces requires xml-apis.  When run in an environment that doesn't have xerces in the JDK like when Temurin or Oracle Java is tested, a NoClassDefFoundError occurs.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
