### PR TITLE
SELECT clause and constructor syntax insertion

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryEdit.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryEdit.java
@@ -17,6 +17,24 @@ package io.openliberty.data.internal.persistence;
  */
 enum QueryEdit {
     /**
+     * Instruction to add a closing parenthesis ) for an added constructor after
+     * the specified index. This instruction is always paired with the
+     * ADD_CONSTRUCTOR_START instruction.
+     */
+    ADD_CONSTRUCTOR_END,
+
+    // TODO 1.1 use Jakarta Persistence enhancement issue 420 instead of
+    // editing the query to enclose the SELECT clause content in
+    // NEW fully.qualified.ClassName(...)
+
+    /**
+     * Instruction to add NEW fully.qualified.ClassName( to the SELECT clause
+     * at the specified index. This instruction is always paired with the
+     * ADD_CONSTRUCTOR_END instruction.
+     */
+    ADD_CONSTRUCTOR_START,
+
+    /**
      * Instruction to add a FROM clause to the query. The FROM clause is added
      * after the first SELECT clause, or, if there is no SELECT clause, then
      * at the beginning of the query.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryEdit.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryEdit.java
@@ -24,8 +24,22 @@ enum QueryEdit {
     ADD_FROM,
 
     /**
+     * Instruction to add a SELECT clause to the query if it is determined that
+     * one is needed.
+     */
+    ADD_SELECT_IF_NEEDED,
+
+    /**
      * Instruction to replace record names with the generated entity class name
      * when the record name appears after the FROM keyword.
      */
-    REPLACE_RECORD_ENTITY
+    REPLACE_RECORD_ENTITY;
+
+    /**
+     * Indicates the position before the beginning of the query, which applies
+     * when inserting a SELECT clause. A negative value is used to ensure that
+     * an added SELECT clause is positioned before an added FROM clause at
+     * position 0.
+     */
+    static final int BEFORE_QUERY = -1;
 }

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -31,6 +31,7 @@ import jakarta.data.constraint.NotBetween;
 import jakarta.data.constraint.NotNull;
 import jakarta.data.expression.TextExpression;
 import jakarta.data.page.CursoredPage;
+import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Cursor;
 import jakarta.inject.Inject;
@@ -342,4 +343,78 @@ public class Data_1_1_Servlet extends FATServlet {
                                      .map(f -> f.name)
                                      .collect(Collectors.toList()));
     }
+
+    /**
+     * Use a repository method that performs a Query with SELECT and ORDER BY
+     * clauses only, retrieving a subset of entity attributes as a Java record.
+     */
+    @Test
+    public void testSelectOrderByQueryReturnsPageOfRecords() {
+
+        Page<Ratio> page1 = fractions.pageOfRatios(PageRequest.ofSize(12));
+
+        assertEquals(List.of("1:19",
+                             "1:18",
+                             "2:18",
+                             "1:17",
+                             "2:17",
+                             "3:17",
+                             "1:16",
+                             "2:16",
+                             "3:16",
+                             "4:16",
+                             "1:15",
+                             "2:15"),
+                     page1.stream()
+                                     .map(Ratio::toString)
+                                     .collect(Collectors.toList()));
+
+        Page<Ratio> page2 = fractions.pageOfRatios(page1.nextPageRequest());
+
+        assertEquals(List.of("3:15",
+                             "4:15",
+                             "5:15",
+                             "1:14",
+                             "2:14",
+                             "3:14",
+                             "4:14",
+                             "5:14",
+                             "6:14",
+                             "1:13",
+                             "2:13",
+                             "3:13"),
+                     page2.stream()
+                                     .map(Ratio::toString)
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
+     * Use a repository method that performs a Query consisting of a SELECT
+     * clause only, retrieving a subset of entity attributes as a Java record.
+     */
+    @Test
+    public void testSelectQueryReturnsStreamOfRecords() {
+
+        assertEquals(List.of("10:1",
+                             "10:10",
+                             "10:2",
+                             "10:3",
+                             "10:4",
+                             "10:5",
+                             "10:6",
+                             "10:7",
+                             "10:8",
+                             "10:9",
+                             "11:1",
+                             "11:2",
+                             "11:3",
+                             "11:4",
+                             "11:5"),
+                     fractions.streamOfRatios()
+                                     .map(Ratio::toString)
+                                     .sorted()
+                                     .limit(15)
+                                     .collect(Collectors.toList()));
+    }
+
 }

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -30,12 +30,14 @@ import jakarta.data.constraint.NotBetween;
 import jakarta.data.constraint.NotEqualTo;
 import jakarta.data.constraint.NotNull;
 import jakarta.data.page.CursoredPage;
+import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.By;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Is;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Select;
 
@@ -62,6 +64,13 @@ public interface Fractions {
     List<String> named(@By(_Fraction.NAME) Like pattern,
                        Order<Fraction> order,
                        Limit limit);
+
+    @Query("SELECT numerator, denominator - numerator" +
+           " ORDER BY denominator - numerator DESC, numerator ASC")
+    Page<Ratio> pageOfRatios(PageRequest pageReq);
+
+    @Query("SELECT numerator, denominator - numerator")
+    Stream<Ratio> streamOfRatios();
 
     @Find
     @OrderBy(_Fraction.DENOMINATOR)

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Ratio.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Ratio.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.v1_1.web;
+
+/**
+ * Represents a ratio such as 3:7.
+ */
+public record Ratio(int term1, int term2) {
+    @Override
+    public String toString() {
+        return term1 + ":" + term2;
+    }
+}


### PR DESCRIPTION
Implement detection and addition of SELECT clause when absent and it is needed, which can be for various reasons. Implement detection and insertion of constructor syntax -- `NEW fully.qualified.ClassName(` ... `)` -- into exist SELECT queries that require it in order to return results as records.  Add tests.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
