### PR TITLE
Update Timeout comment on Netty's SipResolverUdpTransport

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverUdpTransport.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverUdpTransport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2021 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -661,9 +661,9 @@ class SipResolverUdpTransport implements SipResolverTransport {
                 parent.init(ch);
             }
             ChannelPipeline pipeline = ch.pipeline();
-            // TODO: revisit write and read timeouts
-//          pipeline.addLast("writeTimeoutHandler", new WriteTimeoutHandler(WRITE_TIMEOUT, TimeUnit.MILLISECONDS));
-//          pipeline.addLast("readTimeoutHandler", new ReadTimeoutHandler(READ_TIMEOUT, TimeUnit.MILLISECONDS));
+            // Timeout handlers look to be unneccessary for UDP
+            // https://github.com/OpenLiberty/open-liberty/issues/31408
+            // CHFW's SipResolverUdpTransport doesn't set timeouts either
             pipeline.addLast("decoder", new SipMessageBufferDatagramDecoder());
             pipeline.addLast(CHAINNAME, new SipResolverUdpTransportHandler());
         }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #31408