### PR TITLE
Filter with userExternal = true property

### DIFF
--- a/.ci-orchestrator/externalIssueNotice.yml
+++ b/.ci-orchestrator/externalIssueNotice.yml
@@ -16,6 +16,8 @@ triggers:
     include: "Opened by external contributor"
   - property: labels
     exclude: "test"
+  - property: userExternal
+    include: true
   propertyDefinitions:
     - name: user
       isRequired: true


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This change adds further specific criteria to the filter: the pipeline should only be triggered if user who created the issue is a not a member of both the OpenLiberty and IBM GitHub organizations (those conditions means that he is considered an external contributor).

I see this working with same change done under https://github.com/OpenLiberty/for-automation-testing/pull/16.