### PR TITLE
Netty: Use method() rather than deprecated getMethod()

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
@@ -60,12 +60,11 @@ public class LibertyHttpObjectAggregator extends SimpleChannelInboundHandler<Htt
             ctx.channel().attr(COMPOSITE_CONTENT).set(content);
 
             //If POST, check for integer content-length; fail-fast if CL is long which is not supported at this time.
-            String value = request.getMethod().name().equals("POST") ? request.headers().get(io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH) : null ;
+            String value = request.method().name().equals("POST") ? request.headers().get(io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH) : null;
             if (value != null) {
                 try {
                     Integer.parseInt(value);
-                }
-                catch (NumberFormatException e) {
+                } catch (NumberFormatException e) {
                     String longContentLengthNotSupportMsg = "Only POST request with integer content-length is supported at this time.";
                     throw new IllegalArgumentException(longContentLengthNotSupportMsg);
                 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #33227

