### PR TITLE
Cases where count query cannot be inferred

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1203,21 +1203,20 @@ CWWKD1118.param.anno.conflict.explanation=The combination of parameter \
 CWWKD1118.param.anno.conflict.useraction=Remove one or more of the conflicting \
  annotations from the repository method parameter.
 
-CWWKD1119.keyword.prevents.count=CWWKD1119E: Pages that are retrieved by the \
- {0} method of the {1} repository interface do not include a total count of \
- elements and pages because the query contains the {2} keyword. The full query \
- is: {3}.
+CWWKD1119.keyword.prevents.count=CWWKD1119E: The {0} method of the {1} repository \
+ interface retrieves pages that do not include a total count of elements and pages \
+ because the query contains the {2} keyword. The full query is: {3}.
 CWWKD1119.keyword.prevents.count.explanation=The keyword is incompatible with \
  the ability to obtain a total count of elements and pages.
 CWWKD1119.keyword.prevents.count.useraction=Replace the query with one that \
  does not use the keyword or avoid requesting a total count of elements and pages.
 
-CWWKD1120.cursor.keyword.mismatch=CWWKD1120E: The query that is specified by the \
- {0} method of the {1} repository interface includes the {2} keyword, which is \
- incompatible with cursor-based pagination. Queries for cursor-based pagination \
- must end with the WHERE clause and must not include subqueries. The query is: {3}.
+CWWKD1120.cursor.keyword.mismatch=CWWKD1120E: The {0} method of the {1} repository \
+ interface specifies a query that includes the {2} keyword, which is incompatible \
+ with cursor-based pagination. Queries for cursor-based pagination must end with \
+ a WHERE clause and must not include subqueries. The query is: {3}.
 CWWKD1120.cursor.keyword.mismatch.explanation=Keywords such as GROUP BY, HAVING, \
  ORDER BY, EXCEPT, INTERSECT, and UNION are not compatible with cursor-based \
  pagination.
-CWWKD1120.cursor.keyword.mismatch.useraction=Rewrite the query to only include \
- the clauses: SELECT, FROM, WHERE.
+CWWKD1120.cursor.keyword.mismatch.useraction=Rewrite the query to include only \
+ the clauses: SELECT, FROM, and WHERE.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1202,3 +1202,12 @@ CWWKD1118.param.anno.conflict.explanation=The combination of parameter \
  annotations is not valid.
 CWWKD1118.param.anno.conflict.useraction=Remove one or more of the conflicting \
  annotations from the repository method parameter.
+
+CWWKD1119.keyword.prevents.count=CWWKD1119E: Pages that are retrieved by the \
+ {0} method of the {1} repository interface do not include a total count of \
+ elements and pages because the query contains the {2} keyword. The full query \
+ is: {3}.
+CWWKD1119.keyword.prevents.count.explanation=The keyword is incompatible with \
+ the ability to obtain a total count of elements and pages.
+CWWKD1119.keyword.prevents.count.useraction=Replace the query with one that \
+ does not use the keyword or avoid requesting a total count of elements and pages.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1211,3 +1211,13 @@ CWWKD1119.keyword.prevents.count.explanation=The keyword is incompatible with \
  the ability to obtain a total count of elements and pages.
 CWWKD1119.keyword.prevents.count.useraction=Replace the query with one that \
  does not use the keyword or avoid requesting a total count of elements and pages.
+
+CWWKD1120.cursor.keyword.mismatch=CWWKD1120E: The query that is specified by the \
+ {0} method of the {1} repository interface includes the {2} keyword, which is \
+ incompatible with cursor-based pagination. Queries for cursor-based pagination \
+ must end with the WHERE clause and must not include subqueries. The query is: {3}.
+CWWKD1120.cursor.keyword.mismatch.explanation=Keywords such as GROUP BY, HAVING, \
+ ORDER BY, EXCEPT, INTERSECT, and UNION are not compatible with cursor-based \
+ pagination.
+CWWKD1120.cursor.keyword.mismatch.useraction=Rewrite the query to only include \
+ the clauses: SELECT, FROM, WHERE.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -161,6 +161,14 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
                       queryInfo.repositoryInterface.getName(),
                       pageRequest);
 
+        if (queryInfo.jpqlCount.length() < Util.MIN_COUNT_QUERY_LENGTH)
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1119.keyword.prevents.count",
+                      queryInfo.method.getName(),
+                      queryInfo.repositoryInterface.getName(),
+                      queryInfo.jpqlCount,
+                      queryInfo.jpql);
+
         EntityManager em = queryInfo.entityInfo.builder.createEntityManager();
         try {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
@@ -236,7 +244,8 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
 
     @Override
     public boolean hasTotals() {
-        return pageRequest.requestTotal();
+        return queryInfo.jpqlCount.length() >= Util.MIN_COUNT_QUERY_LENGTH &&
+               pageRequest.requestTotal();
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -137,6 +137,14 @@ public class PageImpl<T> implements Page<T> {
             pageRequest.size() < Integer.MAX_VALUE)
             return results.size();
 
+        if (queryInfo.jpqlCount.length() < Util.MIN_COUNT_QUERY_LENGTH)
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1119.keyword.prevents.count",
+                      queryInfo.method.getName(),
+                      queryInfo.repositoryInterface.getName(),
+                      queryInfo.jpqlCount,
+                      queryInfo.jpql);
+
         EntityManager em = queryInfo.entityInfo.builder.createEntityManager();
         try {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
@@ -182,7 +190,8 @@ public class PageImpl<T> implements Page<T> {
 
     @Override
     public boolean hasTotals() {
-        return pageRequest.requestTotal();
+        return queryInfo.jpqlCount.length() >= Util.MIN_COUNT_QUERY_LENGTH &&
+               pageRequest.requestTotal();
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3384,13 +3384,8 @@ public class QueryInfo {
                                     .toString();
                 }
             else
-                throw exc(MappingException.class,
-                          "CWWKD1010.unknown.entity.attr",
-                          name,
-                          entityInfo.getType().getName(),
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          entityInfo.attributeTypes.keySet());
+                // allow functions, such as LENGTH(name)
+                attributeName = name;
         } else if (len == 0) {
             throw exc(MappingException.class,
                       "CWWKD1024.missing.entity.attr",

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -93,6 +93,14 @@ public class Util {
                     Set.of("count", "delete", "exists", "find");
 
     /**
+     * Minimum number of characters in a valid SELECT COUNT clause.
+     * For example: SELECT COUNT(o)
+     * Any value below this number is considered to instead indicate a
+     * keyword that prevented the computation of a count query, such as GROUP.
+     */
+    static final int MIN_COUNT_QUERY_LENGTH = 15;
+
+    /**
      * Commonly used result types that are not entities.
      */
     static final Set<Class<?>> NON_ENTITY_RESULT_TYPES = new HashSet<>();

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataTest.java
@@ -54,7 +54,8 @@ public class DataTest extends FATServletClient {
                                    // work around to prevent bad behavior from EclipseLink (see #30575)
                                    "CWWKD1103E.*romanNumeralSymbolsAsListOfArrayList",
                                    // work around to prevent bad behavior from EclipseLink (see #30575)
-                                   "CWWKD1103E.*romanNumeralSymbolsAsSetOfArrayList"
+                                   "CWWKD1103E.*romanNumeralSymbolsAsSetOfArrayList",
+                                   "CWWKD1119E.*minNumberOfEachNameLength" // cannot infer count for GROUP BY
                     };
 
     @ClassRule

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -370,6 +370,13 @@ public interface Primes {
                     """)
     Stack<String> minMaxSumCountAverageStack(long numBelow);
 
+    @Query("SELECT MIN(numberId)" +
+           " WHERE numberId < ?1" +
+           " GROUP BY LENGTH(name)")
+    @OrderBy("LENGTH(name)")
+    Page<Long> minNumberOfEachNameLength(long max,
+                                         PageRequest req);
+
     @Query("SELECT o.name FROM Prime o WHERE o.numberId < ?1")
     Page<String> namesBelow(long numBelow, Sort<Prime> sort, PageRequest pageRequest);
 

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -123,7 +123,11 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1108E.*Invitation", // JPA entity lacks @Entity
                                    "CWWKD1109E.*Investment", // Record entity has JPA anno
                                    "CWWKD1110E.*findByEmailAddressesGreaterThanEqual", // collection >=
-                                   "CWWKD1110E.*findByEmailAddressesIgnoreCaseContains" // collection IgnoreCase
+                                   "CWWKD1110E.*findByEmailAddressesIgnoreCaseContains", // collection IgnoreCase
+                                   "CWWKD1120E.*groupedByAddress", // cursor pagination with GROUP BY
+                                   "CWWKD1120E.*unionOfAddresses", // cursor pagination with UNION
+                                   "CWWKD1120E.*withNameAndAddress", // cursor pagination with INTERSECT
+                                   "CWWKD1120E.*withNameNotAddress" // cursor pagination with EXCEPT
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -891,6 +891,26 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Verify an appropriate error is raised when a repository method attempts
+     * to use an EXCEPT query with cursor-based pagainstion.
+     */
+    @Test
+    public void testExceptWithCursorPagination() {
+        try {
+            CursoredPage<Voter> page;
+            page = voters.withNameNotAddress("Vincent",
+                                             "770 W Silver Lake Dr NE, Rochester, MN 55906",
+                                             PageRequest.ofSize(5));
+            fail("Obtained a cursored page for an EXCEPT query. " + page);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1120E:") ||
+                !x.getMessage().contains("EXCEPT"))
+                throw x;
+        }
+    }
+
+    /**
      * Verify an error is raised when an exists Query by Method Name method
      * tries to return a true/false value as int.
      */
@@ -1256,6 +1276,26 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1018E") ||
                 !x.getMessage().contains("occupying"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an appropriate error is raised when a repository method attempts
+     * to use an INTERSECT query for cursor-based pagainstion.
+     */
+    @Test
+    public void testIntersectionForCursorPagination() {
+        try {
+            CursoredPage<Voter> page;
+            page = voters.withNameAndAddress("Vincent",
+                                             "770 W Silver Lake Dr NE, Rochester, MN 55906",
+                                             PageRequest.ofSize(5));
+            fail("Obtained a cursored page for an INTERSECT query. " + page);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1120E:") ||
+                !x.getMessage().contains("INTERSECT"))
                 throw x;
         }
     }
@@ -2249,6 +2289,26 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1015E") ||
                 !x.getMessage().contains("addOrUpdate"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an appropriate error is raised when a repository method attempts
+     * to use a UNION query for cursor-based pagainstion.
+     */
+    @Test
+    public void testUnionForCursorPagination() {
+        try {
+            CursoredPage<Voter> page;
+            page = voters.unionOfAddresses("701 Silver Creek Rd NE, Rochester, MN 55906",
+                                           "770 W Silver Lake Dr NE, Rochester, MN 55906",
+                                           PageRequest.ofSize(4));
+            fail("Obtained a cursored page for a UNION query. " + page);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1120E:") ||
+                !x.getMessage().contains("UNION"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -1829,9 +1829,12 @@ public class DataErrPathsTestServlet extends FATServlet {
             List<Voter> found = voters.sortedByEndOfAddress();
             fail("OrderBy annotation with invalid function must cause an error." +
                  " Instead, the repository method returned: " + found);
-        } catch (MappingException x) {
+        } catch (Exception x) {
+            // Jakarta Data cannot filter out invalid functions without
+            // inadvertently filtering out some valid functions as well.
+            // So instead, we let the Jakarta Persistence provider raise the
+            // error,
             if (x.getMessage() != null &&
-                x.getMessage().startsWith("CWWKD1010E") &&
                 x.getMessage().contains("last5DigitsOf(address)"))
                 ; // expected
             else

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -1093,6 +1093,24 @@ public class DataErrPathsTestServlet extends FATServlet {
     }
 
     /**
+     * Verify an appropriate error is raised when a repository method attempts
+     * to use a GROUP BY query for cursor-based pagainstion.
+     */
+    @Test
+    public void testGroupByQueryForCursorPagination() {
+        try {
+            CursoredPage<Voter> page1 = //
+                            voters.groupedByAddress(PageRequest.ofSize(4));
+            fail("Obtained a cursored page for a GROUP BY query. " + page1);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1120E:") ||
+                !x.getMessage().contains("FROM Voter v GROUP BY v.address"))
+                throw x;
+        }
+    }
+
+    /**
      * Verify an appropriate error is raised for the invalid combination of the
      * IgnoreCase and In keywords on a Query by Method Name method.
      */

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -321,6 +321,14 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     long findSSNAsLongBetween(long min, long max);
 
     /**
+     * This invalid method includes GROUP BY in a query that is used for
+     * cursor-based pagination.
+     */
+    @Query("FROM Voter v GROUP BY v.address")
+    @OrderBy("ssn")
+    CursoredPage<Voter> groupedByAddress(PageRequest pageReq);
+
+    /**
      * This invalid method defines an ordering for results of a delete operation
      * but has a return type that disallows returning results.
      */

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -582,6 +582,19 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     Voter storeInDatabase(Voter voter, PageRequest pageReq);
 
     /**
+     * This invalid method includes UNION in a query that is used for
+     * cursor-based pagination.
+     */
+    @Query("""
+                    SELECT v1 FROM Voter v1 WHERE v1.address = ?1
+                     UNION
+                    SELECT v2 FROM Voter v2 WHERE v2.address = ?2""")
+    @OrderBy("ssn")
+    CursoredPage<Voter> unionOfAddresses(String address1,
+                                         String address2,
+                                         PageRequest pageReq);
+
+    /**
      * This invalid method has a query that requires a single positional parameter,
      * but the method supplies 3 parameters.
      */
@@ -595,6 +608,32 @@ public interface Voters extends BasicRepository<Voter, Integer> {
      */
     @Query("WHERE LENGTH(address) < ?1 ORDER BY ssn ASC")
     List<Voter> withAddressShorterThan(@Param("maxLength") int maxAddressLength);
+
+    /**
+     * This invalid method includes INTERSECT in a query that is used for
+     * cursor-based pagination.
+     */
+    @Query("""
+                    SELECT v FROM Voter v WHERE v.name = ?1
+                     INTERSECT
+                    SELECT v FROM Voter v WHERE v.address = ?2""")
+    @OrderBy("ssn")
+    CursoredPage<Voter> withNameAndAddress(String name,
+                                           String address,
+                                           PageRequest pageReq);
+
+    /**
+     * This invalid method includes EXCEPT in a query that is used for
+     * cursor-based pagination.
+     */
+    @Query("""
+                    SELECT this FROM Voter WHERE name = ?1
+                     EXCEPT
+                    SELECT this FROM Voter WHERE address = ?2""")
+    @OrderBy("ssn")
+    CursoredPage<Voter> withNameNotAddress(String name,
+                                           String address,
+                                           PageRequest pageReq);
 
     /**
      * This invalid method places the Limit special parameter ahead of


### PR DESCRIPTION
A count query cannot be inferred from the user's query when there is a GROUP BY clause in the query, or any of the set operations: EXCEPT, INTERSECT, UNION.
Cursor-based pagination is also not possible when the above keywords are used. Detect and raise an error for that as well.
Also, allow functions on entity attributes in the ordering. The lack of that caused a test to fail for this.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
