### PR TITLE
mcpServer-1.0 updates

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mcpServer-1.0/io.openliberty.mcpServer-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mcpServer-1.0/io.openliberty.mcpServer-1.0.feature
@@ -13,7 +13,7 @@ IBM-API-Package: \
 IBM-ShortName: mcpServer-1.0
 Subsystem-Name: Model Context Protocol Server 1.0
 -features=io.openliberty.mcpServer1.0.ee-10.0;ibm.tolerates:=11.0
--bundles=io.openliberty.mcp; location:="dev/api/ibm/", \
+-bundles=io.openliberty.mcp; location:="dev/api/ibm/,lib/", \
  io.openliberty.mcp.internal
 kind=beta
 edition=core

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10Features.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/EE10Features.java
@@ -316,10 +316,11 @@ public class EE10Features {
 
         features.remove("audit-2.0");
 
-        // springBoot-4.0 and nosql-1.0 require Java 17 so if we are currently not using Java 17 or later, remove it from the list of features.
+        // springBoot-3.0, nosql-1.0, and mcpServer-1.0 require Java 17 so if we are currently not using Java 17 or later, remove it from the list of features.
         if (JavaInfo.JAVA_VERSION < 17) {
             features.remove("springBoot-3.0");
             features.remove("nosql-1.0");
+            features.remove("mcpServer-1.0");
         }
 
         return features;

--- a/dev/io.openliberty.mcp/bnd.bnd
+++ b/dev/io.openliberty.mcp/bnd.bnd
@@ -14,7 +14,10 @@ Bundle-SymbolicName: io.openliberty.mcp
 Bundle-Description: Model Context Protocol API, version ${bVersion}
 
 bVersion=1.0
-publish.wlp.jar.suffix: dev/api/ibm
+
+# TODO:  When moving to GA, put this change back in.  We do not want to publish this API to
+# maven until the feature is GA.
+# publish.wlp.jar.suffix: dev/api/ibm
 
 javac.source: 17
 javac.target: 17


### PR DESCRIPTION
- Do not publish the API to the dev/api/ibm directory until GA
- Update io.openliberty.jakartaee10.internal_fat failure when run on Java 11

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
