### PR TITLE
Like and NotLike constraints will always supply escape character

### DIFF
--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -593,11 +593,7 @@ public class Data_1_1 implements DataVersionCompatibility {
         else if (constraintOrValue instanceof LessThan c)
             values = new Object[] { c.bound() };
         else if (constraintOrValue instanceof Like c)
-            values = new Object[] { c.pattern(),
-                                    c.escape() == null ? '\\' : c.escape() };
-        // TODO API change requested to avoid null (above). If we do not get it, then
-        // the escape character will need to be inserted into the value of c.escape()
-        // whenever switching from null to \
+            values = new Object[] { c.pattern(), c.escape() };
         else if (constraintOrValue instanceof NotBetween c)
             values = new Object[] { c.lowerBound(), c.upperBound() };
         else if (constraintOrValue instanceof NotEqualTo c)
@@ -605,11 +601,7 @@ public class Data_1_1 implements DataVersionCompatibility {
         else if (isList = constraintOrValue instanceof NotIn)
             values = ((NotIn) constraintOrValue).expressions().toArray();
         else if (constraintOrValue instanceof NotLike c)
-            values = new Object[] { c.pattern(),
-                                    c.escape() == null ? '\\' : c.escape() };
-        // TODO API change requested to avoid null (above). If we do not get it, then
-        // the escape character will need to be inserted into the value of c.escape()
-        // whenever switching from null to \
+            values = new Object[] { c.pattern(), c.escape() };
         else if (constraintOrValue instanceof NotNull ||
                  constraintOrValue instanceof Null)
             values = new Object[0];

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/Like.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/Like.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package jakarta.data.constraint;
 
+import static jakarta.data.constraint.LikeRecord.CHAR_WILDCARD;
 import static jakarta.data.constraint.LikeRecord.ESCAPE;
 import static jakarta.data.constraint.LikeRecord.STRING_WILDCARD;
 import static jakarta.data.constraint.LikeRecord.translate;
@@ -25,7 +26,7 @@ import jakarta.data.spi.expression.literal.StringLiteral;
  */
 public interface Like extends Constraint<String> {
 
-    Character escape();
+    char escape();
 
     static Like literal(String value) {
 
@@ -40,11 +41,7 @@ public interface Like extends Constraint<String> {
 
     static Like pattern(String pattern) {
 
-        Messages.requireNonNull(pattern, "pattern");
-
-        StringLiteral expression = StringLiteral.of(pattern);
-
-        return new LikeRecord(expression, null);
+        return pattern(pattern, CHAR_WILDCARD, STRING_WILDCARD);
     }
 
     static Like pattern(String pattern, char charWildcard, char stringWildcard) {

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/LikeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/LikeRecord.java
@@ -17,7 +17,7 @@ import jakarta.data.expression.TextExpression;
 /**
  * Method signatures are copied from Jakarta Data.
  */
-record LikeRecord(TextExpression<?> pattern, Character escape)
+record LikeRecord(TextExpression<?> pattern, char escape)
                 implements Like {
 
     static final char CHAR_WILDCARD = '_';
@@ -47,8 +47,7 @@ record LikeRecord(TextExpression<?> pattern, Character escape)
 
     @Override
     public String toString() {
-        return "LIKE " + pattern +
-               (escape == null ? "" : " ESCAPE '" + escape + "'");
+        return "LIKE " + pattern + " ESCAPE '" + escape + "'";
     }
 
     static String translate(String pattern,

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/NotLike.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/NotLike.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package jakarta.data.constraint;
 
+import static jakarta.data.constraint.LikeRecord.CHAR_WILDCARD;
 import static jakarta.data.constraint.LikeRecord.ESCAPE;
 import static jakarta.data.constraint.LikeRecord.STRING_WILDCARD;
 import static jakarta.data.constraint.LikeRecord.translate;
@@ -25,7 +26,7 @@ import jakarta.data.spi.expression.literal.StringLiteral;
  */
 public interface NotLike extends Constraint<String> {
 
-    Character escape();
+    char escape();
 
     static NotLike literal(String value) {
         Messages.requireNonNull(value, "value");
@@ -38,10 +39,7 @@ public interface NotLike extends Constraint<String> {
     TextExpression<?> pattern();
 
     static NotLike pattern(String pattern) {
-        Messages.requireNonNull(pattern, "pattern");
-
-        StringLiteral expression = StringLiteral.of(pattern);
-        return new NotLikeRecord(expression, null);
+        return pattern(pattern, CHAR_WILDCARD, STRING_WILDCARD);
     }
 
     static NotLike pattern(String pattern,

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/NotLikeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/constraint/NotLikeRecord.java
@@ -19,7 +19,7 @@ import jakarta.data.expression.TextExpression;
  */
 record NotLikeRecord(
                 TextExpression<?> pattern,
-                Character escape)
+                char escape)
                 implements NotLike {
 
     @Override
@@ -29,7 +29,6 @@ record NotLikeRecord(
 
     @Override
     public String toString() {
-        return "NOT LIKE " + pattern +
-               (escape == null ? "" : " ESCAPE '" + escape + "'");
+        return "NOT LIKE " + pattern + " ESCAPE '" + escape + "'";
     }
 }


### PR DESCRIPTION
Bring in updates from the spec API and make corresponding changes.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
