### PR TITLE
Removal of the IdentityStorePermission class - Jakarta Security 4.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-3.0/com.ibm.websphere.appserver.appSecurity-3.0.feature
@@ -29,6 +29,7 @@ Subsystem-Name: Application Security 3.0
   com.ibm.websphere.appserver.cdi-2.0, \
   com.ibm.websphere.appserver.security-1.0
 -bundles=com.ibm.websphere.javaee.security.1.0; location:=dev/api/spec/; mavenCoordinates="javax.security.enterprise:javax.security.enterprise-api:1.0", \
+ io.openliberty.security.javaeesec.internal, \
  com.ibm.ws.security.javaeesec.1.0, \
  com.ibm.ws.security.javaeesec.cdi, \
  com.ibm.websphere.javaee.jaspic.1.1; location:=dev/api/spec/; mavenCoordinates="javax.security.auth.message:javax.security.auth.message-api:1.1", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-4.0/io.openliberty.appSecurity-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-4.0/io.openliberty.appSecurity-4.0.feature
@@ -29,6 +29,7 @@ Subsystem-Name: Application Security 4.0 (Jakarta Security 2.0)
   io.openliberty.expressionLanguage-4.0, \
   io.openliberty.webAppSecurity-2.0
 -bundles=\
+  io.openliberty.security.javaeesec.internal.jakarta, \
   io.openliberty.security.jakartasec.2.0.internal, \
   io.openliberty.security.jakartasec.2.0.internal.cdi, \
   io.openliberty.security.authentication.internal.filter, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-5.0/io.openliberty.appSecurity-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appSecurity-5.0/io.openliberty.appSecurity-5.0.feature
@@ -38,6 +38,7 @@ Subsystem-Name: Application Security 5.0 (Jakarta Security 3.0)
   io.openliberty.org.apache.commons.codec, \
   io.openliberty.org.apache.commons.logging, \
   io.openliberty.security.common.internal, \
+  io.openliberty.security.javaeesec.internal.jakarta, \
   io.openliberty.security.jakartasec.2.0.internal, \
   io.openliberty.security.jakartasec.2.0.internal.cdi, \
   io.openliberty.security.oidcclientcore.internal.jakarta, \

--- a/dev/com.ibm.ws.security.javaeesec/bnd.bnd
+++ b/dev/com.ibm.ws.security.javaeesec/bnd.bnd
@@ -74,7 +74,8 @@ Include-Resource: \
     com.ibm.ws.webcontainer.security;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
     com.ibm.ws.app.manager.lifecycle;version=latest,\
-    com.ibm.ws.kernel.service;version=latest
+    com.ibm.ws.kernel.service;version=latest,\
+    io.openliberty.security.javaeesec.internal;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStore.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/DatabaseIdentityStore.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -34,7 +34,6 @@ import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
 import javax.security.enterprise.identitystore.IdentityStore;
-import javax.security.enterprise.identitystore.IdentityStorePermission;
 import javax.security.enterprise.identitystore.PasswordHash;
 import javax.sql.DataSource;
 
@@ -43,7 +42,8 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.security.javaeesec.CDIHelper;
-import com.ibm.ws.security.javaeesec.JavaEESecConstants;
+
+import io.openliberty.security.jakartasec.identitystore.permissions.IdentityStorePermissionService;
 
 /**
  * Liberty's database {@link IdentityStore} implementation.
@@ -166,10 +166,8 @@ public class DatabaseIdentityStore implements IdentityStore {
         if (!validationTypes().contains(ValidationType.PROVIDE_GROUPS)) {
             return groups;
         }
-        SecurityManager securityManager = System.getSecurityManager();
-        if (securityManager != null) {
-            securityManager.checkPermission(new IdentityStorePermission(JavaEESecConstants.GET_GROUPS_PERMISSION));
-        }
+
+        IdentityStorePermissionService.checkPermission("getGroups");
 
         String caller = validationResult.getCallerPrincipal().getName();
         if (caller == null) {

--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/LdapIdentityStore.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/identitystore/LdapIdentityStore.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -39,7 +39,6 @@ import javax.security.enterprise.credential.Credential;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
-import javax.security.enterprise.identitystore.IdentityStorePermission;
 import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition.LdapSearchScope;
 
@@ -50,6 +49,8 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+import io.openliberty.security.jakartasec.identitystore.permissions.IdentityStorePermissionService;
 
 /**
  * Liberty's LDAP {@link IdentityStore} implementation.
@@ -170,10 +171,7 @@ public class LdapIdentityStore implements IdentityStore {
             return new HashSet<String>();
         }
 
-        SecurityManager secManager = System.getSecurityManager();
-        if (secManager != null) {
-            secManager.checkPermission(new IdentityStorePermission("getGroups"));
-        }
+        IdentityStorePermissionService.checkPermission("getGroups");
 
         String userDn = validationResult.getCallerDn();
         if (userDn == null || userDn.isEmpty()) {

--- a/dev/com.ibm.ws.security.javaeesec/test/com/ibm/ws/security/javaeesec/identitystore/IdentityStorePermissionServiceTest.java
+++ b/dev/com.ibm.ws.security.javaeesec/test/com/ibm/ws/security/javaeesec/identitystore/IdentityStorePermissionServiceTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.javaeesec.identitystore;
+
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.openliberty.security.jakartasec.identitystore.permissions.IdentityStorePermissionService;
+
+/**
+ * Test for the IdentityStorePermissionService
+ */
+public class IdentityStorePermissionServiceTest {
+
+    private final Mockery mockery = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+        mockery.assertIsSatisfied();
+    }
+
+    /**
+     * Test the implementation for Jakarta Security 1/2/3.0
+     */
+
+    @Test
+    public void testIdentityStorePermissionService() {
+
+        // should not throw exceptions
+        IdentityStorePermissionService.checkPermission("getGroups");
+        IdentityStorePermissionService.checkPermission("someOtherPermission", "read");
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/bnd.bnd
@@ -29,6 +29,7 @@ Export-Package: \
     io.openliberty.security.jakartasec.credential,\
     io.openliberty.security.jakartasec.el,\
     io.openliberty.security.jakartasec.identitystore,\
+    io.openliberty.security.jakartasec.identitystore.permissions,\
     io.openliberty.security.jakartasec.tokens
 
 Import-Package: \
@@ -52,4 +53,6 @@ instrument.classesExcludes: io/openliberty/security/jakartasec/internal/resource
     com.ibm.ws.security;version=latest,\
     io.openliberty.jakarta.expressionLanguage.6.0;version=latest,\
     com.ibm.json4j;version=latest,\
-    io.openliberty.cdi.4.0.internal.interfaces;version=latest
+    io.openliberty.cdi.4.0.internal.interfaces;version=latest,\
+    com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+    io.openliberty.jakarta.cdi.4.0;version=latest

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/IdentityStorePermissionService.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/IdentityStorePermissionService.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.identitystore.permissions;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Implementation for Jakarta Security 4.0 where the IdentityStorePermission
+ * class has been removed.
+ *
+ * Jakarta Security 4.0 (appSecurity-6.0) =
+ * io.openliberty.security.jakartasec.4.0.internal_1.0.<VER>.jar
+ */
+
+public class IdentityStorePermissionService {
+
+    private static final TraceComponent tc = Tr.register(IdentityStorePermissionService.class);
+
+    public static void checkPermission(String name) {
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Using Jakarta Security 4.0+ implementation (no-op).");
+        }
+    }
+
+    public static void checkPermission(String name, String action) {
+        checkPermission(name);
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/package-info.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/package-info.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
+package io.openliberty.security.jakartasec.identitystore.permissions;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+
+import io.openliberty.security.jakartasec.TraceConstants;

--- a/dev/io.openliberty.security.javaeesec.internal/.classpath
+++ b/dev/io.openliberty.security.javaeesec.internal/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.security.javaeesec.internal/.project
+++ b/dev/io.openliberty.security.javaeesec.internal/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.security.javaeesec.internal</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.security.javaeesec.internal/bnd.bnd
+++ b/dev/io.openliberty.security.javaeesec.internal/bnd.bnd
@@ -1,0 +1,31 @@
+#*******************************************************************************
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+
+-include= ~../cnf/resources/bnd/bundle.props
+
+-sub: *.bnd
+
+bVersion=1.0
+
+WS-TraceGroup: \
+  SECURITY, \
+  SECURITYJAVAEE
+
+Export-Package: \
+  io.openliberty.security.jakartasec.identitystore.permissions
+  
+-buildpath: \
+  com.ibm.websphere.javaee.security.1.0;version=latest,\
+  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+  com.ibm.ws.logging;version=latest,\
+  com.ibm.websphere.org.osgi.service.component;version=latest,\
+  com.ibm.websphere.org.osgi.core;version=latest
+

--- a/dev/io.openliberty.security.javaeesec.internal/original.bnd
+++ b/dev/io.openliberty.security.javaeesec.internal/original.bnd
@@ -1,0 +1,13 @@
+#*******************************************************************************
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+
+Bundle-Name: Liberty Java EE Security Internal 
+Bundle-SymbolicName: io.openliberty.security.javaeesec.internal
+Bundle-Description: Liberty Java EE Security Internal, version=${bVersion}

--- a/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/IdentityStorePermissionService.java
+++ b/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/IdentityStorePermissionService.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.identitystore.permissions;
+
+import javax.security.enterprise.identitystore.IdentityStorePermission;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Implementation for Jakarta Security 1.0, 2.0 and 3.0 which all include
+ * the IdentityStorePermission class.
+ * 
+ * NOTE: For the Jakarta Security 2.0 and 3.0 implementations, they will 
+ * use this bundle but transformed for jakarta instead of javax.
+ * 
+ * Jakarta Security 1.0 (appSecurity-3.0) = 
+ *     io.openliberty.security.javaeesec.internal_1.0.<VER>.jar
+ *
+ * Jakarta Security 2.0 (appSecurity-4.0) = 
+ *     io.openliberty.security.javaeesec.internal.jakarta_1.0.<VER>.jar (transformed)
+ *
+ * Jakarta Security 3.0 (appSecurity-5.0)  = 
+ *     io.openliberty.security.javaeesec.internal.jakarta_1.0.<VER>.jar (transformed)
+ *     
+ * *** appSecurity-3.0 was the first occurrence of the implementation (JSR375).
+ */
+
+public class IdentityStorePermissionService { 
+
+    private static final TraceComponent tc = Tr.register(IdentityStorePermissionService.class);
+
+    @SuppressWarnings("deprecation")
+    public static void checkPermission(String name) {
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Using Jakarta Security 1.0/2.0/3.0 implementation.");
+        }
+        SecurityManager securityManager = System.getSecurityManager();
+        if (securityManager != null) {
+            securityManager.checkPermission(new IdentityStorePermission(name));
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    public static void checkPermission(String name, String action) {
+        SecurityManager securityManager = System.getSecurityManager();
+        if (securityManager != null) {
+            securityManager.checkPermission(new IdentityStorePermission(name, action));
+        }
+    }
+}

--- a/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/package-info.java
+++ b/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = "security", messageBundle = "com.ibm.ws.security.javaeesec.internal.resources.JavaEESecMessages")
+package io.openliberty.security.jakartasec.identitystore.permissions;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+

--- a/dev/io.openliberty.security.javaeesec.internal/transformed.bnd
+++ b/dev/io.openliberty.security.javaeesec.internal/transformed.bnd
@@ -1,0 +1,15 @@
+#*******************************************************************************
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+
+-include= ~../cnf/resources/bnd/transform.props
+
+Bundle-Name: Liberty Jakarta Security Internal
+Bundle-SymbolicName: io.openliberty.security.javaeesec.internal.jakarta
+Bundle-Description: Liberty Jakarta Security Internal, version=${bVersion}


### PR DESCRIPTION
Initial commit for the Jakarta Security 4.0 removal of the  IdentityStorePermission class.

Create an abstraction via a singleton class created by a Factory to provide an IdentityStorePermissions checker.

Two implementations of checker, one for Jakarta Security 3.0 and one for 4.0 and presumably beyond.

- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).

Fixes #32489
