### PR TITLE
Updates EclipseLink to support EXTRACT(TIME FROM X) in DB2

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -975,7 +975,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     
     @Test
     @SkipIfSysProp({
-        DB_DB2, DB_SQLServer, //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/32957
+        DB_SQLServer, //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/32957
         DB_Oracle //Oracle DB doesn't have any conversion function into TIME so whole TIMESTAMP is returned and result is converted to time in EclipseLink/Java
     })
     public void testExtractTimeFromLocalData() throws Exception {

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/platform/database/DB2Platform.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/platform/database/DB2Platform.java
@@ -616,8 +616,10 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
     
     private static final class DB2ExtractOperator extends ExtractOperator {
 
-    	// DATE emulation: CAST(:first AS DATE)
+        // DATE emulation: CAST(:first AS DATE)
         private static final String[] DATE_STRINGS = new String[] {"CAST(", " AS DATE)"};
+        // TIME emulation: TIME(:first)
+        private static final String[] TIME_STRINGS = new String[] {"TIME(", ")"};
 
         private DB2ExtractOperator() {
             super();
@@ -635,6 +637,20 @@ public class DB2Platform extends org.eclipse.persistence.platform.database.Datab
             printer.printString(DATE_STRINGS[0]);
             first.printJava(printer);
             printer.printString(DATE_STRINGS[1]);
+        }
+        
+        @Override
+        protected void printTimeSQL(final Expression first, Expression second, final ExpressionSQLPrinter printer) {
+            printer.printString(TIME_STRINGS[0]);
+            first.printSQL(printer);
+            printer.printString(TIME_STRINGS[1]);
+        }
+
+        @Override
+        protected void printTimeJava(final Expression first, Expression second, final ExpressionJavaPrinter printer) {
+            printer.printString(TIME_STRINGS[0]);
+            first.printJava(printer);
+            printer.printString(TIME_STRINGS[1]);
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This PR implements implements EXTRACT(TIME FROM X) in DB2 through overlay update.
Related to #32957