### PR TITLE
Basic constraints

### DIFF
--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -235,8 +235,8 @@ public class Data_1_0 implements DataVersionCompatibility {
 
     @Override
     @Trivial
-    public Object toLiteralValue(Object value) {
-        return value;
+    public Object[] toConstraintValues(Object value) {
+        return null;
     }
 
 }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/AttributeConstraint.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/AttributeConstraint.java
@@ -33,6 +33,7 @@ public enum AttributeConstraint {
     LessThan("<", 1, false),
     LessThanEqual("<=", 1, false, "AtMost"),
     Like(" LIKE ", 1, false),
+    LikeEscaped(" LIKE ", 2, false),
     Not("<>", 1, Supports.COLLECTIONS, "NotEqualTo"),
     NotBetween(" NOT BETWEEN ", 2, false),
     NotContains(null, 1, Supports.COLLECTIONS),
@@ -40,6 +41,7 @@ public enum AttributeConstraint {
     NotEndsWith(null, 1, false),
     NotIn(" NOT IN ", 1, false),
     NotLike(" NOT LIKE ", 1, false),
+    NotLikeEscaped(" NOT LIKE ", 2, false),
     NotNull(" IS NOT NULL", 0, false),
     NotStartsWith(null, 1, false),
     Null(" IS NULL", 0, false),
@@ -170,6 +172,7 @@ public enum AttributeConstraint {
             case LessThan -> GreaterThanEqual;
             case LessThanEqual -> GreaterThan;
             case Like -> NotLike;
+            case LikeEscaped -> NotLikeEscaped;
             case Not -> Equal;
             case NotBetween -> Between;
             case NotContains -> Contains;
@@ -177,6 +180,7 @@ public enum AttributeConstraint {
             case NotEndsWith -> EndsWith;
             case NotIn -> In;
             case NotLike -> Like;
+            case NotLikeEscaped -> LikeEscaped;
             case NotNull -> Null;
             case NotStartsWith -> StartsWith;
             case Null -> NotNull;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -238,12 +238,13 @@ public interface DataVersionCompatibility {
     Set<Class<?>> specialParamTypes();
 
     /**
-     * Temporary method that obtains the literal value from a constraint if the
-     * supplied value is a constraint. Otherwise, returns the original value.
+     * Temporary method that obtains the literal value(s) from a constraint if the
+     * supplied value is a constraint for a literal expression.
      *
      * @param constraintOrValue a jakarta.data.constraint.Constraint subtype or a
      *                              literal value.
-     * @return literal value.
+     * @return array of literal values obtained from the constraint.
+     *         Null if not a constraint.
      */
-    Object toLiteralValue(Object constraintOrValue);
+    Object[] toConstraintValues(Object constraintOrValue);
 }

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -22,7 +22,15 @@ import java.util.stream.Collectors;
 
 import jakarta.data.Order;
 import jakarta.data.Sort;
+import jakarta.data.constraint.AtMost;
+import jakarta.data.constraint.Between;
+import jakarta.data.constraint.In;
+import jakarta.data.constraint.NotBetween;
+import jakarta.data.constraint.NotNull;
 import jakarta.data.expression.TextExpression;
+import jakarta.data.page.CursoredPage;
+import jakarta.data.page.PageRequest;
+import jakarta.data.page.PageRequest.Cursor;
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
@@ -53,6 +61,32 @@ public class Data_1_1_Servlet extends FATServlet {
                 fractionsToAdd.add(f);
             }
         fractions.supply(fractionsToAdd);
+    }
+
+    /**
+     * Tests that the Between and NotBetween constraint types can be assigned to
+     * repository method parameters to enforce that matching entity attributes
+     * are either within or not within a range.
+     */
+    @Test
+    public void testBetweenAndNotBetweenConstraints() {
+
+        assertEquals(List.of("One Fourteenth",
+                             "Eleven Fourteenths",
+                             "One Fifteenth",
+                             "Four Fifteenths",
+                             "Eleven Fifteenths",
+                             "Fourteen Fifteenths",
+                             "One Sixteenth",
+                             "Eleven Sixteenths",
+                             "Fifteen Sixteenths"),
+                     fractions.withDenominatorBetweenNamedBeforeAndNumeratorNotBetween //
+                     (Between.bounds(14, 16),
+                      "Thirteen",
+                      NotBetween.bounds(5, 10),
+                      true)
+                                     .map(f -> f.name)
+                                     .collect(Collectors.toList()));
     }
 
     /**
@@ -95,6 +129,104 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Tests that the Is annotation can be applied to repository method parameters
+     * to enforce matching a pattern. Use cursor-based pagination to obtain results.
+     */
+    @Test
+    public void testIsAnnoLike() {
+
+        Order<Fraction> descendingNumerator = //
+                        Order.by(Sort.desc(_Fraction.NUMERATOR));
+
+        Cursor threeFifths = Cursor.forKey(5, 3);
+
+        PageRequest page2Req = PageRequest.ofSize(5)
+                        .afterCursor(threeFifths)
+                        .page(2)
+                        .withoutTotal();
+
+        CursoredPage<Fraction> page2 = fractions.namedLike("%fths",
+                                                           descendingNumerator,
+                                                           page2Req);
+        assertEquals(List.of("Two Fifths",
+                             "Eleven Twelfths",
+                             "Ten Twelfths",
+                             "Nine Twelfths",
+                             "Eight Twelfths"),
+                     page2.stream()
+                                     .map(f -> f.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(2L, page2.pageRequest().page());
+        assertEquals(5L, page2.numberOfElements());
+        assertEquals(true, page2.hasPrevious());
+        assertEquals(true, page2.hasNext());
+
+        CursoredPage<Fraction> page1 = fractions.namedLike("%fths",
+                                                           descendingNumerator,
+                                                           page2.previousPageRequest());
+
+        assertEquals(List.of("Four Fifths",
+                             "Three Fifths"),
+                     page1.stream()
+                                     .map(f -> f.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(1L, page1.pageRequest().page());
+        assertEquals(2L, page1.numberOfElements());
+        assertEquals(false, page1.hasPrevious());
+        assertEquals(true, page1.hasNext());
+
+        CursoredPage<Fraction> page3 = fractions.namedLike("%fths",
+                                                           descendingNumerator,
+                                                           page2.nextPageRequest());
+
+        assertEquals(List.of("Seven Twelfths",
+                             "Six Twelfths",
+                             "Five Twelfths",
+                             "Four Twelfths",
+                             "Three Twelfths"),
+                     page3.stream()
+                                     .map(f -> f.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(3L, page3.pageRequest().page());
+        assertEquals(5L, page3.numberOfElements());
+        assertEquals(true, page3.hasPrevious());
+        assertEquals(true, page3.hasNext());
+
+        CursoredPage<Fraction> page4 = fractions.namedLike("%fths",
+                                                           descendingNumerator,
+                                                           page3.nextPageRequest());
+
+        assertEquals(List.of("Two Twelfths"),
+                     page4.stream()
+                                     .map(f -> f.name)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(4L, page4.pageRequest().page());
+        assertEquals(1L, page4.numberOfElements());
+        assertEquals(true, page4.hasPrevious());
+        assertEquals(false, page4.hasNext());
+    }
+
+    /**
+     * Tests that a Constraint parameter and Is annotation parameter can be
+     * intermixed on a single repository method.
+     */
+    @Test
+    public void testMixConstraintAndIsAnno() {
+        Sort<Fraction> alphabetizedByName = Sort.asc(_Fraction.NAME);
+
+        assertEquals(List.of("Eight Ninths",
+                             "Five Ninths",
+                             "Three Ninths"),
+                     fractions.withNumeratorsAndDenominator(In.values(3, 5, 8, -12),
+                                                            9,
+                                                            alphabetizedByName));
+    }
+
+    /**
      * Attempt to use the static metamodel to create an expression for a
      * negative length prefix of an entity attribute value. Verify that
      * IllegalArgumentException is raised for the negative length and that
@@ -117,5 +249,27 @@ public class Data_1_1_Servlet extends FATServlet {
             else
                 throw x;
         }
+    }
+
+    /**
+     * Tests that the NotNull and AtMost constraint types can be assigned to
+     * repository method parameters to enforce that matching entity attributes
+     * are not null and less than or equal to a provided value.
+     */
+    @Test
+    public void testNotNullAndAtMostConstraints() {
+
+        assertEquals(List.of("One Fourth",
+                             "Two Fourths",
+                             "Three Fourths",
+                             "One Third",
+                             "Two Thirds",
+                             "One Half"),
+                     fractions.denominatoredUpTo(NotNull.instance(),
+                                                 AtMost.max(4),
+                                                 Sort.desc(_Fraction.DENOMINATOR),
+                                                 Sort.asc(_Fraction.NUMERATOR)) //
+                                     .map(f -> f.name)
+                                     .collect(Collectors.toList()));
     }
 }

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -20,11 +20,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.constraint.AtMost;
 import jakarta.data.constraint.Between;
 import jakarta.data.constraint.In;
+import jakarta.data.constraint.Like;
 import jakarta.data.constraint.NotBetween;
 import jakarta.data.constraint.NotNull;
 import jakarta.data.expression.TextExpression;
@@ -208,6 +210,74 @@ public class Data_1_1_Servlet extends FATServlet {
         assertEquals(1L, page4.numberOfElements());
         assertEquals(true, page4.hasPrevious());
         assertEquals(false, page4.hasNext());
+    }
+
+    /**
+     * Tests that the Like constraint types can be assigned to a repository
+     * method parameter to enforce that an entity attributes is matched
+     * according to a literal value.
+     */
+    @Test
+    public void testLikeConstraintWithLiteral() {
+
+        assertEquals(List.of("Seven Eighths"),
+                     fractions.named(Like.literal("Seven Eighths"),
+                                     Order.by(),
+                                     Limit.of(7)));
+
+        assertEquals(List.of(),
+                     fractions.named(Like.literal("Seven %"),
+                                     Order.by(),
+                                     Limit.of(8)));
+    }
+
+    /**
+     * Tests that the Like constraint types can be assigned to a repository
+     * method parameter to enforce that an entity attributes is matched
+     * according to an escaped pattern.
+     */
+    @Test
+    public void testLikeConstraintWithCustomEscapedPattern() {
+
+        assertEquals(List.of("Five Sixteenths",
+                             "Five Sixths",
+                             "Four Sixteenths",
+                             "Four Sixths"),
+                     fractions.named(Like.pattern("Fccc Sixxsthxs",
+                                                  'c', // char wildcard, normally _
+                                                  's', // string wildcard, normally %
+                                                  'x'), // escape char, normally \
+                                     Order.by(Sort.asc(_Fraction.NAME)),
+                                     Limit.of(6)));
+    }
+
+    /**
+     * Tests that the Like constraint types can be assigned to a repository
+     * method parameter to enforce that an entity attributes is matched
+     * according to a simple pattern with wildcards. Also use a Limit parameter
+     * to restrict the number of results returned.
+     */
+    @Test
+    public void testLikeConstraintWithPatternAndLimit() {
+
+        assertEquals(List.of("Three Fifths",
+                             "Three Ninths",
+                             "Three Sixths",
+                             "Two Fifths",
+                             "Two Ninths",
+                             "Two Sixths"),
+                     fractions.named(Like.pattern("T% _i_ths"),
+                                     Order.by(Sort.asc(_Fraction.NAME)),
+                                     Limit.of(10)));
+
+        // reversing the order and limiting to 4 results:
+        assertEquals(List.of("Two Sixths",
+                             "Two Ninths",
+                             "Two Fifths",
+                             "Three Sixths"),
+                     fractions.named(Like.pattern("T% _i_ths"),
+                                     Order.by(Sort.desc(_Fraction.NAME)),
+                                     Limit.of(4)));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -13,19 +13,30 @@
 package test.jakarta.data.v1_1.web;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.data.constraint.AtLeast;
 import jakarta.data.constraint.AtMost;
+import jakarta.data.constraint.Between;
 import jakarta.data.constraint.EqualTo;
+import jakarta.data.constraint.In;
+import jakarta.data.constraint.LessThan;
+import jakarta.data.constraint.Like;
+import jakarta.data.constraint.NotBetween;
 import jakarta.data.constraint.NotEqualTo;
+import jakarta.data.constraint.NotNull;
+import jakarta.data.page.CursoredPage;
+import jakarta.data.page.PageRequest;
 import jakarta.data.repository.By;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Is;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Select;
 
 /**
  * Repository for the Fraction entity
@@ -33,18 +44,47 @@ import jakarta.data.repository.Repository;
 @Repository
 public interface Fractions {
     @Find
+    Stream<Fraction> denominatoredUpTo //
+    (@By(_Fraction.DENOMINATOR) NotNull<Integer> notNull,
+     @By(_Fraction.DENOMINATOR) AtMost<Integer> max,
+     Sort<?>... sorts);
+
+    @Find
     @OrderBy(_Fraction.NUMERATOR)
     @OrderBy(_Fraction.DENOMINATOR)
     Stream<Fraction> havingDenominatorWithin//
     (@By(_Fraction.DENOMINATOR) @Is(AtLeast.class) long min,
      @By(_Fraction.DENOMINATOR) @Is(AtMost.class) long max);
 
+    @Find
+    @OrderBy(_Fraction.DENOMINATOR)
+    CursoredPage<Fraction> namedLike //
+    (@By(_Fraction.NAME) @Is(Like.class) String pattern,
+     Order<Fraction> additionalSorting,
+     PageRequest pageReq);
+
     @Insert
     void supply(Collection<Fraction> list);
+
+    @Find
+    @OrderBy(_Fraction.DENOMINATOR)
+    @OrderBy(_Fraction.NUMERATOR)
+    Stream<Fraction> withDenominatorBetweenNamedBeforeAndNumeratorNotBetween //
+    (@By(_Fraction.DENOMINATOR) Between<Integer> denominatorRange,
+     @By(_Fraction.NAME) @Is(LessThan.class) String exclusiveMaxName,
+     @By(_Fraction.NUMERATOR) NotBetween<Integer> excludedNumerators,
+     @By(_Fraction.REDUCED) @Is boolean reduced);
 
     @Find
     Stream<Fraction> withDenominatorButNotNumerator //
     (@By(_Fraction.DENOMINATOR) @Is(EqualTo.class) long denominator,
      @By(_Fraction.NUMERATOR) @Is(NotEqualTo.class) long excludeNumerator,
      Order<Fraction> order);
+
+    @Find
+    @Select(_Fraction.NAME)
+    List<String> withNumeratorsAndDenominator //
+    (@By(_Fraction.NUMERATOR) In<Integer> numerators,
+     @Is int denominator,
+     Sort<Fraction> sort);
 }

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
+import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.constraint.AtLeast;
@@ -55,6 +56,12 @@ public interface Fractions {
     Stream<Fraction> havingDenominatorWithin//
     (@By(_Fraction.DENOMINATOR) @Is(AtLeast.class) long min,
      @By(_Fraction.DENOMINATOR) @Is(AtMost.class) long max);
+
+    @Find
+    @Select(_Fraction.NAME)
+    List<String> named(@By(_Fraction.NAME) Like pattern,
+                       Order<Fraction> order,
+                       Limit limit);
 
     @Find
     @OrderBy(_Fraction.DENOMINATOR)

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/Like.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/Like.java
@@ -48,8 +48,15 @@ public interface Like extends Constraint<String> {
     }
 
     static Like pattern(String pattern, char charWildcard, char stringWildcard) {
+        Messages.requireNonNull(pattern, "pattern");
 
-        return Like.pattern(pattern, charWildcard, stringWildcard, ESCAPE);
+        StringLiteral expression = StringLiteral.of(translate(pattern,
+                                                              charWildcard,
+                                                              stringWildcard,
+                                                              ESCAPE,
+                                                              false));
+
+        return new LikeRecord(expression, ESCAPE);
     }
 
     static Like pattern(String pattern,
@@ -62,7 +69,8 @@ public interface Like extends Constraint<String> {
         StringLiteral expression = StringLiteral.of(translate(pattern,
                                                               charWildcard,
                                                               stringWildcard,
-                                                              escape));
+                                                              escape,
+                                                              true));
 
         return new LikeRecord(expression, escape);
     }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/LikeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/LikeRecord.java
@@ -51,7 +51,11 @@ record LikeRecord(TextExpression<?> pattern, Character escape)
                (escape == null ? "" : " ESCAPE '" + escape + "'");
     }
 
-    static String translate(String pattern, char charWildcard, char stringWildcard, char escape) {
+    static String translate(String pattern,
+                            char charWildcard,
+                            char stringWildcard,
+                            char escape,
+                            boolean patternIsAlreadyEscaped) {
 
         if (charWildcard == stringWildcard) {
             throw new IllegalArgumentException(Character.toString(charWildcard));
@@ -63,21 +67,35 @@ record LikeRecord(TextExpression<?> pattern, Character escape)
 
         StringBuilder result = new StringBuilder();
 
-        for (int c = 0; c < pattern.length(); c++) {
-            char ch = pattern.charAt(c);
-            if (ch == charWildcard) {
+        boolean previousCharIsEscape = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            final char ch = pattern.charAt(i);
+            if (previousCharIsEscape) {
+                if (ch == CHAR_WILDCARD ||
+                    ch == STRING_WILDCARD ||
+                    ch == escape) {
+                    result.append(escape);
+                }
+                result.append(ch);
+                previousCharIsEscape = false;
+            } else if (ch == charWildcard) {
                 result.append(CHAR_WILDCARD);
             } else if (ch == stringWildcard) {
                 result.append(STRING_WILDCARD);
+            } else if (ch == escape && patternIsAlreadyEscaped) {
+                previousCharIsEscape = true;
             } else {
-                if (ch == CHAR_WILDCARD ||
-                    ch == escape ||
-                    ch == STRING_WILDCARD) {
+                if (ch == STRING_WILDCARD ||
+                    ch == CHAR_WILDCARD ||
+                    ch == escape) {
                     result.append(escape);
                 }
                 result.append(ch);
             }
         }
+
+        if (previousCharIsEscape)
+            throw new IllegalArgumentException("pattern: " + pattern);
 
         return result.toString();
     }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/NotLike.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/NotLike.java
@@ -47,7 +47,15 @@ public interface NotLike extends Constraint<String> {
     static NotLike pattern(String pattern,
                            char charWildcard,
                            char stringWildcard) {
-        return NotLike.pattern(pattern, charWildcard, stringWildcard, ESCAPE);
+        Messages.requireNonNull(pattern, "pattern");
+
+        StringLiteral expression = StringLiteral.of(translate(pattern,
+                                                              charWildcard,
+                                                              stringWildcard,
+                                                              ESCAPE,
+                                                              false));
+
+        return new NotLikeRecord(expression, ESCAPE);
     }
 
     static NotLike pattern(String pattern,
@@ -59,7 +67,8 @@ public interface NotLike extends Constraint<String> {
         StringLiteral expression = StringLiteral.of(translate(pattern,
                                                               charWildcard,
                                                               stringWildcard,
-                                                              escape));
+                                                              escape,
+                                                              true));
         return new NotLikeRecord(expression, escape);
     }
 


### PR DESCRIPTION
Updates so that basic constraints can be used.  It needed to allow for 0 or 2 values rather assuming exactly 1.  This also includes a proposed fix to a spec API bug with Like/NotLike.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
