### PR TITLE
Fix ConcurrentModificationException in EJB Timer FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/test-applications/AutoNPTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/auto/npTimer/ejb/AutoCreatedTimerABean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/test-applications/AutoNPTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/auto/npTimer/ejb/AutoCreatedTimerABean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,10 +13,10 @@
 
 package com.ibm.ws.ejbcontainer.timer.auto.npTimer.ejb;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -40,52 +40,52 @@ public class AutoCreatedTimerABean {
 
     public static String SECONDS_EXACT = "seconds_exact";
     public static volatile int seconds_exact_count = 0;
-    public static ArrayList<Long> seconds_exact_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> seconds_exact_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> seconds_exact_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> seconds_exact_next = new CopyOnWriteArrayList<Long>();
 
     public static String SECONDS_INTERVAL = "seconds_interval";
     public static volatile int seconds_interval_count = 0;
-    public static ArrayList<Long> seconds_interval_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> seconds_interval_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> seconds_interval_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> seconds_interval_next = new CopyOnWriteArrayList<Long>();
 
     public static String MINUTES_INTERVAL = "minutes_interval";
     public static volatile int minutes_interval_count = 0;
-    public static ArrayList<Long> minutes_interval_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> minutes_interval_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> minutes_interval_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> minutes_interval_next = new CopyOnWriteArrayList<Long>();
 
     public static String MONTH_RANGE = "month_range";
     public static volatile int month_range_count = 0;
-    public static ArrayList<Long> month_range_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> month_range_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> month_range_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> month_range_next = new CopyOnWriteArrayList<Long>();
 
     public static String RANGE_AND_LIST = "range_and_list";
     public static volatile int range_and_list_count = 0;
-    public static ArrayList<Long> range_and_list_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> range_and_list_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> range_and_list_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> range_and_list_next = new CopyOnWriteArrayList<Long>();
 
     public static final String MULTIPLE_ATTRIBUTES_COMBINED = "multiple_attributes_combined";
     public static volatile int multiple_attributes_combined_count = 0;
-    public static ArrayList<Long> multiple_attributes_combined_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> multiple_attributes_combined_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> multiple_attributes_combined_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> multiple_attributes_combined_next = new CopyOnWriteArrayList<Long>();
 
     public static final String FIRST_SCHEDULE = "first_schedule";
     public static volatile int first_schedule_count = 0;
-    public static ArrayList<Long> first_schedule_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> first_schedule_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> first_schedule_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> first_schedule_next = new CopyOnWriteArrayList<Long>();
 
     public static final String SECOND_SCHEDULE = "second_schedule";
     public static volatile int second_schedule_count = 0;
-    public static ArrayList<Long> second_schedule_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> second_schedule_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> second_schedule_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> second_schedule_next = new CopyOnWriteArrayList<Long>();
 
     public static final String THIRD_SCHEDULE = "third_schedule";
     public static volatile int third_schedule_count = 0;
-    public static ArrayList<Long> third_schedule_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> third_schedule_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> third_schedule_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> third_schedule_next = new CopyOnWriteArrayList<Long>();
 
     public static final String PROGRAMATIC_TIMEOUT = "programatic_timeout";
     public static volatile int programatic_count = 0;
-    public static ArrayList<Long> programatic_timestamps = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> programatic_timestamps = new CopyOnWriteArrayList<Long>();
     private static CountDownLatch svProgramaticTimerLatch = new CountDownLatch(1);
 
     public static final String MINUTES_EXACT = "minutes_exact";

--- a/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/test-applications/AutoNPTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/auto/npTimer/ejb/AutoCreatedTimerSSBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/test-applications/AutoNPTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/auto/npTimer/ejb/AutoCreatedTimerSSBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,10 +13,10 @@
 
 package com.ibm.ws.ejbcontainer.timer.auto.npTimer.ejb;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Logger;
 
 import javax.annotation.PostConstruct;
@@ -38,7 +38,7 @@ public class AutoCreatedTimerSSBean {
 
     public static final String SINGLETON_STARTUP = "singleton_startup";
     public static volatile int singleton_startup_count = 0;
-    public static ArrayList<Long> singleton_startup_timestamps = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> singleton_startup_timestamps = new CopyOnWriteArrayList<Long>();
 
     public static boolean foundTimer = false;
 

--- a/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/test-applications/AutoNPTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/auto/npTimer/ejb/AutoCreatedTimerXBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/test-applications/AutoNPTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/auto/npTimer/ejb/AutoCreatedTimerXBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -13,10 +13,10 @@
 
 package com.ibm.ws.ejbcontainer.timer.auto.npTimer.ejb;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Logger;
 
 import javax.annotation.Resource;
@@ -30,37 +30,37 @@ public class AutoCreatedTimerXBean {
 
     public static String SECONDS_RANGE = "seconds_range";
     public static volatile int seconds_range_count = 0;
-    public static ArrayList<Long> seconds_range_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> seconds_range_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> seconds_range_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> seconds_range_next = new CopyOnWriteArrayList<Long>();
 
     public static String SECONDS_LIST = "seconds_list";
     public static volatile int seconds_list_count = 0;
-    public static ArrayList<Long> seconds_list_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> seconds_list_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> seconds_list_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> seconds_list_next = new CopyOnWriteArrayList<Long>();
 
     public static String MINUTES_RANGE = "minutes_range";
     public static volatile int minutes_range_count = 0;
-    public static ArrayList<Long> minutes_range_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> minutes_range_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> minutes_range_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> minutes_range_next = new CopyOnWriteArrayList<Long>();
 
     public static String MULTIPLE_SETTINGS_DONT_CONFLICT = "multipleSettingsDontConflict";
     public static volatile int multiple_settings_count = 0;
-    public static ArrayList<Long> multiple_settings_timestamps = new ArrayList<Long>();
-    public static ArrayList<Long> multiple_settings_next = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> multiple_settings_timestamps = new CopyOnWriteArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> multiple_settings_next = new CopyOnWriteArrayList<Long>();
 
     public static String START_GATE = "startGate";
     public static volatile int start_gate_count = 0;
-    public static ArrayList<Long> start_gate_timestamps = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> start_gate_timestamps = new CopyOnWriteArrayList<Long>();
 
     public static String STOP_GATE = "stopGate";
     public static volatile int stop_gate_count = 0;
-    public static ArrayList<Long> stop_gate_timestamps = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> stop_gate_timestamps = new CopyOnWriteArrayList<Long>();
 
     // begin F743-16271
     public static String TIME_ZONE = "timeZone";
     public static String time_zone_zone = "uninitialized";
     public static volatile int time_zone_count = 0;
-    public static ArrayList<Long> time_zone_timestamps = new ArrayList<Long>();
+    public static CopyOnWriteArrayList<Long> time_zone_timestamps = new CopyOnWriteArrayList<Long>();
     // end F743-16271
 
     public static String MINUTES_LIST = "minutes_list";

--- a/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/test-applications/AutoNPTimersWeb.war/src/com/ibm/ws/ejbcontainer/timer/auto/npTimer/web/AutoCreatedNPTimerServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/test-applications/AutoNPTimersWeb.war/src/com/ibm/ws/ejbcontainer/timer/auto/npTimer/web/AutoCreatedNPTimerServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -23,6 +23,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 
@@ -258,7 +259,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
         }
     }
 
-    private boolean verifyNextTimeoutsInterval(ArrayList<Long> nextTimeouts, long firstOffset, long interval) {
+    private boolean verifyNextTimeoutsInterval(List<Long> nextTimeouts, long firstOffset, long interval) {
         if (nextTimeouts == null) {
             svLogger.info("The next timeout list for the timer was null.");
             return false;
@@ -282,7 +283,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
         return true;
     }
 
-    private boolean verifyNextTimeoutsRange(ArrayList<Long> nextTimeouts, long firstOffset, long interval, long range, long rangeInterval) {
+    private boolean verifyNextTimeoutsRange(List<Long> nextTimeouts, long firstOffset, long interval, long range, long rangeInterval) {
         if (nextTimeouts == null) {
             svLogger.info("The next timeout list for the timer was null.");
             return false;
@@ -371,7 +372,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties props = driverBean.getTimeoutResults(AutoCreatedTimerABean.SECONDS_EXACT);
         int count = ((Integer) props.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts = (ArrayList<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts = (List<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         boolean validTimeoutCount = verifyAttemptsIsAcceptable(count, 4);
         boolean validNextTimeouts = verifyNextTimeoutsInterval(nextTimeouts, 30 * 1000, 60 * 1000);
@@ -389,7 +390,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties props = driverBean.getTimeoutResults(AutoCreatedTimerXBean.SECONDS_RANGE);
         int count = ((Integer) props.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts = (ArrayList<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts = (List<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         boolean validTimeoutCount = verifyAttemptsIsAcceptable(count, 15);
         boolean validNextTimeouts = verifyNextTimeoutsRange(nextTimeouts, 30 * 1000, 60 * 1000, 7, 1000);
@@ -407,7 +408,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties props = driverBean.getTimeoutResults(AutoCreatedTimerABean.SECONDS_INTERVAL);
         int count = ((Integer) props.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts = (ArrayList<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts = (List<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         boolean validTimeoutCount = verifyAttemptsIsAcceptable(count, 12);
         boolean validNextTimeouts = verifyNextTimeoutsRange(nextTimeouts, 30 * 1000, 60 * 1000, 3, 10 * 1000);
@@ -425,7 +426,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties props = driverBean.getTimeoutResults(AutoCreatedTimerXBean.SECONDS_LIST);
         int count = ((Integer) props.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts = (ArrayList<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts = (List<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         boolean validTimeoutCount = verifyAttemptsIsAcceptable(count, 9);
         boolean validNextTimeouts = verifyNextTimeoutsRange(nextTimeouts, 35 * 1000, 60 * 1000, 3, 10 * 1000);
@@ -477,7 +478,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties props = driverBean.getTimeoutResults(AutoCreatedTimerABean.MINUTES_INTERVAL);
         int count = ((Integer) props.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts = (ArrayList<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts = (List<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         boolean validTimeoutCount = verifyAttemptsIsAcceptable(count, 4);
         boolean validNextTimeouts = verifyNextTimeoutsInterval(nextTimeouts, 60 * 1000, 60 * 1000);
@@ -495,7 +496,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties props = driverBean.getTimeoutResults(AutoCreatedTimerXBean.MINUTES_RANGE);
         int count = ((Integer) props.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts = (ArrayList<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts = (List<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         boolean validTimeoutCount = verifyAttemptsIsAcceptable(count, 4);
         boolean validNextTimeouts = verifyNextTimeoutsRange(nextTimeouts, 60 * 1000, 60 * 60 * 1000, 59, 60 * 1000);
@@ -924,7 +925,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties props = driverBean.getTimeoutResults(AutoCreatedTimerABean.MONTH_RANGE);
         int count = ((Integer) props.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts = (ArrayList<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts = (List<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         boolean validTimeoutCount = verifyAttemptsIsAcceptable(count, 3);
         boolean validNextTimeouts = verifyNextTimeoutsInterval(nextTimeouts, 60 * 1000, 60 * 1000);
@@ -1182,7 +1183,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties props = driverBean.getTimeoutResults(AutoCreatedTimerXBean.MULTIPLE_SETTINGS_DONT_CONFLICT);
         int count = ((Integer) props.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts = (ArrayList<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts = (List<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         boolean validTimeoutCount = verifyAttemptsIsAcceptable(count, 3);
         boolean validNextTimeouts = verifyNextTimeoutsInterval(nextTimeouts, 60 * 1000, 60 * 1000);
@@ -1200,7 +1201,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties props = driverBean.getTimeoutResults(AutoCreatedTimerABean.RANGE_AND_LIST);
         int count = ((Integer) props.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts = (ArrayList<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts = (List<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         boolean validTimeoutCount = verifyAttemptsIsAcceptable(count, 3);
         boolean validNextTimeouts = verifyNextTimeoutsInterval(nextTimeouts, 60 * 1000, 60 * 1000);
@@ -1219,7 +1220,7 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties props = driverBean.getTimeoutResults(AutoCreatedTimerABean.MULTIPLE_ATTRIBUTES_COMBINED);
         int count = ((Integer) props.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts = (ArrayList<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts = (List<Long>) props.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         boolean validTimeoutCount = verifyAttemptsIsAcceptable(count, 2);
         boolean validNextTimeouts = verifyNextTimeoutsInterval(nextTimeouts, 30 * 1000, 2 * 60 * 1000);
@@ -1240,15 +1241,15 @@ public class AutoCreatedNPTimerServlet extends AbstractServlet {
 
         Properties firstProps = driverBean.getTimeoutResults(AutoCreatedTimerABean.FIRST_SCHEDULE);
         int count1 = ((Integer) firstProps.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts1 = (ArrayList<Long>) firstProps.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts1 = (List<Long>) firstProps.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         Properties secondProps = driverBean.getTimeoutResults(AutoCreatedTimerABean.SECOND_SCHEDULE);
         int count2 = ((Integer) secondProps.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts2 = (ArrayList<Long>) secondProps.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts2 = (List<Long>) secondProps.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         Properties thirdProps = driverBean.getTimeoutResults(AutoCreatedTimerABean.THIRD_SCHEDULE);
         int count3 = ((Integer) thirdProps.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();
-        ArrayList<Long> nextTimeouts3 = (ArrayList<Long>) thirdProps.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
+        List<Long> nextTimeouts3 = (List<Long>) thirdProps.get(AutoCreatedTimerDriverBean.NEXT_TIMEOUT_KEY);
 
         Properties fourthProps = driverBean.getTimeoutResults(AutoCreatedTimerABean.PROGRAMATIC_TIMEOUT);
         int count4 = ((Integer) fourthProps.get(AutoCreatedTimerDriverBean.COUNT_KEY)).intValue();


### PR DESCRIPTION
- replace use of ArrayList with CopyOnWriteArrayList to allow for-each while timers are running

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".