### PR TITLE
Revert "Fixes #32782 - remove unusable SAML SHA128 signatureMethodAlgorithm"

### DIFF
--- a/dev/com.ibm.ws.security.saml.websso.2.0/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021,2025 IBM Corporation and others.
+    Copyright (c) 2021,2022 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@
             required="false" type="String" default="SHA256">
                 <!-- defect 168307 Option label="%signatureMethodAlgorithm.NONE"   value="none" / -->
             	<Option label="%signatureMethodAlgorithm.SHA256" value="SHA256" />
+            	<Option label="%signatureMethodAlgorithm.SHA128" value="SHA128" />
             	<Option label="%signatureMethodAlgorithm.SHA1"   value="SHA1" />
         </AD>        
         <AD id="createSession" name ="%createSession" description="%createSession.desc"

--- a/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/rs/RsSamlConfigImpl.java
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/src/com/ibm/ws/security/saml/sso20/rs/RsSamlConfigImpl.java
@@ -313,6 +313,8 @@ public class RsSamlConfigImpl extends PkixTrustEngineConfig implements SsoConfig
     public String getSignatureMethodAlgorithm() {
         if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA256.equalsIgnoreCase(signatureMethodAlgorithm)) {
             return SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256;
+        } else if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA128.equalsIgnoreCase(signatureMethodAlgorithm)) {
+            return SignatureConstants.MORE_ALGO_NS + "rsa-sha128"; //???????
         } else if (CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA1.equalsIgnoreCase(signatureMethodAlgorithm)) {
             // FIPS 140-3: Algorithm assessment complete; no changes required.
             // Already log insure algorithm at top of the class


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#32784

Will bring this issue through POC before releasing