### PR TITLE
Remove io.openliberty.io.netty.ssl from sipServlet-1.1 feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/sipServlet-1.1/com.ibm.websphere.appserver.sipServlet-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/sipServlet-1.1/com.ibm.websphere.appserver.sipServlet-1.1.feature
@@ -30,8 +30,7 @@ Subsystem-Name: SIP Servlet 1.1
   io.openliberty.endpoint, \
   io.openliberty.netty.internal, \
   io.openliberty.netty.internal.impl, \
-  io.openliberty.io.netty, \
-  io.openliberty.io.netty.ssl
+  io.openliberty.io.netty
 -jars=com.ibm.websphere.appserver.api.sipServlet.1.1; location:="dev/api/ibm/,lib/", \
  com.ibm.websphere.javaee.servlet.sip.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="com.ibm.ws.java:com.ibm.ws.java.sipServlet.1.1:1.0.14"
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.sipServlet.1.1_1.0-javadoc.zip


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes https://github.com/OpenLiberty/open-liberty/issues/21048

SSL/TLS bundles are not required by sipServlet unless the TLS/SSL feature is enabled

See my comment [here](https://github.com/OpenLiberty/open-liberty/issues/21048#issuecomment-3320650004) about io.openliberty.io.netty.ssl