### PR TITLE
Updating liberty arquillian to 2.1.3 in Jakarata Validation TCK

### DIFF
--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.jakarta.validation.tck;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
@@ -12,13 +12,11 @@
  *******************************************************************************/
 package io.openliberty.jakarta.validation.tck;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,12 +54,6 @@ public class ValidationTckLauncher {
     public static void setUp() throws Exception {
 
         final OperatingSystem os = server.getMachine().getOperatingSystem();
-
-        /**
-         * Existing issue with the liberty Arquillian plugin running on windows: https://github.com/OpenLiberty/liberty-arquillian/issues/25
-         * Hence skipping the test if the OS is Windows.
-         */
-        Assume.assumeTrue(os != OperatingSystem.WINDOWS);
 
         /*
          * Server config:

--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2024 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2024, 2025 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -30,7 +30,7 @@
 		<jakarta.validation.tck.version>3.1.1</jakarta.validation.tck.version>
 		<jakarta.validation.version>3.1.0</jakarta.validation.version>
 		<arquillian.version>1.9.1.Final</arquillian.version>
-		<arquillian.liberty.managed.jakarta.version>2.1.1</arquillian.liberty.managed.jakarta.version>
+		<arquillian.liberty.managed.jakarta.version>2.1.3</arquillian.liberty.managed.jakarta.version>
 		<testng.version>7.9.0</testng.version>
 		<slf4j.version>2.0.6</slf4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Existing issue with the liberty Arquillian plugin running on windows: https://github.com/OpenLiberty/liberty-arquillian/issues/25

 Potential fix in liberty arquillian 2.1.3.

Reverting the changes from https://github.com/OpenLiberty/open-liberty/pull/32922