### PR TITLE
Include Liberty base FIPS140-3 profile in WLP installs

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -48,6 +48,13 @@ task copyPropertiesToBuildImage (type:Copy) {
            tokens: [PRODUCT_VERSION: bnd.libertyRelease, PRODUCT_EDITION: bnd.productEdition, PRODUCT_LICENSE_TYPE: bnd.productLicenseType])
 }
 
+task copyFips1403PropertiesToBuildImage( type: Copy) {
+    dependsOn jar
+    from project.file('publish/wlp/security')
+    into project.file('wlp/lib/security/fips140_3')
+    include '*.properties'
+}
+
 task copyPublicKeyToBuildImage (type:Copy) {
     dependsOn jar
     from project.file('publish')
@@ -154,6 +161,7 @@ jar {
 assemble {
     dependsOn publishTemplates
     dependsOn copyPropertiesToBuildImage
+    dependsOn copyFips1403PropertiesToBuildImage
     dependsOn addServiceFingerprint
     dependsOn copyReadmeToBuildImage
     dependsOn copyBetaLicenseToBuildImage
@@ -314,6 +322,12 @@ class PackageLibertyWithFeatures extends DefaultTask {
             project.copy {
                 from project.file('wlp')
                 include 'LICENSE'
+                into "$outputTo/wlp"
+            }
+
+            project.copy {
+                from project.file('wlp')
+                include 'lib/security/fips140_3/FIPS140-3-Liberty.properties'
                 into "$outputTo/wlp"
             }
 

--- a/dev/build.image/publish/wlp/security/FIPS140-3-Liberty.properties
+++ b/dev/build.image/publish/wlp/security/FIPS140-3-Liberty.properties
@@ -1,0 +1,15 @@
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3 for Liberty
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.2 = sun.security.provider.Sun [+ \
+    {MessageDigest, SHA-1, *, FullClassName:org.objectweb.asm.commons.SerialVersionUIDAdder}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.eclipse.persistence.internal.libraries.asm.commons.SerialVersionUIDAdder}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.yoko.rmi.impl.ValueDescriptor}, \
+    {MessageDigest, SHA-1, *, FullClassName:com.ibm.ws.wsoc.util.Utils}, \
+    {MessageDigest, SHA-1, *, FullClassName:com.ibm.security.certclient.util.PkUtils}]
+
+# For Collectives
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.7 = com.ibm.ws.collective.security.internal.provider.CollectiveProvider
+
+# For WebServices / SAML (uses JCE underneath)
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.8 = org.apache.jcp.xml.dsig.internal.dom.XMLDSigRI
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty.jce.provider.9 = org.apache.wss4j.dom.transform.STRTransformProvider


### PR DESCRIPTION
Add new task that copies the base Liberty platform into lib directory

As this is the base Liberty profile, it is included within the Lib directory as this is something that is owned by the product

Included profile is a sample - it requires updates before it can be used

#32602

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

