### PR TITLE
Small updates due to recent changes

### DIFF
--- a/dev/com.ibm.ws.jpa.container.v32_fat_tck/fat/src/io/openliberty/jpaContainer/v32/tck/JPAContainerV32Launcher.java
+++ b/dev/com.ibm.ws.jpa.container.v32_fat_tck/fat/src/io/openliberty/jpaContainer/v32/tck/JPAContainerV32Launcher.java
@@ -34,11 +34,11 @@ import componenttest.topology.utils.tck.TCKResultsInfo.Type;
 import componenttest.topology.utils.tck.TCKRunner;
 
 /**
- * This is a test class that runs the whole Fault Tolerance TCK. The TCK results
- * are copied in the results/junit directory before the Simplicity FAT framework
- * generates the html report - so there is detailed information on individual
- * tests as if they were running as simplicity junit FAT tests in the standard
- * location.
+ * This is a test class that runs the Persistence / CDI integration tests from
+ * the Jakarta EE 11 Platform TCK. The TCK results are copied in the
+ * results/junit directory before the Simplicity FAT framework generates the
+ * html report - so there is detailed information on individual tests as if
+ * they were running as simplicity junit FAT tests in the standard location.
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
@@ -75,13 +75,13 @@ public class JPAContainerV32Launcher {
     @Test
     @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
     @SkipIfSysProp(OS_ZOS) //https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=306306 is likely an encoding issue on ZOS. Until its fixed, skip on ZOS.
-    public void launchFaultTolerance40TCK() throws Exception {
+    public void launchJakartaEE11TCK() throws Exception {
 
         Map<String, String> additionalProps = new HashMap<>();
         //For now, only the CDI tests are enabled
         additionalProps.put("included.tests", "ee.jakarta.tck.persistence.ee.cdi.ServletEMLookupTest");
 
-        TCKRunner.build(server, Type.JAKARTA, "JPA")
+        TCKRunner.build(server, Type.JAKARTA, "Platform")
                         .withLogging(Collections.emptyMap())
                         .withAdditionalMvnProps(additionalProps)
                         .runTCK();

--- a/dev/com.ibm.ws.jpa.container.v32_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.jpa.container.v32_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.ibm.ws.jpa.container.v32</groupId>
     <artifactId>tck.runner</artifactId>
-    <version>4.0</version>
+    <version>11.0</version>
     <packaging>pom</packaging>
     <name>jpa.container.v32 CDI integration TCK runner</name>
 
@@ -27,8 +27,8 @@
         <arquillian.version>1.9.1.Final</arquillian.version>
         <arquillian.liberty.managed.jakarta.version>2.1.3</arquillian.liberty.managed.jakarta.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <modules>
@@ -40,7 +40,7 @@
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
-                <version>3.0.0</version>
+                <version>4.1.0</version>
             </dependency>
             <dependency>
               <groupId>org.jboss.arquillian</groupId>
@@ -52,7 +52,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian.jakarta</groupId>
                 <artifactId>arquillian-jakarta-bom</artifactId>
-                <version>10.0.0.Final</version>
+                <version>11.0.0.Final</version>
                 <type>pom</type>
             </dependency>
         </dependencies>
@@ -66,8 +66,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.3.2</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>17</source>
+                        <target>17</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/dev/com.ibm.ws.jpa.container.v32_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.jpa.container.v32_fat_tck/publish/tckRunner/tck/pom.xml
@@ -5,7 +5,7 @@
 	~ terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	~ and is available at 
 	~    http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0 
 	~ Contributors: 
 	~    IBM Corporation - initial API and implementation 
@@ -15,10 +15,10 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>io.openliberty.microprofile.faulttolerance</groupId>
+	<groupId>io.openliberty.platform.persistence.cdi</groupId>
 	<artifactId>tck.runner.tck</artifactId>
-	<version>4.0</version>
-	<name>MicroProfile Fault Tolerance TCK Runner TCK Module</name>
+	<version>11.0</version>
+	<name>Jakarta TCK Runner TCK Module</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/dev/io.openliberty.springboot.fat40.app/bnd.bnd
+++ b/dev/io.openliberty.springboot.fat40.app/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -38,7 +38,7 @@ src: \
 -testpath: \
   org.springframework.boot:spring-boot;${springBootVersion40}, \
   org.springframework.boot:spring-boot-autoconfigure;${springBootVersion40}, \
-  org.springframework.boot:spring-boot-web-server;${springBootVersion40},
+  org.springframework.boot:spring-boot-web-server;${springBootVersion40}, \
 \
   org.springframework:spring-beans;${springVersion40}, \
   org.springframework:spring-context;${springVersion40}, \


### PR DESCRIPTION
- Add missing backslash to bnd.bnd classpath that prevents some dependencies from being added to the buildpath when running in eclipse
- Updates to com.ibm.ws.jpa.container.v32_fat_tck for incorrect information, i.e. Java version and dependencies in pom.xml files and references to fault tolerance in multiple places.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
