### PR TITLE
Decouple Liberty-specific connection error detection from repository implementation

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -21,6 +21,10 @@ import java.beans.PropertyDescriptor;
 import java.io.PrintWriter;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLTransientConnectionException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -515,5 +519,18 @@ public abstract class EntityManagerBuilder {
         writer.println(indent + "  repositories:");
         for (Class<?> r : repositoryInterfaces)
             writer.println(indent + "    " + r.getName());
+    }
+
+    /**
+     * Returns true if the cause exception can be determined to be a
+     * connection-related error, otherwise false.
+     *
+     * @param cause the cause exception.
+     * @return true if known to be a connection-related error, otherise false.
+     */
+    public boolean isConnectionError(SQLException cause) {
+        return cause instanceof SQLRecoverableException ||
+               cause instanceof SQLNonTransientConnectionException ||
+               cause instanceof SQLTransientConnectionException;
     }
 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -379,7 +379,6 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                                         repositoryInterfaces, //
                                         (EntityManagerFactory) resource, //
                                         dataStore, //
-                                        metadata, //
                                         entityTypes);
                 } finally {
                     accessor.endContext();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
@@ -24,7 +24,6 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.runtime.metadata.ComponentMetaData;
 
 import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.EntityManagerBuilder;
@@ -49,8 +48,6 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
      * @param repositoryInterfaces  repository interfaces that use the entities.
      * @param emf                   entity manager factory.
      * @param pesistenceUnitRef     persistence unit reference.
-     * @param metadata              metadata of the application artifact that
-     *                                  contains the repository interface.
      * @param entityTypes           entity classes as known by the user, not generated.
      * @throws Exception if an error occurs.
      */
@@ -59,7 +56,6 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
                           Set<Class<?>> repositoryInterfaces,
                           EntityManagerFactory emf,
                           String persistenceUnitRef,
-                          ComponentMetaData metadata,
                           Set<Class<?>> entityTypes) throws Exception {
         super(provider, //
               repositoryClassLoader, //


### PR DESCRIPTION
Decouple Liberty-specific connection error detection from repository implementation,
and avoid unused reference to ComponentMetaData.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
