### PR TITLE
Correct spelling of implementation

### DIFF
--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/ChannelFrameworkImpl.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/channelfw/internal/ChannelFrameworkImpl.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -1259,7 +1259,7 @@ public class ChannelFrameworkImpl implements ChannelFramework, FFDCSelfIntrospec
 
     /**
      * This method won't actually call the init method of the channel
-     * implemenation unless the channel is uninitialized. If the channel
+     * implementation unless the channel is uninitialized. If the channel
      * doesn't exist in the runtime yet, it will be put in here. The channel
      * in the runtime will then be updated with a reference to the input chain.
      * This method is invoked from the chain implementation.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

for #32902