### PR TITLE
Use a start phase condition to delay components according to current start-phase

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_no_vt/publish/files/internalFeatures/virtualThreadDisabler-1.0.mf
+++ b/dev/com.ibm.ws.concurrent_fat_no_vt/publish/files/internalFeatures/virtualThreadDisabler-1.0.mf
@@ -2,6 +2,6 @@ Subsystem-ManifestVersion: 1
 IBM-ShortName: virtualThreadDisabler-1.0
 Subsystem-SymbolicName: virtualThreadDisabler-1.0; visibility:=public
 Subsystem-Version: 1.0.0
-Subsystem-Content: test.concurrent.no.vt.disabler; version="[1,1.1)"
+Subsystem-Content: test.concurrent.no.vt.disabler; version="[1,1.1)"; start-phase:=SERVICE_EARLY
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -12,6 +12,11 @@
  *******************************************************************************/
 package com.ibm.ws.kernel.feature.internal;
 
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.ACTIVE;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.CONTAINER;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.PREPARE;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.SERVICE_EARLY;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -761,8 +766,8 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
             switch (featureChange.provisioningMode) {
                 case INITIAL_PROVISIONING:
                     // Get through kernel/core startup
-                    if (getStartLevel() < ProvisionerConstants.LEVEL_FEATURE_PREPARE) {
-                        BundleLifecycleStatus startStatus = setStartLevel(ProvisionerConstants.LEVEL_FEATURE_PREPARE);
+                    if (getStartLevel() < PREPARE.level()) {
+                        BundleLifecycleStatus startStatus = setStartLevel(PREPARE.level());
                         checkBundleStatus(startStatus);
                     }
                     break;
@@ -832,7 +837,7 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
                 case INITIAL_PROVISIONING:
                     // Increment the start level to ensure application bundles can start,
                     // even if no features are loaded
-                    BundleLifecycleStatus startStatus = setStartLevel(ProvisionerConstants.LEVEL_ACTIVE);
+                    BundleLifecycleStatus startStatus = setStartLevel(ACTIVE.level());
                     checkBundleStatus(startStatus); // FFDC, etc.
                     checkServerReady();
 
@@ -1638,8 +1643,8 @@ public class FeatureManager implements FixManager, FeatureProvisioner, Framework
                     provisioner.installBundles(bundleContext,
                                                bundleCache,
                                                installStatus,
-                                               ProvisionerConstants.LEVEL_FEATURE_SERVICES - ProvisionerConstants.PHASE_INCREMENT,
-                                               ProvisionerConstants.LEVEL_FEATURE_CONTAINERS,
+                                               SERVICE_EARLY.level(),
+                                               CONTAINER.level(),
                                                fwStartLevel.getInitialBundleStartLevel(),
                                                locService);
                     // add all installed bundles to list of bundlesToStart.

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/ProvisionerConstants.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/ProvisionerConstants.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,17 +22,6 @@ public interface ProvisionerConstants {
 
     /** Location of feature files */
     String LIB_FEATURE_PATH = "lib/features/";
-
-    /** Liberty Server start levels: 0 (stopped) has special meaning w/ OSGi */
-    int LEVEL_FEATURE_PREPARE = 7,
-                    // The next 3 levels all support an early and late level. So changes to these numbers should
-                    // ensure there is at least 2 empty gaps between them.
-                    LEVEL_FEATURE_SERVICES = 9,
-                    LEVEL_FEATURE_CONTAINERS = 12,
-                    LEVEL_FEATURE_APPLICATION = 18,
-                    LEVEL_ACTIVE = 20;
-
-    int PHASE_INCREMENT = 1;
 
     String PHASE_APPLICATION = "APPLICATION";
     String PHASE_APPLICATION_LATE = PHASE_APPLICATION + "_LATE";

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureResourceImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureResourceImpl.java
@@ -1,16 +1,26 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.kernel.feature.internal.subsystem;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.APPLICATION;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.APPLICATION_EARLY;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.APPLICATION_LATE;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.CONTAINER;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.CONTAINER_EARLY;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.CONTAINER_LATE;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.SERVICE;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.SERVICE_EARLY;
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.SERVICE_LATE;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,7 +32,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.osgi.framework.VersionRange;
-import org.osgi.framework.Version;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -203,7 +212,7 @@ public class FeatureResourceImpl implements FeatureResource {
         int result = _startLevel.get();
 
         if (result == -1) {
-            result = ProvisionerConstants.LEVEL_FEATURE_CONTAINERS;
+            result = CONTAINER.level();
             // Directive names are in the attributes map, but end with a colon
             String phase = _rawAttributes.get("start-phase:");
 
@@ -224,23 +233,23 @@ public class FeatureResourceImpl implements FeatureResource {
         }
 
         if (ProvisionerConstants.PHASE_APPLICATION.equals(phase)) {
-            return ProvisionerConstants.LEVEL_FEATURE_APPLICATION;
+            return APPLICATION.level();
         } else if (ProvisionerConstants.PHASE_APPLICATION_LATE.equals(phase)) {
-            return ProvisionerConstants.LEVEL_FEATURE_APPLICATION + ProvisionerConstants.PHASE_INCREMENT;
+            return APPLICATION_LATE.level();
         } else if (ProvisionerConstants.PHASE_APPLICATION_EARLY.equals(phase)) {
-            return ProvisionerConstants.LEVEL_FEATURE_APPLICATION - ProvisionerConstants.PHASE_INCREMENT;
+            return APPLICATION_EARLY.level();
         } else if (ProvisionerConstants.PHASE_SERVICE.equals(phase)) {
-            return ProvisionerConstants.LEVEL_FEATURE_SERVICES;
+            return SERVICE.level();
         } else if (ProvisionerConstants.PHASE_SERVICE_LATE.equals(phase)) {
-            return ProvisionerConstants.LEVEL_FEATURE_SERVICES + ProvisionerConstants.PHASE_INCREMENT;
+            return SERVICE_LATE.level();
         } else if (ProvisionerConstants.PHASE_SERVICE_EARLY.equals(phase)) {
-            return ProvisionerConstants.LEVEL_FEATURE_SERVICES - ProvisionerConstants.PHASE_INCREMENT;
+            return SERVICE_EARLY.level();
         } else if (ProvisionerConstants.PHASE_CONTAINER.equals(phase)) {
-            return ProvisionerConstants.LEVEL_FEATURE_CONTAINERS;
+            return CONTAINER.level();
         } else if (ProvisionerConstants.PHASE_CONTAINER_LATE.equals(phase)) {
-            return ProvisionerConstants.LEVEL_FEATURE_CONTAINERS + ProvisionerConstants.PHASE_INCREMENT;
+            return CONTAINER_LATE.level();
         } else if (ProvisionerConstants.PHASE_CONTAINER_EARLY.equals(phase)) {
-            return ProvisionerConstants.LEVEL_FEATURE_CONTAINERS - ProvisionerConstants.PHASE_INCREMENT;
+            return CONTAINER_EARLY.level();
         } else {
             Tr.warning(tc, "INVALID_START_PHASE_WARNING", new Object[] { phase, this._symbolicName, this._featureName });
             return original;

--- a/dev/com.ibm.ws.kernel.feature_fat/.classpath
+++ b/dev/com.ibm.ws.kernel.feature_fat/.classpath
@@ -17,6 +17,7 @@
 	<classpathentry kind="src" output="bin" path="fat/src"/>
 	<classpathentry kind="src" path="test-bundles/test.feature.fix.manager/src"/>
 	<classpathentry kind="src" path="test-bundles/test.active.condition/src"/>
+	<classpathentry kind="src" path="test-bundles/test.startphase.condition/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
@@ -32,7 +32,8 @@ src: \
 	test-bundles/test.override.requires.javax.swing.plaf/src, \
 	test-bundles/test.feature.fragment.bundle/src, \
 	test-bundles/test.feature.host.bundle/src, \
-	test-bundles/test.active.condition/src
+	test-bundles/test.active.condition/src, \
+	test-bundles/test.startphase.condition/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FATSuite.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,7 +43,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 EECompatibilityTest.class,
                 FeatureFragmentTest.class,
                 FixManagerTest.class,
-                ActiveConditionTest.class
+                ActiveConditionTest.class,
+                StartPhaseConditionTest.class
 })
 /**
  * Purpose: This suite collects and runs all known good test suites.

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/StartPhaseConditionTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/StartPhaseConditionTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.feature.fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+@RunWith(FATRunner.class)
+public class StartPhaseConditionTest {
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.startphase.condition");
+
+    @Test
+    public void testStartPhaseCondition() throws Exception {
+
+        server.startServer();
+        server.stopServer(false);
+        // The test has a different service component for each phase filter.
+        // After starting and stopping the server we should see the following messages for PASSED
+        String[] phases = { //
+                            "SERVICE_EARLY", //
+                            "SERVICE", //
+                            "SERVICE_LATE", //
+                            "CONTAINER_EARLY", //
+                            "CONTAINER", //
+                            "CONTAINER_LATE", //
+                            "APPLICATION_EARLY", //
+                            "APPLICATION", //
+                            "APPLICATION_LATE", //
+                            "ACTIVE" //
+        };
+        for (String phase : phases) {
+            checkOnActivate(phase);
+        }
+        for (String phase : phases) {
+            checkOnDeactivate(phase);
+        }
+    }
+
+    private void checkOnActivate(String phase) {
+        String found = server.waitForStringInLog("ON_ACTIVATE TESTING StartPhaseCondition: " + phase + " - ");
+        assertNotNull("No message found activate for phase: " + phase, found);
+        assertTrue("Test failed: " + found, found.contains("PASSED"));
+    }
+
+    private void checkOnDeactivate(String phase) {
+        String found = server.waitForStringInLog("ON_DEACTIVATE TESTING StartPhaseCondition: " + phase + " - ");
+        assertNotNull("No message found activate for phase: " + phase, found);
+        assertTrue("Test failed: " + found, found.contains("PASSED"));
+    }
+
+    @BeforeClass
+    public static void installFeatures() throws Exception {
+        server.installSystemFeature("test.startphase.condition-1.0");
+        server.installSystemBundle("test.startphase.condition");
+    }
+
+    @AfterClass
+    public static void uninstallFeatures() throws Exception {
+        server.uninstallSystemFeature("test.startphase.condition-1.0");
+        server.uninstallSystemBundle("test.startphase.condition");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+        server.postStopServerArchive();
+    }
+
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.startphase.condition-1.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.startphase.condition-1.0.mf
@@ -1,0 +1,6 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: test.startphase.condition-1.0; visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Content: test.startphase.condition; start-phase:=SERVICE_EARLY
+Subsystem-Type: osgi.subsystem.feature
+IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.startphase.condition/bootstrap.properties
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.startphase.condition/bootstrap.properties
@@ -1,0 +1,3 @@
+com.ibm.ws.kernel.feature.enforce.public=true
+com.ibm.ws.logging.trace.specification=OSGi.Events=all
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.startphase.condition/server.xml
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.startphase.condition/server.xml
@@ -1,0 +1,9 @@
+<server>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>test.startphase.condition-1.0</feature>
+    </featureManager>
+
+</server>

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/AbstractTestStartPhaseCondition.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/AbstractTestStartPhaseCondition.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.ID_NAME;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+
+public abstract class AbstractTestStartPhaseCondition {
+    private final ServiceReference<Condition> startPhaseCondition;
+    private final Logger logger;
+    private final String expectedActivateStartPhase;
+    private final String expectedDeactivateStartPhase;
+
+    protected AbstractTestStartPhaseCondition(ServiceReference<Condition> startPhaseCondition, String expectedActivateStartPhase, String expectedDeactivateStartPhase,
+                                              Logger logger) {
+        this.startPhaseCondition = startPhaseCondition;
+        this.expectedActivateStartPhase = expectedActivateStartPhase;
+        this.expectedDeactivateStartPhase = expectedDeactivateStartPhase;
+        this.logger = logger;
+    }
+
+    private Enum<?> getStartPhase() {
+        return (Enum<?>) startPhaseCondition.getProperty(ID_NAME);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void checkStartPhaseCondition(boolean onActivate) {
+        String testPrefix = onActivate ? "ON_ACTIVATE" : "ON_DEACTIVATE";
+        String expectedStartPhase = onActivate ? expectedActivateStartPhase : expectedDeactivateStartPhase;
+        Enum<?> startPhase = getStartPhase();
+        if (startPhase.equals(Enum.valueOf(startPhase.getClass(), expectedStartPhase))) {
+            logger.audit(testPrefix + " TESTING StartPhaseCondition: {} - PASSED", expectedActivateStartPhase);
+        } else {
+            logger.audit(testPrefix + " TESTING StartPhaseCondition: {} - FAILED - phase={}", expectedActivateStartPhase, startPhase);
+        }
+    }
+
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionActive.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionActive.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.ACTIVE_FILTER;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+@Component
+public class TestStartPhaseConditionActive extends AbstractTestStartPhaseCondition {
+
+    @Activate
+    public TestStartPhaseConditionActive(@Reference(service = Condition.class, target = ACTIVE_FILTER) ServiceReference<Condition> servicesEarlyCondition, //
+                                         @Reference(service = LoggerFactory.class) Logger logger) {
+        super(servicesEarlyCondition, "ACTIVE", "APPLICATION_LATE", logger);
+        checkStartPhaseCondition(true);
+    }
+
+    @Override
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionApplication.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionApplication.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.APPLICATION_FILTER;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+@Component
+public class TestStartPhaseConditionApplication extends AbstractTestStartPhaseCondition {
+
+    @Activate
+    public TestStartPhaseConditionApplication(@Reference(service = Condition.class, target = APPLICATION_FILTER) ServiceReference<Condition> servicesEarlyCondition, //
+                                              @Reference(service = LoggerFactory.class) Logger logger) {
+        super(servicesEarlyCondition, "APPLICATION", "APPLICATION_EARLY", logger);
+        checkStartPhaseCondition(true);
+    }
+
+    @Override
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionApplicationEarly.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionApplicationEarly.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.APPLICATION_EARLY_FILTER;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+@Component
+public class TestStartPhaseConditionApplicationEarly extends AbstractTestStartPhaseCondition {
+
+    @Activate
+    public TestStartPhaseConditionApplicationEarly(@Reference(service = Condition.class, target = APPLICATION_EARLY_FILTER) ServiceReference<Condition> servicesEarlyCondition, //
+                                                   @Reference(service = LoggerFactory.class) Logger logger) {
+        super(servicesEarlyCondition, "APPLICATION_EARLY", "CONTAINER_LATE", logger);
+        checkStartPhaseCondition(true);
+    }
+
+    @Override
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionApplicationLate.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionApplicationLate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.APPLICATION_LATE_FILTER;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+@Component
+public class TestStartPhaseConditionApplicationLate extends AbstractTestStartPhaseCondition {
+
+    @Activate
+    public TestStartPhaseConditionApplicationLate(@Reference(service = Condition.class, target = APPLICATION_LATE_FILTER) ServiceReference<Condition> servicesEarlyCondition, //
+                                                  @Reference(service = LoggerFactory.class) Logger logger) {
+        super(servicesEarlyCondition, "APPLICATION_LATE", "APPLICATION", logger);
+        checkStartPhaseCondition(true);
+    }
+
+    @Override
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionContainers.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionContainers.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.CONTAINER_FILTER;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+@Component
+public class TestStartPhaseConditionContainers extends AbstractTestStartPhaseCondition {
+
+    @Activate
+    public TestStartPhaseConditionContainers(@Reference(service = Condition.class, target = CONTAINER_FILTER) ServiceReference<Condition> servicesEarlyCondition, //
+                                             @Reference(service = LoggerFactory.class) Logger logger) {
+        super(servicesEarlyCondition, "CONTAINER", "CONTAINER_EARLY", logger);
+        checkStartPhaseCondition(true);
+    }
+
+    @Override
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionContainersEarly.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionContainersEarly.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.CONTAINER_EARLY_FILTER;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+@Component
+public class TestStartPhaseConditionContainersEarly extends AbstractTestStartPhaseCondition {
+
+    @Activate
+    public TestStartPhaseConditionContainersEarly(@Reference(service = Condition.class, target = CONTAINER_EARLY_FILTER) ServiceReference<Condition> servicesEarlyCondition, //
+                                                  @Reference(service = LoggerFactory.class) Logger logger) {
+        super(servicesEarlyCondition, "CONTAINER_EARLY", "SERVICE_LATE", logger);
+        checkStartPhaseCondition(true);
+    }
+
+    @Override
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionContainersLate.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionContainersLate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.CONTAINER_LATE_FILTER;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+@Component
+public class TestStartPhaseConditionContainersLate extends AbstractTestStartPhaseCondition {
+
+    @Activate
+    public TestStartPhaseConditionContainersLate(@Reference(service = Condition.class, target = CONTAINER_LATE_FILTER) ServiceReference<Condition> servicesEarlyCondition, //
+                                                 @Reference(service = LoggerFactory.class) Logger logger) {
+        super(servicesEarlyCondition, "CONTAINER_LATE", "CONTAINER", logger);
+        checkStartPhaseCondition(true);
+    }
+
+    @Override
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionServices.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionServices.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.SERVICE_FILTER;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+@Component
+public class TestStartPhaseConditionServices extends AbstractTestStartPhaseCondition {
+
+    @Activate
+    public TestStartPhaseConditionServices(@Reference(service = Condition.class, target = SERVICE_FILTER) ServiceReference<Condition> servicesEarlyCondition, //
+                                           @Reference(service = LoggerFactory.class) Logger logger) {
+        super(servicesEarlyCondition, "SERVICE", "SERVICE_EARLY", logger);
+        checkStartPhaseCondition(true);
+    }
+
+    @Override
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionServicesEarly.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionServicesEarly.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.SERVICE_EARLY_FILTER;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.startlevel.BundleStartLevel;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+@Component
+public class TestStartPhaseConditionServicesEarly extends AbstractTestStartPhaseCondition {
+
+    @Activate
+    public TestStartPhaseConditionServicesEarly(BundleContext context, //
+                                                @Reference(service = Condition.class, target = SERVICE_EARLY_FILTER) ServiceReference<Condition> servicesEarlyCondition, //
+                                                @Reference(service = LoggerFactory.class) Logger logger) {
+        super(servicesEarlyCondition, "SERVICE_EARLY", "PREPARE", logger);
+        checkStartPhaseCondition(true);
+        // This prevents us from getting stopped "too early" during the test so we can see all events on shutdown
+        context.getBundle().adapt(BundleStartLevel.class).setStartLevel(1);
+    }
+
+    @Override
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionServicesLate.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.startphase.condition/src/test/startphase/condition/TestStartPhaseConditionServicesLate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package test.startphase.condition;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.SERVICE_LATE_FILTER;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.service.log.Logger;
+import org.osgi.service.log.LoggerFactory;
+
+@Component
+public class TestStartPhaseConditionServicesLate extends AbstractTestStartPhaseCondition {
+
+    @Activate
+    public TestStartPhaseConditionServicesLate(@Reference(service = Condition.class, target = SERVICE_LATE_FILTER) ServiceReference<Condition> servicesEarlyCondition, //
+                                               @Reference(service = LoggerFactory.class) Logger logger) {
+        super(servicesEarlyCondition, "SERVICE_LATE", "SERVICE", logger);
+        checkStartPhaseCondition(true);
+    }
+
+    @Override
+    @Deactivate
+    public void deactivate() {
+        checkStartPhaseCondition(false);
+    }
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test.startphase.condition.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/test.startphase.condition.bnd
@@ -1,0 +1,35 @@
+#*******************************************************************************
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+# Define the bundle for this FAT
+
+Bundle-Name: test.startphase.condition
+Bundle-SymbolicName: test.startphase.condition
+
+# hide the implementation packages
+Private-Package: \
+ test.startphase.condition
+
+-dsannotations: \
+ test.startphase.condition.TestStartPhaseConditionActive,\
+ test.startphase.condition.TestStartPhaseConditionApplication,\
+ test.startphase.condition.TestStartPhaseConditionApplicationEarly,\
+ test.startphase.condition.TestStartPhaseConditionApplicationLate,\
+ test.startphase.condition.TestStartPhaseConditionContainers,\
+ test.startphase.condition.TestStartPhaseConditionContainersEarly,\
+ test.startphase.condition.TestStartPhaseConditionContainersLate,\
+ test.startphase.condition.TestStartPhaseConditionServices,\
+ test.startphase.condition.TestStartPhaseConditionServicesEarly,\
+ test.startphase.condition.TestStartPhaseConditionServicesLate

--- a/dev/com.ibm.ws.kernel.service/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.service/bnd.bnd
@@ -26,6 +26,7 @@ Bundle-Activator: com.ibm.ws.kernel.service.location.internal.Activator
 
 Export-Package: \
  com.ibm.websphere.kernel.server;provide:=true, \
+ com.ibm.wsspi.kernel.service.condition, \
  com.ibm.wsspi.kernel.service.location, \
  com.ibm.wsspi.kernel.service.utils;provide:=true, \
  com.ibm.ws.kernel.service.util;provide:=true, \
@@ -51,7 +52,8 @@ Import-Package: \
 -dsannotations: \
   com.ibm.ws.kernel.server.internal.InspectCommand, \
   com.ibm.ws.kernel.server.internal.ServerInfoMBeanImpl, \
-  com.ibm.ws.kernel.server.internal.ServerEndpointControlMBeanImpl
+  com.ibm.ws.kernel.server.internal.ServerEndpointControlMBeanImpl, \
+  com.ibm.ws.kernel.server.internal.StartPhaseConditionManager
 
 instrument.classesExcludes: com/ibm/ws/kernel/service/utils/resources/*.class, \
   com/ibm/ws/kernel/**/internal/resources/*.class, \

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/server/internal/StartPhaseConditionManager.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/server/internal/StartPhaseConditionManager.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.kernel.server.internal;
+
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase.getByActiveLevel;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BinaryOperator;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.framework.SynchronousBundleListener;
+import org.osgi.framework.startlevel.FrameworkStartLevel;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.condition.Condition;
+
+import com.ibm.wsspi.kernel.service.condition.StartPhaseCondition;
+import com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.StartPhase;
+
+/**
+ *
+ */
+@Component
+public class StartPhaseConditionManager {
+    private final ServiceRegistration<Condition> startPhaseConditionReg;
+    private final FrameworkStartLevel frameworkStartLevel;
+    private final AtomicReference<StartPhaseCondition.StartPhase> current = new AtomicReference<>(StartPhaseCondition.StartPhase.PREPARE);
+    private final SynchronousBundleListener bundleListener;
+
+    @Activate
+    public StartPhaseConditionManager(BundleContext context) {
+        frameworkStartLevel = context.getBundle(Constants.SYSTEM_BUNDLE_LOCATION).adapt(FrameworkStartLevel.class);
+        startPhaseConditionReg = context.registerService(Condition.class, Condition.INSTANCE,
+                                                         FrameworkUtil.asDictionary(getConditionProps(current.get())));
+
+        BinaryOperator<StartPhase> phaseUpdater = new BinaryOperator<StartPhase>() {
+            @Override
+            public StartPhase apply(final StartPhase c, final StartPhase n) {
+                if (c == n) {
+                    // do nothing
+                    return n;
+                }
+                StartPhase current = c;
+                while (current != n) {
+                    if (current.level() < n.level()) {
+                        current = current.next();
+                    } else {
+                        current = current.previous();
+                    }
+                    if (c == null) {
+                        // should never happen
+                        throw new IllegalStateException();
+                    }
+                    startPhaseConditionReg.setProperties(FrameworkUtil.asDictionary(getConditionProps(current)));
+                }
+                return n;
+            }
+        };
+
+        bundleListener = new SynchronousBundleListener() {
+            @Override
+            public void bundleChanged(BundleEvent e) {
+                if ((e.getType() & (BundleEvent.STARTING | BundleEvent.STOPPING)) != 0) {
+                    StartPhaseCondition.StartPhase newPhase = getByActiveLevel(frameworkStartLevel.getStartLevel());
+                    StartPhase oldPhase = current.getAndSet(newPhase);
+                    if (oldPhase != newPhase) {
+                        phaseUpdater.apply(oldPhase, newPhase);
+                    }
+                }
+            }
+        };
+        context.addBundleListener(bundleListener);
+    }
+
+    static Map<String, Object> getConditionProps(StartPhase phase) {
+        Map<String, Object> result = new HashMap<>();
+        result.put(Condition.CONDITION_ID, StartPhaseCondition.ID_NAME);
+        result.put(StartPhaseCondition.ID_NAME, phase);
+        return result;
+    }
+
+    @Deactivate
+    public void deactivate(BundleContext context) {
+        context.removeBundleListener(bundleListener);
+        startPhaseConditionReg.unregister();
+    }
+}

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/condition/StartPhaseCondition.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/condition/StartPhaseCondition.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.wsspi.kernel.service.condition;
+
+import org.osgi.service.condition.Condition;
+
+/**
+ *
+ */
+public interface StartPhaseCondition {
+    static final String ID_NAME = "io.openliberty.start.phase";
+
+    static final String PREPARE_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                         + ">=PREPARE))";
+    static final String SERVICE_EARLY_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                               + ">=SERVICE_EARLY))";
+    static final String SERVICE_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                         + ">=SERVICE))";
+    static final String SERVICE_LATE_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                              + ">=SERVICE_LATE))";
+
+    static final String CONTAINER_EARLY_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                                 + ">=CONTAINER_EARLY))";
+    static final String CONTAINER_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                           + ">=CONTAINER))";
+    static final String CONTAINER_LATE_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                                + ">=CONTAINER_LATE))";
+
+    static final String APPLICATION_EARLY_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                                   + ">=APPLICATION_EARLY))";
+    static final String APPLICATION_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                             + ">=APPLICATION))";
+    static final String APPLICATION_LATE_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                                  + ">=APPLICATION_LATE))";
+    static final String ACTIVE_FILTER = "(&(" + Condition.CONDITION_ID + "=" + StartPhaseCondition.ID_NAME + ")(" + StartPhaseCondition.ID_NAME
+                                        + ">=ACTIVE))";
+
+    public enum StartPhase {
+        PREPARE(7),
+        SERVICE_EARLY(8),
+        SERVICE(9),
+        SERVICE_LATE(10),
+        CONTAINER_EARLY(11),
+        CONTAINER(12),
+        CONTAINER_LATE(13),
+        APPLICATION_EARLY(17),
+        APPLICATION(18),
+        APPLICATION_LATE(19),
+        ACTIVE(20);
+
+        final int level;
+
+        private StartPhase(int level) {
+            this.level = level;
+        }
+
+        public int level() {
+            return level;
+        }
+
+        public StartPhase previous() {
+            if (this == PREPARE) {
+                return null;
+            }
+            return values()[this.ordinal() - 1];
+        }
+
+        public StartPhase next() {
+            if (this == ACTIVE) {
+                return null;
+            }
+            return values()[this.ordinal() + 1];
+        }
+
+        public static StartPhase getByActiveLevel(int frameworkActiveLevel) {
+            // because of gaps between phases we just do a less-than next phase check
+            // to get the current phase starting at the lowest phase level
+            if (frameworkActiveLevel < SERVICE_EARLY.level) {
+                return PREPARE;
+            }
+            if (frameworkActiveLevel < SERVICE.level) {
+                return SERVICE_EARLY;
+            }
+            if (frameworkActiveLevel < SERVICE_LATE.level) {
+                return SERVICE;
+            }
+            if (frameworkActiveLevel < CONTAINER_EARLY.level) {
+                return SERVICE_LATE;
+            }
+            if (frameworkActiveLevel < CONTAINER.level) {
+                return CONTAINER_EARLY;
+            }
+            if (frameworkActiveLevel < CONTAINER_LATE.level) {
+                return CONTAINER;
+            }
+            if (frameworkActiveLevel < APPLICATION_EARLY.level) {
+                return CONTAINER_LATE;
+            }
+            if (frameworkActiveLevel < APPLICATION.level) {
+                return APPLICATION_EARLY;
+            }
+            if (frameworkActiveLevel < APPLICATION_LATE.level) {
+                return APPLICATION;
+            }
+            if (frameworkActiveLevel < ACTIVE.level) {
+                return APPLICATION_LATE;
+            }
+
+            return ACTIVE;
+        }
+    }
+}

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/condition/package-info.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/condition/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package com.ibm.wsspi.kernel.service.condition;

--- a/dev/com.ibm.ws.threading_policy_fat/publish/files/features/vtOverrideUser-1.0.mf
+++ b/dev/com.ibm.ws.threading_policy_fat/publish/files/features/vtOverrideUser-1.0.mf
@@ -1,7 +1,7 @@
 Subsystem-ManifestVersion: 1
 Subsystem-SymbolicName: vtOverrideUser-1.0; visibility:=public
 Subsystem-Version: 1.0
-Subsystem-Content: test.vtoverrideservice.bundle_fat
+Subsystem-Content: test.vtoverrideservice.bundle_fat; start-phase:=SERVICE_EARLY
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2
 IBM-API-Package: com.ibm.ws.threading; type="ibm-api"

--- a/dev/io.openliberty.threading.virtual.internal/src/io/openliberty/threading/virtual/internal/VirtualThreadOperations.java
+++ b/dev/io.openliberty.threading.virtual.internal/src/io/openliberty/threading/virtual/internal/VirtualThreadOperations.java
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package io.openliberty.threading.virtual.internal;
 
+import static com.ibm.wsspi.kernel.service.condition.StartPhaseCondition.SERVICE_LATE_FILTER;
+
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.concurrent.ThreadFactory;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
@@ -39,8 +42,11 @@ import io.openliberty.threading.virtual.VirtualThreadOps;
            service = VirtualThreadOps.class)
 @SatisfyingConditionTarget("(&(" + Condition.CONDITION_ID + "=" + JavaInfo.CONDITION_ID + ")(" + JavaInfo.CONDITION_ID + ">=21))")
 public class VirtualThreadOperations implements VirtualThreadOps {
-
     private volatile ThreadTypeOverride overrideService;
+
+    @Activate
+    public VirtualThreadOperations(@Reference(target = SERVICE_LATE_FILTER) Condition servicesLate) {
+    }
 
     @Reference(
                cardinality = ReferenceCardinality.OPTIONAL,


### PR DESCRIPTION
Previously there was no condition for start-phase.  All components within a bundle had to be associated witih their own bundles start-phase.

There are cases where a component may want to delay until a higher start-phase than their defining bundle.  For example, kernel components that would like to wait until higher start-phases are achieved before being enabled.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

