### PR TITLE
Set correct content type in MCP responses

### DIFF
--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpTransport.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpTransport.java
@@ -161,6 +161,7 @@ public class McpTransport {
      */
     public void sendResponse(Object result) {
         McpResponse mcpResponse = new McpResultResponse(mcpRequest.id(), result);
+        res.setContentType("application/json");
         jsonb.toJson(mcpResponse, writer);
     }
 
@@ -193,6 +194,7 @@ public class McpTransport {
      */
     public void sendJsonRpcException(JSONRPCException e) {
         McpResponse mcpResponse = new McpErrorResponse(mcpRequest == null ? new McpRequestId("") : mcpRequest.id(), e);
+        res.setContentType("application/json");
         jsonb.toJson(mcpResponse, writer);
     }
 


### PR DESCRIPTION
At the moment, our content type is always application/json

For #32913 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
