### PR TITLE
Most basic intersect and union in JPQL

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -331,8 +331,8 @@ CWWKD1029.first.neg.or.zero.useraction=Update the repository method to specify \
  a positive maximum number of results.
 
 CWWKD1030.ql.lacks.entity=CWWKD1030E: The entity name is missing from the {0} \
- query that is specified for the {1} method of the {2} repository. In Jakarta \
- Data Query Language, {3} queries should be formed like: {4}.
+ query that is specified for the {1} method of the {2} repository. \
+ For {3} queries, use the form: {4}.
 CWWKD1030.ql.lacks.entity.explanation=The query contains a clause that requires \
  the entity name.
 CWWKD1030.ql.lacks.entity.useraction=Update the query for repository method to \

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -2801,6 +2801,24 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Verifies that an INTERSECT statement can be used within a JPQL query.
+     */
+    @Test
+    public void testIntersection() {
+
+        assertEquals(List.of("twenty-three",
+                             "twenty-nine",
+                             "thirty-seven",
+                             "thirty-one"),
+                     primes.withinBoth(10L, 40L,
+                                       20L, 50L)
+                                     .stream()
+                                     .map(p -> p.name)
+                                     .sorted(Comparator.reverseOrder())
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
      * Repository method that returns IntStream.
      */
     @Test
@@ -6285,6 +6303,30 @@ public class DataTestServlet extends FATServlet {
         assertEquals("Found: " + found, 1, found.size());
         assertEquals(4021L, found.get(0).numberId);
         assertEquals(" Four thousand twenty-one ", found.get(0).name);
+    }
+
+    /**
+     * Verifies that a UNION statement can be used within a JPQL query.
+     */
+    @Test
+    public void testUnion() {
+
+        assertEquals(List.of("eleven",
+                             "five",
+                             "forty-one",
+                             "forty-three",
+                             "nineteen",
+                             "seven",
+                             "seventeen",
+                             "thirteen",
+                             "thirty-one",
+                             "thirty-seven"),
+                     primes.withinEither(5L, 20L,
+                                         30L, 45L)
+                                     .stream()
+                                     .map(p -> p.name)
+                                     .sorted()
+                                     .collect(Collectors.toList()));
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -482,6 +482,15 @@ public interface Primes {
     @Query("where (numberId <= :maximum) and numberId>=10 order by name asc")
     Page<Prime> within10toXAndSortedByName(long maximum, PageRequest pageRequest);
 
+    @Query("""
+                    SELECT p1 FROM Prime p1 WHERE p1.numberId BETWEEN ?1 AND ?2
+                    INTERSECT
+                    SELECT p2 FROM Prime p2 WHERE p2.numberId BETWEEN ?3 AND ?4""")
+    // TODO once it is known how to write the JPQL for ORDER BY add it to the above
+    // and remove the manual sorting from the test
+    List<Prime> withinBoth(long min1, long max1,
+                           long min2, long max2);
+
     @OrderBy(value = "even", descending = true)
     @OrderBy(value = "name", descending = false)
     // Query used to contain (numberId-(numberId/10)* 10)<>3
@@ -491,6 +500,16 @@ public interface Primes {
     CursoredPage<Prime> withinButNotEndingIn7or3(@Param("min") long minimum,
                                                  @Param("max") long maximum,
                                                  PageRequest pageRequest);
+
+    @Query("""
+                    SELECT o FROM Prime o WHERE o.numberId BETWEEN ?1 AND ?2
+                    UNION
+                    SELECT o FROM Prime o WHERE o.numberId BETWEEN ?3 AND ?4""")
+    // TODO once it is known how to write the JPQL for ORDER BY, enable this
+    // and remove the manual sorting from the test
+    // @OrderBy(_Prime.NAME)
+    List<Prime> withinEither(long min1, long max1,
+                             long min2, long max2);
 
     @Query("WHERE (LENGTH(TRIM(name))=?1 AND numberId BETWEEN ?2 AND ?3)")
     List<Prime> withTrimmedNameLengthAndNumBetween(int length, long min, long max);


### PR DESCRIPTION
This is a first step toward being able to use queries with UNION and INTERSECT in Jakarta Data.  It adds tests of only the most basic usage and then makes temporary adjustments to code path to avoid interfering with them.  A lot more work is needed to reduce the amount of replacement that happens to the supplied query, some of which will require bug fixes from EclipseLink that we are waiting for. This is at least something we can do to start out with so that we have a couple of working scenarios to build on.  Also, I noticed a message that refers to Jakarta Data Query Language, which we should make more general given that in the next release, it will be the Jakarta Query Language instead.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
