### PR TITLE
Preserve spaces in arguments to server script

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -921,17 +921,17 @@ javaCmd()
       elif [ $ACTION = "checkpoint" ] && [ -z "${option##--at=*}" ]; then
         CHECKPOINT_AT=${option#--at=}
       else
-        if [ -z "$REMAINING_ARGS" ] ; then
-          REMAINING_ARGS="$option"
+        # Quote each option when adding to REMAINING_ARGS.
+        escapeForEval "${option}"
+        if [ -z "$REMAINING_ARGS" ]; then
+          REMAINING_ARGS="${escapeForEvalResult}"
         else
-          REMAINING_ARGS="$REMAINING_ARGS $option"
-        fi  
+          REMAINING_ARGS="$REMAINING_ARGS ${escapeForEvalResult}"
+        fi
       fi
-    else
-      REMAINING_ARGS="$REMAINING_ARGS $option"
     fi
   done
-  
+
   if [ $ACTION = "checkpoint" ]; then
     if [ -z "$CHECKPOINT_AT" ]; then
       CHECKPOINT_AT="beforeAppStart"


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #32908" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


Here's the **new result** (with the fix) of a server create command with a space in the server name:

```
~/dev/git/open-liberty/dev/build.image/wlp/bin > ./server create 'my server'

CWWKE0005E: The runtime environment could not be launched.
CWWKE0012E: The specified server name contains a character that is not valid (name=my server). Valid characters are: Unicode alphanumeric (e.g. 0-9, a-z, A-Z), underscore (_), dash (-), plus (+), and period (.). A server name cannot begin with a dash (-) or period (.).
```

Previously, that command would have created a server named "my".

Neither tWAS nor Liberty support a space character in the server name.
