### PR TITLE
Skipping Jakarta Validation TCK run in windows

### DIFF
--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
@@ -12,12 +12,13 @@
  *******************************************************************************/
 package io.openliberty.jakarta.validation.tck;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.time.Duration;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,6 +56,13 @@ public class ValidationTckLauncher {
     public static void setUp() throws Exception {
 
         final OperatingSystem os = server.getMachine().getOperatingSystem();
+
+        /**
+         * Existing issue with the liberty Arquillian plugin running on windows: https://github.com/OpenLiberty/liberty-arquillian/issues/25
+         * Hence skipping the test if the OS is Windows.
+         */
+        Assume.assumeTrue(os != OperatingSystem.WINDOWS);
+
         /*
          * Server config:
          * - Path that jimage will output modules for signature testing


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Existing issue with the liberty Arquillian plugin running on windows: https://github.com/OpenLiberty/liberty-arquillian/issues/25

SOE builds on windows consistently fails due to this: https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=302022 

Skipping running on windows as TCKs are not certified on Windows. 
