### PR TITLE
Fix for RTC 306195

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/LTPAKeyRotationTests.java
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/LTPAKeyRotationTests.java
@@ -318,7 +318,21 @@ public class LTPAKeyRotationTests {
 
             // should NOT regenerate ltpa to fips-compatible keys
             assertFileWasNotCreated(DEFAULT_KEY_PATH + ".noFips");
-        } else {
+            assertFileWasNotCreated(DEFAULT_KEY_PATH + ".noFips.1");
+
+        } else if (ibmJdk8Fips140_3Enabled) {
+            // TODO: Combine Semeru and IBM JDK FIPS 140-3 check after removal of beta-guards
+            // Beta check in LTPAKeyInfoManager currently prevents LTPA key regeneration on tests running with IBM JDK 8 FIPS 140-3
+
+            // ltpa is ver2 on startup since fips is enabled
+            configureServer("true", "10", true);
+            verifyLTPAKeyVersion(DEFAULT_KEY_PATH, "2.0");
+
+            // should NOT regenerate ltpa to fips-compatible keys
+            assertFileWasNotCreated(DEFAULT_KEY_PATH + ".noFips");
+            assertFileWasNotCreated(DEFAULT_KEY_PATH + ".noFips.1");
+
+        } else if (semeruFips140_3Enabled) {
             // ltpa is ver2 on startup since fips is enabled
             configureServer("true", "10", true);
             verifyLTPAKeyVersion(DEFAULT_KEY_PATH, "2.0");


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

- Test case fails due to a mismatch between FIPS check in product code and in test code.
- In loadLtpaKeysFile() of LTPAKeyInfoManager the LTPA primary key is regenerated if FIPS 140-3 and Beta is enabled.
- The test only has a FIPS 140-3 check and will fail the regeneration assertions when running the test on IBM JDK 8.
- Test has been updated to split the FIPS check into a separate IBM JDK and Semeru checks.
  - TODO: After removal of betaguards, the test should be updated to have only one FIPS check testing the proper regeneration. 
