### PR TITLE
Count query generation, discovery of the entity identification variable, and parentheses insertion

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -369,13 +369,13 @@ CWWKD1033.ql.orderby.disallowed.explanation=The ORDER BY clause is incompatible 
 CWWKD1033.ql.orderby.disallowed.useraction=Replace the ORDER BY clause with \
  annotations that specify the sort criteria.
 
-CWWKD1034.ql.where.required=CWWKD1034E: The query that is specified by the \
+CWWKD1034.ql.req.end.in.where=CWWKD1034E: The query that is specified by the \
  {0} method of the {1} repository interface must end in a WHERE clause because \
  the method returns {2}. There WHERE clause ends at position {3}, but the \
  length of the query is {4}. The query is: {5}.
-CWWKD1034.ql.where.required.explanation=A WHERE clause is required when \
+CWWKD1034.ql.req.end.in.where.explanation=A WHERE clause is required when \
  using cursor-based pagination.
-CWWKD1034.ql.where.required.useraction=Add a WHERE clause to the query.
+CWWKD1034.ql.req.end.in.where.useraction=Add a WHERE clause to the query.
 
 CWWKD1035.incompat.page.mode=CWWKD1035E: A page request with the {0} pagination \
  mode must not be supplied to the {1} method of the {2} repository interface \

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryEdit.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryEdit.java
@@ -17,22 +17,22 @@ package io.openliberty.data.internal.persistence;
  */
 enum QueryEdit {
     /**
-     * Instruction to add a closing parenthesis ) for an added constructor after
-     * the specified index. This instruction is always paired with the
-     * ADD_CONSTRUCTOR_START instruction.
+     * Instruction to add NEW fully.qualified.ClassName( to the SELECT clause
+     * at the specified index. This instruction is always paired with the
+     * ADD_CONSTRUCTOR_END instruction.
      */
-    ADD_CONSTRUCTOR_END,
+    ADD_CONSTRUCTOR_BEGIN,
 
     // TODO 1.1 use Jakarta Persistence enhancement issue 420 instead of
     // editing the query to enclose the SELECT clause content in
     // NEW fully.qualified.ClassName(...)
 
     /**
-     * Instruction to add NEW fully.qualified.ClassName( to the SELECT clause
-     * at the specified index. This instruction is always paired with the
-     * ADD_CONSTRUCTOR_END instruction.
+     * Instruction to add a closing parenthesis ) for an added constructor after
+     * the specified index. This instruction is always paired with the
+     * ADD_CONSTRUCTOR_BEGIN instruction.
      */
-    ADD_CONSTRUCTOR_START,
+    ADD_CONSTRUCTOR_END,
 
     /**
      * Instruction to add a FROM clause to the query. The FROM clause is added
@@ -40,6 +40,20 @@ enum QueryEdit {
      * at the beginning of the query.
      */
     ADD_FROM,
+
+    /**
+     * Instruction to add ( to the WHERE clause at the specified index.
+     * This instruction is always paired with the ADD_PARENTHESIS_END
+     * instruction.
+     */
+    ADD_PARENTHESIS_BEGIN,
+
+    /**
+     * Instruction to add ) to the WHERE clause at the specified index.
+     * This instruction is always paired with the ADD_PARENTHESIS_BEGIN
+     * instruction.
+     */
+    ADD_PARENTHESIS_END,
 
     /**
      * Instruction to add a SELECT clause to the query if it is determined that

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryEdit.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryEdit.java
@@ -62,6 +62,22 @@ enum QueryEdit {
     ADD_SELECT_IF_NEEDED,
 
     /**
+     * Instruction to omit the ORDER BY clause when generating a count query.
+     * The key for this instruction is a negative value (to avoid collision)
+     * of which the absolute value points to the position after the
+     * ORDER keyword.
+     */
+    OMIT_ORDER_IN_COUNT,
+
+    /**
+     * Instruction to omit the SELECT clause when generating a count query.
+     * The key for this instruction is a negative value (to avoid collision)
+     * of which the absolute value points to the position after the end of the
+     * SELECT clause.
+     */
+    OMIT_SELECT_IN_COUNT,
+
+    /**
      * Instruction to replace record names with the generated entity class name
      * when the record name appears after the FROM keyword.
      */

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -345,6 +345,18 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Use a repository method that performs a Query consisting of a SELECT
+     * clause that uses the NEW keyword to specify the constructor for a
+     * Java record.
+     */
+    @Test
+    public void testSelectNewQuery() {
+
+        assertEquals(new Ratio(5, 3),
+                     fractions.singleRatio(5, 8).orElseThrow());
+    }
+
+    /**
      * Use a repository method that performs a Query with SELECT and ORDER BY
      * clauses only, retrieving a subset of entity attributes as a Java record.
      */

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -14,6 +14,7 @@ package test.jakarta.data.v1_1.web;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.data.Limit;
@@ -68,6 +69,11 @@ public interface Fractions {
     @Query("SELECT numerator, denominator - numerator" +
            " ORDER BY denominator - numerator DESC, numerator ASC")
     Page<Ratio> pageOfRatios(PageRequest pageReq);
+
+    @Query("SELECT NEW test.jakarta.data.v1_1.web.Ratio(" +
+           "\t\tnumerator, denominator - numerator)" +
+           "\tWHERE numerator=?1 AND denominator=?2")
+    Optional<Ratio> singleRatio(int numerator, int denominator);
 
     @Query("SELECT numerator, denominator - numerator")
     Stream<Ratio> streamOfRatios();


### PR DESCRIPTION
Implement count query generation, parentheses insertion (for cursor-based pagination), improve awareness of clauses and cover parenthesis insertion on the path that minimally modifies queries.

The old code path is temporarily still need for a workaround but is moved to only occur when it is detected that the workaround is needed.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
