### PR TITLE
make fips enabled message print regardless of features used

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/location/internal/Activator.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/location/internal/Activator.java
@@ -33,6 +33,7 @@ import org.osgi.service.condition.Condition;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.common.crypto.CryptoUtils;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.pseudo.internal.PseudoContextFactory;
 import com.ibm.ws.kernel.service.util.JavaInfo;
@@ -94,6 +95,8 @@ public class Activator implements BundleActivator {
                     Tr.debug(tc, "Failed to install initialContextFactoryBuilder because it was already installed", ex);
             }
 
+            // If FIPS 140-3 is enabled, log the enabled message
+            CryptoUtils.isFips140_3Enabled();
         } catch (Exception t) {
             Tr.audit(tc, "frameworkShutdown");
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

currently, the FIPS enabled message only appears if a security related feature is enabled.
however, even if a security related feature is not enabled, FIPS is still considered enabled if the FIPS JVM args are set.

this PR adds a call to `CryptoUtils.isFips140_3Enabled();` in the `com.ibm.ws.kernel.service`'s `BundleActivator`, so the message can always be logged if FIPS is enabled, regardless if a security related feature is enabled or not.

**example output:**

messages.log:
```
[10/17/25, 11:07:37:631 PDT] 00000001 com.ibm.ws.kernel.launch.internal.FrameworkManager           A CWWKE0001I: The server hello has been launched.
[10/17/25, 11:07:38:039 PDT] 00000029 com.ibm.ws.common.crypto.CryptoUtils                         I BETA: A beta method has been invoked for the class CryptoUtils for the first time.
[10/17/25, 11:07:38:387 PDT] 00000029 com.ibm.ws.common.crypto.CryptoUtils                         I CWWKS5903I: FIPS 140-3 is enabled and using the FIPS provider OpenJCEPlusFIPS
[10/17/25, 11:07:38:734 PDT] 00000001 com.ibm.ws.kernel.launch.internal.FrameworkManager           I CWWKE0002I: The kernel started after 1.43 seconds
[10/17/25, 11:07:38:850 PDT] 00000032 com.ibm.ws.kernel.feature.internal.FeatureManager            I CWWKF0007I: Feature update started.
[10/17/25, 11:07:39:150 PDT] 00000028 com.ibm.ws.app.manager.internal.monitor.DropinMonitor        A CWWKZ0058I: Monitoring dropins for applications.
[10/17/25, 11:07:39:303 PDT] 00000036 io.openliberty.netty.internal.tcp.TCPUtils                   I CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host localhost  (IPv4: 127.0.0.1) port 9080.
[10/17/25, 11:07:39:306 PDT] 00000032 com.ibm.ws.kernel.feature.internal.FeatureManager            A CWWKF0012I: The server installed the following features: [el-3.0, jsp-2.3, servlet-3.1].
[10/17/25, 11:07:39:307 PDT] 00000032 com.ibm.ws.kernel.feature.internal.FeatureManager            I CWWKF0008I: Feature update completed in 0.571 seconds.
[10/17/25, 11:07:39:307 PDT] 00000032 com.ibm.ws.kernel.feature.internal.FeatureManager            A CWWKF0011I: The hello server is ready to run a smarter planet. The hello server started in 2.007 seconds.
```