### PR TITLE
Update interruptHungRequest description

### DIFF
--- a/dev/com.ibm.ws.request.timing/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.request.timing/resources/OSGI-INF/l10n/metatype.properties
@@ -44,4 +44,4 @@ contextInfoPattern=Context information pattern
 contextInfoPattern.desc=The pattern that determines whether this timing element processes a request. To discover the context information for a request, enable the eventLogging-1.0 service and view the events generated for the request. To add a wildcard, put an asterisk at the end of the pattern. If a context information pattern is used, the request timing configuration must set includeContextInfo to true.
 
 interruptHungRequest=Interrupt hung requests
-interruptHungRequest.desc=Indicates whether a request that is hung is to be interrupted. A value of true causes the requestTiming-1.0 feature to attempt to interrupt the hung request. A value of false allows the request to continue to run. This feature is only supported on IBM JRE 8 and is not supported on IBM Semeru 8.
+interruptHungRequest.desc=Specifies whether a hung request is to be interrupted. When set to true, the requestTiming-1.0 feature attempts to interrupt the hung request. When set to false, the request continues to run. This feature is supported only on IBM JRE 8 and is not supported on IBM Semeru 8.

--- a/dev/com.ibm.ws.request.timing/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.request.timing/resources/OSGI-INF/l10n/metatype.properties
@@ -44,4 +44,4 @@ contextInfoPattern=Context information pattern
 contextInfoPattern.desc=The pattern that determines whether this timing element processes a request. To discover the context information for a request, enable the eventLogging-1.0 service and view the events generated for the request. To add a wildcard, put an asterisk at the end of the pattern. If a context information pattern is used, the request timing configuration must set includeContextInfo to true.
 
 interruptHungRequest=Interrupt hung requests
-interruptHungRequest.desc=Indicates whether a request that is hung is to be interrupted. A value of true causes the requestTiming-1.0 feature to attempt to interrupt the hung request. A value of false allows the request to continue to run.
+interruptHungRequest.desc=Indicates whether a request that is hung is to be interrupted. A value of true causes the requestTiming-1.0 feature to attempt to interrupt the hung request. A value of false allows the request to continue to run. This feature is only supported on IBM JRE 8 and is not supported on IBM Semeru 8.

--- a/dev/com.ibm.ws.request.timing/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.request.timing/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Resolves: #32466 

We're looking to update this description to match the changes made here: https://github.ibm.com/websphere/liberty-docs/issues/4494

Specifically that only IBM JRE 8 is supported and `Interrupting requests is not supported on IBM JRE 11 and later versions, and is not supported on IBM Semeru 8 and later versions.`
