### PR TITLE
Add waits to Jakarta Security FATs to ensure LTPA Configuration to complete

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/sharedTests/BasicOIDCAnnotationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/sharedTests/BasicOIDCAnnotationTests.java
@@ -93,6 +93,10 @@ public class BasicOIDCAnnotationTests extends CommonAnnotatedSecurityTests {
 
         // rspValues used to validate the app output will be initialized before each test - any unique values (other than the
         //  app need to be updated by the test case - the app is updated by the invokeApp* methods)
+
+        // Wait to ensure LTPA configuration has completed before starting tests.
+        opServer.waitForStringInLog("CWWKS4105I");
+        rpServer.waitForStringInLog("CWWKS4105I");
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationEndpointValidationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationEndpointValidationTests.java
@@ -94,6 +94,10 @@ public class AuthenticationEndpointValidationTests extends CommonAnnotatedSecuri
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        // Wait to ensure LTPA configuration has completed before starting tests.
+        opServer.waitForStringInLog("CWWKS4105I");
+        rpServer.waitForStringInLog("CWWKS4105I");
+
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationTests.java
@@ -121,6 +121,10 @@ public class AuthenticationTests extends CommonAnnotatedSecurityTests {
 
         // Allow error messages that are issued because the app tries to log information that may not be set
         rpServer.addIgnoredErrors(Arrays.asList(MessageConstants.SESN0066E_RSP_COMMITTED_COOKIE_CANNOT_BE_SET, MessageConstants.SRVE8114W_CANNOT_SET_SESSION_COOKIE));
+
+        // Wait to ensure LTPA configuration has completed before starting tests
+        opServer.waitForStringInLog("CWWKS4105I");
+        rpServer.waitForStringInLog("CWWKS4105I");
         // rspValues used to validate the app output will be initialized before each test - any unique values (other than the
         //  app need to be updated by the test case - the app is updated by the invokeApp* methods)
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/IdentityStoreTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/IdentityStoreTests.java
@@ -84,6 +84,10 @@ public class IdentityStoreTests extends CommonAnnotatedSecurityTests {
 
         deployMyApps();
 
+        // Wait to ensure LTPA configuration has completed before starting tests
+        opServer.waitForStringInLog("CWWKS4105I");
+        rpServer.waitForStringInLog("CWWKS4105I");
+
         // rspValues used to validate the app output will be initialized before each test - any unique values (other than the
         //  app need to be updated by the test case - the app is updated by the invokeApp* methods)
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InjectionScopedTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InjectionScopedTests.java
@@ -82,6 +82,10 @@ public class InjectionScopedTests extends CommonAnnotatedSecurityTests {
 
         deployMyApps();
 
+        // Wait to ensure LTPA configuration has completed before starting tests
+        opServer.waitForStringInLog("CWWKS4105I");
+        rpServer.waitForStringInLog("CWWKS4105I");
+
         // rspValues used to validate the app output will be initialized before each test - any unique values (other than the
         //  app need to be updated by the test case - the app is updated by the invokeApp* methods)
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/TokenValidationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/TokenValidationTests.java
@@ -120,6 +120,10 @@ public class TokenValidationTests extends CommonAnnotatedSecurityTests {
         opServer.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKS1617E_USERINFO_REQUEST_BAD_TOKEN));
         deployMyApps();
 
+        // Wait to ensure LTPA configuration has completed before starting tests
+        opServer.waitForStringInLog("CWWKS4105I");
+        rpServer.waitForStringInLog("CWWKS4105I");
+
     }
 
     /**


### PR DESCRIPTION
Tests are failing as they are running before LTPA Configuration completes. Seen only on Windows. where sometimes the LTPA configuration can take ~30 seconds to complete based on available logs.

Wait for both OP and RP servers to state that LTPA configuration has completed before running any of the tests.

Do this after deploying the applications to reduce the time it should be waiting for.

Resolves RTC 306358

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".