### PR TITLE
Pull in properties file via manifest instead of gradle

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -325,6 +325,12 @@ class PackageLibertyWithFeatures extends DefaultTask {
                 into "$outputTo/wlp"
             }
 
+            project.copy {
+                from project.file('wlp')
+                include 'lib/security/fips140_3/FIPS140-3-Liberty.properties'
+                into "$outputTo/wlp"
+            }
+
             if(isBeta) {
                 //Now add the BETA_NOTICES file
                 project.copy {

--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -325,12 +325,6 @@ class PackageLibertyWithFeatures extends DefaultTask {
                 into "$outputTo/wlp"
             }
 
-            project.copy {
-                from project.file('wlp')
-                include 'lib/security/fips140_3/FIPS140-3-Liberty.properties'
-                into "$outputTo/wlp"
-            }
-
             if(isBeta) {
                 //Now add the BETA_NOTICES file
                 project.copy {

--- a/dev/com.ibm.ws.kernel.boot/publish/platform/kernel-1.0.mf
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/kernel-1.0.mf
@@ -17,6 +17,7 @@ Subsystem-Content: README.TXT; location:="README.TXT"; type="file",
  server.bat; location:="bin/server.bat"; type="file",
  configUtility; location:="bin/configUtility"; type="file",
  configUtility.bat; location:="bin/configUtility.bat"; type="file",
+ FIPS140-3-Liberty.properties; location:="lib/security/fips140_3/FIPS140-3-Liberty.properties"; type="file"
  ws-configUtility.jar; location:="bin/tools/ws-configUtility.jar"; type="file",
  schemaGen; location:="bin/schemaGen"; type="file",
  schemaGen.bat; location:="bin/schemaGen.bat"; type="file",


### PR DESCRIPTION
While the Gradle method got the properties file for FIPS in to the OL images, it was not getting propogated into the WL ones. instead of using gradle to include the file, include via the kernel manifest so that it should appear in all forms of the images


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".