### PR TITLE
Gradle updates

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
+++ b/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
@@ -1,49 +1,52 @@
-/* Copyright (c) 2021, 2024 IBM Corporation and others.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License 2.0
-* which accompanies this distribution, and is available at
-* http://www.eclipse.org/legal/epl-2.0/
- * 
+/* Copyright (c) 2021, 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
  * SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*     IBM Corporation - initial API and implementation
-*******************************************************************************/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 
-addRequiredLibraries {
-    configurations {
-	    	usrFeatures
-	    	usrEsa
-	    	features1
-	    	features2
-    }
-    
-    dependencies {
-      usrFeatures 'test.featureUtility_fat:userFeature:1.0@zip'
-      usrEsa 'test.featureUtility_fat:usertest.with.api:1.0@esa'
-      features1 'test.featureUtility_fat:Archive:1.0@zip'
-      features2 'test.featureUtility_fat:Archive:2.0@zip'
-    }    
-    
-    copy {
-        from configurations.usrFeatures
-        into "publish/repo/userFeature"
-    }
-    
-    copy {
-        from configurations.usrEsa
-        into "publish/features"
-    }
-    
-    copy {
-        from configurations.features1
-        into "publish/repo/archive1"
-    }
-    
-    copy {
-        from configurations.features2
-        into "publish/repo/archive2"
-    }
-
-    dependsOn copyTestContainers
+configurations {
+  usrFeatures
+  usrEsa
+  features1
+  features2
 }
+    
+dependencies {
+  usrFeatures 'test.featureUtility_fat:userFeature:1.0@zip'
+  usrEsa 'test.featureUtility_fat:usertest.with.api:1.0@esa'
+  features1 'test.featureUtility_fat:Archive:1.0@zip'
+  features2 'test.featureUtility_fat:Archive:2.0@zip'
+}
+
+task copyTestArtifacts {
+  doLast {
+    copy {
+      from configurations.usrFeatures
+      into "publish/repo/userFeature"
+    }
+    
+    copy {
+      from configurations.usrEsa
+      into "publish/features"
+    }
+    
+    copy {
+      from configurations.features1
+      into "publish/repo/archive1"
+    }
+    
+    copy {
+      from configurations.features2
+      into "publish/repo/archive2"
+    }
+  }
+}
+
+addRequiredLibraries.dependsOn copyTestArtifacts
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.java11_fat/build.gradle
+++ b/dev/com.ibm.ws.java11_fat/build.gradle
@@ -1,21 +1,24 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-task copyKernelService(type: Copy) {
-  dependsOn ':com.ibm.ws.kernel.service:assemble'
-  from project(':com.ibm.ws.kernel.service').buildDir
-  into new File(autoFvtDir, 'lib')
+configurations {
+  requiredLibs {
+    transitive = false
+  }
 }
 
-addRequiredLibraries.dependsOn copyKernelService
+dependencies {
+  requiredLibs project(':com.ibm.ws.kernel.service')
+}
+
 addRequiredLibraries.dependsOn addDerby

--- a/dev/io.openliberty.java.internal_fat/build.gradle
+++ b/dev/io.openliberty.java.internal_fat/build.gradle
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,6 +21,9 @@ configurations {
     app23
     app24
     app25
+    requiredLibs {
+        transitive = false
+    }
  }
  
  dependencies {
@@ -33,13 +36,8 @@ configurations {
     app23 'io.openliberty:java-apps:23.1.0'
     app24 'io.openliberty:java-apps:24.1.0'
     app25 'io.openliberty:java-apps:25.1.0'
+    requiredLibs project(':com.ibm.ws.kernel.service')
  }
-
-task copyKernelService(type: Copy) {
-  dependsOn ':com.ibm.ws.kernel.service:assemble'
-  from project(':com.ibm.ws.kernel.service').buildDir
-  into new File(autoFvtDir, 'lib')
-}
 
 task copyApp17A(type: Copy) {
   from configurations.app17
@@ -107,7 +105,6 @@ task copyApp25(type: Copy) {
   rename 'java-apps-*.*.*.*', 'io.openliberty.java.internal_fat_25.war'
 }
 
-addRequiredLibraries.dependsOn copyKernelService
 addRequiredLibraries.dependsOn copyApp17A
 addRequiredLibraries.dependsOn copyApp17B
 addRequiredLibraries.dependsOn copyApp18A


### PR DESCRIPTION
- Run copyTestArtifacts during execution phase instead of config phase for com.ibm.ws.install.featureUtility_fat so that we do not need to download things unless doing that particular fat building
- Change from copyKernelService task to setting requiredLibs to not have a dependency on com.ibm.ws.kernel.service which can cause issues with gradle when doing combination of targets

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
