### PR TITLE
fix ENABLE_FIPS140_3 quotes from configureFIPS

### DIFF
--- a/dev/cnf/resources/bin/tool
+++ b/dev/cnf/resources/bin/tool
@@ -301,7 +301,7 @@ if [ -n "${ENABLE_FIPS140_3+set}" ] && [ "${ENABLE_FIPS140_3}" != false ]; then
       SEMERU_FIPS=true
     fi
     if [ -n SEMERU_FIPS ]; then
-      JVM_ARGS="-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Liberty -Djava.security.properties=${WLP_INSTALL_DIR}/lib/security/fips140_3/FIPS140-3-Liberty.properties ${JVM_ARGS}"
+      JVM_ARGS="-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Liberty -Djava.security.properties=\"${WLP_INSTALL_DIR}/lib/security/fips140_3/FIPS140-3-Liberty.properties\" ${JVM_ARGS}"
     fi
   fi
 fi

--- a/dev/cnf/resources/bin/tool.bat
+++ b/dev/cnf/resources/bin/tool.bat
@@ -79,7 +79,7 @@ if defined ENABLE_FIPS140_3 (
       if defined IBM_SDK_8 (
           set JVM_ARGS=-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS !JVM_ARGS!
       ) else if defined SEMERU_FIPS (
-          set JVM_ARGS=-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Liberty -Djava.security.properties=!WLP_INSTALL_DIR!\lib\security\fips140_3\FIPS140-3-Liberty.properties !JVM_ARGS!
+          set JVM_ARGS=-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Liberty -Djava.security.properties="!WLP_INSTALL_DIR!\lib\security\fips140_3\FIPS140-3-Liberty.properties" !JVM_ARGS!
       )
     )
 )

--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
@@ -496,7 +496,7 @@ enableFIPS140_3()
               profile=$match
             fi
           done
-          JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.propertiesList=${ENABLE_FIPS140_3}"
+          JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.propertiesList=\"${ENABLE_FIPS140_3}\""
         fi
       fi
     fi

--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client.bat
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client.bat
@@ -388,7 +388,7 @@ goto:eof
           for %%i in ("!ENABLE_FIPS140_3:;=";"!") do (
             set "file=%%~i"
           )
-          for /f "delims== " %%l in (!file!) do (
+          for /f "usebackq delims== " %%l in ("!file!") do (
             set line=%%l
             if /i "!line:~0,18!" == "RestrictedSecurity" (
               set "line=!line:~19!"
@@ -397,7 +397,7 @@ goto:eof
               )
             )
           )
-          set JVM_OPTIONS=-Dsemeru.fips=true -Dsemeru.customprofile=!profileName! -Djava.security.propertiesList=!ENABLE_FIPS140_3! !JVM_OPTIONS!
+          set JVM_OPTIONS=-Dsemeru.fips=true -Dsemeru.customprofile=!profileName! -Djava.security.propertiesList="!ENABLE_FIPS140_3!" !JVM_OPTIONS!
         )
       )
     )

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1582,7 +1582,7 @@ enableFIPS140_3()
               profile=$match
             fi
           done
-          JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.propertiesList=${ENABLE_FIPS140_3}"
+          JVM_ARGS="${JVM_ARGS} -Dsemeru.fips=true -Dsemeru.customprofile=${profile} -Djava.security.propertiesList=\"${ENABLE_FIPS140_3}\""
         fi
       fi
     fi

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -784,7 +784,7 @@ goto:eof
             if not defined file (
                set file=!WLP_INSTALL_DIR!\lib\security\fips140_3\FIPS140-3-Liberty.properties
             )
-            for /f "delims== " %%l in (!file!) do (
+            for /f "usebackq delims== " %%l in ("!file!") do (
               set line=%%l
               if /i "!line:~0,18!" == "RestrictedSecurity" (
                 set "line=!line:~19!"
@@ -793,7 +793,7 @@ goto:eof
                 )
               )
             )
-            set JVM_OPTIONS=-Dsemeru.fips=true -Dsemeru.customprofile=!profileName! -Djava.security.propertiesList=!ENABLE_FIPS140_3! !JVM_OPTIONS!
+            set JVM_OPTIONS=-Dsemeru.fips=true -Dsemeru.customprofile=!profileName! -Djava.security.propertiesList="!ENABLE_FIPS140_3!" !JVM_OPTIONS!
         )
       )
     )


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

currently, we are always wrapping the `ENABLE_FIPS140_3` value with `""`, which will be treated literally unless `# enable_variable_expansion` is set. the main reason for wrapping the value with `""` is incase there is a space in the value.
however, it was learned that if `# enable_variable_expansion` is not set then the space is automatically preserved, but if it is set, then we'll need to wrap the value in `""` to preserve the space.


