### PR TITLE
feat: allow test servlets to have a minimum java level

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDITest.java
@@ -46,7 +46,7 @@ public class ConcurrentCDITest extends FATServletClient {
 
     @Server("concurrent_fat_cdi")
     @TestServlets({
-                    @TestServlet(servlet = ConcurrentCDIServlet.class, contextRoot = APP_NAME),
+                    @TestServlet(servlet = ConcurrentCDIServlet.class, contextRoot = APP_NAME, minJavaLevel = 17),
                     @TestServlet(servlet = ConcurrentCDI4Servlet.class, contextRoot = APP_NAME_EE10),
                     @TestServlet(servlet = ConcurrentCDIAdditionalServlet.class, contextRoot = WEBAPP_NAME_EE10)
     })

--- a/dev/fattest.simplicity/src/componenttest/annotation/TestServlet.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/TestServlet.java
@@ -44,8 +44,10 @@ public @interface TestServlet {
 
     /**
      * The servlet class should only be scanned if the minimum java level is meet.
-     * This will be used to avoid attempting to initialize a test servlet class during
-     * child test discovery, but before additional test filtering.
+     * This will be used to avoid attempting to load annotations on the servlet class
+     * that were compiled with a later version of java then the current runtime.
+     *
+     * Otherwise, developers should be using the {@link MinimumJavaLevel} annotation.
      *
      * Default: 0
      */

--- a/dev/fattest.simplicity/src/componenttest/annotation/TestServlet.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/TestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -41,5 +41,14 @@ public @interface TestServlet {
      * The servlet class to scan for '@Test' annotations, which will be invoked automatically via HTTP GET request
      */
     Class<?> servlet();
+
+    /**
+     * The servlet class should only be scanned if the minimum java level is meet.
+     * This will be used to avoid attempting to initialize a test servlet class during
+     * child test discovery, but before additional test filtering.
+     *
+     * Default: 0
+     */
+    int minJavaLevel() default 0;
 
 }

--- a/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.SyntheticServletTest;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 public class TestServletProcessor {
@@ -70,6 +71,12 @@ public class TestServletProcessor {
 
             // For each @TestServlet for this server, add all @Test methods
             for (TestServlet anno : testServlets) {
+                if (JavaInfo.JAVA_VERSION < anno.minJavaLevel()) {
+                    Log.info(c, m, "Skipping scan of TestServlet " + anno.servlet()
+                                   + " because the current java level " + JavaInfo.JAVA_VERSION
+                                   + " did not meet the configured minimum " + anno.minJavaLevel());
+                    continue;
+                }
                 int initialSize = testMethods.size();
                 for (Method method : getTestServletMethods(anno)) {
                     if (method.isAnnotationPresent(Test.class)) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

When we run our functional tests we find all the test methods via the following procedure: 
- Search all test classes for test methods
- Search all test classes for `@TestServlet` annotations
  - Search all `@TestServlet.servlet` classes for test methods

After we have a list of all possible test methods, then we apply filters such as `@MinimumJavaLevel` and pair down the test methods to those that can be run given the current state of the runtime environment. 

The issue is when compiling a list of test methods inside a servlet we also evaluate the query path:
https://github.com/OpenLiberty/open-liberty/blob/0621cd5c57c14a76ac9f619fbbc61cb572123337/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java#L109-L122

The call to `getAnnotation`results in the JVM loading all the annotations on the class. 
This results in a runtime exception when the annotation was compiled with a Java level beyond that of the current runtime.

An alternative to the solution here would be to make the result of `getQueryPath` a callable that could be executed JIT for the test to run after the other filtering had already taken place. 
