### PR TITLE
Subqueries in find and insertion of FROM clause rather than query replacement

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryEdit.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryEdit.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.data.internal.persistence;
+
+/**
+ * Instructions for editing a query that is written in query language.
+ */
+enum QueryEdit {
+    /**
+     * Instruction to add a FROM clause to the query. The FROM clause is added
+     * after the first SELECT clause, or, if there is no SELECT clause, then
+     * at the beginning of the query.
+     */
+    ADD_FROM,
+
+    /**
+     * Instruction to replace record names with the generated entity class name
+     * when the record name appears after the FROM keyword.
+     */
+    REPLACE_RECORD_ENTITY
+}

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -5002,13 +5002,13 @@ public class QueryInfo {
                             addFromAt = -1;
                         i += 5;
                         modifyAt.put(i, QueryEdit.REPLACE_RECORD_ENTITY);
-                    } else if (addFromAt == null &&
+                    } else if (depth == 0 &&
+                               addFromAt == null &&
                                i + 5 < length &&
                                !Character.isJavaIdentifierPart(ql.charAt(i + 5)) &&
-                               ql.regionMatches(true, i, "WHERE", 0, 5) ||
-                               ql.regionMatches(true, i, "ORDER", 0, 5)) {
-                        if (addFromAt == null)
-                            addFromAt = i;
+                               (ql.regionMatches(true, i, "WHERE", 0, 5) ||
+                                ql.regionMatches(true, i, "ORDER", 0, 5))) {
+                        addFromAt = i;
                         i += 5;
                     }
                 } else {
@@ -5029,7 +5029,12 @@ public class QueryInfo {
             qlParamNames.add(paramName.toString());
 
         if (addFromAt == null)
-            addFromAt = findQueryStartsWithSelect == Boolean.TRUE ? length : 0;
+            if (findQueryStartsWithSelect == Boolean.TRUE)
+                addFromAt = length;
+            else if (startAt < length && ql.charAt(startAt) == '(')
+                addFromAt = -1; // not a JDQL query
+            else
+                addFromAt = 0;
 
         if (addFromAt != -1)
             modifyAt.put(addFromAt, QueryEdit.ADD_FROM);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -5887,6 +5887,17 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Tests a JPQL find operation with a subquery within the WHERE clause
+     * but lacking a main FROM clause, such that the only FROM clause is
+     * found within the WHERE clause.
+     */
+    @Test
+    public void testSubqueryInWhere() {
+        assertEquals(2L,
+                     primes.smallest().numberId);
+    }
+
+    /**
      * Repository method that supplies pagination information and returns a list.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -5816,6 +5816,29 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Tests JPQL find operation with a subquery, such that there are three FROM
+     * clauses: one in the main query and two in subqueries.
+     */
+    @Test
+    public void testSubqueryInFind() {
+        receipts.removeIfTotalUnder(Float.MAX_VALUE);
+
+        receipts.insertAll(List.of(new Receipt(6001, "TSIF-1", 41.99f),
+                                   new Receipt(6002, "TSIF-2", 22.99f),
+                                   new Receipt(6003, "TSIF-3", 23.99f),
+                                   new Receipt(6004, "TSIF-4", 84.99f),
+                                   new Receipt(6005, "TSIF-5", 95.99f)));
+
+        assertEquals(List.of(6002L, 6003L, 6001L),
+                     receipts.withBelowAverageTotal()
+                                     .map(Receipt::purchaseId)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(5L,
+                     receipts.removeIfTotalUnder(Float.MAX_VALUE));
+    }
+
+    /**
      * Tests JPQL DELETE with a subquery, such that there are two FROM clauses:
      * one in the main query and one in the subquery.
      */

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1604,6 +1604,25 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Verifies that an EXCEPT statement can be used within a query
+     * that combines two subqueries to include results from the first
+     * subquery that do not appear in the results of the second subquery.
+     */
+    @Test
+    public void testExcept() {
+
+        assertEquals(List.of("eleven",
+                             "five",
+                             "thirteen",
+                             "two"),
+                     primes.ofHexLengthNotNameLength(1, 5)
+                                     .stream()
+                                     .map(p -> p.name)
+                                     .sorted()
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
      * Tests whether a user can write an empty repository class.
      * This is only useful when just starting out developing and you don't have methods yet.
      */

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -417,6 +417,18 @@ public interface Primes {
     @Query("SELECT numberId WHERE ID(THIS)=:num")
     Optional<Short> numberAsShortWrapper(long num);
 
+    @Query("""
+                    SELECT p1 FROM Prime p1 WHERE LENGTH(p1.hex) = :hexLen
+                    EXCEPT
+                    SELECT p2 FROM Prime p2 WHERE LENGTH(p2.name) = :excludeNameLen""")
+    List<Prime> ofHexLengthNotNameLength(int hexLen,
+                                         int excludeNameLen
+    // TODO ORDER BY for set operations is undefined in the query language.
+    // If added, enable the following and remove the manual sorting from the
+    // corresponding test
+    // Order<Prime> order
+    );
+
     // discouraged usage, but testing what happens
     @Query("SELECT COUNT(THIS) WHERE ID(THIS) < :max")
     Page<Long> pageOfCountUpTo(long max, PageRequest pageReq);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -468,6 +468,9 @@ public interface Primes {
     @Query("SELECT hex WHERE numberId=:id")
     Optional<Character> singleHexDigit(long id);
 
+    @Query("WHERE numberId = (SELECT MIN(p.numberId) FROM Prime p)")
+    Prime smallest();
+
     @Query("SELECT hex WHERE numberId=?1")
     Optional<String> toHexadecimal(long num);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Receipts.java
@@ -114,6 +114,13 @@ public interface Receipts extends CrudRepository<Receipt, Long> {
     @Query("SELECT total ORDER BY total DESC")
     Page<Float> totalsDecreasing(PageRequest req);
 
+    @Query("""
+                    FROM Receipt
+                    WHERE total < (SELECT SUM(s.total) FROM Receipt s) /
+                                  (SELECT COUNT(c) FROM Receipt c)
+                    ORDER BY total ASC""")
+    Stream<Receipt> withBelowAverageTotal();
+
     @Find
     Receipt withPurchaseNum(long purchaseId);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -4728,6 +4728,69 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Tests a JPQL find operation with a subquery within the ORDER BY clause
+     * but lacking all other clauses, such that the only FROM clause is found
+     * within the ORDER BY clause. The Jakarta Data implementation should
+     * insert a FROM clause prior to the ORDER BY clause to form a valid
+     * query.
+     */
+    @Test
+    public void testSubqueryInOrderBy() {
+        List<DemographicInfo> all = demographics.all();
+
+        assertEquals(List.of(2002,
+                             2003,
+                             2004,
+                             2005,
+                             2006,
+                             2007,
+                             2008,
+                             2009,
+                             2010,
+                             2011,
+                             2012,
+                             2013,
+                             2014,
+                             2015,
+                             2016,
+                             2017,
+                             2018,
+                             2019,
+                             2020,
+                             2021),
+                     all.stream()
+                                     .map(d -> d.collectedOn
+                                                     .atZone(DemographicInfo.TIMEZONE)
+                                                     .getYear())
+                                     .limit(20)
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
+     * Tests a JPQL find operation with a subquery within the ORDER BY clause
+     * but lacking all other clauses, such that the only FROM clause is found
+     * within the ORDER BY clause. The Jakarta Data implementation should
+     * insert a FROM clause prior to the ORDER BY clause to form a valid
+     * query.
+     */
+    @Test
+    public void testSubqueryInSelect() {
+
+        assertEquals(List.of(2002,
+                             2003,
+                             2004,
+                             2005,
+                             2006,
+                             2007,
+                             2008,
+                             2009,
+                             2010),
+                     demographics.yearsUpTo(2010)
+                                     .sorted()
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
      * Use an Entity which has a version attribute of type LocalDateTime.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DemographicInfo.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DemographicInfo.java
@@ -27,6 +27,7 @@ import jakarta.persistence.Id;
  */
 @Entity
 public class DemographicInfo {
+    static final ZoneId TIMEZONE = ZoneId.of("America/New_York");
 
     @Column
     public Instant collectedOn;
@@ -50,7 +51,8 @@ public class DemographicInfo {
     public DemographicInfo(int year, int month, int day,
                            long numFullTimeWorkers,
                            double intragovernmentalDebt, double publicDebt) {
-        this.collectedOn = ZonedDateTime.of(year, month, day, 12, 0, 0, 0, ZoneId.of("America/New_York")).toInstant();
+        this.collectedOn = ZonedDateTime.of(year, month, day, 12, 0, 0, 0, TIMEZONE)
+                        .toInstant();
         this.numFullTimeWorkers = BigInteger.valueOf(numFullTimeWorkers);
         this.intragovernmentalDebt = BigDecimal.valueOf(intragovernmentalDebt);
         this.publicDebt = BigDecimal.valueOf(publicDebt);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,9 @@ import jakarta.data.repository.Repository;
  */
 @Repository
 public interface Demographics {
+
+    @Query("ORDER BY EXTRACT (YEAR FROM collectedOn)")
+    List<DemographicInfo> all();
 
     @Find
     Stream<DebtPerWorker> debtPerFullTimeWorker();
@@ -105,4 +108,8 @@ public interface Demographics {
 
     @Insert
     void write(DemographicInfo info);
+
+    @Query("SELECT EXTRACT (YEAR FROM collectedOn)" +
+           " WHERE EXTRACT (YEAR FROM collectedOn) <= :max")
+    Stream<Long> yearsUpTo(long max);
 }


### PR DESCRIPTION
Implement FROM clause insertion and the necessary query scanning needed to determine when and when not to attempt it.  Avoid rewriting in these cases, preserving all parts of the original query, allowing subqueries to work.  Test various patterns involving subqueries and other patterns related to detection/insertion.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
