### PR TITLE
PH68082: Decrement the handle count that was incremented during getConnection

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
@@ -334,6 +334,14 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
                 mcWrapper.setPoolState(poolState);
                 com.ibm.ws.ffdc.FFDCFilter.processException(e, "com.ibm.ejs.j2c.ConnectionManager.allocateConnection", "344", this);
                 Tr.error(tc, "FAILED_CONNECTION_J2CA0021", new Object[] { e, _pm.gConfigProps.cfName });
+                // Decrement the handle count that was incremented during getConnection
+                if (mcWrapper.getHandleCount() > 0) {
+                    if (isTraceOn && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "getConnection failed, decrementing handle count from " + mcWrapper.getHandleCount());
+                    }
+                    mcWrapper.decrementHandleCount();
+                }
+
 
                 /*
                  * If the Resource Adapter throws a ResourceException and we are not in a

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2021 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Fixes #PH68082
Fixes Issue #32789
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Added code in the ResourceException handler in ConnectionManager.allocateConnection() to ensure proper handle count reporting in MicroProfile Metrics during transaction rollbacks.
This implementation:
- Checks if the handle count is greater than 0 to prevent negative counts
- Adds debug logging to track handle count changes during error scenarios
- Calls decrementHandleCount() to ensure the metrics correctly reflect released connection handles.


