### PR TITLE
fix: jcc driver running on java 24+

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_krb5/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/build.gradle
@@ -19,7 +19,11 @@ configurations {
 dependencies {
     oracle11 'com.oracle.database.jdbc:ojdbc11:23.4.0.24.05'
     
-    // FIXME 11.5.9.0 12.1.0.0 and 12.1.2.0 have a regression that make kerberos authentication impossible
+    // FIXME Upgrade to latest JCC driver version once the following are resolved:
+    // 11.5.*.* - does not support Java 24+ because it attempts to load the removed class sun.security.action.GetPropertyAction
+    // 11.5.9.0 - has a regression that in an error path that causes incorrect error to be thrown.
+    // 12.1.*.* - has a regression that makes successful kerberos authentication to fail.
+    // Expect the version after 12.1.2.0 to work
     db2Legacy 'com.ibm.db2:jcc:11.5.7.0'
 }
 

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
@@ -43,6 +43,7 @@ import com.ibm.ws.jdbc.fat.krb5.containers.KerberosContainer;
 import com.ibm.ws.jdbc.fat.krb5.rules.KerberosPlatformRule;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForSecurity;
 import componenttest.annotation.TestServlet;
@@ -54,6 +55,7 @@ import componenttest.topology.utils.FATServletClient;
 import jdbc.krb5.db2.web.DB2KerberosTestServlet;
 
 @SkipForSecurity(property = FIPS_140_3, runtimeName = SEMERU)
+@MaximumJavaLevel(javaLevel = 23) //TODO remove once JCC driver is updated
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class DB2KerberosTest extends FATServletClient {

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/ErrorPathTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/ErrorPathTest.java
@@ -37,6 +37,7 @@ import com.ibm.ws.jdbc.fat.krb5.containers.DB2KerberosContainer;
 import com.ibm.ws.jdbc.fat.krb5.rules.KerberosPlatformRule;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForSecurity;
 import componenttest.custom.junit.runner.FATRunner;
@@ -45,6 +46,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
+@MaximumJavaLevel(javaLevel = 23) //TODO remove once JCC driver is updated
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class ErrorPathTest extends FATServletClient {


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Fixing regressed test bug https://github.com/OpenLiberty/open-liberty/pull/30786
- Added documentation of errors and current state of this test suite for other developers. 
