### PR TITLE
subqueries in UPDATE and DELETE

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -105,7 +105,7 @@ public class Util {
                            double.class, float.class);
 
     /**
-     * Query language keywords that can appear immediately the entity name when
+     * Query language keywords that can appear immediately after the entity name when
      * there is no entity identifier variable specified.
      *
      * DELETE FROM MyEntity WHERE ...

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -105,6 +105,27 @@ public class Util {
                            double.class, float.class);
 
     /**
+     * Query language keywords that can appear immediately the entity name when
+     * there is no entity identifier variable specified.
+     *
+     * DELETE FROM MyEntity WHERE ...
+     * FROM MyEntity UNION ...
+     * FROM MyEntity ORDER BY ...
+     * UPDATE MyEntity SET ...
+     */
+    public static final Set<String> QL_KEYWORDS_AFTER_ENTITY_NAME = new HashSet<>();
+    static {
+        QL_KEYWORDS_AFTER_ENTITY_NAME.add("EXCEPT");
+        QL_KEYWORDS_AFTER_ENTITY_NAME.add("GROUP");
+        QL_KEYWORDS_AFTER_ENTITY_NAME.add("HAVING");
+        QL_KEYWORDS_AFTER_ENTITY_NAME.add("INTERSECT");
+        QL_KEYWORDS_AFTER_ENTITY_NAME.add("ORDER");
+        QL_KEYWORDS_AFTER_ENTITY_NAME.add("SET");
+        QL_KEYWORDS_AFTER_ENTITY_NAME.add("UNION");
+        QL_KEYWORDS_AFTER_ENTITY_NAME.add("WHERE");
+    }
+
+    /**
      * Return types for deleteBy that distinguish delete-only from find-and-delete.
      */
     static final Set<Class<?>> RETURN_TYPES_FOR_DELETE_ONLY = //

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -5837,6 +5837,33 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Tests JPQL UPDATE with a subquery, such that there are two FROM clauses:
+     * one in the main query and one in the subquery.
+     */
+    @Test
+    public void testSubqueryInUpdate() {
+        receipts.removeIfTotalUnder(Float.MAX_VALUE);
+
+        receipts.insertAll(List.of(new Receipt(8001, "TSIU-1", 61.98f),
+                                   new Receipt(8002, "TSIU-2", 32.98f),
+                                   new Receipt(8003, "TSIU-3", 23.98f),
+                                   new Receipt(8004, "TSIU-4", 74.98f),
+                                   new Receipt(8005, "TSIU-5", 65.98f)));
+
+        assertEquals(3L,
+                     receipts.increaseIfAboveAverageTotal(1.08f));
+
+        Receipt r3 = receipts.findById(8003L).orElseThrow();
+        assertEquals(23.98f, r3.total(), 0.01f);
+
+        Receipt r4 = receipts.findById(8004L).orElseThrow();
+        assertEquals(80.98f, r4.total(), 0.01f);
+
+        assertEquals(5L,
+                     receipts.removeIfTotalUnder(Float.MAX_VALUE));
+    }
+
+    /**
      * Repository method that supplies pagination information and returns a list.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -5816,6 +5816,27 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Tests JPQL DELETE with a subquery, such that there are two FROM clauses:
+     * one in the main query and one in the subquery.
+     */
+    @Test
+    public void testSubqueryInDelete() {
+        receipts.removeIfTotalUnder(Float.MAX_VALUE);
+
+        receipts.insertAll(List.of(new Receipt(7001, "TSID-1", 13.99f),
+                                   new Receipt(7002, "TSID-2", 82.99f),
+                                   new Receipt(7003, "TSID-3", 93.99f),
+                                   new Receipt(7004, "TSID-4", 24.99f),
+                                   new Receipt(7005, "TSID-5", 75.99f)));
+
+        assertEquals(2L,
+                     receipts.removeByBelowAverageTotal());
+
+        assertEquals(3L,
+                     receipts.removeIfTotalUnder(Float.MAX_VALUE));
+    }
+
+    /**
      * Repository method that supplies pagination information and returns a list.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
@@ -83,6 +83,11 @@ public interface Receipts extends CrudRepository<Receipt, Long> {
     @Find
     CursoredPage<Receipt> forCustomer(String customer, PageRequest req, Sort<?>... sorts);
 
+    @Query("""
+                    DELETE FROM Receipt r
+                     WHERE r.total < (SELECT AVG(t.total) FROM Receipt t)""")
+    long removeByBelowAverageTotal();
+
     long removeByPurchaseId(long purchaseId);
 
     Set<Long> removeByTotalBetween(float min, float max);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.enterprise.concurrent.Asynchronous;
@@ -82,6 +83,12 @@ public interface Receipts extends CrudRepository<Receipt, Long> {
 
     @Find
     CursoredPage<Receipt> forCustomer(String customer, PageRequest req, Sort<?>... sorts);
+
+    @Query("""
+                    UPDATE Receipt rct
+                       SET rct.total = rct.total * :ReceiptTotalRateOfIncrease
+                     WHERE rct.total > (SELECT AVG(rt.total) FROM Receipt rt)""")
+    long increaseIfAboveAverageTotal(@Param("ReceiptTotalRateOfIncrease") float rate);
 
     @Query("""
                     DELETE FROM Receipt r


### PR DESCRIPTION
Ability to have subqueries in UPDATE and DELETE (allowed by JPQL). Avoid rewriting the query, instead replacing only the specific places where changes are needed. Ensure that multiple references (due to the subquery) are identified and handled properly.
This is a first step.  In a subsequent PR, I'll look into further consolidating and combining with the find path.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
