### PR TITLE
Netty OKD Social Fix

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
@@ -58,6 +58,12 @@ public class AuthUtils {
                 if (rawHeaderValue.toLowerCase().startsWith("bearer ")) {
                     return rawHeaderValue.substring("bearer ".length()).trim();
                 }
+                // Netty trims whitespace which causes the authentication to pass. Check if rawHeaderValue starts
+                // with any case variation of "Bearer" without the trailing white space after veryfing "Bearer "
+                // with the trailing white space
+                if (rawHeaderValue.toLowerCase().startsWith("bearer")) {
+                    return rawHeaderValue.substring("bearer".length()).trim();
+                }
             }
             // Original case-sensitive check for other schemes
             else if (rawHeaderValue.startsWith(scheme)) {

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
@@ -58,12 +58,6 @@ public class AuthUtils {
                 if (rawHeaderValue.toLowerCase().startsWith("bearer ")) {
                     return rawHeaderValue.substring("bearer ".length()).trim();
                 }
-                // Netty trims whitespace which causes the authentication to pass. Check if rawHeaderValue starts
-                // with any case variation of "Bearer" without the trailing white space after veryfing "Bearer "
-                // with the trailing white space
-                if (rawHeaderValue.toLowerCase().startsWith("bearer")) {
-                    return rawHeaderValue.substring("bearer".length()).trim();
-                }
             }
             // Original case-sensitive check for other schemes
             else if (rawHeaderValue.startsWith(scheme)) {

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTestTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTestTools.java
@@ -106,6 +106,8 @@ public class CommonTestTools {
         String thisMethod = "buildBearerTokenCred";
 
         try {
+            if (accessToken == null || "".equals(accessToken))
+                return "";
             return "Bearer " + accessToken;
         } catch (Exception e) {
             e.printStackTrace();

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTestTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTestTools.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTestTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTestTools.java
@@ -106,7 +106,10 @@ public class CommonTestTools {
         String thisMethod = "buildBearerTokenCred";
 
         try {
-            if (accessToken == null || "".equals(accessToken))
+            // On a Netty endpoint, the trailing whitespace in a header is trimmed given the RFC specification referring
+            // to the surrounding whitespace as optional https://datatracker.ietf.org/doc/html/rfc9112#name-field-syntax
+            // Therefore to test an empty access token here, we send an empty value for the Bearer token credential.
+            if ("".equals(accessToken))
                 return "";
             return "Bearer " + accessToken;
         } catch (Exception e) {

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTestTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTestTools.java
@@ -108,9 +108,10 @@ public class CommonTestTools {
         try {
             // On a Netty endpoint, the trailing whitespace in a header is trimmed given the RFC specification referring
             // to the surrounding whitespace as optional https://datatracker.ietf.org/doc/html/rfc9112#name-field-syntax
-            // Therefore to test an empty access token here, we send an empty value for the Bearer token credential.
+            // Therefore to test an empty access token here, we send a stripped Bearer header for both endpoints
+            // and so giving the same behavior
             if ("".equals(accessToken))
-                return "";
+                return "Bearer";
             return "Bearer " + accessToken;
         } catch (Exception e) {
             e.printStackTrace();

--- a/dev/com.ibm.ws.security.social_fat.okdServiceLogin/fat/src/com/ibm/ws/security/social/fat/okdServiceLogin/commonTests/OKDServiceLogin_GenericTests.java
+++ b/dev/com.ibm.ws.security.social_fat.okdServiceLogin/fat/src/com/ibm/ws/security/social/fat/okdServiceLogin/commonTests/OKDServiceLogin_GenericTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -118,7 +118,28 @@ public class OKDServiceLogin_GenericTests extends OKDServiceLoginCommonTest {
         updatedSocialTestSettings.setHeaderName(SocialConstants.BEARER_HEADER);
         updatedSocialTestSettings.setHeaderValue(cttools.buildBearerTokenCred(""));
 
-        List<validationData> expectations = setErrorPageForSocialLogin(SocialMessageConstants.CWWKS5375E_MISSING_REQUIRED_ACCESS_TOKEN);
+        List<validationData> expectations = setErrorPageForSocialLogin(SocialMessageConstants.CWWKS5452E_NOTAUTH_DUE_TO_MISSING_CLAIMS, SocialMessageConstants.CWWKS5382E_USER_API_RESPONSE_CANNOT_BE_PROCESSED); 
+
+        genericSocial(_testName, webClient, SocialConstants.INVOKE_SOCIAL_RESOURCE_ONLY, updatedSocialTestSettings, expectations);
+
+    }
+
+    /**
+     * pass an empty Authorization header - expect a bad response from the user validation api server
+     *
+     * @throws Exception
+     */
+    @Test
+    public void OKDServiceLogin_GenericTests_emptyAuthorizationHeader() throws Exception {
+
+        WebClient webClient = getAndSaveWebClient();
+
+        SocialTestSettings updatedSocialTestSettings = socialSettings.copyTestSettings();
+        updatedSocialTestSettings.setProtectedResource(genericTestServer.getServerHttpsString() + "/helloworld/rest/helloworld");
+        updatedSocialTestSettings.setHeaderName(SocialConstants.BEARER_HEADER);
+        updatedSocialTestSettings.setHeaderValue("");
+
+       List<validationData> expectations = setErrorPageForSocialLogin(SocialMessageConstants.CWWKS5375E_MISSING_REQUIRED_ACCESS_TOKEN);
 
         genericSocial(_testName, webClient, SocialConstants.INVOKE_SOCIAL_RESOURCE_ONLY, updatedSocialTestSettings, expectations);
 


### PR DESCRIPTION
Added fix for okd social FAT given that Netty trims the Bearer token from it's trailing whitespace and so when parsed by the filter it accepts the token as is which shouldn't be


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

for #31988