### PR TITLE
Fix SHA512 MessageDigest not available

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallException.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,6 +65,13 @@ public class InstallException extends Exception {
     public InstallException(String message, int rc) {
         super(message);
         this.rc = rc;
+    }
+
+    /**
+     * Wrap original exception as InstallException
+     */
+    public InstallException(Throwable cause) {
+        super(cause);
     }
 
     /**

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
@@ -42,10 +42,10 @@ import java.util.concurrent.Future;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import com.ibm.ws.common.crypto.CryptoUtils;
 import com.ibm.ws.install.InstallConstants.VerifyOption;
 import com.ibm.ws.install.InstallException;
 import com.ibm.ws.install.internal.InstallLogUtils.Messages;
-import com.ibm.ws.common.crypto.CryptoUtils;
 
 public class ArtifactDownloader implements AutoCloseable {
 
@@ -212,7 +212,6 @@ public class ArtifactDownloader implements AutoCloseable {
         checksumFormats[1] = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256;
         checksumFormats[0] = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512;
 
-
         dLocation = FormatPathSuffix(dLocation);
         String repo = FormatUrlSuffix(repository.getRepositoryUrl());
 
@@ -283,9 +282,9 @@ public class ArtifactDownloader implements AutoCloseable {
                 fine("No checksums found for file in remote repository");
             }
         } catch (URISyntaxException e) {
-            throw new InstallException(e.getMessage());
+            throw new InstallException(e);
         } catch (NoSuchAlgorithmException e) {
-            throw new InstallException(e.getMessage());
+            throw new InstallException(e);
         }
     }
 

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
@@ -44,10 +44,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.ibm.websphere.crypto.PasswordUtil;
+import com.ibm.ws.common.crypto.CryptoUtils;
 import com.ibm.ws.install.InstallConstants.VerifyOption;
 import com.ibm.ws.install.InstallException;
 import com.ibm.ws.install.internal.InstallLogUtils.Messages;
-import com.ibm.ws.common.crypto.CryptoUtils;
 
 public class ArtifactDownloaderUtils {
 
@@ -158,6 +158,8 @@ public class ArtifactDownloaderUtils {
     public static String getChecksum(String filename, String format) throws NoSuchAlgorithmException, IOException {
         if (format.equals(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256)) {
             format = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_256;
+        } else if (format.equals(CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512)) {
+            format = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_512;
         }
         byte[] b = createChecksum(filename, format);
         String result = "";


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Issue with non IBM / Oracle Java 8. Reproduced with `openjdk version "1.8.0_462" IBM Semeru Runtime Open Edition (build 1.8.0_462-b08)`
```
featureUtility installFeature --acceptLicense --noCache xmlWS-4.0
Initializing ...
Using 8 threads to download artifacts.
SHA512 MessageDigest not available
```

Fixes #32934 
Fixes #PH68239