### PR TITLE
 Initial commit for Jakarta Security 4.0 - Multiple

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2025 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -83,7 +83,8 @@ Include-Resource: \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
 	com.ibm.ws.transport.http;version=latest,\
-	com.ibm.ws.security.mp.jwt.proxy;version=latest
+	com.ibm.ws.security.mp.jwt.proxy;version=latest,\
+        io.openliberty.security.javaeesec.internal;version=latest
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/BasicHttpAuthenticationMechanism.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/BasicHttpAuthenticationMechanism.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -51,8 +51,21 @@ public class BasicHttpAuthenticationMechanism implements HttpAuthenticationMecha
 
     private final Utils utils;
 
+    // JS 4.0+ - store properties for qualified HAMs only
+    private Properties qualifiedProperties = null;
+
     public BasicHttpAuthenticationMechanism() {
         utils = new Utils();
+    }
+
+    /**
+     * Used for HAMs with qualifiers, need to store them per HAM as the
+     * properties will (should!) be different.
+     *
+     * @param props The properties for this qualified HAM instance
+     */
+    public void setQualifiedProperties(Properties props) {
+        this.qualifiedProperties = props;
     }
 
     // this is for unit test.
@@ -100,12 +113,18 @@ public class BasicHttpAuthenticationMechanism implements HttpAuthenticationMecha
     }
 
     private void setRealmName() {
-        mpp = getModulePropertiesProvider();
-        if (mpp != null) {
-            Properties props = mpp.getAuthMechProperties(BasicHttpAuthenticationMechanism.class);
-            if (props != null) {
-                realmName = (String) props.get(JavaEESecConstants.REALM_NAME);
+        Properties props = null;
+        // JS 4.0+ - if set, use explicitly specified properties, else fall back to previous
+        if (qualifiedProperties != null) {
+            props = qualifiedProperties;
+        } else {
+            mpp = getModulePropertiesProvider();
+            if (mpp != null) {
+                props = mpp.getAuthMechProperties(BasicHttpAuthenticationMechanism.class);
             }
+        }
+        if (props != null) {
+            realmName = (String) props.get(JavaEESecConstants.REALM_NAME);
         }
     }
 

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/CustomFormAuthenticationMechanism.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/CustomFormAuthenticationMechanism.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,7 @@
 package com.ibm.ws.security.javaeesec.cdi.beans;
 
 import java.util.Map;
+import java.util.Properties;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
@@ -43,6 +44,9 @@ public class CustomFormAuthenticationMechanism implements HttpAuthenticationMech
 
     private final Utils utils;
 
+    // JS 4.0+ - store properties for qualified HAMs only
+    private Properties qualifiedProperties = null;
+
     public CustomFormAuthenticationMechanism() {
         utils = new Utils();
     }
@@ -50,6 +54,21 @@ public class CustomFormAuthenticationMechanism implements HttpAuthenticationMech
     // this is for unit test.
     protected CustomFormAuthenticationMechanism(Utils utils) {
         this.utils = utils;
+    }
+
+    /**
+     * Used for HAMs with qualifiers, need to store them per HAM as the
+     * properties will (should!) be different.
+     *
+     * NOTE: Currently not used, but here for consistency (with Basic),
+     * allows for consistent interrogation of HAM (if required), enables
+     * future enhancements (similar to Basic) as infrastructure
+     * already in place, and overhead is minimal.
+     *
+     * @param props The properties for this qualified HAM instance
+     */
+    public void setQualifiedProperties(Properties props) {
+        this.qualifiedProperties = props;
     }
 
     @Override

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/FormAuthenticationMechanism.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/FormAuthenticationMechanism.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,6 +13,7 @@
 package com.ibm.ws.security.javaeesec.cdi.beans;
 
 import java.util.Map;
+import java.util.Properties;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
@@ -44,6 +45,9 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
 
     private final Utils utils;
 
+    // JS 4.0+ - store properties for qualified HAMs only
+    private Properties qualifiedProperties = null;
+
     public FormAuthenticationMechanism() {
         utils = new Utils();
     }
@@ -51,6 +55,21 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism 
     // this is for unit test.
     protected FormAuthenticationMechanism(Utils utils) {
         this.utils = utils;
+    }
+
+    /**
+     * Used for HAMs with qualifiers, need to store them per HAM as the
+     * properties will (should!) be different.
+     *
+     * NOTE: Currently not used, but here for consistency (with Basic),
+     * allows for consistent interrogation of HAM (if required), enables
+     * future enhancements (similar to Basic) as infrastructure
+     * already in place, and overhead is minimal.
+     *
+     * @param props The properties for this qualified HAM instance
+     */
+    public void setQualifiedProperties(Properties props) {
+        this.qualifiedProperties = props;
     }
 
     @Override

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/HttpAuthenticationMechanismsTracker.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/HttpAuthenticationMechanismsTracker.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -110,10 +110,6 @@ public class HttpAuthenticationMechanismsTracker {
     public void addAuthMech(String applicationName, Class<?> annotatedClass, Class<?> implClass, Set<Annotation> annotations, Properties props) {
         Map<String, ModuleProperties> moduleMap = moduleMapsPerApplication.get(applicationName);
         String moduleName = getModuleFromClass(annotatedClass, moduleMap);
-
-        if (tc.isDebugEnabled()) {
-            Tr.debug(tc, "moduleName: " + moduleName);
-        }
 
         if (moduleMap.containsKey(moduleName)) {
             moduleMap.get(moduleName).putToAuthMechMap(implClass, props);
@@ -229,5 +225,4 @@ public class HttpAuthenticationMechanismsTracker {
         }
         return result;
     }
-
 }

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/JavaEESecCDIExtension.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/JavaEESecCDIExtension.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -77,6 +77,8 @@ import com.ibm.ws.webcontainer.security.metadata.LoginConfiguration;
 import com.ibm.ws.webcontainer.security.metadata.SecurityMetadata;
 import com.ibm.ws.webcontainer.security.util.WebConfigUtils;
 import com.ibm.wsspi.webcontainer.metadata.WebModuleMetaData;
+
+import io.openliberty.security.jakartasec.services.JakartaSecurityValidationService;
 
 /**
  * TODO: Add all JSR-375 API classes that can be bean types to api.classes.
@@ -874,7 +876,10 @@ public class JavaEESecCDIExtension<T> implements Extension, WebSphereCDIExtensio
     }
 
     /**
-     * make sure that there is one HAM for each modules, and if there is a HAM in a module, make sure there is no login configuration in web.xml.
+     * Verify the configuration after all the beans have been discovered.
+     *
+     * - ensure for Jakarta Security 1.0-3.0, there is one HAM for each module, and
+     * - if there is a HAM in a module, make sure there is no login configuration in web.xml
      **/
     private void verifyConfiguration() throws DeploymentException {
         Map<URL, ModuleMetaData> mmds = getModuleMetaDataMap();
@@ -885,8 +890,8 @@ public class JavaEESecCDIExtension<T> implements Extension, WebSphereCDIExtensio
                     String j2eeModuleName = mmd.getJ2EEName().getModule();
                     Map<Class<?>, Properties> authMechs = httpAuthenticationMechanismsTracker.getAuthMechs(applicationName, j2eeModuleName);
                     if (authMechs != null && !authMechs.isEmpty()) {
-                        // make sure that only one HAM.
-                        if (authMechs.size() != 1 && !isDecoratorOrAlternative(authMechs)) {
+                        // ensure one HAM for each module (JS 1.0-3.0 only)
+                        if (!JakartaSecurityValidationService.isJakartaSecurity40OrHigher() && authMechs.size() != 1 && !isDecoratorOrAlternative(authMechs)) {
                             String appName = mmd.getJ2EEName().getApplication();
                             String authMechNames = getAuthMechNames(authMechs);
                             Tr.error(tc, "JAVAEESEC_CDI_ERROR_MULTIPLE_HTTPAUTHMECHS", j2eeModuleName, appName, authMechNames);
@@ -894,6 +899,7 @@ public class JavaEESecCDIExtension<T> implements Extension, WebSphereCDIExtensio
                             throw new DeploymentException(msg);
                         }
 
+                        // correct number of HAMs, ensure no login config in web.xml
                         SecurityMetadata smd = (SecurityMetadata) ((WebModuleMetaData) mmd).getSecurityMetaData();
                         if (smd != null) {
                             LoginConfiguration lc = smd.getLoginConfiguration();

--- a/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/extensions/JavaEESecCDIExtensionTest.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/extensions/JavaEESecCDIExtensionTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -1076,6 +1076,11 @@ public class JavaEESecCDIExtensionTest {
         JavaEESecCDIExtension.setHttpAuthenticationMechanismsTracker(httpAuthenticationMechanismsTracker);
         mockery.checking(new Expectations() {
             {
+
+                // NEW: Allow getModuleMap() to be called and return null (no qualifiers)
+                allowing(httpAuthenticationMechanismsTracker).getModuleMap(APP_NAME1);
+                will(returnValue(null));
+
                 allowing(httpAuthenticationMechanismsTracker).initialize(APP_NAME1);
                 one(httpAuthenticationMechanismsTracker).existAuthMech(APP_NAME1, mechanismClass);
                 will(returnValue(authMechExists));
@@ -1175,7 +1180,8 @@ public class JavaEESecCDIExtensionTest {
         assertFalse("the result should be false.", j3ce.equalsDatabaseDefinition(disd1, disd2));
     }
 
-    public @interface InvalidAnnotation {}
+    public @interface InvalidAnnotation {
+    }
 
     private InvalidAnnotation getIAInstance() {
         InvalidAnnotation ann = new InvalidAnnotation() {
@@ -1723,9 +1729,11 @@ public class JavaEESecCDIExtensionTest {
         return mm;
     }
 
-    class HAMClass1 {};
+    class HAMClass1 {
+    };
 
-    class HAMClass2 {};
+    class HAMClass2 {
+    };
 
     class ApplicationHAM implements HttpAuthenticationMechanism {
         @Override
@@ -1745,12 +1753,14 @@ public class JavaEESecCDIExtensionTest {
         @Override
         public void cleanSubject(HttpServletRequest request,
                                  HttpServletResponse response,
-                                 HttpMessageContext httpMessageContext) {}
+                                 HttpMessageContext httpMessageContext) {
+        }
     }
 
     class CustomPasswordHash1 implements PasswordHash {
         @Override
-        public void initialize(Map<String, String> parameters) {}
+        public void initialize(Map<String, String> parameters) {
+        }
 
         @Override
         public String generate(char[] password) {
@@ -1765,7 +1775,8 @@ public class JavaEESecCDIExtensionTest {
 
     class CustomPasswordHash2 implements PasswordHash {
         @Override
-        public void initialize(Map<String, String> parameters) {}
+        public void initialize(Map<String, String> parameters) {
+        }
 
         @Override
         public String generate(char[] password) {

--- a/dev/com.ibm.ws.security.javaeesec/resources/com/ibm/ws/security/javaeesec/internal/resources/JavaEESecMessages.nlsprops
+++ b/dev/com.ibm.ws.security.javaeesec/resources/com/ibm/ws/security/javaeesec/internal/resources/JavaEESecMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -28,6 +28,10 @@ JAVAEESEC_ERROR_NO_VALIDATION.useraction=Make sure that at least one IdentitySto
 JAVAEESEC_ERROR_NO_HAM=CWWKS1912E: The HttpAuthenticationMechanism object for the {0} module in the {1} application could not be created.
 JAVAEESEC_ERROR_NO_HAM.explanation=The reason that the HttpAuthenticationMechanism object cannot be created varies. The error messages for the HttpAuthenticationMechanism object provide information on why the the HttpAuthenticationMechanism object cannot be created.
 JAVAEESEC_ERROR_NO_HAM.useraction=Investigate any error messages from the HttpAuthenticationMechanism object and make corrections based on the error messages.
+
+JAVAEESEC_ERROR_NO_HAM_SERVICE_IMPL=CWWKS1913E: The HttpAuthenticationMechanismService implementation object for the {0} module in the {1} application was not found as an OSGi bundle.
+JAVAEESEC_ERROR_NO_HAM_SERVICE_IMPL.explanation=The HttpAuthenticationMechanismService implementation object was not found because one of the dependent bundles that contains this implementation is missing from the features manifest file.
+JAVAEESEC_ERROR_NO_HAM_SERVICE_IMPL.useraction=Ensure that the feature manifest references a bundle that contains an implementation of the HttpAuthenticationMechanismService.
 
 #Note to translator, do not translate EL.
 JAVAEESEC_WARNING_IDSTORE_CONFIG=CWWKS1916W: The Expression Language (EL) expression for the ''{0}'' attribute of the identity store annotation cannot be resolved to a valid value. Ensure that the EL expression and the result are valid and ensure that any referenced beans that are used in the expression are resolvable. The default attribute value of ''{1}'' is used instead.

--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/AuthModule.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/AuthModule.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -36,6 +36,9 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.security.javaeesec.properties.ModulePropertiesUtils;
+
+import io.openliberty.security.jakartasec.services.HttpAuthenticationMechanismHandlerService;
+import io.openliberty.security.jakartasec.services.JakartaSecurityValidationService;
 
 /*
  * This JASPI authentication module is used as the bridge ServerAuthModule for JSR-375.
@@ -82,11 +85,16 @@ public class AuthModule implements ServerAuthModule {
     public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject) throws AuthException {
         AuthStatus status = AuthStatus.SEND_FAILURE;
         try {
-            HttpAuthenticationMechanism authMech = getModulePropertiesUtils().getHttpAuthenticationMechanism();
             HttpMessageContext httpMessageContext = createHttpMessageContext(messageInfo, clientSubject);
-            AuthenticationStatus authenticationStatus = authMech.validateRequest(httpMessageContext.getRequest(),
-                                                                                 httpMessageContext.getResponse(),
-                                                                                 httpMessageContext);
+
+            // only retrieve authMech for JS 1.0/2.0/3.0
+            // (not 4.0, it doesn't need it and an unnecessary overhead to call).
+            HttpAuthenticationMechanism authMech = null;
+            if (!JakartaSecurityValidationService.isJakartaSecurity40OrHigher()) {
+                authMech = getModulePropertiesUtils().getHttpAuthenticationMechanism();
+            }
+            AuthenticationStatus authenticationStatus = HttpAuthenticationMechanismHandlerService.validateRequest(httpMessageContext, authMech);
+
             status = translateValidateRequestStatus(authenticationStatus);
             registerSession(httpMessageContext);
         } catch (Exception e) {
@@ -105,11 +113,16 @@ public class AuthModule implements ServerAuthModule {
         AuthStatus status = AuthStatus.SEND_FAILURE;
         // TODO: Determine if HttpMessageContext and HttpAuthenticationMechanism must have been cached in the MessageInfo
         try {
-            HttpAuthenticationMechanism authMech = getModulePropertiesUtils().getHttpAuthenticationMechanism();
             HttpMessageContext httpMessageContext = createHttpMessageContext(messageInfo, null);
-            AuthenticationStatus authenticationStatus = authMech.secureResponse(httpMessageContext.getRequest(),
-                                                                                httpMessageContext.getResponse(),
-                                                                                httpMessageContext);
+
+            // only retrieve authMech for JS 1.0/2.0/3.0
+            // (not 4.0, it doesn't need it and an unnecessary overhead to call).
+            HttpAuthenticationMechanism authMech = null;
+            if (!JakartaSecurityValidationService.isJakartaSecurity40OrHigher()) {
+                authMech = getModulePropertiesUtils().getHttpAuthenticationMechanism();
+            }
+            AuthenticationStatus authenticationStatus = HttpAuthenticationMechanismHandlerService.secureResponse(httpMessageContext, authMech);
+
             status = translateSecureResponseStatus(authenticationStatus);
         } catch (AuthenticationException e) {
             // TODO: Issue serviceability message.
@@ -123,9 +136,15 @@ public class AuthModule implements ServerAuthModule {
 
     @Override
     public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
-        HttpAuthenticationMechanism authMech = getModulePropertiesUtils().getHttpAuthenticationMechanism();
         HttpMessageContext httpMessageContext = createHttpMessageContext(messageInfo, null);
-        authMech.cleanSubject(httpMessageContext.getRequest(), httpMessageContext.getResponse(), httpMessageContext);
+
+        // only retrieve authMech for JS 1.0/2.0/3.0
+        // (not 4.0, it doesn't need it and an unnecessary overhead to call).
+        HttpAuthenticationMechanism authMech = null;
+        if (!JakartaSecurityValidationService.isJakartaSecurity40OrHigher()) {
+            authMech = getModulePropertiesUtils().getHttpAuthenticationMechanism();
+        }
+        HttpAuthenticationMechanismHandlerService.cleanSubject(httpMessageContext, authMech);
     }
 
     protected HttpMessageContext createHttpMessageContext(MessageInfo messageInfo, Subject clientSubject) {
@@ -184,5 +203,4 @@ public class AuthModule implements ServerAuthModule {
         }
         return status;
     }
-
 }

--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/CDIHelper.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/CDIHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,13 +21,14 @@ import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.CDI;
 
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.cdi.CDIService;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 @Component(service = { CDIHelper.class },
            configurationPolicy = ConfigurationPolicy.IGNORE,
@@ -36,6 +37,7 @@ import com.ibm.ws.cdi.CDIService;
 public class CDIHelper {
 
     private static CDIService cdiService;
+    private static final TraceComponent tc = Tr.register(CDIHelper.class);
 
     @SuppressWarnings("static-access")
     @Reference
@@ -71,7 +73,7 @@ public class CDIHelper {
     @SuppressWarnings("rawtypes")
     @FFDCIgnore(IllegalStateException.class)
     public static CDI getCDI() {
-        if (! cdiService.isCurrentModuleCDIEnabled()) {
+        if (!cdiService.isCurrentModuleCDIEnabled()) {
             return null;
         }
         try {
@@ -97,5 +99,4 @@ public class CDIHelper {
         }
         return elProcessor;
     }
-
 }

--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/JavaEESecConstants.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/JavaEESecConstants.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,6 +24,7 @@ public class JavaEESecConstants {
     public static final String LOGIN_TO_CONTINUE_LOGIN_FORM_CONTEXT_ROOT = "formLoginContextRoot";
 
     public static final String DEFAULT_REALM = "defaultRealm";
+    public static final String QUALIFIERS = "qualifiers";
 
     public static final String SECURITY_CONTEXT_AUTH_PARAMS = "com.ibm.ws.security.javaeesec.auth.params";
 

--- a/dev/com.ibm.ws.security.javaeesec/test/com/ibm/ws/security/javaeesec/AuthModuleTest.java
+++ b/dev/com.ibm.ws.security.javaeesec/test/com/ibm/ws/security/javaeesec/AuthModuleTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -259,7 +259,9 @@ public class AuthModuleTest {
         setNormalPathExpectations();
         mockery.checking(new Expectations() {
             {
-                one(ham).cleanSubject(with(request), with(response), with(aNonNull(HttpMessageContext.class)));
+                one(ham).cleanSubject(with(aNonNull(HttpServletRequest.class)), 
+                                     with(aNonNull(HttpServletResponse.class)), 
+                                     with(aNonNull(HttpMessageContext.class)));
             }
         });
 
@@ -306,7 +308,9 @@ public class AuthModuleTest {
     private AuthModuleTest authMechValidatesRequest(final AuthenticationStatus status) throws Exception {
         mockery.checking(new Expectations() {
             {
-                one(ham).validateRequest(with(request), with(response), with(aNonNull(HttpMessageContext.class)));
+                one(ham).validateRequest(with(aNonNull(HttpServletRequest.class)), 
+                                        with(aNonNull(HttpServletResponse.class)), 
+                                        with(aNonNull(HttpMessageContext.class)));
                 will(returnValue(status));
             }
         });
@@ -316,7 +320,9 @@ public class AuthModuleTest {
     private AuthModuleTest authMechValidateRequestThrowsException() throws Exception {
         mockery.checking(new Expectations() {
             {
-                one(ham).validateRequest(with(request), with(response), with(aNonNull(HttpMessageContext.class)));
+                one(ham).validateRequest(with(aNonNull(HttpServletRequest.class)), 
+                                        with(aNonNull(HttpServletResponse.class)), 
+                                        with(aNonNull(HttpMessageContext.class)));
                 will(throwException(new AuthenticationException()));
             }
         });
@@ -326,7 +332,9 @@ public class AuthModuleTest {
     private AuthModuleTest authMechSecuresResponse(final AuthenticationStatus status) throws Exception {
         mockery.checking(new Expectations() {
             {
-                one(ham).secureResponse(with(request), with(response), with(aNonNull(HttpMessageContext.class)));
+                one(ham).secureResponse(with(aNonNull(HttpServletRequest.class)), 
+                                       with(aNonNull(HttpServletResponse.class)), 
+                                       with(aNonNull(HttpMessageContext.class)));
                 will(returnValue(status));
             }
         });
@@ -336,7 +344,9 @@ public class AuthModuleTest {
     private AuthModuleTest authMechSecuresResponseThrowsException() throws Exception {
         mockery.checking(new Expectations() {
             {
-                one(ham).secureResponse(with(request), with(response), with(aNonNull(HttpMessageContext.class)));
+                one(ham).secureResponse(with(aNonNull(HttpServletRequest.class)), 
+                                       with(aNonNull(HttpServletResponse.class)), 
+                                       with(aNonNull(HttpMessageContext.class)));
                 will(throwException(new AuthenticationException()));
             }
         });

--- a/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/beans/OidcHttpAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -89,14 +89,28 @@ public class OidcHttpAuthenticationMechanism implements HttpAuthenticationMechan
     private final Utils utils;
     private final AuthorizationRequestUtils requestUtils;
 
+    // Jakarta Security 4.0+ - Store properties directly for qualified HAMs
+    private Properties qualifiedProperties = null;
+
     public OidcHttpAuthenticationMechanism() {
         mpp = getModulePropertiesProvider();
         utils = getUtils();
         requestUtils = getRequestUtils();
     }
 
+    /**
+     * Used for HAMs with qualifiers, need to store them per HAM as the
+     * properties will (should!) be different.
+     *
+     * @param props The properties for this qualified HAM instance
+     */
+    public void setQualifiedProperties(Properties props) {
+        this.qualifiedProperties = props;
+    }
+
     private OpenIdAuthenticationMechanismDefinitionWrapper getOpenIdAuthenticationMechanismDefinition(HttpServletRequest request) {
-        Properties props = mpp.getAuthMechProperties(OidcHttpAuthenticationMechanism.class);
+        // JS 4.0+ - if set, use explicitly specified properties, else fall back to previous
+        Properties props = (qualifiedProperties != null) ? qualifiedProperties : mpp.getAuthMechProperties(OidcHttpAuthenticationMechanism.class);
         /*
          * Build the baseURL from the incoming HttpRequest as the redirectURL may contain baseURL variable, such as ${baseURL}/Callback
          */

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2025 IBM Corporation and others.
+# Copyright (c) 2025, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -19,11 +19,14 @@ Bundle-Name: Jakarta Security 4.0 CDI
 Bundle-SymbolicName: io.openliberty.security.jakartasec.4.0.internal.cdi
 Bundle-Description: Jakarta Security 4.0 CDI; version=${bVersion}
 
-WS-TraceGroup: JAKARTASEC 
+WS-TraceGroup: JakartaSecurity40
+
+Private-Package: io.openliberty.security.jakartasec.cdi.internal.resources.*
 
 Export-Package: \
     io.openliberty.security.jakartasec.cdi.beans, \
-    io.openliberty.security.jakartasec.cdi.extensions
+    io.openliberty.security.jakartasec.cdi.extensions, \
+    io.openliberty.security.jakartasec40.cdi.extensions
 
 Import-Package: \
     io.openliberty.cdi40.internal.utils,\
@@ -32,10 +35,6 @@ Import-Package: \
     javax.security.auth,\
     !javax.*,\
     *
-
-Private-Package: \
-    io.openliberty.security.jakartasec.cdi,\
-    io.openliberty.security.jakartasec.cdi.internal.*
 
 Include-Resource: \
     META-INF=resources/META-INF
@@ -47,6 +46,8 @@ src: src, resources
 -dsannotations: \
     io.openliberty.security.jakartasec.cdi.extensions.JakartaSecurity40CDIExtensionMetadata,\
     io.openliberty.security.jakartasec.cdi.extensions.JakartaSecurity40CDIExtension,\
+    io.openliberty.security.jakartasec40.cdi.extensions.JakartaSecurity40CDIExtensionMetadata,\
+    io.openliberty.security.jakartasec40.cdi.extensions.JakartaSecurity40CDIExtension,\
     io.openliberty.security.jakartasec.cdi.extensions.JakartaSecurity30CDIExtensionMetadata,\
     io.openliberty.security.jakartasec.cdi.extensions.JakartaSecurity30CDIExtension
 
@@ -57,15 +58,34 @@ src: src, resources
     io.openliberty.security.jakartasec.3.0.internal.cdi;version=latest,\
     io.openliberty.jakarta.authentication.3.0;version=latest,\
     io.openliberty.jakarta.cdi.4.1,\
+    io.openliberty.jakarta.interceptor.2.1;version=latest,\
     io.openliberty.jakarta.jsonp.2.1,\
     io.openliberty.jakarta.security.4.0,\
     io.openliberty.jakarta.servlet.6.1,\
+    io.openliberty.jakarta.annotation.3.0,\
     io.openliberty.security.jakartasec.2.0.internal,\
     io.openliberty.security.jakartasec.2.0.internal.cdi,\
     io.openliberty.security.jakartasec.4.0.internal,\
     io.openliberty.security.oidcclientcore.internal.jakarta,\
     com.ibm.ws.cdi.interfaces.jakarta;version=latest,\
+    com.ibm.ws.security.javaeesec.cdi;version=latest,\
     io.openliberty.webcontainer.security.internal;version=latest,\
     com.ibm.ws.security;version=latest,\
     com.ibm.websphere.security;version=latest,\
     com.ibm.ws.security.token;version=latest
+
+-testpath: \
+    ../build.sharedResources/lib/junit/old/junit.jar;version=file,\
+    com.ibm.ws.junit.extensions;version=latest,\
+    org.jmock:jmock-legacy;version=2.5.0,\
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest,\
+    org.hamcrest:hamcrest-all;version=1.3,\
+    org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
+    org.jmock:jmock;strategy=exact;version=2.5.1,\
+    com.ibm.ws.org.objenesis:objenesis;version=1.0,\
+    io.openliberty.jakarta.expressionLanguage.5.0;version=latest,\
+    com.ibm.ws.security.common.jsonwebkey;version=latest,\
+    com.ibm.json4j;version=latest,\
+    com.ibm.ws.container.service;version=latest,\
+    com.ibm.ws.org.jose4j;version=latest

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.lang=ALL-UNNAMED"]
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,2 +1,3 @@
 io.openliberty.security.jakartasec.cdi.extensions.JakartaSecurity30CDIExtension
 io.openliberty.security.jakartasec.cdi.extensions.JakartaSecurity40CDIExtension
+io.openliberty.security.jakartasec40.cdi.extensions.JakartaSecurity40CDIExtension

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/resources/io/openliberty/security/jakartasec/cdi/internal/resources/JakartaSecurity40Messages.nlsprops
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/resources/io/openliberty/security/jakartasec/cdi/internal/resources/JakartaSecurity40Messages.nlsprops
@@ -1,0 +1,34 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#CMVCPATHNAME io.openliberty.security.jakartasec.4.0.internal.cdi/resources/io/openliberty/security/jakartasec/cdi/internal/resources/JakartaSecurity40Messages.nlsprops
+#COMPONENTPREFIX CWWKS
+#COMPONENTNAMEFOR WebSphere Application Server Jakarta Security 4.0
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+# -------------------------------------------------------------------------------------------------
+
+# Message prefix block: 2610-2620
+
+JAKARTA_SECURITY_CDI_ERROR_CUSTOM_QUALIFIERS_NO_HAM_HANDLER=CWWKS2610E: Missing a custom handler when using qualified HttpAuthenticationMechanisms.
+JAKARTA_SECURITY_CDI_ERROR_CUSTOM_QUALIFIERS_NO_HAM_HANDLER.explanation=If qualified HttpAuthenticationMechanisms are specified, then the default HttpAuthenticationMechanismHandler cannot determine which HAM to use, therefore a custom implementation of the HttpAuthenticationMechanismHandler must be provided.
+JAKARTA_SECURITY_CDI_ERROR_CUSTOM_QUALIFIERS_NO_HAM_HANDLER.useraction=Implement an HttpAuthenticationMechanismHandler using customized logic to select a unique HttpAuthenticationMechanism.
+
+JAKARTASEC_CDI_ERROR_PROCESSING_HAM_LIST=CWWKS2611E: Processing annotations for the {0} definition within a list failed.
+JAKARTASEC_CDI_ERROR_PROCESSING_HAM_LIST.explanation=Whilst processing a list of HttpAuthenticationMechanism definitions, an error occured whilst extracting annotation values.
+JAKARTASEC_CDI_ERROR_PROCESSING_HAM_LIST.useraction=Investigate the cause of the exception and correct the application configuration.
+
+JAKARTASEC_CDI_ERROR_EXTRACTING_HAM_PROPERTIES=CWWKS2612E: Processing properties the {0} type failed.
+JAKARTASEC_CDI_ERROR_EXTRACTING_HAM_PROPERTIES.explanation=Whilst processing a specific HttpAuthenticationMechanism annotation, an error occured whilst extracting property values.
+JAKARTASEC_CDI_ERROR_EXTRACTING_HAM_PROPERTIES.useraction=Investigate the cause of the exception and correct the application configuration.
+
+JAKARTASEC_CDI_ERROR_CREATING_QUALIFIERS=CWWKS2613E: Could not create custom qualifier annotation {0} for qualifier class {1}.
+JAKARTASEC_CDI_ERROR_CREATING_QUALIFIERS.explanation=Whilst creating a qualified HttpAuthenticationMechanism, an error occured whilst creating a custom qualifier annotation.
+JAKARTASEC_CDI_ERROR_CREATING_QUALIFIERS.useraction=Investigate the cause of the exception and correct the application configuration.

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/package-info.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/package-info.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 /**
  * @version 1.0.0
  */
 @org.osgi.annotation.versioning.Version("1.0.0")
-@TraceOptions(traceGroup = "JAKARTASEC", messageBundle = "io.openliberty.security.jakartasec.cdi.internal.resources.JakartaSecurity30Messages")
+@TraceOptions(traceGroup = "JakartaSecurity40", messageBundle = "io.openliberty.security.jakartasec.cdi.internal.resources.JakartaSecurity40Messages")
 package io.openliberty.security.jakartasec.cdi.extensions;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec40/cdi/extensions/HttpAuthenticationMechanismHandlerBean.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec40/cdi/extensions/HttpAuthenticationMechanismHandlerBean.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec40.cdi.extensions;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.PassivationCapable;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.TypeLiteral;
+import io.openliberty.security.jakartasec.handlers.HttpAuthenticationMechanismHandlerImpl;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanismHandler;
+
+/* ***
+ * A CDI bean that is always registered by the CDI extension (JakartaSecurity40CDIExtension).
+ * Its main purpose is:
+ * - to create and manage the HttpAuthenticationMechanismHandler internal implementation, and
+ * - to bridge the CDI and http authentication mechanism handler implementations.
+ *
+ * <... when required, this bean manages the internal HttpAuthenticationMechanismHandler implementation via ...>
+ *
+ *           `--> create() create a new HttpAuthenticationMechanismHandler internal implementation
+ *           `--> destroy() destroys the existing HttpAuthenticationMechanismHandler internal implementation
+ */
+
+public class HttpAuthenticationMechanismHandlerBean implements Bean<HttpAuthenticationMechanismHandler>, PassivationCapable {
+
+    private final Set<Annotation> qualifiers;
+    private final Type type;
+    private final Set<Type> types;
+    private final String name;
+    private final String id;
+
+    @SuppressWarnings("serial")
+    public HttpAuthenticationMechanismHandlerBean(BeanManager beanManager) {
+        qualifiers = new HashSet<Annotation>();
+        qualifiers.add(new AnnotationLiteral<Default>() {
+        });
+        qualifiers.add(new AnnotationLiteral<Any>() {
+        });
+
+        type = new TypeLiteral<HttpAuthenticationMechanismHandler>() {
+        }.getType();
+        types = Collections.singleton(type);
+        name = this.getClass().getName() + "[" + type + "]";
+        id = beanManager.hashCode() + "#" + this.name;
+    }
+
+    @Override
+    public HttpAuthenticationMechanismHandler create(CreationalContext<HttpAuthenticationMechanismHandler> creationalContext) {
+        return new HttpAuthenticationMechanismHandlerImpl();
+    }
+
+    @Override
+    public void destroy(HttpAuthenticationMechanismHandler arg0, CreationalContext<HttpAuthenticationMechanismHandler> arg1) {
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return ApplicationScoped.class;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getStereotypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Type> getTypes() {
+        return types;
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public Class<?> getBeanClass() {
+        return HttpAuthenticationMechanismHandlerBean.class;
+    }
+
+    @Override
+    public Set<InjectionPoint> getInjectionPoints() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec40/cdi/extensions/JakartaSecurity40CDIExtension.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec40/cdi/extensions/JakartaSecurity40CDIExtension.java
@@ -1,0 +1,486 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec40.cdi.extensions;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.javaeesec.JavaEESecConstants;
+import com.ibm.ws.security.javaeesec.cdi.beans.BasicHttpAuthenticationMechanism;
+import com.ibm.ws.security.javaeesec.cdi.beans.CustomFormAuthenticationMechanism;
+import com.ibm.ws.security.javaeesec.cdi.beans.FormAuthenticationMechanism;
+import com.ibm.ws.security.javaeesec.cdi.extensions.HttpAuthenticationMechanismsTracker;
+import com.ibm.ws.security.javaeesec.cdi.extensions.PrimarySecurityCDIExtension;
+
+import io.openliberty.security.jakartasec.JakartaSec30Constants;
+import io.openliberty.security.jakartasec.OpenIdAuthenticationMechanismDefinitionHolder;
+import io.openliberty.security.jakartasec.cdi.beans.OidcHttpAuthenticationMechanism;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
+import jakarta.enterprise.inject.spi.ProcessBean;
+import jakarta.enterprise.inject.spi.WithAnnotations;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.CustomFormAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.FormAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanismHandler;
+import jakarta.security.enterprise.authentication.mechanism.http.OpenIdAuthenticationMechanismDefinition;
+
+/*-
+ * CDI Extension to register beans required for Jakarta Security 4.0.
+ *
+ * Handles Multiple HAMs with qualifiers, the registration of a custom HAM handler
+ * (if present), and HAMs with qualifiers. Those without qualifiers will be
+ * handled by the standard HAM bean handling process (JavaEESecCDIExtension).
+ *
+ * It's important to note the extension method ordering (although not all
+ * apply in this class):
+ *
+ * 1. @Observes @WithAnnotations ProcessAnnotatedType
+ * └─ processAnnotatedHAMs()
+ *     └─ processHAMList()
+ *        └─ processHAMDefinition()
+ *
+ * 2. @Observes ProcessBean
+ * └─ processBean()
+ *     └─ set boolean regarding custom ham handler
+ *     └─ (veto other HAMs - not applicable here!)
+ *
+ * 3. @Observes AfterBeanDiscovery
+ * └─ afterBeanDiscovery()
+ *     └─ create all qualified HAM beans
+ *     └─ create internal (in-built) custom ham handler if required
+ *
+ * So by the time afterBeanDiscovery() is called, all your bean data should be in place.
+ */
+
+@Component(service = {},
+           immediate = true,
+           configurationPolicy = ConfigurationPolicy.IGNORE,
+           property = { "service.vendor=IBM", "api.classes=jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanismHandler" })
+public class JakartaSecurity40CDIExtension implements Extension {
+
+    private static final TraceComponent tc = Tr.register(JakartaSecurity40CDIExtension.class);
+    private boolean httpAuthenticationMechanismHandlerRegistered = false;
+    private final String applicationName;
+    private final Set<Bean<?>> beansToAdd = new HashSet<Bean<?>>();
+
+    private static PrimarySecurityCDIExtension primarySecurityCDIExtension;
+
+    // for multi-ham, if there are qualifiers, helper class to store HAM details
+    //   as they are created and added into the CDI in afterBeanDiscovery()
+    private final List<HAMDefinition> hamDefinitions = new ArrayList<>();
+
+    private static class HAMDefinition {
+        Class<?> implClass;
+        List<Class<?>> qualifiers;
+        Properties props;
+
+        HAMDefinition(Class<?> implClass, List<Class<?>> qualifiers, Properties props) {
+            this.implClass = implClass;
+            this.qualifiers = qualifiers;
+            this.props = props;
+        }
+    }
+
+    public JakartaSecurity40CDIExtension() {
+        applicationName = HttpAuthenticationMechanismsTracker.getApplicationName();
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "JakartaSecurity40CDIExtension", "Using application name [" + applicationName + "].");
+        }
+    }
+
+    @SuppressWarnings("static-access")
+    @Reference
+    protected void setPrimarySecurityCDIExtension(PrimarySecurityCDIExtension primarySecurityCDIExtension) {
+        // we need this to add to the http tracker auth mech
+        this.primarySecurityCDIExtension = primarySecurityCDIExtension;
+    }
+
+    /**
+     * This method processes annotations in the application which specify HAMs.
+     *
+     * We have to watch for the single HAM definition class, and also lists as single HAMs
+     * can appear in nested lists as they are repeatable (but only if there is more than one
+     * will they appear in a list).
+     *
+     * NOTE: ApplicationScoped annotation is included to catch List annotations which can't be
+     * explicitly listed as they are nested interfaces only in Jakarta Security 4.0+.
+     */
+    public <T> void processAnnotatedHAMs(@WithAnnotations({ BasicAuthenticationMechanismDefinition.class,
+                                                            FormAuthenticationMechanismDefinition.class,
+                                                            CustomFormAuthenticationMechanismDefinition.class,
+                                                            OpenIdAuthenticationMechanismDefinition.class,
+                                                            ApplicationScoped.class }) @Observes ProcessAnnotatedType<T> event,
+                                         BeanManager beanManager) {
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "instance: " + Integer.toHexString(this.hashCode()) + " BeanManager: " + Integer.toHexString(beanManager.hashCode()));
+        }
+
+        AnnotatedType<T> annotatedType = event.getAnnotatedType();
+        Class<?> annotatedClass = annotatedType.getJavaClass();
+        Set<Annotation> annotations = annotatedType.getAnnotations();
+
+        // look at all annotatoins including class level
+        for (Annotation annotation : annotations) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Annotation found: " + annotation);
+                Tr.debug(tc, "Annotation class: ", annotation.getClass());
+            }
+
+            Class<? extends Annotation> annotationType = annotation.annotationType();
+            String annotationTypeName = annotationType.getName();
+
+            // check for HAM lists first, then singles HAMs
+            if (annotationTypeName.contains("OpenIdAuthenticationMechanismDefinition$List")) {
+                processHAMList(OidcHttpAuthenticationMechanism.class, "OpenId",
+                               OpenIdAuthenticationMechanismDefinition.class, annotation, annotatedClass, annotatedType);
+            } else if (annotationTypeName.contains("BasicAuthenticationMechanismDefinition$List")) {
+                processHAMList(BasicHttpAuthenticationMechanism.class, "Basic",
+                               BasicAuthenticationMechanismDefinition.class, annotation, annotatedClass, annotatedType);
+            } else if (annotationTypeName.contains("CustomFormAuthenticationMechanismDefinition$List")) {
+                processHAMList(CustomFormAuthenticationMechanism.class, "CustomForm",
+                               CustomFormAuthenticationMechanismDefinition.class, annotation, annotatedClass, annotatedType);
+            } else if (annotationTypeName.contains("FormAuthenticationMechanismDefinition$List")) {
+                processHAMList(FormAuthenticationMechanism.class, "Form",
+                               FormAuthenticationMechanismDefinition.class, annotation, annotatedClass, annotatedType);
+            }
+            // now the single HAMs
+            else if (OpenIdAuthenticationMechanismDefinition.class.equals(annotationType)) {
+                processHAMDefinition(OidcHttpAuthenticationMechanism.class, annotation, annotationType, annotatedClass, annotatedType);
+            } else if (BasicAuthenticationMechanismDefinition.class.equals(annotationType)) {
+                processHAMDefinition(BasicHttpAuthenticationMechanism.class, annotation, annotationType, annotatedClass, annotatedType);
+            } else if (FormAuthenticationMechanismDefinition.class.equals(annotationType)) {
+                processHAMDefinition(FormAuthenticationMechanism.class, annotation, annotationType, annotatedClass, annotatedType);
+            } else if (CustomFormAuthenticationMechanismDefinition.class.equals(annotationType)) {
+                processHAMDefinition(CustomFormAuthenticationMechanism.class, annotation, annotationType, annotatedClass, annotatedType);
+            }
+        }
+    }
+
+    /**
+     * Process a List annotation containing multiple HAM definitions.
+     */
+    private <T> void processHAMList(Class<?> hamImplClass, String hamTypeName,
+                                    Class<? extends Annotation> singleAnnotationType,
+                                    Annotation listAnnotation, Class<?> annotatedClass,
+                                    AnnotatedType<T> annotatedType) {
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Processing " + hamTypeName + "AuthenticationMechanismDefinition.List");
+        }
+
+        try {
+            Method valueMethod = listAnnotation.annotationType().getMethod("value");
+            Annotation[] hamAnnotations = (Annotation[]) valueMethod.invoke(listAnnotation);
+
+            for (Annotation hamAnnotation : hamAnnotations) {
+                processHAMDefinition(hamImplClass, hamAnnotation, singleAnnotationType, annotatedClass, annotatedType);
+            }
+        } catch (Exception e) {
+            Tr.error(tc, "JAKARTASEC_CDI_ERROR_PROCESSING_HAM_LIST", hamTypeName);
+            String msg = Tr.formatMessage(tc, "JAKARTASEC_CDI_ERROR_PROCESSING_HAM_LIST", hamTypeName);
+            throw new DeploymentException(msg);
+        }
+    }
+
+    /**
+     * Process a single HAM definition annotation, and add it to our internal
+     * hamDefinitions tracker if it has custom annotations.
+     */
+    private <T> void processHAMDefinition(Class<?> hamImplClass, Annotation annotation,
+                                          Class<? extends Annotation> annotationType,
+                                          Class<?> annotatedClass, AnnotatedType<T> annotatedType) {
+        List<Class<?>> qualifiers = getQualifierClassesFromAnnotation(annotation, annotationType);
+
+        // only add to hamDefinitions if it has custom qualifiers, no qualifiers or
+        //   only the default qualifier will get added by other extension classes
+        if (hasCustomQualifiers(qualifiers)) {
+            Properties props = extractHAMProperties(hamImplClass, annotation, annotationType);
+
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Processing HAM type [" + hamImplClass.getSimpleName()
+                             + "] with custom qualifiers [" + qualifiers.toString()
+                             + "] and props [" + props.toString() + "].");
+            }
+
+            hamDefinitions.add(new HAMDefinition(hamImplClass, qualifiers, props));
+
+            // add to tracker EARLY (during ProcessAnnotatedType phase) to prevent other extensions
+            //   (such as JavaEESecCDIExtension) from vetoing the bean (and only add one of the HAM type)
+            if (primarySecurityCDIExtension != null && !primarySecurityCDIExtension.existAuthMech(applicationName, hamImplClass)) {
+                Set<Annotation> annotations = annotatedType.getAnnotations();
+                primarySecurityCDIExtension.addAuthMech(applicationName, hamImplClass, hamImplClass, annotations, props);
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Added qualified HAM to tracker early: " + hamImplClass.getSimpleName());
+                }
+            }
+        } else {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Processing HAM type [" + hamImplClass.getSimpleName()
+                             + "] with default/no qualifiers - will be handled by standard CDI");
+            }
+            // HAMs without custom qualifiers are handled in other extensions
+        }
+    }
+
+    /**
+     * Extract properties from HAM annotation based on HAM type.
+     */
+    private Properties extractHAMProperties(Class<?> hamImplClass, Annotation annotation,
+                                            Class<? extends Annotation> annotationType) {
+        Properties props = new Properties();
+
+        try {
+            // OpenID HAM
+            if (hamImplClass != null && OidcHttpAuthenticationMechanism.class.equals(hamImplClass)) {
+                props.put(JakartaSec30Constants.OIDC_ANNOTATION,
+                          new OpenIdAuthenticationMechanismDefinitionHolder((OpenIdAuthenticationMechanismDefinition) annotation));
+            }
+            // Basic HAM
+            else if (BasicAuthenticationMechanismDefinition.class.equals(annotationType)) {
+                Method realmNameMethod = annotationType.getMethod("realmName");
+                String realmName = (String) realmNameMethod.invoke(annotation);
+                props.put(JavaEESecConstants.REALM_NAME, realmName);
+            }
+            // Form/CustomForm HAM
+            else if (FormAuthenticationMechanismDefinition.class.equals(annotationType) ||
+                     CustomFormAuthenticationMechanismDefinition.class.equals(annotationType)) {
+                Method loginToContinueMethod = annotationType.getMethod("loginToContinue");
+                Annotation ltcAnnotation = (Annotation) loginToContinueMethod.invoke(annotation);
+                props = parseLoginToContinue(ltcAnnotation);
+            }
+        } catch (Exception e) {
+            String simpleAnnotationTypeName = annotationType.getSimpleName();
+            Tr.error(tc, "JAKARTASEC_CDI_ERROR_EXTRACTING_HAM_PROPERTIES", simpleAnnotationTypeName);
+            String msg = Tr.formatMessage(tc, "JAKARTASEC_CDI_ERROR_EXTRACTING_HAM_PROPERTIES", simpleAnnotationTypeName);
+            throw new DeploymentException(msg);
+        }
+
+        return props;
+    }
+
+    /**
+     * Parse LoginToContinue annotation to extract properties - specific to *FormHAMs.
+     */
+    private Properties parseLoginToContinue(Annotation ltcAnnotation) throws Exception {
+        Properties props = new Properties();
+        Class<? extends Annotation> ltcType = ltcAnnotation.annotationType();
+
+        Method loginPageMethod = ltcType.getMethod("loginPage");
+        String loginPage = (String) loginPageMethod.invoke(ltcAnnotation);
+        props.put(JavaEESecConstants.LOGIN_TO_CONTINUE_LOGINPAGE, loginPage);
+
+        Method errorPageMethod = ltcType.getMethod("errorPage");
+        String errorPage = (String) errorPageMethod.invoke(ltcAnnotation);
+        props.put(JavaEESecConstants.LOGIN_TO_CONTINUE_ERRORPAGE, errorPage);
+
+        Method useForwardToLoginMethod = ltcType.getMethod("useForwardToLogin");
+        boolean useForwardToLogin = (boolean) useForwardToLoginMethod.invoke(ltcAnnotation);
+        props.put(JavaEESecConstants.LOGIN_TO_CONTINUE_USEFORWARDTOLOGIN, useForwardToLogin);
+
+        Method useForwardToLoginExpressionMethod = ltcType.getMethod("useForwardToLoginExpression");
+        String useForwardToLoginExpression = (String) useForwardToLoginExpressionMethod.invoke(ltcAnnotation);
+        props.put(JavaEESecConstants.LOGIN_TO_CONTINUE_USEFORWARDTOLOGINEXPRESSION, useForwardToLoginExpression);
+
+        return props;
+    }
+
+    /**
+     * For the *HamDefinition annotations, extract the qualifiers value.
+     */
+    @FFDCIgnore(Exception.class)
+    private List<Class<?>> getQualifierClassesFromAnnotation(Annotation annotation,
+                                                             Class<? extends Annotation> annotationType) {
+        try {
+            Method qualifiersMethod = annotationType.getMethod(JavaEESecConstants.QUALIFIERS);
+            Class<?>[] qualifiers = (Class<?>[]) qualifiersMethod.invoke(annotation);
+
+            if (qualifiers != null && qualifiers.length > 0) {
+                return new ArrayList<>(Arrays.asList(qualifiers));
+            }
+        } catch (Exception e) {
+            // no qualifiers which is okay
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Does a list of qualifier classes have a custom
+     * qualifier (i.e. "Admin" or "User") which isn't the default one
+     * (which will be processed by the other extension processing)
+     */
+    private boolean hasCustomQualifiers(List<Class<?>> qualifiers) {
+        if (qualifiers == null || qualifiers.isEmpty()) {
+            return false;
+        }
+        return qualifiers.stream().anyMatch(q -> !isDefaultQualifier(q));
+    }
+
+    /**
+     * Check if a qualifier class is a default qualifier for HAMs (JS 4.0+).
+     */
+    private boolean isDefaultQualifier(Class<?> qualifierClass) {
+        String qualifierName = qualifierClass.getName();
+        return qualifierName.contains("$BasicAuthenticationMechanism") ||
+               qualifierName.contains("$FormAuthenticationMechanism") ||
+               qualifierName.contains("$CustomFormAuthenticationMechanism") ||
+               qualifierName.contains("$OpenIdAuthenticationMechanism");
+    }
+
+    /**
+     * Create a custom qualifier annotation instance from a qualifier class.
+     */
+    private Annotation createQualifierAnnotation(Class<?> qualifierClass) {
+        String qualifierName = qualifierClass.getName();
+
+        // For custom application-defined qualifiers
+        return new AnnotationLiteral() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return (Class<? extends Annotation>) qualifierClass;
+            }
+        };
+
+    }
+
+    public void processBean(@Observes ProcessBean<?> processBean, BeanManager beanManager) {
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "instance: " + Integer.toHexString(this.hashCode()) + " BeanManager: " + Integer.toHexString(beanManager.hashCode()));
+        }
+        if (!httpAuthenticationMechanismHandlerRegistered) {
+            if (isHttpAuthenticationMechanismHandler(processBean)) {
+                httpAuthenticationMechanismHandlerRegistered = true;
+            }
+        }
+    }
+
+    protected boolean isHttpAuthenticationMechanismHandler(ProcessBean<?> processBean) {
+        Bean<?> bean = processBean.getBean();
+        // Skip interface class
+        if (bean.getBeanClass() != HttpAuthenticationMechanismHandler.class) {
+            Set<Type> types = bean.getTypes();
+            if (types.contains(HttpAuthenticationMechanismHandler.class)) {
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "found a custom HttpAuthenticationMechanismHandler : " + bean.getBeanClass());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public <T> void afterBeanDiscovery(@Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
+
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "afterBeanDiscovery : instance : " + Integer.toHexString(this.hashCode()));
+            Tr.debug(tc, "Number of custom qualified HAM definitions: " + hamDefinitions.size());
+        }
+
+        try {
+            verifyConfiguration();
+
+            // Note: Qualified HAMs are already added to tracker during ProcessAnnotatedType phase
+            // to prevent old extensions from vetoing them
+
+            // Create QualifiedHAMBean for each HAM definition with qualifiers
+            for (HAMDefinition hamDef : hamDefinitions) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Creating QualifiedHAMBean for class ["
+                                 + hamDef.implClass.getCanonicalName() + "] with qualifiers ["
+                                 + hamDef.qualifiers.toString() + "].");
+                }
+
+                // Build qualifier annotations
+                List<Annotation> qualifierAnnotations = new ArrayList<>();
+                qualifierAnnotations.add(new AnnotationLiteral<Any>() {
+                    private static final long serialVersionUID = 1L;
+                });
+
+                for (Class<?> qClass : hamDef.qualifiers) {
+                    Annotation qualifier = createQualifierAnnotation(qClass);
+                    if (qualifier != null) {
+                        qualifierAnnotations.add(qualifier);
+                    }
+                }
+
+                // Create and add QualifiedHAMBean
+                Set<Annotation> qualifierSet = new HashSet<>(qualifierAnnotations);
+                QualifiedHAMBean qualifiedHAMBean = new QualifiedHAMBean(beanManager, hamDef.implClass, qualifierSet, hamDef.props);
+                beansToAdd.add(qualifiedHAMBean);
+
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Added QualifiedHAMBean for " + hamDef.implClass.getName() +
+                                 " with qualifiers: " + qualifierSet);
+                }
+            }
+
+            // Register default HttpAuthenticationMechanismHandler if needed
+            if (!httpAuthenticationMechanismHandlerRegistered) {
+                beansToAdd.add(new HttpAuthenticationMechanismHandlerBean(beanManager));
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "registering the default HttpAuthenticationMechanismHandler.");
+            } else {
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "HttpAuthenticationMechanismHandler is not registered because a custom HttpAuthenticationMechanismHandler has been registered");
+            }
+        } catch (DeploymentException de) {
+            afterBeanDiscovery.addDefinitionError(de);
+        }
+
+        // Add all beans
+        for (Bean<?> bean : beansToAdd) {
+            afterBeanDiscovery.addBean(bean);
+        }
+    }
+
+    /**
+     * Verify the configuration after all the beans have been discovered.
+     *
+     * - if qualified HAMs exist, then ensure there is a custom ham handler (spec requirement)
+     **/
+    private void verifyConfiguration() throws DeploymentException {
+
+        boolean hasCustomQualifiedHAMs = !hamDefinitions.isEmpty();
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Have custom qualified HAMs is [" + hasCustomQualifiedHAMs + "].");
+            Tr.debug(tc, "Have a custom HAM handler [" + httpAuthenticationMechanismHandlerRegistered + "].");
+        }
+
+        if (hasCustomQualifiedHAMs && !httpAuthenticationMechanismHandlerRegistered) {
+            Tr.error(tc, "JAKARTA_SECURITY_CDI_ERROR_CUSTOM_QUALIFIERS_NO_HAM_HANDLER");
+            String msg = Tr.formatMessage(tc, "JAKARTA_SECURITY_CDI_ERROR_CUSTOM_QUALIFIERS_NO_HAM_HANDLER");
+            throw new DeploymentException(msg);
+        }
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec40/cdi/extensions/JakartaSecurity40CDIExtensionMetadata.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec40/cdi/extensions/JakartaSecurity40CDIExtensionMetadata.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec40.cdi.extensions;
+
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import com.ibm.ws.cdi.extension.CDIExtensionMetadataInternal;
+
+import io.openliberty.cdi.spi.CDIExtensionMetadata;
+import jakarta.enterprise.inject.spi.Extension;
+
+@Component(service = CDIExtensionMetadata.class,
+           configurationPolicy = ConfigurationPolicy.IGNORE,
+           immediate = true)
+public class JakartaSecurity40CDIExtensionMetadata implements CDIExtensionMetadata, CDIExtensionMetadataInternal {
+
+    @Override
+    public Set<Class<? extends Extension>> getExtensions() {
+        Set<Class<? extends Extension>> extensions = new HashSet<Class<? extends Extension>>();
+        extensions.add(JakartaSecurity40CDIExtension.class);
+        return extensions;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getBeanDefiningAnnotationClasses() {
+        Set<Class<? extends Annotation>> BDAs = new HashSet<Class<? extends Annotation>>();
+        return BDAs;
+    }
+
+    @Override
+    public boolean applicationBeansVisible() {
+        return true;
+    }
+
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec40/cdi/extensions/QualifiedHAMBean.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec40/cdi/extensions/QualifiedHAMBean.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec40.cdi.extensions;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.InterceptionFactory;
+import jakarta.enterprise.inject.spi.PassivationCapable;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+
+/**
+ * Custom CDI bean for qualified HttpAuthenticationMechanism instances.
+ */
+public class QualifiedHAMBean implements Bean<HttpAuthenticationMechanism>, PassivationCapable {
+
+    private final BeanManager beanManager;
+    private final Class<? extends HttpAuthenticationMechanism> hamClass;
+    private final Set<Annotation> qualifiers;
+    private final Set<Type> types;
+    private final Properties props;
+    private final String name;
+    private final String id;
+
+    public QualifiedHAMBean(BeanManager beanManager,
+                            Class<?> hamClass,
+                            Set<Annotation> qualifiers,
+                            Properties props) {
+        this.beanManager = beanManager;
+        this.hamClass = (Class<? extends HttpAuthenticationMechanism>) hamClass;
+        this.qualifiers = qualifiers;
+        this.props = props;
+
+        Set<Type> typeSet = new HashSet<>();
+        typeSet.add(hamClass);
+        typeSet.add(HttpAuthenticationMechanism.class);
+        typeSet.add(Object.class);
+        this.types = Collections.unmodifiableSet(typeSet);
+
+        this.name = this.getClass().getName() + "@" + this.hashCode() + "[" + hamClass.getName() + "]";
+        this.id = beanManager.hashCode() + "#" + this.name;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public HttpAuthenticationMechanism create(CreationalContext<HttpAuthenticationMechanism> cc) throws DeploymentException {
+        Class<HttpAuthenticationMechanism> hamClassRaw = (Class<HttpAuthenticationMechanism>) hamClass;
+
+        // for interceptors - currently just LoginToContinue on Forms, but handled generically with metadata
+        InterceptionFactory<HttpAuthenticationMechanism> factory = beanManager.createInterceptionFactory(cc, hamClassRaw);
+        for (Annotation annotation : hamClass.getAnnotations()) {
+            if (annotation.annotationType().isAnnotationPresent(InterceptorBinding.class)) {
+                factory.configure().add(annotation);
+            }
+        }
+
+        // create and configure HAM instance
+        // do this without any specific HAM class reference, so it works for
+        // Basic/Form/CustomForm and OpenID HAMs created via qualifiers
+        HttpAuthenticationMechanism ham;
+        try {
+            ham = hamClass.getDeclaredConstructor().newInstance();
+            Method setPropsMethod = hamClass.getMethod("setQualifiedProperties", Properties.class);
+            setPropsMethod.invoke(ham, props);
+        } catch (Exception e) {
+            throw new DeploymentException("Failed to create HAM: " + hamClass.getName(), e);
+        }
+
+        return factory.createInterceptedInstance(ham);
+    }
+
+    @Override
+    public void destroy(HttpAuthenticationMechanism instance, CreationalContext<HttpAuthenticationMechanism> ctx) {
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return ApplicationScoped.class;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getStereotypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Type> getTypes() {
+        return types;
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public Class<?> getBeanClass() {
+        return hamClass;
+    }
+
+    @Override
+    public Set<InjectionPoint> getInjectionPoints() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec40/cdi/extensions/package-info.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec40/cdi/extensions/package-info.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = "JakartaSecurity40", messageBundle = "io.openliberty.security.jakartasec.cdi.internal.resources.JakartaSecurity40Messages")
+package io.openliberty.security.jakartasec40.cdi.extensions;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/test/io/openliberty/security/jakartasec40/cdi/extensions/HttpAuthentiationMechanismHandlerBeanTest.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/test/io/openliberty/security/jakartasec40/cdi/extensions/HttpAuthentiationMechanismHandlerBeanTest.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec40.cdi.extensions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+
+//import io.openliberty.security.jakartasec.handlers.HttpAuthenticationMechanismHandlerImpl;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanismHandler;
+
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.openliberty.security.jakartasec.cdi.extensions.OidcIdentityStoreBean;
+import io.openliberty.security.jakartasec.handlers.HttpAuthenticationMechanismHandlerImpl;
+import io.openliberty.security.jakartasec.identitystore.OidcIdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.util.TypeLiteral;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+
+/**
+ * Unit tests for the HttpAuthentiationMechanismHandlerBean class.
+ */
+public class HttpAuthentiationMechanismHandlerBeanTest {
+
+    private final Mockery mockery = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+
+    private HttpAuthenticationMechanismHandlerBean httpAuthenticationMechanismHandlerBean;
+    private BeanManager beanManager;
+    private OidcIdentityStoreBean oidcIdentityStoreBean;
+    
+    private HttpAuthenticationMechanismHandlerBean bean;
+    
+    @Before
+    public void setUp() throws Exception {
+        beanManager = mockery.mock(BeanManager.class);
+        httpAuthenticationMechanismHandlerBean = new HttpAuthenticationMechanismHandlerBean(beanManager);
+        bean = new HttpAuthenticationMechanismHandlerBean(beanManager);        
+        oidcIdentityStoreBean = new OidcIdentityStoreBean(beanManager);        
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testCreate() {
+    	// given ...
+        @SuppressWarnings("unchecked")
+		CreationalContext<HttpAuthenticationMechanismHandler> creationalContext = 
+            mockery.mock(CreationalContext.class);
+
+        // when ...
+        HttpAuthenticationMechanismHandler handler = httpAuthenticationMechanismHandlerBean.create(creationalContext);
+
+        // then ..
+        assertNotNull("Created handler should not be null", handler);
+        assertTrue("Created handler should be an instance of HttpAuthenticationMechanismHandlerImpl",
+                  handler instanceof HttpAuthenticationMechanismHandlerImpl);
+    }
+
+    @Test
+    public void testDestroy() {
+    	// just verifying that this method doesn't thrown an exception
+    	
+        // given ...
+        @SuppressWarnings("unchecked")    	
+        CreationalContext<HttpAuthenticationMechanismHandler> creationalContext = 
+            mockery.mock(CreationalContext.class);
+        HttpAuthenticationMechanismHandler handler = 
+            mockery.mock(HttpAuthenticationMechanismHandler.class);
+        
+        // when/then ...
+        bean.destroy(handler, creationalContext);
+    }
+
+    @Test
+    public void testGetName() {
+    	// given/when ...
+        String name = bean.getName();
+        
+        // then ...
+        assertNotNull("Bean name should not be null", name);
+        assertTrue("Bean name should contain the class name", 
+                  name.contains(HttpAuthenticationMechanismHandlerBean.class.getName()));
+        assertTrue("Bean name should contain the type", 
+                  name.contains(HttpAuthenticationMechanismHandler.class.getName()));
+    }
+
+    @Test
+    public void testGetQualifiers() {
+    	// given/when ...
+        Set<Annotation> qualifiers = bean.getQualifiers();
+
+        // then ...
+        assertNotNull("Qualifiers set should not be null", qualifiers);
+        assertEquals("Qualifiers set should contain exactly two entries", 2, qualifiers.size());
+        
+        boolean hasDefault = false;
+        boolean hasAny = false;
+        
+        for (Annotation annotation : qualifiers) {
+            if (annotation.annotationType().getSimpleName().equals("Default")) {
+                hasDefault = true;
+            } else if (annotation.annotationType().getSimpleName().equals("Any")) {
+                hasAny = true;
+            }
+        }
+        
+        assertTrue("Qualifiers should include @Default", hasDefault);
+        assertTrue("Qualifiers should include @Any", hasAny);
+    }
+
+    @Test
+    public void testGetScope() {
+    	// given/when ...
+        Class<?> scope = bean.getScope();
+
+        // then ...        
+        assertEquals("Scope should be ApplicationScoped", ApplicationScoped.class, scope);
+    }
+
+    @Test
+    public void testGetStereotypes() {
+    	// given/when ...
+        Set<Class<? extends Annotation>> stereotypes = bean.getStereotypes();
+        
+        // then ...
+        assertNotNull("Stereotypes set should not be null", stereotypes);
+        assertTrue("Stereotypes set should be empty", stereotypes.isEmpty());
+    }
+
+    @Test
+    public void testGetTypes() {
+    	// given/when ...
+        Set<Type> types = bean.getTypes();
+        
+        // then ...
+        assertNotNull("Types set should not be null", types);
+        assertEquals("Types set should contain exactly one entry", 1, types.size());
+        assertEquals("Type should be HttpAuthenticationMechanismHandler", 
+                    HttpAuthenticationMechanismHandler.class, types.iterator().next());
+    }
+
+
+    @Test
+    public void testIsAlternative() {
+    	// given/when/then ...
+        assertFalse("Bean should not be an alternative", bean.isAlternative());
+    }
+
+    @Test
+    public void testGetBeanClass() {
+    	//given/when ...
+        Class<?> beanClass = bean.getBeanClass();
+        
+        // then ...
+        assertEquals("Bean class should be HttpAuthentiationMechanismHandlerBean", 
+                    HttpAuthenticationMechanismHandlerBean.class, beanClass);
+    }
+
+    @Test
+    public void testGetInjectionPoints() {
+    	// given/when ...
+        Set<InjectionPoint> injectionPoints = bean.getInjectionPoints();
+        
+        // then ...
+        assertNotNull("Injection points set should not be null", injectionPoints);
+        assertTrue("Injection points set should be empty", injectionPoints.isEmpty());
+    }
+
+    @Test
+    public void testGetId() {
+    	// given/when ...
+        String id = bean.getId();
+        
+        // then ...
+        assertNotNull("Bean ID should not be null", id);
+        assertTrue("Bean ID should contain the bean manager hashcode", 
+                  id.contains(String.valueOf(beanManager.hashCode())));
+        assertTrue("Bean ID should contain the bean name", 
+                  id.contains(bean.getName()));
+    }
+}    
+

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/test/io/openliberty/security/jakartasec40/cdi/extensions/JakartaSecurity40CDIExtensionMetadataTest.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/test/io/openliberty/security/jakartasec40/cdi/extensions/JakartaSecurity40CDIExtensionMetadataTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec40.cdi.extensions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import jakarta.enterprise.inject.spi.Extension;
+
+/**
+ * unit tests for the JakartaSecurity40CDIExtensionMetadata class.
+ */
+public class JakartaSecurity40CDIExtensionMetadataTest {
+
+    private JakartaSecurity40CDIExtensionMetadata metadata;
+
+    @Before
+    public void setUp() throws Exception {
+        metadata = new JakartaSecurity40CDIExtensionMetadata();
+    }
+
+    @Test
+    public void testGetExtensions() {
+        Set<Class<? extends Extension>> extensions = metadata.getExtensions();
+        
+        assertNotNull("Extensions set should not be null", extensions);
+        assertEquals("Extensions set should contain exactly one entry", 1, extensions.size());
+        assertTrue("Extensions set should contain JakartaSecurity40CDIExtension", 
+                  extensions.contains(JakartaSecurity40CDIExtension.class));
+    }
+
+    @Test
+    public void testGetBeanDefiningAnnotationClasses() {
+        Set<Class<? extends Annotation>> annotations = metadata.getBeanDefiningAnnotationClasses();
+        
+        assertNotNull("Bean defining annotations set should not be null", annotations);
+        assertEquals("Bean defining annotations set should be empty", 0, annotations.size());
+    }
+
+    @Test
+    public void testApplicationBeansVisible() {
+        assertTrue("Application beans should be visible", metadata.applicationBeansVisible());
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/test/io/openliberty/security/jakartasec40/cdi/extensions/JakartaSecurity40CDIExtensionTest.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/test/io/openliberty/security/jakartasec40/cdi/extensions/JakartaSecurity40CDIExtensionTest.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec40.cdi.extensions;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.ProcessBean;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanismHandler;
+
+/**
+ * Unit tests for the JakartaSecurity40CDIExtension class.
+ * 
+ * 
+ */
+public class JakartaSecurity40CDIExtensionTest {
+
+    private final Mockery mockery = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+
+    private JakartaSecurity40CDIExtension extension;
+    private ProcessBean<?> processBean;
+    private Bean<?> bean;
+    private BeanManager beanManager;
+    private AfterBeanDiscovery afterBeanDiscovery;
+    private HttpAuthenticationMechanismHandler hamHandler;
+    
+    @Before
+    public void setUp() throws Exception {
+        processBean = mockery.mock(ProcessBean.class);
+        bean = mockery.mock(Bean.class);
+        beanManager = mockery.mock(BeanManager.class);
+        afterBeanDiscovery = mockery.mock(AfterBeanDiscovery.class);
+        extension = new JakartaSecurity40CDIExtension();
+        hamHandler = mockery.mock(HttpAuthenticationMechanismHandler.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void testProcessBeanWithNonHttpAuthenticationMechanismHandler() throws Exception {
+        // given ...
+        mockery.checking(new Expectations() {
+            {
+                oneOf(processBean).getBean();
+                will(returnValue(bean));
+                
+                oneOf(bean).getBeanClass();
+                will(returnValue(String.class));
+                
+                oneOf(bean).getTypes();
+                will(returnValue(createTypeSet(String.class)));
+            }
+        });
+        setPrivateField(extension, "httpAuthenticationMechanismHandlerRegistered", false);
+        
+        // when ...
+        extension.processBean(processBean, beanManager);
+        
+        // then ...
+        assertFalse("httpAuthenticationMechanismHandlerRegistered should still be false",
+                   getPrivateField(extension, "httpAuthenticationMechanismHandlerRegistered"));
+    }
+
+    @Test
+    public void testProcessBeanWithHttpAuthenticationMechanismHandler() throws Exception {
+    	// given
+        mockery.checking(new Expectations() {
+            {
+                oneOf(processBean).getBean();
+                will(returnValue(bean));
+                
+                oneOf(bean).getBeanClass();
+                will(returnValue(hamHandler.getClass()));
+                
+                oneOf(bean).getTypes();
+                will(returnValue(createTypeSet(HttpAuthenticationMechanismHandler.class)));
+            }
+        });
+        setPrivateField(extension, "httpAuthenticationMechanismHandlerRegistered", false);
+        
+        // when ...
+        extension.processBean(processBean, beanManager);
+        
+        // then ...
+        assertTrue("httpAuthenticationMechanismHandlerRegistered should be true",
+                  getPrivateField(extension, "httpAuthenticationMechanismHandlerRegistered"));
+    }
+
+    @Test
+    public void testAfterBeanDiscoveryWithNoCustomHandler() throws Exception {
+    	// given ...
+        mockery.checking(new Expectations() {
+            {
+                oneOf(afterBeanDiscovery).addBean(with(any(HttpAuthenticationMechanismHandlerBean.class)));
+            }
+        });
+        setPrivateField(extension, "httpAuthenticationMechanismHandlerRegistered", false);
+        
+        // when/then ...
+        extension.afterBeanDiscovery(afterBeanDiscovery, beanManager);
+    }
+
+    @Test
+    public void testAfterBeanDiscoveryWithCustomHandler() throws Exception {
+    	// given ...
+        setPrivateField(extension, "httpAuthenticationMechanismHandlerRegistered", true);
+        
+        // when/then ...
+        extension.afterBeanDiscovery(afterBeanDiscovery, beanManager);
+    }
+
+    // Helper method to create a set of types
+    private Set<java.lang.reflect.Type> createTypeSet(Class<?>... types) {
+        Set<java.lang.reflect.Type> typeSet = new HashSet<>();
+        for (Class<?> type : types) {
+            typeSet.add(type);
+        }
+        return typeSet;
+    }
+    
+    // Helper method to set a private field
+    private void setPrivateField(Object object, String fieldName, Object value) throws Exception {
+        Field field = object.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(object, value);
+    }
+    
+    // Helper method to get a private field
+    private boolean getPrivateField(Object object, String fieldName) throws Exception {
+        Field field = object.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (boolean) field.get(object);
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/.classpath
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="src" output="bin_test" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -24,6 +24,10 @@ WS-TraceGroup: \
 
 Private-Package: io.openliberty.security.jakartasec.internal.resources.*,\
                  io.openliberty.security.jakartasec40.internal.resources.*
+-dsannotations: \
+  io.openliberty.security.jakartasec.services.HttpAuthenticationMechanismHandlerServiceImpl
+
+-dsannotations-inherit: true
 
 Export-Package: \
     io.openliberty.security.jakartasec,\
@@ -33,8 +37,10 @@ Export-Package: \
     io.openliberty.security.jakartasec.identitystore.permissions,\
     io.openliberty.security.jakartasec.tokens,\
     io.openliberty.security.jakartasec40,\
-    io.openliberty.security.jakartasec40.identitystore    
-    
+    io.openliberty.security.jakartasec40.identitystore,\
+    io.openliberty.security.jakartasec.services,\
+    io.openliberty.security.jakartasec.handlers
+
 Import-Package: \
     *
 
@@ -46,7 +52,9 @@ instrument.classesExcludes: io/openliberty/security/jakartasec40/internal/resour
     com.ibm.ws.kernel.service;version=latest,\
     com.ibm.ws.logging;version=latest,\
     com.ibm.ws.logging.core;version=latest,\
+    com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    io.openliberty.jakarta.cdi.4.0,\
     io.openliberty.security.jakartasec.2.0.internal,\
     io.openliberty.jakarta.security.4.0,\
     io.openliberty.security.oidcclientcore.internal.jakarta,\
@@ -57,13 +65,24 @@ instrument.classesExcludes: io/openliberty/security/jakartasec40/internal/resour
     io.openliberty.jakarta.expressionLanguage.6.0;version=latest,\
     com.ibm.json4j;version=latest,\
     io.openliberty.cdi.4.0.internal.interfaces;version=latest,\
-    com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.crypto.passwordutil;version=latest,\
-    io.openliberty.jakarta.cdi.4.0;version=latest
+    io.openliberty.jakarta.annotation.3.0,\
+    io.openliberty.jakarta.authentication.3.0;version=latest,\
+    com.ibm.websphere.security;version=latest
 
 -testpath: \
-    ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
-    com.ibm.ws.junit.extensions;version=latest, \
-    org.hamcrest:hamcrest-all;version=1.3, \
-    org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
-    org.jmock:jmock;strategy=exact;version=2.5.1
+    ../build.sharedResources/lib/junit/old/junit.jar;version=file,\
+    com.ibm.ws.junit.extensions;version=latest,\
+    org.hamcrest:hamcrest-all;version=1.3,\
+    org.jmock:jmock-junit4;strategy=exact;version=2.5.1,\
+    org.jmock:jmock;strategy=exact;version=2.5.1,\
+    org.jmock:jmock-legacy;version=2.5.0,\
+    cglib:cglib;version=3.3.0, \
+    com.ibm.ws.org.objectweb.asm;version=latest,\
+    com.ibm.ws.org.objenesis:objenesis;version=1.0,\
+    io.openliberty.jakarta.expressionLanguage.5.0;version=latest,\
+    com.ibm.ws.security.common.jsonwebkey;version=latest,\
+    com.ibm.json4j;version=latest,\
+    com.ibm.ws.container.service;version=latest,\
+    com.ibm.ws.org.jose4j;version=latest
+

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/build.gradle
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+test {
+   jvmArgs = ["--add-opens", "java.base/java.lang=ALL-UNNAMED"]
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity40Messages.nlsprops
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity40Messages.nlsprops
@@ -1,0 +1,45 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+#CMVCPATHNAME io.openliberty.security.jakartasec.4.0.internal/resources/io/openliberty/security/jakartasec/internal/resources/JakartaSecurity40Messages.nlsprops
+#COMPONENTPREFIX CWWKS
+#COMPONENTNAMEFOR WebSphere Application Server Jakarta Security 4.0
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+# -------------------------------------------------------------------------------------------------
+
+# Message prefix block: 2600-2610
+
+JAKARTASEC_WARNING_PRODUCTION_USE=CWWKS2600W: An identity store that is configured by using an @InMemoryIdentityStoreDefinition annotation was detected within this application. Do not use this definition in a production environment.
+JAKARTASEC_WARNING_PRODUCTION_USE.explanation=Only use the @InMemoryIdentityStoreDefinition definition for development, testing, and debugging purposes only.
+JAKARTASEC_WARNING_PRODUCTION_USE.useraction=Before your application goes into production, remove the @InMemoryIdentityStoreDefinition and replace it with a supported production-grade identity store such as LDAP or Database.
+
+JAKARTASEC_WARNING_ENV_VARIABLE_NOT_SET=CWWKS2601W: The {0} environment variable is empty or unset. Any subsequent authentication request validations that use the associated caller will fail.
+JAKARTASEC_WARNING_ENV_VARIABLE_NOT_SET.explanation=An environment variable was used as the value of a password field in the @Credential annotation, but this variable is not set externally, or is set to an empty string.
+JAKARTASEC_WARNING_ENV_VARIABLE_NOT_SET.useraction=Make sure you set the environment variable referenced in the annotation, typically specified in server.env.
+
+JAKARTASEC_ERROR_WRONG_CRED=CWWKS2602E: The credential provided to the IdentityStore object is not a UsernamePasswordCredential and cannot be validated.
+JAKARTASEC_ERROR_WRONG_CRED.explanation=The credential provided to the IdentityStore object is not a UsernamePasswordCredential class and cannot be validated.
+JAKARTASEC_ERROR_WRONG_CRED.useraction=Review the type of credential passed into the IdentityStore object by the HttpAuthMechanism implementation.
+
+#Note to translator, do not translate "EL"
+JAKARTASEC_WARNING_IDSTORE_CONFIG=CWWKS2603W: The Expression Language (EL) expression for the ''{0}'' attribute of the identity store annotation cannot be resolved to a valid value. Ensure that the EL expression and the result are valid and ensure that any referenced beans that are used in the expression are resolvable. The default attribute value of ''{1}'' is used instead.
+JAKARTASEC_WARNING_IDSTORE_CONFIG.useraction=Make sure that the annotation contains a valid configuration value. Ensure that the EL expressions are valid, that any referenced beans that are used in the expression are resolvable, and that the type of the result corresponds with the attribute.
+JAKARTASEC_WARNING_IDSTORE_CONFIG.explanation=The cause of the error is a mismatch of the type between the EL result and the expected attribute value. For example, if the expected attribute type is String, the EL result must be String.
+
+# NOTE, this error message (JAKARTASEC_ERROR_NO_HAM) is copied directly from bundle com.ibm.ws.security.javaeesec
+JAKARTASEC_ERROR_NO_HAM=CWWKS2604E: The HttpAuthenticationMechanism object for the {0} module in the {1} application could not be created.
+JAKARTASEC_ERROR_NO_HAM.explanation=The reason that the HttpAuthenticationMechanism object cannot be created varies. The error messages for the HttpAuthenticationMechanism object provide information on why the the HttpAuthenticationMechanism object cannot be created.
+JAKARTASEC_ERROR_NO_HAM.useraction=Investigate any error messages from the HttpAuthenticationMechanism object and make corrections based on the error messages.
+
+JAKARTASEC_ERROR_AMBIGUOUS_RESOLUTION=CWWKS2605E: Unable to determine which HttpAuthenticationMechanism to handle request. The following HttpAuthenticationMechanisms have the same priority or Http Authentiation Mechanism Type {0}.
+JAKARTASEC_ERROR_AMBIGUOUS_RESOLUTION.explanation=If multiple HttpAuthenticationMechanisms are specified, a unique one must be selected for authorization based on Priority, Http Authentication Mechanism type and optional Http Authentiation Mechanism qualifiers.
+JAKARTASEC_ERROR_AMBIGUOUS_RESOLUTION.useraction=Set or adjust the priority value of one of these HttpAuthenticationMechanisms.
+

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/TraceConstants.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/TraceConstants.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec;
+
+/**
+ *
+ */
+public class TraceConstants {
+
+    public static final String TRACE_GROUP = "Security40";
+    public static final String MESSAGE_BUNDLE = "io.openliberty.security.jakartasec.internal.resources.JakartaSecurity40Messages";
+
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/handlers/HttpAuthenticationMechanismHandlerImpl.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/handlers/HttpAuthenticationMechanismHandlerImpl.java
@@ -1,0 +1,430 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.security.jakartasec.handlers;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.javaeesec.CDIHelper;
+import com.ibm.ws.security.javaeesec.properties.ModulePropertiesUtils;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.AmbiguousResolutionException;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanismHandler;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Implementation of the HttpAuthenticationMechanismHandler interface.
+ * This class selects the highest priority HttpAuthenticationMechanism
+ * and delegates authentication operations to it.
+ */
+@Default
+@ApplicationScoped
+public class HttpAuthenticationMechanismHandlerImpl implements HttpAuthenticationMechanismHandler {
+
+    private static final TraceComponent tc = Tr.register(HttpAuthenticationMechanismHandlerImpl.class);
+
+    // Priority constants for built-in HAMs (lower values = lower priority)
+    private static final int PRIORITY_BASIC = Integer.MIN_VALUE + 1;
+    private static final int PRIORITY_FORM = Integer.MIN_VALUE + 2;
+    private static final int PRIORITY_CUSTOM_FORM = Integer.MIN_VALUE + 3;
+    private static final int PRIORITY_OIDC = Integer.MIN_VALUE + 4;
+
+    protected static Map<String, Integer> hamClassPriorities;
+    {
+        Map<String, Integer> temp = new HashMap<String, Integer>();
+        temp.put("BasicHttpAuthenticationMechanism", PRIORITY_BASIC);
+        temp.put("FormAuthenticationMechanism", PRIORITY_FORM);
+        temp.put("CustomFormAuthenticationMechanism", PRIORITY_CUSTOM_FORM);
+        temp.put("OidcHttpAuthenticationMechanism", PRIORITY_OIDC);
+        hamClassPriorities = Collections.unmodifiableMap(temp);
+    }
+
+    /**
+     * Map of module names to sets of HttpAuthenticationMechanism instances sorted by priority.
+     */
+    private final ConcurrentHashMap<String, Set<MultiHttpAuthenticationMechanism>> authMechanismMap = new ConcurrentHashMap<>();
+
+    // cache the last, highest priority HAM name to avoid duplicate logging
+    private static volatile String lastLoggedHAMName = null;
+
+    /**
+     * Default constructor
+     */
+    public HttpAuthenticationMechanismHandlerImpl() {
+        // empty
+    }
+
+    protected ModulePropertiesUtils getModulePropertiesUtils() {
+        return ModulePropertiesUtils.getInstance();
+    }
+
+    /**
+     * Logs the HAM name **to the debug output** if it's different from the last logged one.
+     *
+     * This handles application reloads where the HAM may change.
+     *
+     * @param httpAuthenticationMechanism is the HAM to log, cannot be null.
+     */
+    private static void logHAMToDebugIfChanged(MultiHttpAuthenticationMechanism httpAuthenticationMechanism) {
+        if (tc.isDebugEnabled()) {
+            String hamName = httpAuthenticationMechanism.getSimpleName();
+            // only output if HAM name has changed
+            if (!hamName.equals(lastLoggedHAMName)) {
+                Tr.debug(tc, "The (highest priority) HttpAuthenticationMechanism being used is: " + hamName);
+                lastLoggedHAMName = hamName;
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) {
+
+        MultiHttpAuthenticationMechanism multiHttpAuthenticationMechanism = getHighestPriorityHttpAuthenticationMechanism();
+        if (multiHttpAuthenticationMechanism == null) {
+            if (tc.isWarningEnabled()) {
+                Tr.warning(tc, "No HttpAuthenticationMechanism available.");
+            }
+            return AuthenticationStatus.NOT_DONE;
+        }
+        logHAMToDebugIfChanged(multiHttpAuthenticationMechanism);
+
+        // Use privileged action for security sensitive operations
+        PrivilegedAction<AuthenticationStatus> action = new PrivilegedAction<AuthenticationStatus>() {
+            @Override
+            public AuthenticationStatus run() {
+                try {
+                    return multiHttpAuthenticationMechanism.validateRequest(request, response, httpMessageContext);
+                } catch (Exception e) {
+                    if (tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Exception during validateRequest: " + e.getMessage(), e);
+                    }
+                    return AuthenticationStatus.SEND_FAILURE;
+                }
+            }
+        };
+
+        return AccessController.doPrivileged(action);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthenticationStatus secureResponse(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) {
+
+        MultiHttpAuthenticationMechanism multiHttpAuthenticationMechanism = getHighestPriorityHttpAuthenticationMechanism();
+        if (multiHttpAuthenticationMechanism == null) {
+            if (tc.isWarningEnabled()) {
+                Tr.warning(tc, "No HttpAuthenticationMechanism available.");
+            }
+            return AuthenticationStatus.NOT_DONE;
+        }
+        logHAMToDebugIfChanged(multiHttpAuthenticationMechanism);
+
+        // Use privileged action for security sensitive operations
+        PrivilegedAction<AuthenticationStatus> action = new PrivilegedAction<AuthenticationStatus>() {
+            @Override
+            public AuthenticationStatus run() {
+                try {
+                    return multiHttpAuthenticationMechanism.secureResponse(request, response, httpMessageContext);
+                } catch (Exception e) {
+                    if (tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Exception during secureResponse: " + e.getMessage(), e);
+                    }
+                    return AuthenticationStatus.SEND_FAILURE;
+                }
+            }
+        };
+
+        return AccessController.doPrivileged(action);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void cleanSubject(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) {
+
+        MultiHttpAuthenticationMechanism multiHttpAuthenticationMechanism = getHighestPriorityHttpAuthenticationMechanism();
+
+        if (multiHttpAuthenticationMechanism == null) {
+            if (tc.isWarningEnabled()) {
+                Tr.warning(tc, "No HttpAuthenticationMechanism available.");
+            }
+            return;
+        }
+        logHAMToDebugIfChanged(multiHttpAuthenticationMechanism);
+
+        // Use privileged action for security sensitive operations
+        PrivilegedAction<Void> action = new PrivilegedAction<Void>() {
+            @Override
+            public Void run() {
+                try {
+                    multiHttpAuthenticationMechanism.cleanSubject(request, response, httpMessageContext);
+                } catch (Exception e) {
+                    if (tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Exception during cleanSubject: " + e.getMessage(), e);
+                    }
+                }
+                return null;
+            }
+        };
+
+        if (action != null) {
+            AccessController.doPrivileged(action);
+        }
+    }
+
+    /**
+     * Gets the highest priority HttpAuthenticationMechanism.
+     *
+     * @return The highest priority HttpAuthenticationMechanism, or
+     *         null if none are available
+     */
+    protected MultiHttpAuthenticationMechanism getHighestPriorityHttpAuthenticationMechanism() {
+        String moduleName = getModuleName();
+
+        Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms = authMechanismMap.get(moduleName);
+
+        if (multiHttpAuthenticationMechanisms == null) {
+            // first time fetching the auth mechanisms
+            multiHttpAuthenticationMechanisms = new TreeSet<>(priorityComparator);
+            scanAuthenticationMechanisms(multiHttpAuthenticationMechanisms);
+            authMechanismMap.put(moduleName, multiHttpAuthenticationMechanisms);
+            // output hams every time the authMechanismMap is rebuilt
+            logHttpAuthenticationMechanisms(multiHttpAuthenticationMechanisms);
+        } else if (multiHttpAuthenticationMechanisms.size() > 1) {
+            // Re-sort since priority can change due to deferred EL expressions
+            Set<MultiHttpAuthenticationMechanism> oldMultiHttpAuthenticationMechanisms = multiHttpAuthenticationMechanisms;
+            multiHttpAuthenticationMechanisms = new TreeSet<>(priorityComparator);
+            multiHttpAuthenticationMechanisms.addAll(oldMultiHttpAuthenticationMechanisms);
+        }
+
+        if (multiHttpAuthenticationMechanisms.isEmpty()) {
+            Tr.error(tc, "JAKARTASEC_ERROR_NO_HAM", getModuleName(), getApplicationName());
+            return null;
+        }
+
+        checkUniquePriorityFound(multiHttpAuthenticationMechanisms);
+
+        // Return the highest priority mechanism (first in the sorted set)
+        return multiHttpAuthenticationMechanisms.iterator().next();
+    }
+
+    /**
+     * Ensure a unique HAM is found and throw an exception if one cannot be found.
+     *
+     * All in-built HAMs will have a unique, ordered priority, so this only applies
+     * if there are multiple application HAMs with the same highest priority,
+     * or if there are duplicate in-built HAMs of the same type.
+     *
+     * @param multiHttpAuthenticationMechanisms is a list of current HAMs.
+     */
+
+    private void checkUniquePriorityFound(Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms) {
+        // if we have fewer than 2 mechanisms, there's no ambiguity
+        if (multiHttpAuthenticationMechanisms.size() < 2) {
+            return;
+        }
+
+        // get the first two mechanisms from the set ...
+        Iterator<MultiHttpAuthenticationMechanism> iterator = multiHttpAuthenticationMechanisms.iterator();
+        MultiHttpAuthenticationMechanism first = iterator.next();
+        MultiHttpAuthenticationMechanism second = iterator.next();
+
+        // ... and compare their priorities
+        if (first.getPriority() == second.getPriority()) {
+            // get the top priority value as this is the ambiguous case
+            int topPriority = first.getPriority();
+
+            // create a comma-separated list of only the MultiHttpAuthenticationMechanism
+            //   instances with the top priority
+            StringBuilder mechanismList = new StringBuilder();
+            boolean isFirst = true;
+
+            // reset the iterator to include all mechanisms
+            iterator = multiHttpAuthenticationMechanisms.iterator();
+            while (iterator.hasNext()) {
+                MultiHttpAuthenticationMechanism mechanism = iterator.next();
+
+                // so build a list of HAMs which have the same priority as the
+                //   top one, as it could be more than just the two
+                if (mechanism.getPriority() == topPriority) {
+                    if (!isFirst) {
+                        mechanismList.append(", ");
+                    }
+
+                    // output name only if in hamClassPriorities map, otherwise include priority
+                    String simpleName = mechanism.getSimpleName();
+                    if (hamClassPriorities.containsKey(simpleName)) {
+                        mechanismList.append(simpleName);
+                    } else {
+                        mechanismList.append(simpleName).append(" Priority = ").append(mechanism.getPriority());
+                    }
+                    isFirst = false;
+                } else {
+                    // can break as set is ordered by priority
+                    break;
+                }
+            }
+
+            Tr.error(tc, "JAKARTASEC_ERROR_AMBIGUOUS_RESOLUTION", mechanismList.toString());
+
+            throw new AmbiguousResolutionException(Tr.formatMessage(tc, "JAKARTASEC_ERROR_AMBIGUOUS_RESOLUTION", mechanismList.toString()));
+        }
+    }
+
+    /**
+     * Output a message showing the ordering of the discovered hams.
+     *
+     * @param multiHttpAuthenticationMechanisms is a list of hams.
+     */
+    private void logHttpAuthenticationMechanisms(Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms) {
+        // only log the output if debug tracing turned on
+        if (tc.isDebugEnabled() == false) {
+            return;
+        }
+        StringBuffer msg = new StringBuffer("Order of HttpAuthenticationMechanisms found (the first one will be used if its prioritization is unique - @Priority for application HAMs and HAM type - Oidc/CustomForm/Form/Basic - for in-built HAMs): ");
+        final String prioritySeperator = ", ";
+        for (MultiHttpAuthenticationMechanism httpAuthenticationMechanism : multiHttpAuthenticationMechanisms) {
+            String simpleName = httpAuthenticationMechanism.getSimpleName();
+            msg = msg.append(simpleName);
+            // don't output priority for in-built hams
+            if (hamClassPriorities.containsKey(simpleName) == false) {
+                msg = msg.append(" Priority = " + httpAuthenticationMechanism.getPriority());
+            }
+            msg = msg.append(prioritySeperator);
+        }
+        // remove trailing ", "
+        Tr.debug(tc, getApplicationName(), msg.toString().substring(0, msg.length() - prioritySeperator.length()));
+    }
+
+    /**
+     * Scans for all available HttpAuthenticationMechanism implementations.
+     *
+     * @param multiHttpAuthenticationMechanisms The set to populate with found mechanisms
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    protected void scanAuthenticationMechanisms(Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms) {
+
+        Instance<HttpAuthenticationMechanism> httpAuthenticationMechanismInstances = null;
+        CDI cdi = getCDI();
+
+        if (cdi != null) {
+            httpAuthenticationMechanismInstances = cdi.select(HttpAuthenticationMechanism.class);
+        }
+
+        if (httpAuthenticationMechanismInstances != null) {
+            for (HttpAuthenticationMechanism httpAuthenticationMechanismInstance : httpAuthenticationMechanismInstances) {
+                MultiHttpAuthenticationMechanism multiHttpAuthenticationMechanism = new MultiHttpAuthenticationMechanism(httpAuthenticationMechanismInstance);
+                multiHttpAuthenticationMechanisms.add(multiHttpAuthenticationMechanism);
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Found an HttpAuthenticationMechanism from CDI: "
+                                 + multiHttpAuthenticationMechanism.getSimpleName());
+                }
+            }
+        }
+
+        // If the mechanism is from the extension, then check the app's bean manager too
+        if (cdi != null && cdi.getBeanManager() != null && !cdi.getBeanManager().equals(CDIHelper.getBeanManager())) {
+            for (HttpAuthenticationMechanism mechanism : CDIHelper.getBeansFromCurrentModule(HttpAuthenticationMechanism.class)) {
+                MultiHttpAuthenticationMechanism multiHttpAuthenticationMechanism = new MultiHttpAuthenticationMechanism(mechanism);
+                multiHttpAuthenticationMechanisms.add(multiHttpAuthenticationMechanism);
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Found an HttpAuthenticationMechanism from module BeanManager: "
+                                 + multiHttpAuthenticationMechanism.getSimpleName());
+                }
+            }
+        }
+    }
+
+    /**
+     * Comparator for ordering HttpAuthenticationMechanism instances by priority.
+     * Highest priority values come first.
+     */
+    private final Comparator<MultiHttpAuthenticationMechanism> priorityComparator = new Comparator<MultiHttpAuthenticationMechanism>() {
+        @Override
+        public int compare(MultiHttpAuthenticationMechanism o1, MultiHttpAuthenticationMechanism o2) {
+
+            int result = -1;
+            if (o1.equals(o2)) {
+                result = 0;
+            } else {
+                int p1 = o1.getPriority();
+                int p2 = o2.getPriority();
+                if (p1 < p2) {
+                    result = 1;
+                }
+            }
+            return result;
+        }
+    };
+
+    /**
+     * Gets the current module name.
+     *
+     * @return The module name
+     */
+    protected String getModuleName() {
+        return ModulePropertiesUtils.getInstance().getJ2EEModuleName();
+    }
+
+    /**
+     * Gets the current application name.
+     *
+     * @return The module name
+     */
+    protected String getApplicationName() {
+        return ModulePropertiesUtils.getInstance().getJ2EEApplicationName();
+    }
+
+    /**
+     * Clears the authentication mechanism map.
+     * Used primarily for testing.
+     */
+    protected void clearAuthMechanismMap() {
+        authMechanismMap.clear();
+    }
+
+    /**
+     * Gets the CDI instance.
+     * This method can be overridden for testing.
+     *
+     * @return The CDI instance
+     */
+    protected CDI<?> getCDI() {
+        return CDI.current();
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/handlers/MultiHttpAuthenticationMechanism.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/handlers/MultiHttpAuthenticationMechanism.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.handlers;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+
+import jakarta.annotation.Priority;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Add Multi HAM specific functionality to the HttpAuthenticationMechanism (Form, Basic, etc ...)
+ * to augment (decorate) existing functionality.
+ *
+ * Only a single implementation/subclass of this Decorator pattern, so no need to make this class
+ * abstract and then extend it as we only have a single concrete subclass.
+ */
+public class MultiHttpAuthenticationMechanism implements HttpAuthenticationMechanism {
+
+    private HttpAuthenticationMechanism wrappedHttpAuthenticationMechanism;
+    private final String cachedSimpleName;
+
+    // ensure only the single-arg constructor can be used
+    @SuppressWarnings("unused")
+    private MultiHttpAuthenticationMechanism() {
+        cachedSimpleName = null;
+    }
+
+    public MultiHttpAuthenticationMechanism(HttpAuthenticationMechanism wrappedHttpAuthenticationMechanism) {
+        this.wrappedHttpAuthenticationMechanism = wrappedHttpAuthenticationMechanism;
+        this.cachedSimpleName = calculateSimpleName();
+    }
+
+    // interface methods from HttpAuthenticationMechanism to wrap
+    @Override
+    public AuthenticationStatus validateRequest(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
+                                                HttpMessageContext httpMessageContext) throws AuthenticationException {
+        return wrappedHttpAuthenticationMechanism.validateRequest(httpServletRequest, httpServletResponse, httpMessageContext);
+    }
+
+    @Override
+    public AuthenticationStatus secureResponse(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
+                                               HttpMessageContext httpMessageContext) throws AuthenticationException {
+        return wrappedHttpAuthenticationMechanism.secureResponse(httpServletRequest, httpServletResponse, httpMessageContext);
+    }
+
+    @Override
+    public void cleanSubject(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
+                             HttpMessageContext httpMessageContext) {
+        wrappedHttpAuthenticationMechanism.cleanSubject(httpServletRequest, httpServletResponse, httpMessageContext);
+    }
+
+    /**
+     * Get just the class name, minus the package, taking into account Proxies
+     * wrapping packages and class names.
+     *
+     * i.e. if the object class name is "com.foo.bar.foobar$23729$Proxy$_$$_WeldClientProxy",
+     * returned would be "foobar".
+     *
+     * @return a string with the class name only, or null if mechanism was null.
+     */
+
+    private String calculateSimpleName() {
+        if (wrappedHttpAuthenticationMechanism != null) {
+            String className = wrappedHttpAuthenticationMechanism.getClass().getSimpleName();
+            // Handle proxy classes that contain '$'
+            return className.split("\\$")[0];
+        }
+        return null;
+    }
+
+    // new methods to decorate/mix-in for multi HAM purposes
+
+    protected String getSimpleName() {
+        return cachedSimpleName;
+    }
+
+    /**
+     * Gets the priority value for an authentication mechanism.
+     *
+     * For in-built http authentication mechanisms, then there is a priority order
+     * defined by static class variable hamClassPriorities.
+     *
+     * For custom http authentication mechanisms, these should come above any in-built one,
+     * and if there are more than one custom http authentication mechanism, then
+     * the priority is used.
+     *
+     * @return The priority value (default is one greater than in-built ones to
+     *         ensure they are chosen over those).
+     */
+
+    protected int getPriority() {
+        if (wrappedHttpAuthenticationMechanism != null) {
+            String simpleName = getSimpleName();
+            Integer hamPriority = HttpAuthenticationMechanismHandlerImpl.hamClassPriorities.get(simpleName);
+            // first check for an in-built (i.e. Basic/Form/etc ...) HAM and get the fixed priorities
+            if (hamPriority != null) {
+                return hamPriority;
+            }
+
+            // must be an application HAM so extract @Priority value
+            Priority priority = getAnnotation(Priority.class);
+            if (priority != null) {
+                return priority.value();
+            }
+        }
+
+        // if no priority for application HAM, ensure it is greater than the built-in HAMs
+        // this could lead to two application HAMs having the same priority if not
+        //   explicitly specified, but a clear error message will show this situation,
+        //   and the user can set @Priority on the HAMs, or write their own custom HAM handler.
+        return (Collections.max(HttpAuthenticationMechanismHandlerImpl.hamClassPriorities.values())) + 1;
+    }
+
+    /**
+     * Generic(ish) function to return an annotation for a given annotation class.
+     * Looks up the class hierarchy to find the annotation in case the initial class
+     * is wrapped in a Proxy or similar.
+     *
+     * @param annotationClass is the annotated class to get the annotation for (i.e. Priority.class)
+     * @return the annotation itself, or null if not found.
+     */
+
+    private <A extends Annotation> A getAnnotation(final Class<A> annotationClass) {
+        if (wrappedHttpAuthenticationMechanism != null) {
+            Class<?> classType = wrappedHttpAuthenticationMechanism.getClass();
+            while (!classType.getName().equals(Object.class.getName())) {
+                if (classType.isAnnotationPresent(annotationClass)) {
+                    return classType.getAnnotation(annotationClass);
+                }
+                classType = classType.getSuperclass();
+            }
+        }
+        return null;
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/handlers/package-info.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/handlers/package-info.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
+package io.openliberty.security.jakartasec.handlers;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+
+import io.openliberty.security.jakartasec.TraceConstants;

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/IdentityStorePermissionService.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/IdentityStorePermissionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,9 +21,16 @@ public class IdentityStorePermissionService {
 
     private static final TraceComponent tc = Tr.register(IdentityStorePermissionService.class);
 
+    // static flag to ensure the debug message is logged only once
+    private static volatile boolean debugMessageLogged = false;
+
     public static void checkPermission(String name) {
-        if (tc.isDebugEnabled()) {
+        // **deliberately** functionally empty as this interface signature needs to be kept 
+        //   as is, to bypass this check in JS 4.0 when it is unconditionally invoked
+        //   from the identity stores credential validation code
+        if (!(debugMessageLogged) && tc.isDebugEnabled()) {
             Tr.debug(tc, "Using Jakarta Security 4.0+ implementation (no-op).");
+            debugMessageLogged = true;
         }
     }
 

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/services/HttpAuthenticationMechanismHandlerService.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/services/HttpAuthenticationMechanismHandlerService.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.services;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.javaeesec.CDIHelper;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanismHandler;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+
+/**
+ * Implementation for Jakarta Security 4.0, used by the AuthModule.
+ *
+ * This HAMHandler Service delegates the its methods to a HAMHandler
+ * (part of the Jakarta Security 4.0 specification) which actually determines
+ * which *single* HAM (from potentially multiple HAMs available) to use.
+ *
+ * It works very similar to the IdentityStoreHandler, but that handler
+ * gathers and *all* identity stores and fires methods on each, whereas the
+ * HAMHandler only uses a single HAM.
+ *
+ * Jakarta Security 4.0 (appSecurity-6.0) =
+ * io.openliberty.security.jakartasec.4.0.internal_1.0.<VER>.jar
+ *
+ */
+
+public class HttpAuthenticationMechanismHandlerService {
+
+    private static final TraceComponent tc = Tr.register(HttpAuthenticationMechanismHandlerService.class);
+
+    // cache the last logged handler name to avoid duplicate logging
+    private static volatile String lastLoggedHandlerName = null;
+
+    /**
+     * Logs the handler name only **to the debug output** if it's different
+     * from the last logged one.
+     *
+     * This handles application reloads where the handler instance may change.
+     *
+     * @param handler is the HttpAuthenticationMechanismHandler to log, cannot be null
+     */
+    private static void logHandlerToDebugIfChanged(HttpAuthenticationMechanismHandler handler) {
+        if (tc.isDebugEnabled()) {
+            String currentHandlerName = handler.getClass().getSimpleName().split("\\$")[0];
+            // only output if log handler name has changed
+            if (!currentHandlerName.equals(lastLoggedHandlerName)) {
+                Tr.debug(tc, "The HttpAuthenticationMechanismHandler being used is: " + currentHandlerName);
+                lastLoggedHandlerName = currentHandlerName;
+            }
+        }
+    }
+
+    /**
+     * Here to reduce repeated identical code and in the case we want to do something
+     * different when a handler is not found such as throw an exception.
+     */
+    private static AuthenticationStatus handleAuthMechNotFound() {
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, """
+                            An HttpAuthenticationMechanismHandler was not found within the application's bean manager or the CDI
+                            (or if it was found in the CDI, the handler was ambiguous or unsatisfied and couldn't be used).""");
+        }
+
+        return AuthenticationStatus.NOT_DONE;
+    }
+
+    /**
+     * Execute the validate request of the http authentication mechanism handler.
+     * The handler will fetch a single HAM and execute the functionality directly on the HAM.
+     *
+     * @param httpMessageContext is the calculated Http context
+     * @param authMech           ** Not used **
+     * @return the status of the secure response
+     * @throws AuthenticationException raised by the auth mechanism
+     */
+    public static AuthenticationStatus validateRequest(HttpMessageContext httpMessageContext,
+                                                       HttpAuthenticationMechanism authMech) throws AuthenticationException {
+        AuthenticationStatus authenticationStatus = AuthenticationStatus.NOT_DONE;
+        CDI<?> cdi = getCDI();
+        HttpAuthenticationMechanismHandler httpAuthenticationMechanismHandler = getHttpAuthenticationMechanismHandler(cdi);
+        if (httpAuthenticationMechanismHandler != null) {
+            logHandlerToDebugIfChanged(httpAuthenticationMechanismHandler);
+            authenticationStatus = httpAuthenticationMechanismHandler.validateRequest(httpMessageContext.getRequest(),
+                                                                                      httpMessageContext.getResponse(),
+                                                                                      httpMessageContext);
+        } else {
+            return handleAuthMechNotFound();
+        }
+
+        return authenticationStatus;
+    }
+
+    /**
+     * Execute the secure response functionality of the http authentication mechanism handler.
+     * The handler will fetch a single HAM and execute the functionality directly on the HAM.
+     *
+     * @param httpMessageContext is the calculated Http context
+     * @param authMech           ** Not used **
+     * @return the status of the secure response
+     * @throws AuthenticationException raised by the auth mechanism
+     */
+    public static AuthenticationStatus secureResponse(HttpMessageContext httpMessageContext,
+                                                      HttpAuthenticationMechanism authMech) throws AuthenticationException {
+        AuthenticationStatus authenticationStatus = AuthenticationStatus.NOT_DONE;
+        CDI<?> cdi = getCDI();
+        HttpAuthenticationMechanismHandler httpAuthenticationMechanismHandler = getHttpAuthenticationMechanismHandler(cdi);
+        if (httpAuthenticationMechanismHandler != null) {
+            logHandlerToDebugIfChanged(httpAuthenticationMechanismHandler);
+            authenticationStatus = httpAuthenticationMechanismHandler.secureResponse(httpMessageContext.getRequest(),
+                                                                                     httpMessageContext.getResponse(),
+                                                                                     httpMessageContext);
+        } else {
+            return handleAuthMechNotFound();
+        }
+
+        return authenticationStatus;
+    }
+
+    /**
+     * Execute the clean subject functionality of the http authentication mechanism handler.
+     * The handler will fetch a single HAM and execute the functionality directly on the HAM.
+     *
+     * NOTE: Unlike validateRequest() and secureResponse(), the http authentication mechanism
+     * handler does not throw any exceptions, hence none thrown here.
+     *
+     * @param httpMessageContext is the calculated Http context
+     * @param authMech           ** Not used **
+     * @return the status of the secure response
+     */
+
+    public static void cleanSubject(HttpMessageContext httpMessageContext, HttpAuthenticationMechanism authMech) {
+        CDI<?> cdi = getCDI();
+        HttpAuthenticationMechanismHandler httpAuthenticationMechanismHandler = getHttpAuthenticationMechanismHandler(cdi);
+        if (httpAuthenticationMechanismHandler != null) {
+            logHandlerToDebugIfChanged(httpAuthenticationMechanismHandler);
+            httpAuthenticationMechanismHandler.cleanSubject(httpMessageContext.getRequest(),
+                                                            httpMessageContext.getResponse(),
+                                                            httpMessageContext);
+        } else {
+            handleAuthMechNotFound(); // ignore return value not used in this flow
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static HttpAuthenticationMechanismHandler getHttpAuthenticationMechanismHandler(CDI cdi) {
+
+        HttpAuthenticationMechanismHandler httpAuthenticationMechanismHandler = null;
+        Instance<HttpAuthenticationMechanismHandler> httpAuthenticationMechanismHandlerInstance = cdi.select(HttpAuthenticationMechanismHandler.class);
+        if (httpAuthenticationMechanismHandlerInstance.isUnsatisfied() == false && httpAuthenticationMechanismHandlerInstance.isAmbiguous() == false) {
+            httpAuthenticationMechanismHandler = httpAuthenticationMechanismHandlerInstance.get();
+        }
+        // if the ham is from the extension, then the httpAuthenticationMechanismHandler from the application needs to be found using the app's bean manager.
+        if (httpAuthenticationMechanismHandler == null && cdi.getBeanManager().equals(CDIHelper.getBeanManager()) == false) {
+            httpAuthenticationMechanismHandler = (HttpAuthenticationMechanismHandler) CDIHelper.getBeanFromCurrentModule(HttpAuthenticationMechanismHandler.class);
+        }
+        return httpAuthenticationMechanismHandler;
+    }
+
+    /**
+     * Gets the CDI instance.
+     * This method can be overridden for testing.
+     *
+     * @return The CDI instance
+     */
+    protected static CDI<?> getCDI() {
+        return CDI.current();
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/services/JakartaSecurityValidationService.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/services/JakartaSecurityValidationService.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.services;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Implementation for Jakarta Security 4.0, providing
+ * functional services for components whose implementation or
+ * conditional evaluations that may be different for JS 1.0-3.0 than 4.0+.
+ *
+ * This whole bundle is only loaded for JS 4.0 (appSecurity 6.0).
+ * For pre-JS 4.0+ (appSecurity-1.0-5.0), another bundle is loaded with the
+ * same package name and class, but different implementations.
+ */
+
+public class JakartaSecurityValidationService {
+
+    private static final TraceComponent tc = Tr.register(JakartaSecurityValidationService.class);
+
+    // static flag to ensure the debug message is logged only once
+    private static volatile boolean debugMessageLogged = false;
+
+    /**
+     * Logs the implementation version message once across all
+     * methods which is useful debugging information.
+     */
+    private static void logImplementationOnce() {
+        if (!debugMessageLogged && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Using Jakarta Security 4.0+ implementation.");
+            debugMessageLogged = true;
+        }
+    }
+
+    /**
+     * Are we operating in a JS 4.0 environment or higher - avoiding
+     * costly operations with OSGi or class loading which may
+     * yield the same information.
+     *
+     * @return true if in a JS 4.0 environment or higher, false else.
+     *
+     */
+    public static boolean isJakartaSecurity40OrHigher() {
+        logImplementationOnce();
+        return true;
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/services/package-info.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/services/package-info.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
+package io.openliberty.security.jakartasec.services;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+
+import io.openliberty.security.jakartasec.TraceConstants;

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/test/io/openliberty/security/jakartasec/handlers/HttpAuthenticationMechanismHandlerImplTest.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/test/io/openliberty/security/jakartasec/handlers/HttpAuthenticationMechanismHandlerImplTest.java
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.handlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.context.SubjectManager;
+//import com.ibm.ws.security.javaeesec.cdi.beans.BasicHttpAuthenticationMechanism;
+
+import io.openliberty.security.jakartasec.handlers.wrappers.HttpAuthenticationMechanismHandlerWrapper;
+import io.openliberty.security.jakartasec.handlers.wrappers.MultiHttpAuthenticationMechanismWrapper;
+import jakarta.enterprise.inject.AmbiguousResolutionException;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Testing the HttpAuthenticationMechanismHandlerImpl class which implements the
+ * Jakarta Security 4.0 interface HttpAuthenticationMechanismHandler.
+ *
+ * NOTE: The implementation of validateRequest, cleanSubject and secureResponse are
+ * identical, so have only comprehensively tested validateRequest.
+ *
+ */
+public class HttpAuthenticationMechanismHandlerImplTest {
+
+    private final Mockery mockery = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private HttpMessageContext httpMessageContext;
+    private CDI<?> cdi;
+    private MultiHttpAuthenticationMechanism multiHttpAuthenticationMechanism;
+    private HttpAuthenticationMechanism httpAuthenticationMechanism;
+
+    private final SubjectManager subjectManager = new SubjectManager();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        cdi = mockery.mock(CDI.class);
+        request = mockery.mock(HttpServletRequest.class);
+        response = mockery.mock(HttpServletResponse.class);
+        httpMessageContext = mockery.mock(HttpMessageContext.class);
+        multiHttpAuthenticationMechanism = mockery.mock(MultiHttpAuthenticationMechanism.class);
+        httpAuthenticationMechanism = mockery.mock(HttpAuthenticationMechanism.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        subjectManager.clearSubjects();
+        mockery.assertIsSatisfied();
+    }
+
+    /**
+     * Test the happy case scenario, just ensuring
+     */
+    @Test
+    public void testValidateRequest_success() {
+        // given ...
+        AuthenticationStatus authenticationStatus = AuthenticationStatus.NOT_DONE;
+
+        // although a subclass, it only overrides methods for mocking
+        HttpAuthenticationMechanismHandlerWrapper mechanism = new HttpAuthenticationMechanismHandlerWrapper(cdi) {
+            @Override
+            protected MultiHttpAuthenticationMechanism getHighestPriorityHttpAuthenticationMechanism() {
+                return multiHttpAuthenticationMechanism;
+            }
+        };
+
+        // all expectations of actions on mocked objects
+        try {
+
+            mockery.checking(new Expectations() {
+                {
+                    allowing(multiHttpAuthenticationMechanism).validateRequest(with(any(HttpServletRequest.class)),
+                                                                               with(any(HttpServletResponse.class)),
+                                                                               with(any(HttpMessageContext.class)));
+                    will(returnValue(AuthenticationStatus.SUCCESS));
+                }
+            });
+
+            // when ...
+            authenticationStatus = mechanism.validateRequest(request, response, httpMessageContext);
+        } catch (Exception e) {
+            fail("Unexpected Exception " + e.getMessage() + " thrown.");
+        }
+
+        // then ...
+        assertEquals("The AuthenticationStatus must be SUCCESS.", AuthenticationStatus.SUCCESS, authenticationStatus);
+    }
+
+    /**
+     * Ensure that the SEND_FAILURE status is returned after an exception is generated
+     */
+    @Test
+    public void testValidateRequest_send_failure() {
+        // given ...
+        AuthenticationStatus authenticationStatus = AuthenticationStatus.NOT_DONE;
+
+        // although a subclass, it only overrides methods for mocking
+        HttpAuthenticationMechanismHandlerWrapper mechanism = new HttpAuthenticationMechanismHandlerWrapper(cdi) {
+            @Override
+            protected MultiHttpAuthenticationMechanism getHighestPriorityHttpAuthenticationMechanism() {
+                return multiHttpAuthenticationMechanism;
+            }
+        };
+
+        // all expectations of actions on mocked objects
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    oneOf(multiHttpAuthenticationMechanism).validateRequest(with(any(HttpServletRequest.class)),
+                                                                            with(any(HttpServletResponse.class)),
+                                                                            with(any(HttpMessageContext.class)));
+                    will(throwException(new AuthenticationException()));
+                }
+            });
+
+            // when ...
+            authenticationStatus = mechanism.validateRequest(request, response, httpMessageContext);
+        } catch (Exception e) {
+            fail("Unexpected Exception " + e.getMessage() + " thrown.");
+        }
+
+        // then ...
+        assertEquals("The AuthenticationStatus must be SEND_FAILURE.", AuthenticationStatus.SEND_FAILURE, authenticationStatus);
+    }
+
+    /**
+     * Ensure that the NOT_DONE status is returned if an HttpAuthenticationMechanism
+     * cannot be found
+     */
+    @Test
+    public void testValidateRequest_not_done() {
+        // given ...
+        AuthenticationStatus authenticationStatus = AuthenticationStatus.SUCCESS;
+
+        // although a subclass, it only overrides methods for mocking
+        // force getHighestPriorityAuthMechanism to return null to ensure correct status is returned
+        HttpAuthenticationMechanismHandlerWrapper mechanism = new HttpAuthenticationMechanismHandlerWrapper(cdi) {
+            @Override
+            protected MultiHttpAuthenticationMechanism getHighestPriorityHttpAuthenticationMechanism() {
+                return null;
+            }
+        };
+
+        // when ...
+        try {
+            authenticationStatus = mechanism.validateRequest(request, response, httpMessageContext);
+        } catch (Exception e) {
+            fail("Unexpected Exception " + e.getMessage() + " thrown.");
+        }
+
+        // then ...
+        assertEquals("The AuthenticationStatus must be NOT_DONE.", AuthenticationStatus.NOT_DONE, authenticationStatus);
+    }
+
+    @Test
+    public void testGetHighestPriorityHttpAuthenticationMechanism_with_application_ham() throws Exception {
+        // given ...
+
+        final MultiHttpAuthenticationMechanism expectedValue = getMultiHttpAuthenticationMechanism("ApplicationHttpAuthenticationMechanism");
+
+        try {
+            HttpAuthenticationMechanismHandlerWrapper mechanism = new HttpAuthenticationMechanismHandlerWrapper(cdi) {
+                @Override
+                protected void scanAuthenticationMechanisms(Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms) {
+                    multiHttpAuthenticationMechanisms.clear();
+
+                    multiHttpAuthenticationMechanisms.add(getMultiHttpAuthenticationMechanism("CustomFormAuthenticationMechanism"));
+                    multiHttpAuthenticationMechanisms.add(getMultiHttpAuthenticationMechanism("OidcHttpAuthenticationMechanism"));
+                    multiHttpAuthenticationMechanisms.add(getMultiHttpAuthenticationMechanism("FormAuthenticationMechanism"));
+                    multiHttpAuthenticationMechanisms.add(getMultiHttpAuthenticationMechanism("BasicHttpAuthenticationMechanism"));
+                    multiHttpAuthenticationMechanisms.add(expectedValue); // "ApplicationHttpAuthenticationMechanism"
+                }
+            };
+
+            // when ...
+            MultiHttpAuthenticationMechanism multiHttpAuthenticationMechanism = mechanism.getHighestPriorityHttpAuthenticationMechanism();
+
+            // then ...
+            assertEquals(multiHttpAuthenticationMechanism, expectedValue);
+        } catch (Exception e) {
+            fail("Unexpected Exception " + e.getMessage() + " thrown.");
+        }
+    }
+
+    @Test
+    public void testGetHighestPriorityHttpAuthenticationMechanism_in_built_hams() throws Exception {
+        // given ...
+        final MultiHttpAuthenticationMechanism expectedValue = getMultiHttpAuthenticationMechanism("OidcHttpAuthenticationMechanism");
+
+        try {
+            HttpAuthenticationMechanismHandlerWrapper mechanism = new HttpAuthenticationMechanismHandlerWrapper(cdi) {
+                @Override
+                protected void scanAuthenticationMechanisms(Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms) {
+                    multiHttpAuthenticationMechanisms.clear();
+
+                    multiHttpAuthenticationMechanisms.add(getMultiHttpAuthenticationMechanism("CustomFormAuthenticationMechanism"));
+                    multiHttpAuthenticationMechanisms.add(getMultiHttpAuthenticationMechanism("BasicHttpAuthenticationMechanism"));
+                    multiHttpAuthenticationMechanisms.add(getMultiHttpAuthenticationMechanism("FormAuthenticationMechanism"));
+                    multiHttpAuthenticationMechanisms.add(expectedValue);
+                }
+            };
+
+            // when ...
+            MultiHttpAuthenticationMechanism multiHttpAuthenticationMechanism = mechanism.getHighestPriorityHttpAuthenticationMechanism();
+
+            // then ...
+            assertEquals("Found: " + multiHttpAuthenticationMechanism.getSimpleName() + ", but expected: " + expectedValue.getSimpleName(), multiHttpAuthenticationMechanism,
+                         expectedValue);
+        } catch (Exception e) {
+            fail("Unexpected Exception " + e.getMessage() + " thrown.");
+        }
+    }
+
+    @Test(expected = AmbiguousResolutionException.class)
+    public void testGetHighestPriorityHttpAuthenticationMechanism_ambiguous_resolution_exception() throws Exception {
+        // given ...
+        String[] hamNames = { "ApplicationAuthenticationMechanism1",
+                              "ApplicationAuthenticationMechanism2",
+                              "ApplicationAuthenticationMechanism3" };
+        try {
+            HttpAuthenticationMechanismHandlerWrapper mechanism = new HttpAuthenticationMechanismHandlerWrapper(cdi) {
+                @Override
+                protected void scanAuthenticationMechanisms(Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms) {
+                    multiHttpAuthenticationMechanisms.clear();
+
+                    for (String name : hamNames) {
+                        multiHttpAuthenticationMechanisms.add(getMultiHttpAuthenticationMechanism(name));
+
+                    }
+                }
+            };
+
+            // when ...
+            MultiHttpAuthenticationMechanism multiHttpAuthenticationMechanism = mechanism.getHighestPriorityHttpAuthenticationMechanism();
+            fail("Expected AbiguousResolutionException, but getHighestPriorityHttpAuthenticationMechanism() returned a value.");
+
+            // then ...
+        } catch (AmbiguousResolutionException ae) {
+            assertTrue("Missing substring", ae.getMessage().contains("Unable to determine which HttpAuthenticationMechanism to handle request"));
+            assertTrue("Missing one or more HAM names", Arrays.asList(ae.getMessage().split(" ")).containsAll(Arrays.asList(hamNames)));
+
+            throw ae;
+        } catch (Exception e) {
+            fail("Unexpected Exception " + e.getMessage() + " thrown.");
+        }
+    }
+
+    private MultiHttpAuthenticationMechanism getMultiHttpAuthenticationMechanism(String hamName) {
+        return new MultiHttpAuthenticationMechanismWrapper(httpAuthenticationMechanism, hamName);
+    }
+
+    @Test
+    public void testGetHighestPriorityAuthMechanism_no_hams_found() throws Exception {
+
+        // although a subclass, it only overrides methods for mocking
+        HttpAuthenticationMechanismHandlerWrapper mechanism = new HttpAuthenticationMechanismHandlerWrapper(cdi) {
+            @Override
+            protected void scanAuthenticationMechanisms(Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms) {
+                multiHttpAuthenticationMechanisms.clear();
+            }
+        };
+
+        // all expectations of actions on mocked objects
+
+        try {
+            // when ...
+            HttpAuthenticationMechanism ham = mechanism.getHighestPriorityHttpAuthenticationMechanism();
+
+            // then ...
+            assertTrue(ham == null);
+        } catch (Exception e) {
+            fail("Unexpected Exception " + e.getMessage() + " thrown.");
+        }
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/test/io/openliberty/security/jakartasec/handlers/MultiHttpAuthenticationMechanismTest.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/test/io/openliberty/security/jakartasec/handlers/MultiHttpAuthenticationMechanismTest.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.handlers;
+
+import static org.junit.Assert.assertTrue;
+
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.context.SubjectManager;
+//import com.ibm.ws.security.javaeesec.cdi.beans.BasicHttpAuthenticationMechanism;
+
+import io.openliberty.security.jakartasec.handlers.wrappers.MultiHttpAuthenticationMechanismWrapper;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+
+/**
+ * Testing the MultiHttpAuthenticationMechanism class which simply adds
+ * Multi HAM specific functionality to the HttpAuthenticationMechanism
+ * (Form, Basic, etc ...) to augment (decorate) existing functionality.
+ *
+ */
+public class MultiHttpAuthenticationMechanismTest {
+
+    private final Mockery mockery = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+
+    private HttpAuthenticationMechanism httpAuthenticationMechanism;
+
+    private final SubjectManager subjectManager = new SubjectManager();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        httpAuthenticationMechanism = mockery.mock(HttpAuthenticationMechanism.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        subjectManager.clearSubjects();
+        mockery.assertIsSatisfied();
+    }
+
+    /**
+     * Ensure that all the in-built HAMs are ordered correctly, not worrying
+     * about the absolute priority values (as these could change), but about
+     * their relative (to each other) ordering.
+     *
+     * Also, ensure an application HAM (i.e. not an in-built one) has the highest
+     * priority.
+     *
+     * @throws AuthenticationException
+     */
+
+    @Test
+    public void testGetPriority() throws Exception {
+        // given/when ...
+        int customFormPriority = getPriority("CustomFormAuthenticationMechanism");
+        int oidcPriority = getPriority("OidcHttpAuthenticationMechanism");
+        int formPriority = getPriority("FormAuthenticationMechanism");
+        int basicPriority = getPriority("BasicHttpAuthenticationMechanism");
+        int applicationPriority = getPriority(null);
+
+        // then
+        assertTrue("Expected BasicHttpAuthenticationMechanism to be lower than FormAuthenticationMechanism.",
+                   basicPriority < formPriority);
+        assertTrue("Expected FormAuthenticationMechanism to be lower than CustomFormAuthenticationMechanism.",
+                   formPriority < customFormPriority);
+        assertTrue("Expected CustomFormAuthenticationMechanism to be lower than OidcAuthenticationMechanism.",
+                   customFormPriority < oidcPriority);
+        assertTrue("Expected OidcAuthenticationMechanism to be lower any application defined one.",
+                   oidcPriority < applicationPriority);
+    }
+
+    private int getPriority(String hamName) {
+        return new MultiHttpAuthenticationMechanismWrapper(httpAuthenticationMechanism, hamName).getPriority();
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/test/io/openliberty/security/jakartasec/handlers/wrappers/HttpAuthenticationMechanismHandlerWrapper.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/test/io/openliberty/security/jakartasec/handlers/wrappers/HttpAuthenticationMechanismHandlerWrapper.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.handlers.wrappers;
+
+import io.openliberty.security.jakartasec.handlers.HttpAuthenticationMechanismHandlerImpl;
+import jakarta.enterprise.inject.spi.CDI;
+
+/**
+ * A subclass so of HttpAuthenticationMechanismHandlerImpl so we can override internal methods
+ * which return objects/components we can't easily mock.
+ */
+
+public class HttpAuthenticationMechanismHandlerWrapper extends HttpAuthenticationMechanismHandlerImpl {
+
+    private final String APPLICATION_NAME = "io.openliberty.security.jakartasec.handlers.HttpAuthenticationMechanismHandlerImplTest";
+    private final String MODULE_NAME = "HAMHandlerImplTest.war";
+
+    private CDI<?> cdi;
+
+    @SuppressWarnings("unused")
+    private HttpAuthenticationMechanismHandlerWrapper() {
+    }
+
+    public HttpAuthenticationMechanismHandlerWrapper(CDI<?> cdi) {
+        super();
+        this.cdi = cdi;
+    }
+
+    @Override
+    protected CDI<?> getCDI() {
+        return cdi;
+    }
+
+    @Override
+    protected String getModuleName() {
+        return MODULE_NAME;
+    }
+
+    @Override
+    protected String getApplicationName() {
+        // the implementation of getApplicationName() uses ModulePropertiesUtils() which
+        //   is very difficult to mock, as it drags in many other classes
+        return APPLICATION_NAME;
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/test/io/openliberty/security/jakartasec/handlers/wrappers/MultiHttpAuthenticationMechanismWrapper.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/test/io/openliberty/security/jakartasec/handlers/wrappers/MultiHttpAuthenticationMechanismWrapper.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.handlers.wrappers;
+
+import io.openliberty.security.jakartasec.handlers.MultiHttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+
+/**
+ * A subclass wrapper so of MultiHttpAuthenticationMechanism so we can override internal methods
+ * which return objects/components we can't easily mock.
+ */
+
+public class MultiHttpAuthenticationMechanismWrapper extends MultiHttpAuthenticationMechanism {
+
+    private String simpleName = null;
+
+    /**
+     * @param wrappedHttpAuthenticationMechanism
+     */
+    public MultiHttpAuthenticationMechanismWrapper(HttpAuthenticationMechanism wrappedHttpAuthenticationMechanism, String simpleName) {
+        super(wrappedHttpAuthenticationMechanism);
+        this.simpleName = simpleName;
+    }
+
+    @Override
+    public String getSimpleName() {
+        return this.simpleName;
+    }
+
+    @Override
+    public int getPriority() {
+        return super.getPriority();
+    }
+}

--- a/dev/io.openliberty.security.javaeesec.internal/bnd.bnd
+++ b/dev/io.openliberty.security.javaeesec.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2025 IBM Corporation and others.
+# Copyright (c) 2025, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -19,7 +19,8 @@ WS-TraceGroup: \
   SECURITYJAVAEE
 
 Export-Package: \
-  io.openliberty.security.jakartasec.identitystore.permissions
+  io.openliberty.security.jakartasec.identitystore.permissions,\
+  io.openliberty.security.jakartasec.services
   
 -buildpath: \
   com.ibm.websphere.javaee.security.1.0;version=latest,\
@@ -27,5 +28,5 @@ Export-Package: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.logging;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\
-  com.ibm.websphere.org.osgi.core;version=latest
-
+  com.ibm.websphere.org.osgi.core;version=latest,\
+  com.ibm.websphere.javaee.servlet.4.0;version=latest

--- a/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/IdentityStorePermissionService.java
+++ b/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/identitystore/permissions/IdentityStorePermissionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,6 @@
 package io.openliberty.security.jakartasec.identitystore.permissions;
 
 import javax.security.enterprise.identitystore.IdentityStorePermission;
-
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -40,10 +37,14 @@ public class IdentityStorePermissionService {
 
     private static final TraceComponent tc = Tr.register(IdentityStorePermissionService.class);
 
+    // static flag to ensure the debug message is logged only once
+    private static volatile boolean debugMessageLogged = false;
+
     @SuppressWarnings("deprecation")
     public static void checkPermission(String name) {
-        if (tc.isDebugEnabled()) {
+        if (!(debugMessageLogged) && tc.isDebugEnabled()) {
             Tr.debug(tc, "Using Jakarta Security 1.0/2.0/3.0 implementation.");
+            debugMessageLogged = true;
         }
         SecurityManager securityManager = System.getSecurityManager();
         if (securityManager != null) {

--- a/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/services/HttpAuthenticationMechanismHandlerService.java
+++ b/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/services/HttpAuthenticationMechanismHandlerService.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.services;
+
+import javax.security.enterprise.AuthenticationException;
+import javax.security.enterprise.AuthenticationStatus;
+import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Implementation for Jakarta Security 1.0, 2.0 and 3.0, used by the AuthModule.
+ *
+ * This Handler Service executes the exact same functionality as prior to
+ * Jakarta Security 4.0, but simply abstracts it so that this service can be
+ * rewritten for Jakarta Security 4.0, but the integration (with AuthModule)
+ * therefore remains unchanged.
+ *
+ * NOTE: For the Jakarta Security 2.0 and 3.0 implementations, they will
+ * use the this *same* bundle but transformed for jakarta instead of javax.
+ *
+ */
+
+public class HttpAuthenticationMechanismHandlerService {
+
+    private static final TraceComponent tc = Tr.register(HttpAuthenticationMechanismHandlerService.class);
+    
+    // static flag to ensure the debug message is logged only once
+    private static volatile boolean debugMessageLogged = false;
+
+    /**
+     * Logs the implementation version message once across all methods which is useful debugging information.
+     */
+    private static void logImplementationOnce() {
+        if (!debugMessageLogged && tc.isDebugEnabled()) {
+        	Tr.debug(tc, "Using Jakarta Security 1.0/2.0/3.0 implementation.");
+        	debugMessageLogged = true;
+        }
+    }
+
+    /**
+     * Validate an authentication request.  Simply uses the passed authentication mechanism to
+     * perform the actual request.
+     *
+     * @param httpMessageContext is the calculated Http context
+     * @param authMech is the authentication mechanism
+     * @return the status of the validate request.
+     * @throws AuthenticationException raised by the auth mechanism
+     */
+	public static AuthenticationStatus validateRequest(HttpMessageContext httpMessageContext,
+	                                                    HttpAuthenticationMechanism authMech) throws AuthenticationException {
+		
+		logImplementationOnce();
+        AuthenticationStatus authenticationStatus = authMech.validateRequest(httpMessageContext.getRequest(),
+                                                                             httpMessageContext.getResponse(),
+                                                                             httpMessageContext);
+        return authenticationStatus;
+	}
+
+    /**
+     * Execute the secure response functionality of a passed authentication mechanism.
+     *
+     * @param httpMessageContext is the calculated Http context
+     * @param authMech is the authentication mechanism
+     * @return the status of the secure response
+     * @throws AuthenticationException raised by the auth mechanism
+     */
+	public static AuthenticationStatus secureResponse(HttpMessageContext httpMessageContext,
+            HttpAuthenticationMechanism authMech) throws AuthenticationException {
+		logImplementationOnce();
+		AuthenticationStatus authenticationStatus = authMech.secureResponse(httpMessageContext.getRequest(),
+                                                                            httpMessageContext.getResponse(),
+                                                                            httpMessageContext);
+		return authenticationStatus;
+	}
+
+    /**
+     * Execute the clean subject functionality of a passed authentication mechanism.
+     *
+     * @param httpMessageContext is the calculated Http context
+     * @param authMech is the authentication mechanism
+     * @return the status of the clean subject
+     * @throws AuthenticationException raised by the auth mechanism
+     */
+	public static void cleanSubject(HttpMessageContext httpMessageContext,
+	                                 HttpAuthenticationMechanism authMech) {
+		logImplementationOnce();
+        authMech.cleanSubject(httpMessageContext.getRequest(), httpMessageContext.getResponse(), httpMessageContext);
+	}
+}

--- a/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/services/JakartaSecurityValidationService.java
+++ b/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/services/JakartaSecurityValidationService.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.services;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Implementation for Jakarta Security 1.0, 2.0 and 3.0, providing 
+ * functional services for components whose implementation or 
+ * conditional evaluations that may be different for JS 1.0-3.0 than 4.0+.
+ * 
+ * This whole bundle is only loaded for JS 1.0-3.0 (appSecurity 1.0-5.0).
+ * For JS 4.0+ (appSecurity-6.0), another bundle is loaded with the 
+ * same package name and class, but different implementations.
+ */
+
+public class JakartaSecurityValidationService {
+
+    private static final TraceComponent tc = Tr.register(JakartaSecurityValidationService.class);
+    
+    // static flag to ensure the debug message is logged only once
+    private static volatile boolean debugMessageLogged = false;
+
+    /**
+     * Logs the implementation version message once across all 
+     * methods which is useful debugging information.
+     */
+    private static void logImplementationOnce() {
+        if (!debugMessageLogged && tc.isDebugEnabled()) {
+        	Tr.debug(tc, "Using Jakarta Security 1.0/2.0/3.0 implementation.");
+        	debugMessageLogged = true;
+        }
+    }
+    
+    /**
+     * Are we operating in a JS 4.0 environment or higher - avoiding
+     * costly operations with OSGi or class loading which may
+     * yield the same information.
+     *
+     * @return true if in a JS 4.0 environment or higher, false else.
+     */
+    public static boolean isJakartaSecurity40OrHigher() {
+    	logImplementationOnce();
+    	return false;
+    }
+}

--- a/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/services/package-info.java
+++ b/dev/io.openliberty.security.javaeesec.internal/src/io/openliberty/security/jakartasec/services/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = "security", messageBundle = "com.ibm.ws.security.javaeesec.internal.resources.JavaEESecMessages")
+package io.openliberty.security.jakartasec.services;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+


### PR DESCRIPTION
HttpAuthenticationMechanisms.

All functionality works for Jakarta Security 1/2/3.0 and 4.0.

A new service called HttpAuthenticationMechanismHandlerService was inserted into AuthModule for the interface methods validateRequest, cleanSubject and secureResponse.

The HAMHandlerService is fetched from the OSGi, and differs for Jakarta Security 1/2/3.0 and 4.0.

For Jakarta Security 1/2/3.0, the HAMHandlerService implements the identical functionality as previous for the methods methods above.

For Jakarta Security 4.0, the HAMHandlerService finds the implementation ( in-built or application specified ) of the
HttpAuthenticationmechansimHandler interface ( this is Jakarta 4.0 specified ) from the CDI, and defers to this implementation to execute the methods above.

For Jakarta Security 4.0, an additional completely internal HAM handler is created also with the @Alternative annotation to ensure the check for multiple HAM Handlers is skipped ( as per the specification ).

Fixes #32464

- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
