### PR TITLE
Add Oracle 23 support for JPA 2.1

### DIFF
--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
@@ -130,10 +130,9 @@ publish.wlp.jar.suffix: dev/api/third-party
 
 -pedantic: false
 
-instrument.classesExcludes: \
-  org/eclipse/persistence/exceptions/i18n/*.class, \
-  org/eclipse/persistence/internal/localization/i18n/*.class, \
-  org/eclipse/persistence/internal/helper/*.class
+# Exclude this bundle from instrumentation (RAS & FFDC trace injection)
+instrument.disabled: true
+instrument.ffdc: false
 
 -buildpath: \
     com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.core;version=${eclFullVersion};strategy=exact,\

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
@@ -118,7 +118,13 @@ Include-Resource: \
   @${repo;com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa.jpql;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   @${repo;com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   @${repo;com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
-  org/eclipse/persistence/internal/helper=${bin}/org/eclipse/persistence/internal/helper
+  org/eclipse/persistence/internal/helper=${bin}/org/eclipse/persistence/internal/helper,\
+  org/eclipse/persistence/internal/core/databaseaccess=${bin}/org/eclipse/persistence/internal/core/databaseaccess,\
+  org/eclipse/persistence/internal/databaseaccess=${bin}/org/eclipse/persistence/internal/databaseaccess,\
+  org/eclipse/persistence/mappings/converters=${bin}/org/eclipse/persistence/mappings/converters,\
+  org/eclipse/persistence/platform/database=${bin}/org/eclipse/persistence/platform/database,\
+  org/eclipse/persistence/platform/database/oracle/plsql=${bin}/org/eclipse/persistence/platform/database/oracle/plsql,\
+  org/eclipse/persistence/internal/jpa/metadata/converters=${bin}/org/eclipse/persistence/internal/jpa/metadata/converters
 
 publish.wlp.jar.suffix: dev/api/third-party
 

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/bnd.bnd
@@ -119,6 +119,7 @@ Include-Resource: \
   @${repo;com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   @${repo;com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   org/eclipse/persistence/internal/helper=${bin}/org/eclipse/persistence/internal/helper,\
+  org/eclipse/persistence/internal/helper=resources/org/eclipse/persistence/internal/helper,\
   org/eclipse/persistence/internal/core/databaseaccess=${bin}/org/eclipse/persistence/internal/core/databaseaccess,\
   org/eclipse/persistence/internal/databaseaccess=${bin}/org/eclipse/persistence/internal/databaseaccess,\
   org/eclipse/persistence/mappings/converters=${bin}/org/eclipse/persistence/mappings/converters,\

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/resources/org/eclipse/persistence/internal/helper/VendorNameToPlatformMapping.properties
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/resources/org/eclipse/persistence/internal/helper/VendorNameToPlatformMapping.properties
@@ -1,0 +1,76 @@
+#
+# Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1998, 2019 IBM Corporation. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+# Contributors:
+#     Oracle - initial API and implementation from Oracle TopLink
+#     03/02/2015-2.6.0 Dalia Abo Sheasha
+#       - 461236: Running EclipseLink with Informix using a DB2 jdbc driver doesn't work
+#     03/19/2015 - Rick Curtis
+#       - 462586 : Add national character support for z/OS.
+#     04/30/2015 - Will Dazey
+#       - 465063 : Updated platform regex to match productName returned from a DB2/I connection.
+#     05/22/2018 - Will Dazey
+#       - 532160 : Add support for non-extension OracleXPlatform classes
+#     05/06/2019 - Jody Grassel
+#       - 547023 : Add LOB Locator support for core Oracle platform.
+
+# Key-Value file containing mappings between DB product name, major version, product version and
+# database platform class name.
+#
+# The key of the property is in the form of a java regular expression.
+# At runtime, DatabaseMetaData.getDatabaseProductName() is concatenated with DatabaseMetaData.getDatabaseMajorVersion()
+# and DatabaseMetaData.getDatabaseProductVersion(). That String is matched
+# against the regular expression to determine which DatabasePlaform to set.
+#
+# This file is parsed sequentially, top to bottom; More specific regular expression
+# to platform class entries should be placed before less specific entries. Each
+# platform entry must be on its own line, an entry cannot span multiple lines.
+
+(?is)oracle.*23.*=org.eclipse.persistence.platform.database.oracle.Oracle23Platform
+(?is)oracle.*21.*=org.eclipse.persistence.platform.database.oracle.Oracle21Platform
+(?is)oracle.*19.*=org.eclipse.persistence.platform.database.oracle.Oracle19Platform
+(?is)oracle.*18.*=org.eclipse.persistence.platform.database.oracle.Oracle18Platform
+(?is)oracle.*12.*=org.eclipse.persistence.platform.database.oracle.Oracle12Platform
+(?is)oracle.*11.*=org.eclipse.persistence.platform.database.oracle.Oracle11Platform
+(?is)oracle.*10.*=org.eclipse.persistence.platform.database.oracle.Oracle10Platform
+(?is)oracle.*9.*=org.eclipse.persistence.platform.database.oracle.Oracle9Platform
+(?is)core.oracle.*23.*=org.eclipse.persistence.platform.database.Oracle23Platform
+(?is)core.oracle.*21.*=org.eclipse.persistence.platform.database.Oracle21Platform
+(?is)core.oracle.*19.*=org.eclipse.persistence.platform.database.Oracle19Platform
+(?is)core.oracle.*18.*=org.eclipse.persistence.platform.database.Oracle18Platform
+(?is)core.oracle.*12.*=org.eclipse.persistence.platform.database.Oracle12Platform
+(?is)core.oracle.*11.*=org.eclipse.persistence.platform.database.Oracle11Platform
+(?is)core.oracle.*10.*=org.eclipse.persistence.platform.database.Oracle10Platform
+(?is)core.oracle.*9.*=org.eclipse.persistence.platform.database.Oracle9Platform
+(?is)oracle.*=org.eclipse.persistence.platform.database.oracle.OraclePlatform
+SQL\ Anywhere.*=org.eclipse.persistence.platform.database.SQLAnywherePlatform
+(?i)(sybase.*)|(adaptive\ server\ enterprise.*)|(SQL\ Server.*)=org.eclipse.persistence.platform.database.SybasePlatform
+(?i)microsoft.*=org.eclipse.persistence.platform.database.SQLServerPlatform
+#Use JavaDBPlatform as the platform for Derby
+(?i).*derby.*=org.eclipse.persistence.platform.database.JavaDBPlatform
+(?i).*db2.*dsn.*=org.eclipse.persistence.platform.database.DB2ZPlatform
+(?i).*(db2|AS).*(AS/400|qsq).*=org.eclipse.persistence.platform.database.DB2MainframePlatform
+(?i).*db2.*=org.eclipse.persistence.platform.database.DB2Platform
+(?is)pointbase.*=org.eclipse.persistence.platform.database.PointBasePlatform
+(?i)mysql.*=org.eclipse.persistence.platform.database.MySQLPlatform
+(?i)(informix.*)|(ids.*)=org.eclipse.persistence.platform.database.Informix11Platform
+(?is)postgresql.*=org.eclipse.persistence.platform.database.PostgreSQLPlatform
+(?is)h2.*=org.eclipse.persistence.platform.database.H2Platform
+(?is)hsql.*=org.eclipse.persistence.platform.database.HSQLPlatform
+(?is)firebird.*=org.eclipse.persistence.platform.database.FirebirdPlatform
+(?is).*symfoware.*=org.eclipse.persistence.platform.database.SymfowarePlatform
+(?is)access.*=org.eclipse.persistence.platform.database.AccessPlatform
+SAP\ DB.*=org.eclipse.persistence.platform.database.MaxDBPlatform
+HDB.*=org.eclipse.persistence.platform.database.HANAPlatform
+Pervasive\.SQL.*=org.eclipse.persistence.platform.database.PervasivePlatform
+

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/internal/core/databaseaccess/CorePlatform.java
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/internal/core/databaseaccess/CorePlatform.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Blaise Doughan - 2.5 - initial implementation
+package org.eclipse.persistence.internal.core.databaseaccess;
+
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.internal.core.helper.CoreConversionManager;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+
+public interface CorePlatform<CONVERSION_MANAGER extends CoreConversionManager> {
+
+    /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method
+     * @param object - the object that must be converted
+     * @param javaClass - the class that the object must be converted to
+     * @exception - ConversionException, all exceptions will be thrown as this type.
+     * @return - the newly converted object
+     */
+    Object convertObject(Object sourceObject, Class javaClass);
+
+    /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method.
+     * @param sourceObject the object that must be converted
+     * @param javaClass the class that the object must be converted to
+     * @param session current database session
+     * @exception ConversionException all exceptions will be thrown as this type.
+     * @return the newly converted object
+     */
+    Object convertObject(Object sourceObject, Class javaClass, AbstractSession session) throws ConversionException;
+
+    /**
+     * The platform hold its own instance of conversion manager to allow customization.
+     */
+    CONVERSION_MANAGER getConversionManager();
+
+}

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
@@ -1154,7 +1154,7 @@ public class DatasourcePlatform implements Platform {
      * Override this method if the platform needs to use a custom function based on the DatabaseField
      * @return An expression for the given field set equal to a parameter matching the field
      */
-    public Expression createExpressionFor(DatabaseField field, Expression builder, String fieldClassificationClassName) {
+    public Expression createExpressionFor(DatabaseField field, Expression builder) {
         Expression subExp1 = builder.getField(field);
         Expression subExp2 = builder.getParameter(field);
         return subExp1.equal(subExp2);

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/internal/databaseaccess/DatasourcePlatform.java
@@ -1,0 +1,1170 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+//     09/29/2016-2.7 Tomas Kraus
+//       - 426852: @GeneratedValue(strategy=GenerationType.IDENTITY) support in Oracle 12c
+//     09/14/2017-2.6 Will Dazey
+//       - 522312: Add the eclipselink.sequencing.start-sequence-at-nextval property
+//     02/20/2018-2.7 Will Dazey
+//       - 529602: Added support for CLOBs in DELETE statements for Oracle
+package org.eclipse.persistence.internal.databaseaccess;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Vector;
+
+import org.eclipse.persistence.descriptors.DescriptorQueryManager;
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.ValidationException;
+import org.eclipse.persistence.expressions.Expression;
+import org.eclipse.persistence.expressions.ExpressionOperator;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.helper.ConversionManager;
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.queries.Call;
+import org.eclipse.persistence.queries.DataModifyQuery;
+import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.queries.SQLCall;
+import org.eclipse.persistence.queries.ValueReadQuery;
+import org.eclipse.persistence.sequencing.DefaultSequence;
+import org.eclipse.persistence.sequencing.QuerySequence;
+import org.eclipse.persistence.sequencing.Sequence;
+
+/**
+ * DatasourcePlatform is private to TopLink. It encapsulates behavior specific to a datasource platform
+ * (eg. Oracle, Sybase, DB2, Attunity, MQSeries), and provides protocol for TopLink to access this behavior.
+ *
+ * @see DatabasePlatform
+ * @see org.eclipse.persistence.eis.EISPlatform
+ *
+ * @since OracleAS TopLink 10<i>g</i> (10.0.3)
+ */
+public class DatasourcePlatform implements Platform {
+
+    /** Supporting name scopes in database by prefixing the table names with the table qualifier/creator. */
+    protected String tableQualifier;
+
+    /** Allow for conversion to be customized in the platform. */
+    protected transient ConversionManager conversionManager;
+
+    /** Store the query use to query the current server time. */
+    protected ValueReadQuery timestampQuery;
+
+    /** Operators specific to this platform */
+    protected transient Map platformOperators;
+
+    /** Store the list of Classes that can be converted to from the key. */
+    protected Hashtable dataTypesConvertedFromAClass;
+
+    /** Store the list of Classes that can be converted from to the key. */
+    protected Hashtable dataTypesConvertedToAClass;
+
+    /** Store default sequence */
+    protected Sequence defaultSequence;
+
+    /** Store map of sequence names to sequences */
+    protected Map sequences;
+
+    /** Delimiter to use for fields and tables using spaces or other special values */
+    protected String startDelimiter = null;
+    protected String endDelimiter = null;
+
+    /** Ensures that only one thread at a time can add/remove sequences */
+    protected Object sequencesLock = Boolean.valueOf(true);
+
+    /** If the native sequence type is not supported, if table sequencing should be used. */
+    protected boolean defaultNativeSequenceToTable;
+
+    /** If sequences should start at Next Value */
+    protected boolean defaultSeqenceAtNextValue;
+
+    /**
+     * This property configures if the database platform will use {@link java.sql.Statement#getGeneratedKeys()}, 
+     * or a separate query, in order to obtain javax.persistence.GenerationType.IDENTITY generated values.
+     * <p>
+     * <b>Allowed Values:</b>
+     * <ul>
+     * <li>"<code>true</code>" - IDENTITY generated values will be obtained with {@link java.sql.Statement#getGeneratedKeys()}
+     * <li>"<code>false</code>" (DEFAULT) - IDENTITY generated values will be obtained with a separate query {@link #buildSelectQueryForIdentity()}
+     * </ul>
+     * <p>
+     * See:
+     * <ul>
+     * <li>{@link #buildSelectQueryForIdentity()} will be disabled if this property is enabled
+     * </ul>
+     */
+    protected boolean supportsReturnGeneratedKeys;
+
+    public DatasourcePlatform() {
+        this.tableQualifier = "";
+        this.startDelimiter = "";
+        this.endDelimiter = "";
+        this.supportsReturnGeneratedKeys = false;
+    }
+
+    /**
+     * Return if the native sequence type is not supported, if table sequencing should be used.
+     */
+    public boolean getDefaultNativeSequenceToTable() {
+        return defaultNativeSequenceToTable;
+    }
+
+    /**
+     * Set if the native sequence type is not supported, if table sequencing should be used.
+     */
+    public void setDefaultNativeSequenceToTable(boolean defaultNativeSequenceToTable) {
+        this.defaultNativeSequenceToTable = defaultNativeSequenceToTable;
+    }
+
+    /**
+     * Return if the sequence generation should start at next value.
+     */
+    public boolean getDefaultSeqenceAtNextValue() {
+        return defaultSeqenceAtNextValue;
+    }
+
+    /**
+     * Set if the sequence generation should start at next value.
+     */
+    public void setDefaultSeqenceAtNextValue(boolean defaultSeqenceAtNextValue) {
+        this.defaultSeqenceAtNextValue = defaultSeqenceAtNextValue;
+    }
+
+    protected void addOperator(ExpressionOperator operator) {
+        platformOperators.put(Integer.valueOf(operator.getSelector()), operator);
+    }
+
+    /**
+     * Add the parameter.
+     * Convert the parameter to a string and write it.
+     */
+    @Override
+    public void appendParameter(Call call, Writer writer, Object parameter) {
+        String parameterValue = (String)getConversionManager().convertObject(parameter, ClassConstants.STRING);
+        if (parameterValue == null) {
+            parameterValue = "";
+        }
+        try {
+            writer.write(parameterValue);
+        } catch (IOException exception) {
+            throw ValidationException.fileError(exception);
+        }
+    }
+
+    /**
+     * Allow for the platform to handle the representation of parameters specially.
+     */
+    @Override
+    public Object getCustomModifyValueForCall(Call call, Object value, DatabaseField field, boolean shouldBind) {
+        return value;
+    }
+
+    /**
+     * Used by SQLCall.appendModify(..)
+     * If the field should be passed to customModifyInDatabaseCall, retun true,
+     * otherwise false.
+     * Methods shouldCustomModifyInDatabaseCall and customModifyInDatabaseCall should be
+     * kept in sync: shouldCustomModifyInDatabaseCall should return true if and only if the field
+     * is handled by customModifyInDatabaseCall.
+     */
+    @Override
+    public boolean shouldUseCustomModifyForCall(DatabaseField field) {
+        return false;
+    }
+
+    @Override
+    public Object clone() {
+        try {
+            DatasourcePlatform clone = (DatasourcePlatform)super.clone();
+            clone.sequencesAfterCloneCleanup();
+            return clone;
+        } catch (CloneNotSupportedException exception) {
+            ;//Do nothing
+        }
+
+        return null;
+    }
+
+    protected void sequencesAfterCloneCleanup() {
+        Sequence defaultSequenceClone = null;
+        if (hasDefaultSequence()) {
+            defaultSequenceClone = (Sequence)getDefaultSequence().clone();
+            setDefaultSequence(defaultSequenceClone);
+        }
+        if (getSequences() != null) {
+            HashMap sequencesCopy = new HashMap(getSequences());
+            HashMap sequencesDeepClone = new HashMap(getSequences().size());
+            Iterator it = sequencesCopy.values().iterator();
+            while (it.hasNext()) {
+                Sequence sequence = (Sequence)it.next();
+                if ((defaultSequenceClone != null) && (sequence == getDefaultSequence())) {
+                    sequencesDeepClone.put(defaultSequenceClone.getName(), defaultSequenceClone);
+                } else {
+                    Sequence sequenceClone = (Sequence)sequence.clone();
+                    if (sequenceClone instanceof DefaultSequence) {
+                        if (!((DefaultSequence)sequenceClone).hasPreallocationSize()) {
+                            continue;
+                        }
+                    }
+                    sequencesDeepClone.put(sequenceClone.getName(), sequenceClone);
+                }
+            }
+            this.setSequences(sequencesDeepClone);
+        }
+    }
+
+    /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method
+     * @param object - the object that must be converted
+     * @param javaClass - the class that the object must be converted to
+     * @exception - ConversionException, all exceptions will be thrown as this type.
+     * @return - the newly converted object
+     */
+    @Override
+    public Object convertObject(Object sourceObject, Class javaClass) throws ConversionException {
+        return getConversionManager().convertObject(sourceObject, javaClass);
+    }
+
+    /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method.
+     * @param sourceObject the object that must be converted
+     * @param javaClass the class that the object must be converted to
+     * @param session current database session
+     * @exception ConversionException all exceptions will be thrown as this type.
+     * @return the newly converted object
+     */
+    @Override
+    public Object convertObject(Object sourceObject, Class javaClass, AbstractSession session) throws ConversionException {
+        return convertObject(sourceObject, javaClass);
+    }
+
+    /**
+     * Copy the state into the new platform.
+     */
+    @Override
+    public void copyInto(Platform platform) {
+        if (!(platform instanceof DatasourcePlatform)) {
+            return;
+        }
+        DatasourcePlatform datasourcePlatform = (DatasourcePlatform)platform;
+        datasourcePlatform.setTableQualifier(getTableQualifier());
+        datasourcePlatform.setTimestampQuery(this.timestampQuery);
+        datasourcePlatform.setConversionManager(getConversionManager());
+        if (hasDefaultSequence()) {
+            datasourcePlatform.setDefaultSequence(getDefaultSequence());
+        }
+        datasourcePlatform.setSequences(getSequences());
+        datasourcePlatform.sequencesAfterCloneCleanup();
+        datasourcePlatform.setDefaultNativeSequenceToTable(getDefaultNativeSequenceToTable());
+        datasourcePlatform.setDefaultSeqenceAtNextValue(getDefaultSeqenceAtNextValue());
+    }
+
+    /**
+     * The platform hold its own instance of conversion manager to allow customization.
+     */
+    @Override
+    public ConversionManager getConversionManager() {
+        // Lazy init for serialization.
+        if (conversionManager == null) {
+            //Clone the default to allow customers to easily override the conversion manager
+            conversionManager = (ConversionManager)ConversionManager.getDefaultManager().clone();
+        }
+        return conversionManager;
+    }
+
+    /**
+     * The platform hold its own instance of conversion manager to allow customization.
+     */
+    @Override
+    public void setConversionManager(ConversionManager conversionManager) {
+        this.conversionManager = conversionManager;
+    }
+
+    /**
+     * Return the driver version.
+     */
+    public String getDriverVersion() {
+        return "";
+    }
+
+    /**
+     * Delimiter to use for fields and tables using spaces or other special values.
+     *
+     * Some databases use different delimiters for the beginning and end of the value.
+     * This delimiter indicates the end of the value.
+     */
+    @Override
+    public String getEndDelimiter() {
+        return endDelimiter;
+    }
+
+    /**
+     * Delimiter to use for fields and tables using spaces or other special values.
+     *
+     * Some databases use different delimiters for the beginning and end of the value.
+     * This delimiter indicates the end of the value.
+     */
+    public void setEndDelimiter(String endDelimiter) {
+        this.endDelimiter = endDelimiter;
+    }
+
+    /**
+     * Return the operator for the operator constant defined in ExpressionOperator.
+     */
+    public ExpressionOperator getOperator(int selector) {
+        return (ExpressionOperator)getPlatformOperators().get(Integer.valueOf(selector));
+    }
+
+    /**
+     * Return any platform-specific operators
+     */
+    public Map getPlatformOperators() {
+        if (platformOperators == null) {
+            synchronized (this) {
+                if (platformOperators == null) {
+                    initializePlatformOperators();
+                }
+            }
+        }
+        return platformOperators;
+    }
+
+    /**
+     * OBSOLETE:
+     * This method lazy initializes the select sequence number query.  It
+     * allows for other queries to be used instead of the default one.
+     */
+    public ValueReadQuery getSelectSequenceQuery() {
+        if (getDefaultSequence() instanceof QuerySequence) {
+            return ((QuerySequence)getDefaultSequence()).getSelectQuery();
+        } else {
+            throw ValidationException.wrongSequenceType(Helper.getShortClassName(getDefaultSequence()), "getSelectQuery");
+        }
+    }
+
+    public int getSequencePreallocationSize() {
+        return getDefaultSequence().getPreallocationSize();
+    }
+
+
+    /**
+     * Delimiter to use for fields and tables using spaces or other special values.
+     *
+     * Some databases use different delimiters for the beginning and end of the value.
+     * This delimiter indicates the start of the value.
+     */
+    @Override
+    public String getStartDelimiter() {
+        return startDelimiter;
+    }
+
+    /**
+     * Delimiter to use for fields and tables using spaces or other special values.
+     *
+     * Some databases use different delimiters for the beginning and end of the value.
+     * This delimiter indicates the start of the value.
+     */
+    public void setStartDelimiter(String startDelimiter) {
+        this.startDelimiter = startDelimiter;
+    }
+
+    /**
+     * Return the qualifier for the table. Required by some
+     * databases such as Oracle and DB2
+     */
+    @Override
+    public String getTableQualifier() {
+        return tableQualifier;
+    }
+
+    /**
+     * Answer the timestamp from the server.
+     */
+    @Override
+    public java.sql.Timestamp getTimestampFromServer(AbstractSession session, String sessionName) {
+        if (getTimestampQuery() == null) {
+            return new java.sql.Timestamp(System.currentTimeMillis());
+        } else {
+            getTimestampQuery().setSessionName(sessionName);
+            Object result = session.executeQuery(getTimestampQuery());
+            return (java.sql.Timestamp) session.getDatasourcePlatform().convertObject(result, ClassConstants.TIMESTAMP);
+        }
+    }
+
+    /**
+     * This method can be overridden by subclasses to return a
+     * query that will return the timestamp from the server.
+     * return null if the time should be the local time.
+     */
+    @Override
+    public ValueReadQuery getTimestampQuery() {
+        return timestampQuery;
+    }
+
+    /**
+     * OBSOLETE:
+     * This method lazy initializes the update sequence number query.  It
+     * allows for other queries to be used instead of the default one.
+     */
+    public DataModifyQuery getUpdateSequenceQuery() {
+        if (getDefaultSequence() instanceof QuerySequence) {
+            return ((QuerySequence)getDefaultSequence()).getUpdateQuery();
+        } else {
+            throw ValidationException.wrongSequenceType(Helper.getShortClassName(getDefaultSequence()), "getUpdateQuery");
+        }
+    }
+
+    /**
+     * Initialize any platform-specific operators
+     */
+    protected void initializePlatformOperators() {
+        this.platformOperators = new HashMap();
+
+        // Outer join
+        addOperator(ExpressionOperator.equalOuterJoin());
+
+        // General
+        addOperator(ExpressionOperator.toUpperCase());
+        addOperator(ExpressionOperator.toLowerCase());
+        addOperator(ExpressionOperator.chr());
+        addOperator(ExpressionOperator.concat());
+        addOperator(ExpressionOperator.hexToRaw());
+        addOperator(ExpressionOperator.initcap());
+        addOperator(ExpressionOperator.instring());
+        addOperator(ExpressionOperator.soundex());
+        addOperator(ExpressionOperator.leftPad());
+        addOperator(ExpressionOperator.leftTrim());
+        addOperator(ExpressionOperator.leftTrim2());
+        addOperator(ExpressionOperator.replace());
+        addOperator(ExpressionOperator.rightPad());
+        addOperator(ExpressionOperator.rightTrim());
+        addOperator(ExpressionOperator.rightTrim2());
+        addOperator(ExpressionOperator.substring());
+        addOperator(ExpressionOperator.substringSingleArg());
+        addOperator(ExpressionOperator.toNumber());
+        addOperator(ExpressionOperator.toChar());
+        addOperator(ExpressionOperator.toCharWithFormat());
+        addOperator(ExpressionOperator.translate());
+        addOperator(ExpressionOperator.trim());
+        addOperator(ExpressionOperator.trim2());
+        addOperator(ExpressionOperator.ascii());
+        addOperator(ExpressionOperator.length());
+        addOperator(ExpressionOperator.locate());
+        addOperator(ExpressionOperator.locate2());
+        addOperator(ExpressionOperator.nullIf());
+        addOperator(ExpressionOperator.ifNull());
+        addOperator(ExpressionOperator.cast());
+        addOperator(ExpressionOperator.regexp());
+        addOperator(ExpressionOperator.union());
+        addOperator(ExpressionOperator.unionAll());
+        addOperator(ExpressionOperator.intersect());
+        addOperator(ExpressionOperator.intersectAll());
+        addOperator(ExpressionOperator.except());
+        addOperator(ExpressionOperator.exceptAll());
+
+        addOperator(ExpressionOperator.count());
+        addOperator(ExpressionOperator.sum());
+        addOperator(ExpressionOperator.average());
+        addOperator(ExpressionOperator.minimum());
+        addOperator(ExpressionOperator.maximum());
+        addOperator(ExpressionOperator.distinct());
+        addOperator(ExpressionOperator.notOperator());
+        addOperator(ExpressionOperator.ascending());
+        addOperator(ExpressionOperator.descending());
+        addOperator(ExpressionOperator.as());
+        addOperator(ExpressionOperator.nullsFirst());
+        addOperator(ExpressionOperator.nullsLast());
+        addOperator(ExpressionOperator.any());
+        addOperator(ExpressionOperator.some());
+        addOperator(ExpressionOperator.all());
+        addOperator(ExpressionOperator.in());
+        addOperator(ExpressionOperator.inSubQuery());
+        addOperator(ExpressionOperator.notIn());
+        addOperator(ExpressionOperator.notInSubQuery());
+
+        addOperator(ExpressionOperator.and());
+        addOperator(ExpressionOperator.or());
+        addOperator(ExpressionOperator.isNull());
+        addOperator(ExpressionOperator.notNull());
+
+        // Date
+        addOperator(ExpressionOperator.addMonths());
+        addOperator(ExpressionOperator.dateToString());
+        addOperator(ExpressionOperator.lastDay());
+        addOperator(ExpressionOperator.monthsBetween());
+        addOperator(ExpressionOperator.nextDay());
+        addOperator(ExpressionOperator.roundDate());
+        addOperator(ExpressionOperator.toDate());
+        addOperator(ExpressionOperator.today());
+        addOperator(ExpressionOperator.currentDate());
+        addOperator(ExpressionOperator.currentTime());
+        addOperator(ExpressionOperator.extract());
+
+        // Math
+        addOperator(ExpressionOperator.add());
+        addOperator(ExpressionOperator.subtract());
+        addOperator(ExpressionOperator.multiply());
+        addOperator(ExpressionOperator.divide());
+        addOperator(ExpressionOperator.negate());
+
+        addOperator(ExpressionOperator.equal());
+        addOperator(ExpressionOperator.notEqual());
+        addOperator(ExpressionOperator.lessThan());
+        addOperator(ExpressionOperator.lessThanEqual());
+        addOperator(ExpressionOperator.greaterThan());
+        addOperator(ExpressionOperator.greaterThanEqual());
+
+        addOperator(ExpressionOperator.like());
+        addOperator(ExpressionOperator.likeEscape());
+        addOperator(ExpressionOperator.notLike());
+        addOperator(ExpressionOperator.notLikeEscape());
+        addOperator(ExpressionOperator.between());
+        addOperator(ExpressionOperator.notBetween());
+
+        addOperator(ExpressionOperator.exists());
+        addOperator(ExpressionOperator.notExists());
+
+        addOperator(ExpressionOperator.ceil());
+        addOperator(ExpressionOperator.cos());
+        addOperator(ExpressionOperator.cosh());
+        addOperator(ExpressionOperator.abs());
+        addOperator(ExpressionOperator.acos());
+        addOperator(ExpressionOperator.asin());
+        addOperator(ExpressionOperator.atan());
+        addOperator(ExpressionOperator.exp());
+        addOperator(ExpressionOperator.sqrt());
+        addOperator(ExpressionOperator.floor());
+        addOperator(ExpressionOperator.ln());
+        addOperator(ExpressionOperator.log());
+        addOperator(ExpressionOperator.mod());
+        addOperator(ExpressionOperator.power());
+        addOperator(ExpressionOperator.round());
+        addOperator(ExpressionOperator.sign());
+        addOperator(ExpressionOperator.sin());
+        addOperator(ExpressionOperator.sinh());
+        addOperator(ExpressionOperator.tan());
+        addOperator(ExpressionOperator.tanh());
+        addOperator(ExpressionOperator.trunc());
+        addOperator(ExpressionOperator.greatest());
+        addOperator(ExpressionOperator.least());
+
+        addOperator(ExpressionOperator.standardDeviation());
+        addOperator(ExpressionOperator.variance());
+
+        // Object-relational
+        addOperator(ExpressionOperator.deref());
+        addOperator(ExpressionOperator.ref());
+        addOperator(ExpressionOperator.refToHex());
+        addOperator(ExpressionOperator.value());
+
+        addOperator(ExpressionOperator.coalesce());
+        addOperator(ExpressionOperator.caseStatement());
+        addOperator(ExpressionOperator.caseConditionStatement());
+    }
+
+    /**
+     * INTERNAL:
+     * Allow the platform to initialize the CRUD queries to defaults.
+     * This is mainly used by EIS platforms, but could be used by relational ones for special behavior.
+     */
+    public void initializeDefaultQueries(DescriptorQueryManager queryManager, AbstractSession session) {
+
+    }
+
+    @Override
+    public boolean isAccess() {
+        return false;
+    }
+
+    @Override
+    public boolean isAttunity() {
+        return false;
+    }
+
+    @Override
+    public boolean isCloudscape() {
+        return false;
+    }
+
+    @Override
+    public boolean isDerby() {
+        return false;
+    }
+
+    @Override
+    public boolean isDB2() {
+        return false;
+    }
+
+    @Override
+    public boolean isDB2Z() {
+        return false;
+    }
+
+    @Override
+    public boolean isHANA() {
+        return false;
+    }
+
+    @Override
+    public boolean isH2() {
+        return false;
+    }
+
+    @Override
+    public boolean isDBase() {
+        return false;
+    }
+
+    @Override
+    public boolean isHSQL() {
+        return false;
+    }
+
+    @Override
+    public boolean isInformix() {
+        return false;
+    }
+
+    @Override
+    public boolean isMySQL() {
+        return false;
+    }
+
+    @Override
+    public boolean isODBC() {
+        return false;
+    }
+
+    @Override
+    public boolean isOracle() {
+        return false;
+    }
+
+    @Override
+    public boolean isOracle9() {
+        return false;
+    }
+
+    @Override
+    public boolean isOracle23() {
+        return false;
+    }
+
+    public boolean isPervasive(){
+        return false;
+    }
+
+    @Override
+    public boolean isPostgreSQL(){
+        return false;
+    }
+
+    @Override
+    public boolean isPointBase() {
+        return false;
+    }
+
+    @Override
+    public boolean isSQLAnywhere() {
+        return false;
+    }
+
+    public boolean isFirebird() {
+        return false;
+    }
+
+    @Override
+    public boolean isSQLServer() {
+        return false;
+    }
+
+    @Override
+    public boolean isSybase() {
+        return false;
+    }
+
+    @Override
+    public boolean isSymfoware() {
+        return false;
+    }
+
+    @Override
+    public boolean isTimesTen() {
+        return false;
+    }
+
+    @Override
+    public boolean isTimesTen7() {
+        return false;
+    }
+
+    @Override
+    public boolean isMaxDB() {
+        return false;
+    }
+
+    /**
+     * Allow the platform to initialize itself after login/init.
+     */
+    @Override
+    public void initialize() {
+
+    }
+
+    /**
+     * OBSOLETE:
+     * Can override the default query for returning the sequence numbers.
+     * This query must be a valid query that has one parameter which is
+     * the sequence name.
+     */
+    public void setSelectSequenceNumberQuery(ValueReadQuery seqQuery) {
+        if (getDefaultSequence() instanceof QuerySequence) {
+            ((QuerySequence)getDefaultSequence()).setSelectQuery(seqQuery);
+        } else {
+            throw ValidationException.wrongSequenceType(Helper.getShortClassName(getDefaultSequence()), "setSelectQuery");
+        }
+    }
+
+    /**
+     *    Set the number of sequence values to preallocate.
+     *    Preallocating sequence values can greatly improve insert performance.
+     */
+    public void setSequencePreallocationSize(int size) {
+        getDefaultSequence().setPreallocationSize(size);
+    }
+
+    /**
+     * Set the qualifier for the table. Required by some
+     * databases such as Oracle and DB2
+     */
+    @Override
+    public void setTableQualifier(String qualifier) {
+        tableQualifier = qualifier;
+    }
+
+    /**
+     * Can override the default query for returning a timestamp from the server.
+     * See: getTimestampFromServer
+     */
+    @Override
+    public void setTimestampQuery(ValueReadQuery tsQuery) {
+        timestampQuery = tsQuery;
+    }
+
+    /**
+     * This method sets the update sequence number query.  It
+     * allows for other queries to be used instead of the default one.
+     */
+    public void setUpdateSequenceQuery(DataModifyQuery updateSequenceNumberQuery) {
+        if (getDefaultSequence() instanceof QuerySequence) {
+            ((QuerySequence)getDefaultSequence()).setUpdateQuery(updateSequenceNumberQuery);
+        } else {
+            throw ValidationException.wrongSequenceType(Helper.getShortClassName(getDefaultSequence()), "setUpdateQuery");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return Helper.getShortClassName(this.getClass());
+    }
+
+    /**
+     * PUBLIC:
+     * Return the list of Classes that can be converted to from the passed in javaClass.
+     * @param javaClass - the class that is converted from
+     * @return - a vector of classes
+     */
+    public Vector getDataTypesConvertedFrom(Class javaClass) {
+        return getConversionManager().getDataTypesConvertedFrom(javaClass);
+    }
+
+    /**
+     * PUBLIC:
+     * Return the list of Classes that can be converted from to the passed in javaClass.
+     * @param javaClass - the class that is converted to
+     * @return - a vector of classes
+     */
+    public Vector getDataTypesConvertedTo(Class javaClass) {
+        return getConversionManager().getDataTypesConvertedTo(javaClass);
+    }
+
+    /**
+     * Get default sequence
+     */
+    @Override
+    public Sequence getDefaultSequence() {
+        if (!hasDefaultSequence()) {
+            setDefaultSequence(createPlatformDefaultSequence());
+        }
+        return defaultSequence;
+    }
+
+    /**
+     * Get default sequence
+     */
+    public boolean hasDefaultSequence() {
+        return defaultSequence != null;
+    }
+
+    /**
+     * Set default sequence. In case the passed sequence is of type DefaultSequence - use platformDefaultSequence
+     * with name and size of the passed sequence.
+     */
+    @Override
+    public void setDefaultSequence(Sequence sequence) {
+        if (sequence instanceof DefaultSequence) {
+            Sequence platformDefaultSequence = createPlatformDefaultSequence();
+            if (platformDefaultSequence != null) {
+                platformDefaultSequence.setName(sequence.getName());
+                if (((DefaultSequence)sequence).hasPreallocationSize()) {
+                    platformDefaultSequence.setPreallocationSize(sequence.getPreallocationSize());
+                }
+            }
+            defaultSequence = platformDefaultSequence;
+        } else {
+            defaultSequence = sequence;
+        }
+    }
+
+    /**
+     * Add sequence corresponding to the name
+     */
+    @Override
+    public void addSequence(Sequence sequence) {
+        addSequence(sequence, false);
+    }
+
+    /**
+     * Indicates whether the platform supports the use of {@link java.sql.Statement#RETURN_GENERATED_KEYS}.
+     * If supported, IDENTITY values will be obtained through {@link java.sql.Statement#getGeneratedKeys()}
+     * and will replace usage of {@link #buildSelectQueryForIdentity()}
+     */
+    public void setSupportsReturnGeneratedKeys(boolean supportsReturnGeneratedKeys) {
+        this.supportsReturnGeneratedKeys = supportsReturnGeneratedKeys;
+    }
+
+    /**
+     * Add sequence corresponding to the name.
+     * Use this method with isSessionConnected parameter set to true
+     * to add a sequence to connected session.
+     * If the session is connected then the sequence is added only
+     * if there is no sequence with the same name already in use.
+     */
+    @Override
+    public void addSequence(Sequence sequence, boolean isSessionConnected) {
+        synchronized(sequencesLock) {
+            if (isSessionConnected) {
+                if (this.sequences == null) {
+                    this.sequences = new HashMap();
+                    this.sequences.put(sequence.getName(), sequence);
+                } else {
+                    if (!this.sequences.containsKey(sequence.getName())) {
+                        Map newSequences = (Map)((HashMap)this.sequences).clone();
+                        newSequences.put(sequence.getName(), sequence);
+                        this.sequences = newSequences;
+                    }
+                }
+            } else {
+                if (this.sequences == null) {
+                    this.sequences = new HashMap();
+                }
+                this.sequences.put(sequence.getName(), sequence);
+            }
+        }
+    }
+
+    /**
+     * Get sequence corresponding to the name
+     */
+    @Override
+    public Sequence getSequence(String seqName) {
+        if (seqName == null) {
+            return getDefaultSequence();
+        } else {
+            if (this.sequences != null) {
+                return (Sequence)this.sequences.get(seqName);
+            } else {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * Create platform-default Sequence
+     */
+    protected Sequence createPlatformDefaultSequence() {
+        throw ValidationException.createPlatformDefaultSequenceUndefined(Helper.getShortClassName(this));
+    }
+
+    /**
+     * Remove sequence corresponding to name.
+     * Doesn't remove default sequence.
+     */
+    @Override
+    public Sequence removeSequence(String seqName) {
+        if (this.sequences != null) {
+            synchronized(sequencesLock) {
+                return (Sequence)this.sequences.remove(seqName);
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Remove all sequences, but the default one.
+     */
+    @Override
+    public void removeAllSequences() {
+        this.sequences = null;
+    }
+
+    /**
+     * INTERNAL:
+     * Returns a map of sequence names to Sequences (may be null).
+     */
+    @Override
+    public Map getSequences() {
+        return this.sequences;
+    }
+
+    /**
+     * INTERNAL:
+     * Used only for writing into XML or Java.
+     */
+    @Override
+    public Map getSequencesToWrite() {
+        if ((getSequences() == null) || getSequences().isEmpty()) {
+            return null;
+        }
+        Map sequencesCopy = new HashMap(getSequences());
+        Map sequencesToWrite = new HashMap();
+        Iterator it = sequencesCopy.values().iterator();
+        while (it.hasNext()) {
+            Sequence sequence = (Sequence)it.next();
+            if (!(sequence instanceof DefaultSequence) || ((DefaultSequence)sequence).hasPreallocationSize()) {
+                sequencesToWrite.put(sequence.getName(), sequence);
+            }
+        }
+        return sequencesToWrite;
+    }
+
+    /**
+     * INTERNAL:
+     * Used only for writing into XML or Java.
+     */
+    @Override
+    public Sequence getDefaultSequenceToWrite() {
+        if (usesPlatformDefaultSequence()) {
+            return null;
+        } else {
+            return getDefaultSequence();
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * Sets sequences - for XML support only
+     */
+    @Override
+    public void setSequences(Map sequences) {
+        this.sequences = sequences;
+    }
+
+    /**
+     * INTERNAL:
+     * Indicates whether defaultSequence is the same as platform default sequence.
+     */
+    @Override
+    public boolean usesPlatformDefaultSequence() {
+        if (!hasDefaultSequence()) {
+            return true;
+        } else {
+            return getDefaultSequence().equals(createPlatformDefaultSequence());
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * Returns the correct quote character to use around SQL Identifiers that contain
+     * Space characters
+     * @deprecated
+     * @see getStartDelimiter()
+     * @see getEndDelimiter()
+     * @return The quote character for this platform
+     */
+    @Deprecated
+    public String getIdentifierQuoteCharacter() {
+        return "";
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public ConnectionCustomizer createConnectionCustomizer(Accessor accessor, AbstractSession session) {
+        return null;
+    }
+
+    /**
+     * Allows query prepare to be disable in the platform.
+     * This is required for some EIS platforms, that cannot prepare the call.
+     */
+    public boolean shouldPrepare(DatabaseQuery query) {
+        return true;
+    }
+
+    /**
+     * Return if the database requires the ORDER BY fields to be part of the select clause.
+     */
+    public boolean shouldSelectIncludeOrderBy() {
+        return false;
+    }
+
+    /**
+     * Return if the database requires the ORDER BY fields to be part of the select clause.
+     */
+    public boolean shouldSelectDistinctIncludeOrderBy() {
+        return true;
+    }
+
+    /**
+     * INTERNAL:
+     * Indicates whether a separate transaction is required for NativeSequence.
+     * This method is to be used *ONLY* by sequencing classes
+     */
+    public boolean shouldNativeSequenceUseTransaction() {
+        return false;
+    }
+
+    /**
+     * INTERNAL:
+     * Indicates whether the platform supports identity.
+     * This method is to be used *ONLY* by sequencing classes
+     */
+    public boolean supportsIdentity() {
+        return false;
+    }
+
+    public boolean supportsNativeSequenceNumbers() {
+        return this.supportsSequenceObjects() || this.supportsIdentity();
+    }
+
+    /**
+     *  INTERNAL:
+     *  Indicates whether the platform supports sequence objects.
+     *  This method is to be used *ONLY* by sequencing classes
+     */
+    public boolean supportsSequenceObjects() {
+        return false;
+    }
+
+    /**
+     * Indicates whether the platform supports the use of {@link java.sql.Statement#RETURN_GENERATED_KEYS}.
+     * If supported, IDENTITY values will be obtained through {@link java.sql.Statement#getGeneratedKeys()}
+     * and will replace usage of {@link #buildSelectQueryForIdentity()}
+     */
+    public boolean supportsReturnGeneratedKeys() {
+        return supportsReturnGeneratedKeys;
+    }
+
+    /**
+     * INTERNAL:
+     * Returns query used to read value generated by sequence object (like Oracle sequence).
+     * This method is called when sequence object NativeSequence is connected,
+     * the returned query used until the sequence is disconnected.
+     * If the platform supportsSequenceObjects then (at least) one of buildSelectQueryForSequenceObject
+     * methods should return non-null query.
+     */
+    public ValueReadQuery buildSelectQueryForSequenceObject() {
+        return null;
+    }
+
+    /**
+     * INTERNAL:
+     * Returns query used to read value generated by sequence object (like Oracle sequence).
+     * In case the other version of this method (taking no parameters) returns null,
+     * this method is called every time sequence object NativeSequence reads.
+     * If the platform supportsSequenceObjects then (at least) one of buildSelectQueryForSequenceObject
+     * methods should return non-null query.
+     */
+    public ValueReadQuery buildSelectQueryForSequenceObject(String qualifiedSeqName, Integer size) {
+        return null;
+    }
+
+    /**
+     * INTERNAL:
+     * Returns query used to read back the value generated by Identity.
+     * This method is called when identity NativeSequence is connected,
+     * the returned query used until the sequence is disconnected.
+     * If the platform supportsIdentity then (at least) one of buildSelectQueryForIdentity
+     * methods should return non-null query.
+     * <p>
+     * Alternatively, if the platform supports {@link java.sql.Statement#getGeneratedKeys()}, 
+     * see {@link DatabasePlatform#supportsReturnGeneratedKeys()}
+     */
+    public ValueReadQuery buildSelectQueryForIdentity() {
+        return null;
+    }
+
+    /**
+     * INTERNAL:
+     * Returns query used to read back the value generated by Identity.
+     * In case the other version of this method (taking no parameters) returns null,
+     * this method is called every time identity NativeSequence reads.
+     * If the platform supportsIdentity then (at least) one of buildSelectQueryForIdentity
+     * methods should return non-null query.
+     */
+    public ValueReadQuery buildSelectQueryForIdentity(String seqName, Integer size) {
+        return null;
+    }
+
+    /**
+     * INTERNAL:
+     * Return the correct call type for the native query string.
+     * This allows EIS platforms to use different types of native calls.
+     */
+    public DatasourceCall buildNativeCall(String queryString) {
+        return new SQLCall(queryString);
+    }
+
+    /**
+     * INTERNAL:
+     * Override this method if the platform needs to use a custom function based on the DatabaseField
+     * @return An expression for the given field set equal to a parameter matching the field
+     */
+    public Expression createExpressionFor(DatabaseField field, Expression builder, String fieldClassificationClassName) {
+        Expression subExp1 = builder.getField(field);
+        Expression subExp2 = builder.getParameter(field);
+        return subExp1.equal(subExp2);
+    }
+
+    /**
+     * INTERNAL:
+     * Some database platforms have a limit for the number of parameters in an IN clause.
+     */
+    public int getINClauseLimit() {
+        return 0;
+    }
+}

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/internal/databaseaccess/Platform.java
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/internal/databaseaccess/Platform.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 IBM Corporation. All rights reserved.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+package org.eclipse.persistence.internal.databaseaccess;
+
+import java.io.*;
+import java.util.Map;
+import org.eclipse.persistence.exceptions.*;
+import org.eclipse.persistence.queries.*;
+import org.eclipse.persistence.internal.core.databaseaccess.CorePlatform;
+import org.eclipse.persistence.internal.helper.*;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.sequencing.Sequence;
+
+/**
+ * Platform is private to TopLink. It encapsulates behavior specific to a datasource platform
+ * (eg. Oracle, Sybase, DB2, Attunity, MQSeries), and provides the interface for TopLink to access this behavior.
+ *
+ * @see DatasourcePlatform
+ * @see DatabasePlatform
+ * @see org.eclipse.persistence.eis.EISPlatform
+ *
+ * @since OracleAS TopLink 10<i>g</i> (10.0.3)
+ */
+public interface Platform extends CorePlatform<ConversionManager>, Serializable, Cloneable {
+    public Object clone();
+
+    /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method
+     * @param object - the object that must be converted
+     * @param javaClass - the class that the object must be converted to
+     * @exception - ConversionException, all exceptions will be thrown as this type.
+     * @return - the newly converted object
+     */
+    public Object convertObject(Object sourceObject, Class javaClass) throws ConversionException;
+
+    /**
+     * Convert the object to the appropriate type by invoking the appropriate
+     * ConversionManager method.
+     * @param sourceObject the object that must be converted
+     * @param javaClass the class that the object must be converted to
+     * @param session current database session
+     * @exception ConversionException all exceptions will be thrown as this type.
+     * @return the newly converted object
+     */
+    public Object convertObject(Object sourceObject, Class javaClass, AbstractSession session) throws ConversionException;
+
+    /**
+     * Copy the state into the new platform.
+     */
+    public void copyInto(Platform platform);
+
+    /**
+     * The platform hold its own instance of conversion manager to allow customization.
+     */
+    @Override
+    public ConversionManager getConversionManager();
+
+    /**
+     * The platform hold its own instance of conversion manager to allow customization.
+     */
+    public void setConversionManager(ConversionManager conversionManager);
+
+    /**
+     * Return the driver version.
+     */
+    public String getDriverVersion();
+
+    /**
+     * Return the qualifier for the table. Required by some
+     * databases such as Oracle and DB2
+     */
+    public String getTableQualifier();
+
+    /**
+     * Answer the timestamp from the server.
+     */
+    public java.sql.Timestamp getTimestampFromServer(AbstractSession session, String sessionName);
+
+    /**
+     * This method can be overridden by subclasses to return a
+     * query that will return the timestamp from the server.
+     * return null if the time should be the local time.
+     */
+    public ValueReadQuery getTimestampQuery();
+
+    public boolean isH2();
+
+    public boolean isAccess();
+
+    public boolean isAttunity();
+
+    public boolean isCloudscape();
+
+    public boolean isDerby();
+
+    public boolean isDB2();
+
+    public boolean isDB2Z();
+
+    public boolean isDBase();
+
+    public boolean isHANA();
+
+    public boolean isHSQL();
+
+    public boolean isInformix();
+
+    public boolean isMaxDB();
+
+    public boolean isMySQL();
+
+    public boolean isODBC();
+
+    public boolean isOracle();
+
+    public boolean isOracle9();
+
+    public boolean isOracle23();
+
+    public boolean isPointBase();
+
+    public boolean isSQLAnywhere();
+
+    public boolean isSQLServer();
+
+    public boolean isSybase();
+
+    public boolean isSymfoware();
+
+    public boolean isTimesTen();
+
+    public boolean isTimesTen7();
+
+    public boolean isPostgreSQL();
+
+    /**
+     * Allow the platform to initialize itself after login/init.
+     */
+    public void initialize();
+
+    /**
+     * Set the qualifier for the table. Required by some
+     * databases such as Oracle and DB2
+     */
+    public void setTableQualifier(String qualifier);
+
+    /**
+     * Can override the default query for returning a timestamp from the server.
+     * See: getTimestampFromServer
+     */
+    public void setTimestampQuery(ValueReadQuery tsQuery);
+
+    /**
+     * Add the parameter.
+     * Convert the parameter to a string and write it.
+     */
+    public void appendParameter(Call call, Writer writer, Object parameter);
+
+    /**
+     * Allow for the platform to handle the representation of parameters specially.
+     */
+    public Object getCustomModifyValueForCall(Call call, Object value, DatabaseField field, boolean shouldBind);
+
+    /**
+     * Delimiter to use for fields and tables using spaces or other special values.
+     *
+     * Some databases use different delimiters for the beginning and end of the value.
+     * This delimiter indicates the end of the value.
+     */
+    public String getEndDelimiter();
+
+    /**
+     * Delimiter to use for fields and tables using spaces or other special values.
+     *
+     * Some databases use different delimiters for the beginning and end of the value.
+     * This delimiter indicates the start of the value.
+     */
+    public String getStartDelimiter();
+
+    /**
+     * Allow for the platform to handle the representation of parameters specially.
+     */
+    public boolean shouldUseCustomModifyForCall(DatabaseField field);
+
+    /**
+     * Get default sequence.
+     * Sequence name shouldn't be altered -
+     * don't do: getDefaultSequence().setName(newName).
+     */
+    public Sequence getDefaultSequence();
+
+    /**
+     * Set default sequence.
+     * The sequence should have a unique name
+     * that shouldn't be altered after the sequence has been set:
+     * don't do: getDefaultSequence().setName(newName)).
+     * Default constructors for Sequence subclasses
+     * set name to "SEQ".
+     */
+    public void setDefaultSequence(Sequence sequence);
+
+    /**
+     * Add sequence.
+     * The sequence should have a unique name
+     * that shouldn't be altered after the sequence has been added -
+     * don't do: getSequence(name).setName(newName))
+     * Don't use if the session is connected.
+     */
+    public void addSequence(Sequence sequence);
+
+    /**
+     * Add sequence.
+     * The sequence should have a unique name
+     * that shouldn't be altered after the sequence has been added -
+     * don't do: getSequence(name).setName(newName))
+     * Use this method with isConnected parameter set to true
+     * to add a sequence to connected session.
+     * If sequencing is connected then the sequence is added only
+     * if there is no sequence with the same name already in use.
+     */
+    public void addSequence(Sequence sequence, boolean isConnected);
+
+    /**
+     * Get sequence corresponding to the name.
+     * The name shouldn't be altered -
+     * don't do: getSequence(name).setName(newName)
+     */
+    public Sequence getSequence(String seqName);
+
+    /**
+     * Remove sequence corresponding to the name
+     * (the sequence was added through addSequence method)
+     * Don't use if the session is connected.
+     */
+    public Sequence removeSequence(String seqName);
+
+    /**
+     * Remove all sequences that were added through addSequence method.
+     */
+    public void removeAllSequences();
+
+    /**
+     * INTERNAL:
+     * Returns a map of sequence names to Sequences (may be null).
+     */
+    public Map getSequences();
+
+    /**
+     * INTERNAL:
+     * Used only for writing into XML or Java.
+     */
+    public Map getSequencesToWrite();
+
+    /**
+     * INTERNAL:
+     * Used only for writing into XML or Java.
+     */
+    public Sequence getDefaultSequenceToWrite();
+
+    /**
+     * INTERNAL:
+     * Used only for reading from XML.
+     */
+    public void setSequences(Map sequences);
+
+    /**
+     * INTERNAL:
+     * Indicates whether defaultSequence is the same as platform default sequence.
+     */
+    public boolean usesPlatformDefaultSequence();
+}

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/internal/jpa/metadata/converters/LobMetadata.java
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/internal/jpa/metadata/converters/LobMetadata.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     05/16/2008-1.0M8 Guy Pelletier
+//       - 218084: Implement metadata merging functionality between mapping files
+//     03/27/2009-2.0 Guy Pelletier
+//       - 241413: JPA 2.0 Add EclipseLink support for Map type attributes
+//     04/27/2010-2.1 Guy Pelletier
+//       - 309856: MappedSuperclasses from XML are not being initialized properly
+//     03/24/2011-2.3 Guy Pelletier
+//       - 337323: Multi-tenant with shared schema support (part 1)
+package org.eclipse.persistence.internal.jpa.metadata.converters;
+
+import java.io.Serializable;
+
+import org.eclipse.persistence.mappings.DatabaseMapping;
+import org.eclipse.persistence.mappings.converters.SerializedObjectConverter;
+import org.eclipse.persistence.mappings.converters.TypeConversionConverter;
+
+import org.eclipse.persistence.exceptions.ValidationException;
+import org.eclipse.persistence.internal.jpa.metadata.accessors.MetadataAccessor;
+import org.eclipse.persistence.internal.jpa.metadata.accessors.mappings.MappingAccessor;
+import org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataAnnotation;
+import org.eclipse.persistence.internal.jpa.metadata.accessors.objects.MetadataClass;
+
+/**
+ * INTERNAL:
+ * Abstract converter class that parents both the JPA and Eclipselink
+ * converters.
+ *
+ * Key notes:
+ * - any metadata mapped from XML to this class must be compared in the
+ *   equals method.
+ * - when loading from annotations, the constructor accepts the metadata
+ *   accessor this metadata was loaded from. Used it to look up any
+ *   'companion' annotation needed for processing.
+ * - methods should be preserved in alphabetical order.
+ *
+ * @author Guy Pelletier
+ * @since EclipseLink 1.2
+ */
+public class LobMetadata extends MetadataConverter {
+    /**
+     * INTERNAL:
+     * Used for XML loading.
+     */
+    public LobMetadata() {
+        super("<lob>");
+    }
+
+    /**
+     * INTERNAL:
+     * Used for annotation loading.
+     */
+    public LobMetadata(MetadataAnnotation lob, MetadataAccessor accessor) {
+        super(lob, accessor);
+
+        // Nothing to read off a lob.
+    }
+
+    /**
+     * INTERNAL:
+     */
+    @Override
+    public boolean equals(Object objectToCompare) {
+        return super.equals(objectToCompare) && objectToCompare instanceof LobMetadata;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * INTERNAL:
+     * Returns true if the given class is a valid blob type.
+     */
+    public static boolean isValidBlobType(MetadataClass cls) {
+        return cls.equals(byte[].class) ||
+               cls.equals(Byte[].class) ||
+               cls.equals(java.sql.Blob.class);
+    }
+
+    /**
+     * INTERNAL:
+     * Returns true if the given class is a valid clob type.
+     */
+    public static boolean isValidClobType(MetadataClass cls) {
+        return cls.equals(char[].class) ||
+               cls.equals(String.class) ||
+               cls.equals(Character[].class) ||
+               cls.equals(java.sql.Clob.class);
+    }
+
+    /**
+     * INTERNAL:
+     * Returns true if the given class is a valid lob type.
+     */
+    public static boolean isValidLobType(MetadataClass cls) {
+        return isValidClobType(cls) || isValidBlobType(cls);
+    }
+
+    /**
+     * INTERNAL:
+     * Every converter needs to be able to process themselves.
+     */
+    public void process(DatabaseMapping mapping, MappingAccessor accessor, MetadataClass referenceClass, boolean isForMapKey) {
+        // Set the field classification type on the mapping based on the
+        // referenceClass type.
+        if (isValidClobType(referenceClass)) {
+            setFieldClassification(mapping, java.sql.Clob.class, isForMapKey);
+            TypeConversionConverter typeConversionConverter = new TypeConversionConverter(mapping);
+            typeConversionConverter.setDataClass(java.sql.Clob.class);
+            setConverter(mapping, typeConversionConverter, isForMapKey);
+        } else if (isValidBlobType(referenceClass)) {
+            setFieldClassification(mapping, java.sql.Blob.class, isForMapKey);
+            TypeConversionConverter typeConversionConverter = new TypeConversionConverter(mapping);
+            typeConversionConverter.setDataClass(java.sql.Blob.class);
+            setConverter(mapping, typeConversionConverter, isForMapKey);
+        } else if (referenceClass.extendsInterface(Serializable.class)) {
+            setFieldClassification(mapping, java.sql.Blob.class, isForMapKey);
+            setConverter(mapping, new SerializedObjectConverter(mapping), isForMapKey);
+        } else {
+            // The referenceClass is neither a valid BLOB or CLOB attribute.
+            throw ValidationException.invalidTypeForLOBAttribute(mapping.getAttributeName(), referenceClass, accessor.getJavaClass());
+        }
+    }
+}

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/mappings/converters/TypeConversionConverter.java
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/mappings/converters/TypeConversionConverter.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+//     06/03/2013-2.5.1 Guy Pelletier
+//       - 402380: 3 jpa21/advanced tests failed on server with
+//         "java.lang.NoClassDefFoundError: org/eclipse/persistence/testing/models/jpa21/advanced/enums/Gender"
+package org.eclipse.persistence.mappings.converters;
+
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+
+import org.eclipse.persistence.mappings.*;
+import org.eclipse.persistence.mappings.foundation.AbstractDirectMapping;
+import org.eclipse.persistence.sessions.*;
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.ValidationException;
+import org.eclipse.persistence.internal.descriptors.ClassNameConversionRequired;
+import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.internal.security.PrivilegedClassForName;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+
+/**
+ * <b>Purpose</b>: Type conversion converters are used to explicitly map a database type to a
+ * Java type.
+ *
+ * @author James Sutherland
+ * @since OracleAS TopLink 10<i>g</i> (10.0.3)
+ */
+public class TypeConversionConverter implements Converter, ClassNameConversionRequired {
+    protected DatabaseMapping mapping;
+
+    /** Field type */
+    protected Class dataClass;
+    protected String dataClassName;
+
+    /** Object type */
+    protected Class objectClass;
+    protected String objectClassName;
+
+    /**
+     * PUBLIC:
+     * Default constructor.
+     */
+    public TypeConversionConverter() {
+    }
+
+    /**
+     * PUBLIC:
+     * Default constructor.
+     */
+    public TypeConversionConverter(DatabaseMapping mapping) {
+        this.mapping = mapping;
+    }
+
+    /**
+     * INTERNAL:
+     * Convert all the class-name-based settings in this converter to actual class-based
+     * settings. This method is used when converting a project that has been built
+     * with class names to a project with classes.
+     * This method is implemented by subclasses as necessary.
+     * @param classLoader
+     */
+    public void convertClassNamesToClasses(ClassLoader classLoader){
+        Class dataClass = null;
+        Class objectClass = null;
+        try{
+            if (dataClassName != null){
+                if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()){
+                    try {
+                        dataClass = (Class)AccessController.doPrivileged(new PrivilegedClassForName(dataClassName, true, classLoader));
+                    } catch (PrivilegedActionException exception) {
+                        throw ValidationException.classNotFoundWhileConvertingClassNames(dataClassName, exception.getException());
+                    }
+                } else {
+                    dataClass = PrivilegedAccessHelper.getClassForName(dataClassName, true, classLoader);
+                }
+                setDataClass(dataClass);
+            }
+        } catch (ClassNotFoundException exc){
+            throw ValidationException.classNotFoundWhileConvertingClassNames(dataClassName, exc);
+        }
+        try {
+            if (objectClassName != null){
+                if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()){
+                    try {
+                        objectClass = (Class)AccessController.doPrivileged(new PrivilegedClassForName(objectClassName, true, classLoader));
+                    } catch (PrivilegedActionException exception) {
+                        throw ValidationException.classNotFoundWhileConvertingClassNames(objectClassName, exception.getException());
+                    }
+                } else {
+                    objectClass = PrivilegedAccessHelper.getClassForName(objectClassName, true, classLoader);
+                }
+                setObjectClass(objectClass);
+            }
+        } catch (ClassNotFoundException exc){
+            throw ValidationException.classNotFoundWhileConvertingClassNames(objectClassName, exc);
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * The field value must first be converted to the field type, then the attribute type.
+     */
+    public Object convertDataValueToObjectValue(Object fieldValue, Session session) {
+        Object attributeValue = fieldValue;
+        if (attributeValue != null) {
+            try {
+                attributeValue = ((AbstractSession)session).getDatasourcePlatform().convertObject(attributeValue, getDataClass());
+            } catch (ConversionException e) {
+                throw ConversionException.couldNotBeConverted(mapping, mapping.getDescriptor(), e);
+            }
+
+            try {
+                attributeValue = ((AbstractSession)session).getDatasourcePlatform().convertObject(attributeValue, getObjectClass());
+            } catch (ConversionException e) {
+                throw ConversionException.couldNotBeConverted(mapping, mapping.getDescriptor(), e);
+            }
+        }
+
+        return attributeValue;
+    }
+
+    /**
+     * PUBLIC:
+     * Returns the class type of the object value.
+     */
+    public Class getObjectClass() {
+        return objectClass;
+    }
+
+    /**
+     * INTERNAL:
+     * Return the name of the object type for the MW usage.
+     */
+    public String getObjectClassName() {
+        if ((objectClassName == null) && (objectClass != null)) {
+            objectClassName = objectClass.getName();
+        }
+        return objectClassName;
+    }
+
+    /**
+     * PUBLIC:
+     * Returns the class type of the data value.
+     */
+    public Class getDataClass() {
+        return dataClass;
+    }
+
+    /**
+     * INTERNAL:
+     * Return the name of the data type for the MW usage.
+     */
+    public String getDataClassName() {
+        if ((dataClassName == null) && (dataClass != null)) {
+            dataClassName = dataClass.getName();
+        }
+        return dataClassName;
+    }
+
+    /**
+     * PUBLIC:
+     * Set the class type of the data value.
+     */
+    public void setDataClass(Class dataClass) {
+        this.dataClass = dataClass;
+    }
+
+    /**
+     * INTERNAL:
+     * Set the name of the data type for the MW usage.
+     */
+    public void setDataClassName(String dataClassName) {
+        this.dataClassName = dataClassName;
+    }
+
+    /**
+     * PUBLIC:
+     * Set the class type of the object value.
+     */
+    public void setObjectClass(Class objectClass) {
+        this.objectClass = objectClass;
+    }
+
+    /**
+     * INTERNAL:
+     * Set the name of the object type for the MW usage.
+     */
+    public void setObjectClassName(String objectClassName) {
+        this.objectClassName = objectClassName;
+    }
+
+    /**
+     *  INTERNAL:
+     *  Convert to the field class.
+     */
+    public Object convertObjectValueToDataValue(Object attributeValue, Session session) {
+        try {
+            if (session.isConnected()) {
+                //Should handle conversions where DB connection is needed like String -> java.sql.Clob
+                return session.getDatasourcePlatform().convertObject(attributeValue, getDataClass(), (AbstractSession)session);
+            } else {
+                return session.getDatasourcePlatform().convertObject(attributeValue, getDataClass());
+            }
+        } catch (ConversionException e) {
+            throw ConversionException.couldNotBeConverted(mapping, mapping.getDescriptor(), e);
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * Set the mapping.
+     */
+    public void initialize(DatabaseMapping mapping, Session session) {
+        this.mapping = mapping;
+        // CR#... Mapping must also have the field classification.
+        if (getMapping().isDirectToFieldMapping()) {
+            AbstractDirectMapping directMapping = (AbstractDirectMapping)getMapping();
+
+            // Allow user to specify field type to override computed value. (i.e. blob, nchar)
+            if (directMapping.getFieldClassification() == null) {
+                directMapping.setFieldClassification(getDataClass());
+            }
+
+            // Set the object class from the attribute, if null.
+            if (getObjectClass() == null) {
+                setObjectClass(directMapping.getAttributeClassification());
+            }
+        } else if (getMapping().isDirectCollectionMapping()) {
+            ((DirectCollectionMapping) getMapping()).setAttributeClassification(getObjectClass());
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * Return the mapping.
+     */
+    protected DatabaseMapping getMapping() {
+        return mapping;
+    }
+
+    /**
+     * INTERNAL:
+     * If the converter converts the value to a non-atomic value, i.e.
+     * a value that can have its' parts changed without being replaced,
+     * then it must return false, serialization can be non-atomic.
+     */
+    public boolean isMutable() {
+        return false;
+    }
+}

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/platform/database/Oracle23Platform.java
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/platform/database/Oracle23Platform.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.platform.database;
+
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Hashtable;
+
+import static org.eclipse.persistence.internal.helper.StringHelper.EMPTY_STRING;
+
+public class Oracle23Platform extends Oracle21Platform {
+	public Oracle23Platform() {
+		super();
+	}
+
+	@Override
+	protected Hashtable<Class<?>, FieldTypeDefinition> buildFieldTypes() {
+		Hashtable<Class<?>, FieldTypeDefinition> fieldTypes = super.buildFieldTypes();
+		fieldTypes.put(java.time.LocalDateTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+		fieldTypes.put(java.time.LocalTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+		return fieldTypes;
+	}
+
+	/**
+	 * INTERNAL:
+	 * Check whether current platform is Oracle 23c or later.
+	 * @return Always returns {@code true} for instances of Oracle 23c platform.
+	 * @since 2.7.14
+	 */
+	@Override
+	public boolean isOracle23() {
+		return true;
+	}
+
+	/**
+	 * INTERNAL:
+	 * Allow for conversion from the Oracle type to the Java type. Used in cases when DB connection is needed like BLOB, CLOB.
+	 */
+	@Override
+	public Object convertObject(Object sourceObject, Class javaClass, AbstractSession session) throws ConversionException, DatabaseException {
+		//Handle special case when empty String ("") is passed from the entity into CLOB type column
+		if (ClassConstants.CLOB.equals(javaClass) && sourceObject instanceof String && EMPTY_STRING.equals(sourceObject)) {
+			Connection connection = session.getAccessor().getConnection();
+			Clob clob = null;
+			try {
+				clob = connection.createClob();
+				clob.setString(1, (String)sourceObject);
+			} catch (SQLException e) {
+				throw ConversionException.couldNotBeConvertedToClass(sourceObject, ClassConstants.CLOB, e);
+			}
+			return clob;
+		}
+		return super.convertObject(sourceObject, javaClass);
+	}
+}

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/platform/database/oracle/plsql/PLSQLStoredProcedureCall.java
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink/src/org/eclipse/persistence/platform/database/oracle/plsql/PLSQLStoredProcedureCall.java
@@ -1,0 +1,1390 @@
+/*
+ * Copyright (c) 1998, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+
+package org.eclipse.persistence.platform.database.oracle.plsql;
+
+//javase imports
+import static java.lang.Integer.MIN_VALUE;
+import static org.eclipse.persistence.internal.helper.DatabaseType.DatabaseTypeHelper.databaseTypeHelper;
+import static org.eclipse.persistence.internal.helper.Helper.INDENT;
+import static org.eclipse.persistence.internal.helper.Helper.NL;
+import static org.eclipse.persistence.platform.database.jdbc.JDBCTypes.getDatabaseTypeForCode;
+import static org.eclipse.persistence.platform.database.oracle.plsql.OraclePLSQLType.PLSQLBoolean_IN_CONV;
+import static org.eclipse.persistence.platform.database.oracle.plsql.OraclePLSQLType.PLSQLBoolean_OUT_CONV;
+import static org.eclipse.persistence.platform.database.oracle.plsql.OraclePLSQLTypes.PLSQLBoolean;
+import static org.eclipse.persistence.platform.database.oracle.plsql.OraclePLSQLTypes.XMLType;
+
+import java.io.Serializable;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
+import java.util.concurrent.TimeUnit;
+
+// EclipseLink imports
+import org.eclipse.persistence.exceptions.QueryException;
+import org.eclipse.persistence.internal.databaseaccess.Accessor;
+import org.eclipse.persistence.internal.databaseaccess.DatabaseAccessor;
+import org.eclipse.persistence.internal.helper.ComplexDatabaseType;
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.internal.helper.DatabaseType;
+import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.internal.sessions.AbstractRecord;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.mappings.structures.ObjectRelationalDatabaseField;
+import org.eclipse.persistence.platform.database.DatabasePlatform;
+import org.eclipse.persistence.platform.database.jdbc.JDBCTypes;
+import org.eclipse.persistence.platform.database.oracle.jdbc.OracleArrayType;
+import org.eclipse.persistence.queries.StoredProcedureCall;
+import org.eclipse.persistence.sessions.DatabaseRecord;
+/**
+ * <b>Purpose</b>:
+ * Generates an Anonymous PL/SQL block to invoke the specified Stored Procedure
+ * with arguments that may or may not have JDBC equivalents.
+ * This handles conversion of PLSQL Record and Table types into SQL ARRAY (VARRAY) and STRUCT (OBJECT TYPE).
+ * It also handles conversion of flat PLSQL Record types and PLSQL BOOLEAN and other basic types.
+ */
+@SuppressWarnings("unchecked")
+public class PLSQLStoredProcedureCall extends StoredProcedureCall {
+
+    // can't use Helper.cr(), Oracle PL/SQL parser only likes Unix-style newlines '\n'
+    final static String BEGIN_DECLARE_BLOCK = NL + "DECLARE" + NL;
+    final static String BEGIN_BEGIN_BLOCK = "BEGIN" + NL;
+    final static String END_BEGIN_BLOCK = "END;";
+    final static String PL2SQL_PREFIX = "EL_PL2SQL_";
+    final static String SQL2PL_PREFIX = "EL_SQL2PL_";
+    final static String BEGIN_DECLARE_FUNCTION = "FUNCTION ";
+    final static String RTURN = "RETURN ";
+
+    /**
+     * List of procedure IN/OUT/INOUT arguments.
+     */
+    protected List<PLSQLargument> arguments = new ArrayList<PLSQLargument>();
+
+    /**
+     * Keeps track of the next procedure argument index.
+     */
+    protected int originalIndex = 0;
+    /**
+     * Translation row stored after translation on the call clone, used only for logging.
+     */
+    protected AbstractRecord translationRow;
+    /**
+     * Map of conversion function routines for converting complex PLSQL types.
+     */
+    protected Map<String, TypeInfo> typesInfo;
+    /**
+     * Id used to generate unique local functions.
+     */
+    protected int functionId = 0;
+
+    public PLSQLStoredProcedureCall() {
+        super();
+        setIsCallableStatementRequired(true);
+    }
+
+    /**
+     * PUBLIC:
+     * Add a named IN argument to the stored procedure. The databaseType parameter classifies the
+     * parameter (JDBCType vs. OraclePLSQLType, simple vs. complex)
+     */
+    public void addNamedArgument(String procedureParameterName, DatabaseType databaseType) {
+        DatabaseType dt = databaseType.isComplexDatabaseType() ?
+            ((ComplexDatabaseType)databaseType).clone() : databaseType;
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.IN, dt));
+    }
+
+    /**
+     * PUBLIC:
+     * Add a named IN argument to the stored procedure. The databaseType parameter classifies the
+     * parameter (JDBCType vs. OraclePLSQLType, simple vs. complex). The extra length parameter
+     * indicates that this parameter, when used in an Anonymous PL/SQL block, requires a length.
+     */
+    public void addNamedArgument(String procedureParameterName, DatabaseType databaseType,
+        int length) {
+        DatabaseType dt = databaseType.isComplexDatabaseType() ?
+            ((ComplexDatabaseType)databaseType).clone() : databaseType;
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.IN, dt, length));
+    }
+
+    /**
+     * PUBLIC:
+     * Add a named IN argument to the stored procedure. The databaseType parameter classifies the
+     * parameter (JDBCType vs. OraclePLSQLType, simple vs. complex). The extra scale and precision
+     * parameters indicates that this parameter, when used in an Anonymous PL/SQL block, requires
+     * scale and precision specification
+     */
+    public void addNamedArgument(String procedureParameterName, DatabaseType databaseType,
+        int precision, int scale) {
+        DatabaseType dt = databaseType.isComplexDatabaseType() ?
+            ((ComplexDatabaseType)databaseType).clone() : databaseType;
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.IN, dt, precision, scale));
+    }
+
+    @Override
+    public void addNamedArgument(String procedureParameterName, String argumentFieldName, int type) {
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.IN,
+            getDatabaseTypeForCode(type))); // figure out databaseType from the sqlType
+    }
+
+    @Override
+    public void addNamedArgument(String procedureParameterName, String argumentFieldName, int type,
+        String typeName) {
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.IN,
+            getDatabaseTypeForCode(type)));
+    }
+
+    /**
+     * PUBLIC: Add a named IN OUT argument to the stored procedure. The databaseType parameter
+     * classifies the parameter (JDBCType vs. OraclePLSQLType, simple vs. complex)
+     */
+    public void addNamedInOutputArgument(String procedureParameterName, DatabaseType databaseType) {
+        DatabaseType dt = databaseType.isComplexDatabaseType() ?
+            ((ComplexDatabaseType)databaseType).clone() : databaseType;
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.INOUT, dt));
+    }
+
+    /**
+     * PUBLIC: Add a named IN OUT argument to the stored procedure. The databaseType parameter
+     * classifies the parameter (JDBCType vs. OraclePLSQLType, simple vs. complex). The extra length
+     * parameter indicates that this parameter, when used in an Anonymous PL/SQL block, requires a
+     * length.
+     */
+    public void addNamedInOutputArgument(String procedureParameterName, DatabaseType databaseType,
+        int length) {
+        DatabaseType dt = databaseType.isComplexDatabaseType() ?
+            ((ComplexDatabaseType)databaseType).clone() : databaseType;
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.INOUT, dt, length));
+    }
+
+    /**
+     * PUBLIC: Add a named IN OUT argument to the stored procedure. The databaseType parameter
+     * classifies the parameter (JDBCType vs. OraclePLSQLType, simple vs. complex). The extra scale
+     * and precision parameters indicates that this parameter, when used in an Anonymous PL/SQL
+     * block, requires scale and precision specification
+     */
+    public void addNamedInOutputArgument(String procedureParameterName, DatabaseType databaseType,
+        int precision, int scale) {
+        DatabaseType dt = databaseType.isComplexDatabaseType() ?
+            ((ComplexDatabaseType)databaseType).clone() : databaseType;
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.INOUT, dt,
+            precision, scale));
+    }
+
+    @Override
+    public void addNamedInOutputArgument(String procedureParameterName, String inArgumentFieldName,
+        String outArgumentFieldName, int type) {
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.INOUT,
+            getDatabaseTypeForCode(type)));
+    }
+
+    @Override
+    public void addNamedInOutputArgument(String procedureParameterName, String inArgumentFieldName,
+        String outArgumentFieldName, int type, String typeName) {
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.INOUT,
+            getDatabaseTypeForCode(type)));
+    }
+
+    @Override
+    public void addNamedInOutputArgument(String procedureParameterName, String inArgumentFieldName,
+        String outArgumentFieldName, int type, String typeName, Class classType) {
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.INOUT,
+            getDatabaseTypeForCode(type)));
+    }
+
+    @Override
+    public void addNamedInOutputArgument(String procedureParameterName, String inArgumentFieldName,
+        String outArgumentFieldName, int type, String typeName, Class javaType,
+        DatabaseField nestedType) {
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.INOUT,
+            getDatabaseTypeForCode(type)));
+    }
+
+    /**
+     * PUBLIC: Add a named OUT argument to the stored procedure. The databaseType parameter
+     * classifies the parameter (JDBCType vs. OraclePLSQLType, simple vs. complex)
+     */
+    public void addNamedOutputArgument(String procedureParameterName, DatabaseType databaseType) {
+        DatabaseType dt = databaseType.isComplexDatabaseType() ?
+            ((ComplexDatabaseType)databaseType).clone() : databaseType;
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.OUT, dt));
+    }
+
+    /**
+     * PUBLIC: Add a named OUT argument to the stored procedure. The databaseType parameter
+     * classifies the parameter (JDBCType vs. OraclePLSQLType, simple vs. complex). The extra length
+     * parameter indicates that this parameter, when used in an Anonymous PL/SQL block, requires a
+     * length.
+     */
+    public void addNamedOutputArgument(String procedureParameterName, DatabaseType databaseType,
+        int length) {
+        DatabaseType dt = databaseType.isComplexDatabaseType() ?
+            ((ComplexDatabaseType)databaseType).clone() : databaseType;
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.OUT, dt, length));
+    }
+
+    /**
+     * PUBLIC: Add a named OUT argument to the stored procedure. The databaseType parameter
+     * classifies the parameter (JDBCType vs. OraclePLSQLType, simple vs. complex). The extra scale
+     * and precision parameters indicates that this parameter, when used in an Anonymous PL/SQL
+     * block, requires scale and precision specification
+     */
+    public void addNamedOutputArgument(String procedureParameterName, DatabaseType databaseType,
+        int precision, int scale) {
+        DatabaseType dt = databaseType.isComplexDatabaseType() ?
+            ((ComplexDatabaseType)databaseType).clone() : databaseType;
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.OUT, dt,
+            precision, scale));
+    }
+
+    @Override
+    public void addNamedOutputArgument(String procedureParameterName, String argumentFieldName,
+        int jdbcType, String typeName, Class javaType) {
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.OUT,
+            getDatabaseTypeForCode(jdbcType)));
+    }
+
+    @Override
+    public void addNamedOutputArgument(String procedureParameterName, String argumentFieldName,
+        int jdbcType, String typeName, Class javaType, DatabaseField nestedType) {
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.OUT,
+            getDatabaseTypeForCode(jdbcType)));
+    }
+
+    @Override
+    public void addNamedOutputArgument(String procedureParameterName, String argumentFieldName,
+        int type, String typeName) {
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.OUT,
+            getDatabaseTypeForCode(type)));
+    }
+
+    @Override
+    public void addNamedOutputArgument(String procedureParameterName, String argumentFieldName,
+        int type) {
+        arguments.add(new PLSQLargument(procedureParameterName, originalIndex++, ParameterType.OUT,
+            getDatabaseTypeForCode(type)));
+    }
+
+    // un-supported addXXX operations
+
+    @Override
+    public void addNamedArgument(String procedureParameterAndArgumentFieldName) {
+        throw QueryException.addArgumentsNotSupported("named arguments without DatabaseType classification");
+    }
+
+    @Override
+    public void addNamedArgumentValue(String procedureParameterName, Object argumentValue) {
+        throw QueryException.addArgumentsNotSupported("named argument values without DatabaseType classification");
+    }
+
+    @Override
+    public void addNamedArgument(String procedureParameterName, String argumentFieldName) {
+        throw QueryException.addArgumentsNotSupported("named argument values without DatabaseType classification");
+    }
+
+    @Override
+    public void addNamedInOutputArgument(String procedureParameterAndArgumentFieldName) {
+        throw QueryException.addArgumentsNotSupported("named IN OUT argument without DatabaseType classification");
+    }
+
+    @Override
+    public void addNamedInOutputArgument(String procedureParameterName, String argumentFieldName) {
+        throw QueryException.addArgumentsNotSupported("named IN OUT arguments without DatabaseType classification");
+    }
+
+    @Override
+    public void addNamedInOutputArgument(String procedureParameterName, String argumentFieldName,
+        Class type) {
+        throw QueryException.addArgumentsNotSupported("named IN OUT arguments without DatabaseType classification");
+    }
+
+    @Override
+    public void addNamedInOutputArgument(String procedureParameterName, String inArgumentFieldName,
+        String outArgumentFieldName, Class type) {
+        throw QueryException.addArgumentsNotSupported("named IN OUT arguments without DatabaseType classification");
+    }
+
+    @Override
+    public void addNamedInOutputArgumentValue(String procedureParameterName,
+        Object inArgumentValue, String outArgumentFieldName, Class type) {
+        throw QueryException.addArgumentsNotSupported("named IN OUT argument values without DatabaseType classification");
+    }
+
+    @Override
+    public void addNamedOutputArgument(String procedureParameterAndArgumentFieldName) {
+        throw QueryException.addArgumentsNotSupported("named OUT arguments without DatabaseType classification");
+    }
+
+    @Override
+    public void addNamedOutputArgument(String procedureParameterName, String argumentFieldName) {
+        throw QueryException.addArgumentsNotSupported("named OUT arguments without DatabaseType classification");
+    }
+
+    @Override
+    public void addNamedOutputArgument(String procedureParameterName, String argumentFieldName,
+        Class type) {
+        throw QueryException.addArgumentsNotSupported("named OUT arguments without DatabaseType classification");
+    }
+
+    @Override
+    public void useNamedCursorOutputAsResultSet(String argumentName) {
+        throw QueryException.addArgumentsNotSupported("named OUT cursor arguments without DatabaseType classification");
+    }
+
+    // unlikely we will EVER support unnamed parameters
+    @Override
+    public void addUnamedArgument(String argumentFieldName, Class type) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedArgument(String argumentFieldName, int type, String typeName,
+        DatabaseField nestedType) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedArgument(String argumentFieldName, int type, String typeName) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedArgument(String argumentFieldName, int type) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedArgument(String argumentFieldName) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedArgumentValue(Object argumentValue) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedInOutputArgument(String argumentFieldName, Class type) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedInOutputArgument(String inArgumentFieldName, String outArgumentFieldName,
+        Class type) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedInOutputArgument(String inArgumentFieldName, String outArgumentFieldName,
+        int type, String typeName, Class collection, DatabaseField nestedType) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedInOutputArgument(String inArgumentFieldName, String outArgumentFieldName,
+        int type, String typeName, Class collection) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedInOutputArgument(String inArgumentFieldName, String outArgumentFieldName,
+        int type, String typeName) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedInOutputArgument(String inArgumentFieldName, String outArgumentFieldName,
+        int type) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedInOutputArgument(String argumentFieldName) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedInOutputArgumentValue(Object inArgumentValue, String outArgumentFieldName,
+        Class type) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedOutputArgument(String argumentFieldName, Class type) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedOutputArgument(String argumentFieldName, int jdbcType, String typeName,
+        Class javaType, DatabaseField nestedType) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedOutputArgument(String argumentFieldName, int jdbcType, String typeName,
+        Class javaType) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedOutputArgument(String argumentFieldName, int type, String typeName) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedOutputArgument(String argumentFieldName, int type) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void addUnamedOutputArgument(String argumentFieldName) {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    @Override
+    public void useUnnamedCursorOutputAsResultSet() {
+        throw QueryException.unnamedArgumentsNotSupported();
+    }
+
+    /**
+     * PUBLIC: Add a named OUT cursor argument to the stored procedure. The databaseType parameter
+     * classifies the parameter (JDBCType vs. OraclePLSQLType, simple vs. complex).
+     */
+    public void useNamedCursorOutputAsResultSet(String argumentName, DatabaseType databaseType) {
+        DatabaseType dt = databaseType.isComplexDatabaseType() ?
+            ((ComplexDatabaseType)databaseType).clone() : databaseType;
+        PLSQLargument newArg = new PLSQLargument(argumentName, originalIndex++, ParameterType.OUT, dt);
+        newArg.cursorOutput = true;
+        arguments.add(newArg);
+    }
+
+    /**
+     * INTERNAL compute the re-ordered indices - Do the IN args first, then the
+     * 'IN-half' of the INOUT args next, the OUT args, then the 'OUT-half' of
+     * the INOUT args
+     */
+    protected void assignIndices() {
+        List<PLSQLargument> inArguments = getArguments(arguments, ParameterType.IN);
+        List<PLSQLargument> inOutArguments = getArguments(arguments, ParameterType.INOUT);
+        DatabasePlatform platform = this.getQuery().getSession().getPlatform();
+        inArguments.addAll(inOutArguments);
+        int newIndex = 1;
+        List<PLSQLargument> expandedArguments = new ArrayList<PLSQLargument>();
+        // Must move any expanded types to the end, as they are assigned after
+        // in the BEGIN clause.
+        for (ListIterator<PLSQLargument> inArgsIter = inArguments.listIterator(); inArgsIter.hasNext();) {
+            PLSQLargument inArg = inArgsIter.next();
+            if (inArg.databaseType.isComplexDatabaseType() && (!((ComplexDatabaseType) inArg.databaseType).hasCompatibleType())) {
+                expandedArguments.add(inArg);
+                inArgsIter.remove();
+            }
+        }
+        inArguments.addAll(expandedArguments);
+        for (ListIterator<PLSQLargument> inArgsIter = inArguments.listIterator(); inArgsIter.hasNext();) {
+            PLSQLargument inArg = inArgsIter.next();
+            // delegate to arg's DatabaseType - ComplexTypes may expand arguments
+            // use ListIterator so that computeInIndex can add expanded args
+            newIndex = inArg.databaseType.computeInIndex(inArg, newIndex, inArgsIter);
+        }
+        for (PLSQLargument inArg : inArguments) {
+            DatabaseType type = inArg.databaseType;
+            if (platform.isOracle23() && type == OraclePLSQLTypes.PLSQLBoolean && Helper.compareVersions(platform.getDriverVersion(), "23.0.0") >= 0) {
+                type = JDBCTypes.BOOLEAN_TYPE;
+                inArg.databaseType = JDBCTypes.BOOLEAN_TYPE;
+            }
+            String inArgName = inArg.name;
+            if (!type.isComplexDatabaseType()) {
+                // for XMLType, we need to set type name parameter (will be "XMLTYPE")
+                if (type == XMLType) {
+                    super.addNamedArgument(inArgName, inArgName, type.getConversionCode(), type.getTypeName());
+                } else {
+                    super.addNamedArgument(inArgName, inArgName, type.getConversionCode());
+                }
+            } else {
+                ComplexDatabaseType complexType = (ComplexDatabaseType) type;
+                if (inArg.inIndex != MIN_VALUE) {
+                    if (complexType.isStruct()) {
+                        super.addNamedArgument(inArgName, inArgName, complexType.getSqlCode(), complexType.getTypeName());
+                    } else if (complexType.isArray()) {
+                        DatabaseType nestedType = ((OracleArrayType) complexType).getNestedType();
+                        if (nestedType != null) {
+                            ObjectRelationalDatabaseField field = new ObjectRelationalDatabaseField("");
+                            field.setSqlType(nestedType.getSqlCode());
+                            field.setSqlTypeName(nestedType.getTypeName());
+                            super.addNamedArgument(inArgName, inArgName, complexType.getSqlCode(), complexType.getTypeName(), field);
+                        } else {
+                            super.addNamedArgument(inArgName, inArgName, complexType.getSqlCode(), complexType.getTypeName());
+                        }
+                    } else if (complexType.isCollection()) {
+                        DatabaseType nestedType = ((PLSQLCollection) complexType).getNestedType();
+                        if (nestedType != null) {
+                            ObjectRelationalDatabaseField field = new ObjectRelationalDatabaseField("");
+                            field.setSqlType(nestedType.getConversionCode());
+                            if (nestedType.isComplexDatabaseType()) {
+                                field.setSqlTypeName(((ComplexDatabaseType) nestedType).getCompatibleType());
+                            }
+                            super.addNamedArgument(inArgName, inArgName, type.getConversionCode(), complexType.getCompatibleType(), field);
+                        } else {
+                            super.addNamedArgument(inArgName, inArgName, type.getConversionCode(), complexType.getCompatibleType());
+                        }
+                    } else {
+                        super.addNamedArgument(inArgName, inArgName, type.getConversionCode(), complexType.getCompatibleType());
+                    }
+                }
+            }
+        }
+        List<PLSQLargument> outArguments = getArguments(arguments, ParameterType.OUT);
+        outArguments.addAll(inOutArguments);
+        for (ListIterator<PLSQLargument> outArgsIter = outArguments.listIterator(); outArgsIter.hasNext();) {
+            PLSQLargument outArg = outArgsIter.next();
+            newIndex = outArg.databaseType.computeOutIndex(outArg, newIndex, outArgsIter);
+        }
+        for (PLSQLargument outArg : outArguments) {
+            String outArgName = outArg.name;
+            if (outArg.cursorOutput) {
+                super.useNamedCursorOutputAsResultSet(outArgName);
+            } else {
+                DatabaseType type = outArg.databaseType;
+                if (platform.isOracle23() && type == OraclePLSQLTypes.PLSQLBoolean && Helper.compareVersions(platform.getDriverVersion(), "23.0.0") >= 0) {
+                    type = JDBCTypes.BOOLEAN_TYPE;
+                    outArg.databaseType = JDBCTypes.BOOLEAN_TYPE;
+                }
+                if (!type.isComplexDatabaseType()) {
+                    // for XMLType, we need to set type name parameter (will be "XMLTYPE")
+                    if (type == XMLType) {
+                        super.addNamedOutputArgument(outArgName, outArgName, type.getConversionCode(), type.getTypeName());
+                    } else {
+                        super.addNamedOutputArgument(outArgName, outArgName, type.getConversionCode());
+                    }
+                } else {
+                    ComplexDatabaseType complexType = (ComplexDatabaseType) type;
+                    if (outArg.outIndex != MIN_VALUE) {
+                        if (complexType.isStruct()) {
+                            super.addNamedOutputArgument(outArgName, outArgName, complexType.getSqlCode(), complexType.getTypeName(), complexType.getJavaType());
+                        } else if (complexType.isArray()) {
+                            DatabaseType nestedType = ((OracleArrayType) complexType).getNestedType();
+                            if (nestedType != null) {
+                                ObjectRelationalDatabaseField nestedField = new ObjectRelationalDatabaseField("");
+                                nestedField.setSqlType(nestedType.getSqlCode());
+                                if (nestedType.isComplexDatabaseType()) {
+                                    ComplexDatabaseType complexNestedType = (ComplexDatabaseType) nestedType;
+                                    nestedField.setType(complexNestedType.getJavaType());
+                                    nestedField.setSqlTypeName(complexNestedType.getCompatibleType());
+                                }
+                                super.addNamedOutputArgument(outArgName, outArgName, type.getSqlCode(), complexType.getTypeName(), complexType.getJavaType(), nestedField);
+                            } else {
+                                super.addNamedOutputArgument(outArgName, outArgName, type.getSqlCode(), complexType.getTypeName(), complexType.getJavaType());
+                            }
+                        } else if (complexType.isCollection()) {
+                            DatabaseType nestedType = ((PLSQLCollection) complexType).getNestedType();
+                            if (nestedType != null) {
+                                ObjectRelationalDatabaseField nestedField = new ObjectRelationalDatabaseField(outArgName);
+                                nestedField.setSqlType(nestedType.getSqlCode());
+                                if (nestedType.isComplexDatabaseType()) {
+                                    ComplexDatabaseType complexNestedType = (ComplexDatabaseType) nestedType;
+                                    nestedField.setType(complexNestedType.getJavaType());
+                                    nestedField.setSqlTypeName(complexNestedType.getCompatibleType());
+                                }
+                                super.addNamedOutputArgument(outArgName, outArgName, type.getSqlCode(), complexType.getCompatibleType(), complexType.getJavaType(), nestedField);
+                            } else {
+                                super.addNamedOutputArgument(outArgName, outArgName, type.getSqlCode(), complexType.getCompatibleType());
+                            }
+                        } else if (complexType.hasCompatibleType()) {
+                            super.addNamedOutputArgument(outArgName, outArgName, type.getSqlCode(), complexType.getCompatibleType(), complexType.getJavaType());
+                        } else {
+                            // If there is no STRUCT type set, then the output is
+                            // expanded, so one output for each field.
+                            super.addNamedOutputArgument(outArgName, outArgName, type.getSqlCode());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * INTERNAL
+     * Generate portion of the Anonymous PL/SQL block that declares the temporary variables
+     * in the DECLARE section.
+     */
+    protected void buildDeclareBlock(StringBuilder sb, List<PLSQLargument> arguments) {
+        List<PLSQLargument> inArguments = getArguments(arguments, ParameterType.IN);
+        List<PLSQLargument> inOutArguments = getArguments(arguments, ParameterType.INOUT);
+        inArguments.addAll(inOutArguments);
+        List<PLSQLargument> outArguments = getArguments(arguments, ParameterType.OUT);
+        Collections.sort(inArguments, new InArgComparer());
+        for (PLSQLargument arg : inArguments) {
+            arg.databaseType.buildInDeclare(sb, arg);
+        }
+        Collections.sort(outArguments, new OutArgComparer());
+        for (PLSQLargument arg : outArguments) {
+            arg.databaseType.buildOutDeclare(sb, arg);
+        }
+    }
+
+    /**
+     * INTERNAL
+     * Add the nested function string required for the type and its subtypes. The functions
+     * must be added in inverse order to resolve dependencies.
+     */
+    protected void addNestedFunctionsForArgument(List functions, PLSQLargument argument,
+                                                 DatabaseType databaseType, Set<DatabaseType> processed) {
+        if ((databaseType == null)
+                || !databaseType.isComplexDatabaseType()
+                || databaseType.isJDBCType()
+                || argument.cursorOutput
+                || processed.contains(databaseType)) {
+            return;
+        }
+        ComplexDatabaseType type = (ComplexDatabaseType)databaseType;
+        if (!type.hasCompatibleType()) {
+            return;
+        }
+        processed.add(type);
+        boolean isNestedTable = false;
+        if (type.isCollection()) {
+            isNestedTable = ((PLSQLCollection)type).isNestedTable();
+            DatabaseType nestedType = ((PLSQLCollection)type).getNestedType();
+            addNestedFunctionsForArgument(functions, argument, nestedType, processed);
+        } else if (type.isRecord()) {
+            for (PLSQLargument field : ((PLSQLrecord)type).getFields()) {
+                DatabaseType nestedType = field.databaseType;
+                addNestedFunctionsForArgument(functions, argument, nestedType, processed);
+            }
+        }
+        TypeInfo info = this.typesInfo.get(type.getTypeName());
+        // If the info was not found in publisher, then generate it.
+        if (info == null) {
+            info = generateNestedFunction(type, isNestedTable);
+        }
+        if (type.getTypeName().equals(type.getCompatibleType())) {
+            if (!functions.contains(info.pl2SqlConv)) {
+                functions.add(info.pl2SqlConv);
+            }
+        } else {
+            if (argument.pdirection == ParameterType.IN) {
+                if (!functions.contains(info.sql2PlConv)) {
+                    functions.add(info.sql2PlConv);
+                }
+            } else if (argument.pdirection == ParameterType.INOUT) {
+                if (!functions.contains(info.sql2PlConv)) {
+                    functions.add(info.sql2PlConv);
+                }
+                if (!functions.contains(info.pl2SqlConv)) {
+                    functions.add(info.pl2SqlConv);
+                }
+            } else if (argument.pdirection == ParameterType.OUT) {
+                if (!functions.contains(info.pl2SqlConv)) {
+                    functions.add(info.pl2SqlConv);
+                }
+            }
+        }
+    }
+
+    /**
+     * INTERNAL: Generate the nested function to convert the PLSQL type to its compatible SQL type.
+     */
+    protected TypeInfo generateNestedFunction(ComplexDatabaseType type) {
+        return generateNestedFunction(type, false);
+    }
+
+    /**
+     * INTERNAL: Generate the nested function to convert the PLSQL type to its compatible SQL type.
+     */
+    protected TypeInfo generateNestedFunction(ComplexDatabaseType type, boolean isNonAssociativeCollection) {
+        TypeInfo info = new TypeInfo();
+        info.pl2SqlName = PL2SQL_PREFIX + (this.functionId++);
+        info.sql2PlName = SQL2PL_PREFIX + (this.functionId++);
+        if (type.isRecord()) {
+            PLSQLrecord record = (PLSQLrecord)type;
+            StringBuilder sb = new StringBuilder();
+            sb.append(INDENT);
+            sb.append(BEGIN_DECLARE_FUNCTION);
+            sb.append(info.pl2SqlName);
+            sb.append("(aPlsqlItem ");
+            sb.append(record.getTypeName());
+            sb.append(")");
+            sb.append(NL);sb.append(INDENT);
+            sb.append(RTURN);
+            sb.append(record.getCompatibleType());
+            sb.append(" IS");
+            sb.append(NL);sb.append(INDENT);sb.append(INDENT);
+            sb.append("aSqlItem ");
+            sb.append(record.getCompatibleType());
+            sb.append(";");
+            sb.append(NL);sb.append(INDENT);
+            sb.append(BEGIN_BEGIN_BLOCK);
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append("aSqlItem := ");
+            sb.append(record.getCompatibleType());
+            sb.append("(");
+            int size = record.getFields().size();
+            for (int index = 0; index < size; index++) {
+                sb.append("NULL");
+                if ((index + 1) != size) {
+                    sb.append(", ");
+                }
+            }
+            sb.append(");");
+            sb.append(NL);
+            for (PLSQLargument argument : record.getFields()) {
+                sb.append(INDENT);sb.append(INDENT);
+                sb.append("aSqlItem.");
+                sb.append(argument.name);
+                if (argument.databaseType.isComplexDatabaseType() && !((ComplexDatabaseType)argument.databaseType).isJDBCType()) {
+                    sb.append(" := ");
+                    sb.append(getPl2SQLName((ComplexDatabaseType)argument.databaseType));
+                    sb.append("(aPlsqlItem.");
+                    sb.append(argument.name);
+                    sb.append(");");
+                }
+                else if (argument.databaseType.equals(PLSQLBoolean)) {
+                    sb.append(" := ");
+                    sb.append(PLSQLBoolean_OUT_CONV);
+                    sb.append("(aPlsqlItem.");
+                    sb.append(argument.name);
+                    sb.append(");");
+                }
+                else {
+                    sb.append(" := aPlsqlItem.");
+                    sb.append(argument.name);
+                    sb.append(";");
+                }
+                sb.append(NL);
+            }
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append(RTURN);
+            sb.append("aSqlItem;");
+            sb.append(NL);
+            sb.append(INDENT);
+            sb.append("END ");
+            sb.append(info.pl2SqlName);
+            sb.append(";");
+            sb.append(NL);
+
+            info.pl2SqlConv = sb.toString();
+
+            sb = new StringBuilder();
+            sb.append(INDENT);
+            sb.append(BEGIN_DECLARE_FUNCTION);
+            sb.append(info.sql2PlName);
+            sb.append("(aSqlItem ");
+            sb.append(record.getCompatibleType());
+            sb.append(") ");
+            sb.append(NL);sb.append(INDENT);
+            sb.append(RTURN);
+            sb.append(record.getTypeName());
+            sb.append(" IS");
+            sb.append(NL);sb.append(INDENT);sb.append(INDENT);
+            sb.append("aPlsqlItem ");
+            sb.append(record.getTypeName());
+            sb.append(";");
+            sb.append(NL);sb.append(INDENT);
+            sb.append(BEGIN_BEGIN_BLOCK);
+            for (PLSQLargument argument : record.getFields()) {
+                sb.append(INDENT);sb.append(INDENT);
+                sb.append("aPlsqlItem.");
+                sb.append(argument.name);
+                if (argument.databaseType.isComplexDatabaseType() && !((ComplexDatabaseType)argument.databaseType).isJDBCType()) {
+                    sb.append(" := ");
+                    sb.append(getSQL2PlName((ComplexDatabaseType)argument.databaseType));
+                    sb.append("(aSqlItem.");
+                    sb.append(argument.name);
+                    sb.append(");");
+                }
+                else if (argument.databaseType.equals(PLSQLBoolean)) {
+                    sb.append(" := ");
+                    sb.append(PLSQLBoolean_IN_CONV);
+                    sb.append("(aSqlItem.");
+                    sb.append(argument.name);
+                    sb.append(");");
+                }
+                else {
+                    sb.append(" := aSqlItem.");
+                    sb.append(argument.name);
+                    sb.append(";");
+                }
+                sb.append(NL);
+            }
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append(RTURN);
+            sb.append("aPlsqlItem;");
+            sb.append(NL);
+            sb.append(INDENT);
+            sb.append("END ");
+            sb.append(info.sql2PlName);
+            sb.append(";");
+            sb.append(NL);
+
+            info.sql2PlConv = sb.toString();
+        }
+        else if (type.isCollection()) {
+            PLSQLCollection collection = (PLSQLCollection)type;
+            StringBuilder sb = new StringBuilder();
+            sb.append(INDENT);
+            sb.append(BEGIN_DECLARE_FUNCTION);
+            sb.append(info.pl2SqlName);
+            sb.append("(aPlsqlItem ");
+            sb.append(collection.getTypeName());
+            sb.append(")");
+            sb.append(NL);sb.append(INDENT);
+            sb.append(RTURN);
+            sb.append(collection.getCompatibleType());
+            sb.append(" IS");
+            sb.append(NL);sb.append(INDENT);sb.append(INDENT);
+            sb.append("aSqlItem ");
+            sb.append(collection.getCompatibleType());
+            sb.append(";");
+            sb.append(NL);sb.append(INDENT);
+            sb.append(BEGIN_BEGIN_BLOCK);
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append("aSqlItem := ");
+            sb.append(collection.getCompatibleType());
+            sb.append("();");
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append("aSqlItem.EXTEND(aPlsqlItem.COUNT);");
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append("IF aPlsqlItem.COUNT > 0 THEN");
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append("FOR I IN aPlsqlItem.FIRST..aPlsqlItem.LAST LOOP");
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);sb.append(INDENT);
+            sb.append("aSqlItem(I + 1 - aPlsqlItem.FIRST) := ");
+            if (collection.nestedType != null && (collection.nestedType.isComplexDatabaseType() && !((ComplexDatabaseType)collection.nestedType).isJDBCType())) {
+                sb.append(getPl2SQLName((ComplexDatabaseType)collection.nestedType));
+                sb.append("(aPlsqlItem(I));");
+            }
+            else if (PLSQLBoolean.equals(collection.nestedType)) {
+                sb.append(PLSQLBoolean_OUT_CONV);
+                sb.append("(aPlsqlItem(I));");
+            }
+            else {
+                sb.append("aPlsqlItem(I);");
+            }
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);sb.append(INDENT);
+            sb.append("END LOOP;");
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append("END IF;");
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append(RTURN);
+            sb.append("aSqlItem;");
+            sb.append(NL);sb.append(INDENT);
+            sb.append("END ");
+            sb.append(info.pl2SqlName);
+            sb.append(";");
+            sb.append(NL);
+
+            info.pl2SqlConv = sb.toString();
+
+            sb = new StringBuilder();
+            sb.append(INDENT);
+            sb.append(BEGIN_DECLARE_FUNCTION);
+            sb.append(info.sql2PlName);
+            sb.append("(aSqlItem ");
+            sb.append(collection.getCompatibleType());
+            sb.append(")");
+            sb.append(NL);
+            sb.append(INDENT);
+            sb.append(RTURN);
+            sb.append(collection.getTypeName());
+            sb.append(" IS");
+            sb.append(NL);sb.append(INDENT);sb.append(INDENT);
+            sb.append("aPlsqlItem ");
+            sb.append(collection.getTypeName());
+            sb.append(";");
+            sb.append(NL);sb.append(INDENT);
+            sb.append(BEGIN_BEGIN_BLOCK);
+            sb.append(INDENT);sb.append(INDENT);
+            // if the collection is non-associative we need to initialize it
+            if (isNonAssociativeCollection) {
+                sb.append("aPlsqlItem := ");
+                sb.append(collection.getTypeName());
+                sb.append("();");
+                sb.append(NL);
+                sb.append(INDENT);sb.append(INDENT);
+                sb.append("aPlsqlItem.EXTEND(aSqlItem.COUNT);");
+                sb.append(NL);
+                sb.append(INDENT);sb.append(INDENT);
+            }
+            sb.append("IF aSqlItem.COUNT > 0 THEN");
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);sb.append(INDENT);
+            sb.append("FOR I IN 1..aSqlItem.COUNT LOOP");
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);sb.append(INDENT);sb.append(INDENT);
+            if ((collection.nestedType != null) && collection.nestedType.isComplexDatabaseType()) {
+                sb.append("aPlsqlItem(I) := ");
+                sb.append(getSQL2PlName((ComplexDatabaseType)collection.nestedType));
+                sb.append("(aSqlItem(I));");
+            }
+            else if (PLSQLBoolean.equals(collection.nestedType)) {
+                sb.append("aPlsqlItem(I + 1 - aSqlItem.FIRST) := ");
+                sb.append(PLSQLBoolean_IN_CONV);
+                sb.append("(aSqlItem(I));");
+            }
+            else {
+                sb.append("aPlsqlItem(I) := aSqlItem(I);");
+            }
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);sb.append(INDENT);
+            sb.append("END LOOP;");
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append("END IF;");
+            sb.append(NL);
+            sb.append(INDENT);sb.append(INDENT);
+            sb.append(RTURN);
+            sb.append("aPlsqlItem;");
+            sb.append(NL);
+            sb.append(INDENT);
+            sb.append("END ");
+            sb.append(info.sql2PlName);
+            sb.append(";");
+            sb.append(NL);
+
+            info.sql2PlConv = sb.toString();
+        }
+        this.typesInfo.put(type.getTypeName(), info);
+        return info;
+    }
+
+    /**
+     * INTERNAL
+     * Generate portion of the Anonymous PL/SQL block with PL/SQL conversion routines as
+     * nested functions.
+     */
+    protected void buildNestedFunctions(StringBuilder stream, List<PLSQLargument> arguments) {
+        List<String> nestedFunctions = new ArrayList<String>();
+        Set<DatabaseType> processed = new HashSet<DatabaseType>();
+        for (PLSQLargument arg : arguments) {
+            DatabaseType type = arg.databaseType;
+            addNestedFunctionsForArgument(nestedFunctions, arg, type, processed);
+        }
+        if (!nestedFunctions.isEmpty()) {
+            for (String function : nestedFunctions) {
+                stream.append(function);
+            }
+        }
+    }
+
+    /**
+     * INTERNAL Generate portion of the Anonymous PL/SQL block that assigns fields at the beginning
+     * of the BEGIN block (before invoking the target procedure).
+     */
+    protected void buildBeginBlock(StringBuilder sb, List<PLSQLargument> arguments) {
+        List<PLSQLargument> inArguments = getArguments(arguments, ParameterType.IN);
+        inArguments.addAll(getArguments(arguments, ParameterType.INOUT));
+        for (PLSQLargument arg : inArguments) {
+            arg.databaseType.buildBeginBlock(sb, arg, this);
+        }
+    }
+
+    /**
+     * INTERNAL Generate portion of the Anonymous PL/SQL block that invokes the target procedure.
+     */
+    protected void buildProcedureInvocation(StringBuilder sb, List<PLSQLargument> arguments) {
+        sb.append("  ");
+        sb.append(getProcedureName());
+        sb.append("(");
+        int size = arguments.size(), idx = 1;
+        for (PLSQLargument argument : arguments) {
+            sb.append(argument.name);
+            sb.append("=>");
+            sb.append(databaseTypeHelper.buildTarget(argument));
+            if (idx < size) {
+                sb.append(", ");
+                idx++;
+            }
+        }
+        sb.append(");");
+        sb.append(NL);
+    }
+
+    /**
+     * INTERNAL Generate portion of the Anonymous PL/SQL block after the target procedures has been
+     * invoked and OUT parameters must be handled.
+     */
+    protected void buildOutAssignments(StringBuilder sb, List<PLSQLargument> arguments) {
+        List<PLSQLargument> outArguments = getArguments(arguments, ParameterType.OUT);
+        outArguments.addAll(getArguments(arguments, ParameterType.INOUT));
+        for (PLSQLargument arg : outArguments) {
+            arg.databaseType.buildOutAssignment(sb, arg, this);
+        }
+    }
+
+    /**
+     * Generate the Anonymous PL/SQL block
+     */
+    @Override
+    protected void prepareInternal(AbstractSession session) {
+        // build any and all required type conversion routines for
+        // complex PL/SQL types in packages
+        this.typesInfo = new HashMap<String, TypeInfo>();
+        // Rest parameters to be recomputed if being reprepared.
+        this.parameters = null;
+        // create a copy of the arguments re-ordered with different indices
+        assignIndices();
+
+        // Filter out any optional arguments that are null.
+        List<PLSQLargument> specifiedArguments = this.arguments;
+        AbstractRecord row = getQuery().getTranslationRow();
+        if ((row != null) && hasOptionalArguments()) {
+            for (PLSQLargument argument : this.arguments) {
+                DatabaseField queryArgument = new DatabaseField(argument.name);
+                if (this.optionalArguments.contains(queryArgument) && (row.get(queryArgument) == null)) {
+                    if (specifiedArguments == this.arguments) {
+                        specifiedArguments = new ArrayList<PLSQLargument>(this.arguments);
+                    }
+                    specifiedArguments.remove(argument);
+                }
+            }
+        }
+        // build the Anonymous PL/SQL block in sections
+        StringBuilder sb = new StringBuilder();
+        if (!specifiedArguments.isEmpty()) {
+            sb.append(BEGIN_DECLARE_BLOCK);
+            buildDeclareBlock(sb, specifiedArguments);
+            buildNestedFunctions(sb, specifiedArguments);
+        }
+        sb.append(BEGIN_BEGIN_BLOCK);
+        buildBeginBlock(sb, specifiedArguments);
+        buildProcedureInvocation(sb, specifiedArguments);
+        buildOutAssignments(sb, specifiedArguments);
+        sb.append(END_BEGIN_BLOCK);
+        setSQLStringInternal(sb.toString());
+        super.prepareInternalParameters(session);
+    }
+
+    /**
+     * INTERNAL:
+     * Prepare the JDBC statement, this may be parameterize or a call statement.
+     * If caching statements this must check for the pre-prepared statement and re-bind to it.
+     */
+    @Override
+    public Statement prepareStatement(DatabaseAccessor accessor, AbstractRecord translationRow, AbstractSession session) throws SQLException {
+        //#Bug5200836 pass shouldUnwrapConnection flag to indicate whether or not using unwrapped connection.
+        Statement statement = accessor.prepareStatement(this, session);
+
+        // Setup the max rows returned and query timeout limit.
+        if (this.queryTimeout > 0 && this.queryTimeoutUnit != null) {
+            long timeout = TimeUnit.SECONDS.convert(this.queryTimeout, this.queryTimeoutUnit);
+
+            if(timeout > Integer.MAX_VALUE){
+                timeout = Integer.MAX_VALUE;
+            }
+
+            //Round up the timeout if SECONDS are larger than the given units
+            if(TimeUnit.SECONDS.compareTo(this.queryTimeoutUnit) > 0 && this.queryTimeout % 1000 > 0){
+                timeout += 1;
+            }
+            statement.setQueryTimeout((int)timeout);
+        }
+        if (!this.ignoreMaxResultsSetting && this.maxRows > 0) {
+            statement.setMaxRows(this.maxRows);
+        }
+        if (this.resultSetFetchSize > 0) {
+            statement.setFetchSize(this.resultSetFetchSize);
+        }
+
+        if (this.parameters == null) {
+            return statement;
+        }
+        List parameters = getParameters();
+        int size = parameters.size();
+        for (int index = 0; index < size; index++) {
+            session.getPlatform().setParameterValueInDatabaseCall(parameters.get(index), (PreparedStatement)statement, index+1, session);
+        }
+
+        return statement;
+    }
+
+    /**
+     * Translate the PLSQL procedure translation row, into the row
+     * expected by the SQL procedure.
+     * This handles expanding and re-ordering parameters.
+     */
+    @Override
+    public void translate(AbstractRecord translationRow, AbstractRecord modifyRow, AbstractSession session) {
+        // re-order elements in translationRow to conform to re-ordered indices
+        AbstractRecord copyOfTranslationRow = translationRow.clone();
+        int len = copyOfTranslationRow.size();
+        List<DatabaseField> copyOfTranslationFields = copyOfTranslationRow.getFields();
+        translationRow.clear();
+        Vector<DatabaseField> translationRowFields = translationRow.getFields();
+        translationRowFields.setSize(len);
+        Vector translationRowValues = translationRow.getValues();
+        translationRowValues.setSize(len);
+        for (PLSQLargument arg : arguments) {
+            if (arg.pdirection == ParameterType.IN || arg.pdirection == ParameterType.INOUT) {
+                arg.databaseType.translate(arg, translationRow,
+                    copyOfTranslationRow, copyOfTranslationFields, translationRowFields,
+                    translationRowValues, this);
+            }
+        }
+        this.translationRow = translationRow; // save a copy for logging
+        super.translate(translationRow, modifyRow, session);
+    }
+
+    /**
+     * Translate the SQL procedure output row, into the row
+     * expected by the PLSQL procedure.
+     * This handles re-ordering parameters.
+     */
+    @Override
+    public AbstractRecord buildOutputRow(CallableStatement statement, DatabaseAccessor accessor, AbstractSession session) throws SQLException {
+
+        AbstractRecord outputRow = super.buildOutputRow(statement, accessor, session);
+        if (!shouldBuildOutputRow) {
+            outputRow.put("", 1); // fake-out Oracle executeUpdate rowCount, always 1
+            return outputRow;
+        }
+        // re-order elements in outputRow to conform to original indices
+        Vector outputRowFields = outputRow.getFields();
+        Vector outputRowValues = outputRow.getValues();
+        DatabaseRecord newOutputRow = new DatabaseRecord();
+        List<PLSQLargument> outArguments = getArguments(arguments, ParameterType.OUT);
+        outArguments.addAll(getArguments(arguments, ParameterType.INOUT));
+        Collections.sort(outArguments, new Comparator<PLSQLargument>() {
+            @Override
+            public int compare(PLSQLargument o1, PLSQLargument o2) {
+                return o1.originalIndex - o2.originalIndex;
+            }
+        });
+        for (PLSQLargument outArg : outArguments) {
+            outArg.databaseType.buildOutputRow(outArg, outputRow, newOutputRow, outputRowFields, outputRowValues);
+        }
+        return newOutputRow;
+    }
+
+    /**
+     * INTERNAL:
+     * Build the log string for the call.
+     */
+    @Override
+    public String getLogString(Accessor accessor) {
+
+        StringBuilder sb = new StringBuilder(getSQLString());
+        sb.append(Helper.cr());
+        sb.append(INDENT);
+        sb.append("bind => [");
+        List<PLSQLargument> specifiedArguments = this.arguments;
+        AbstractRecord row = getQuery().getTranslationRow();
+        if ((row != null) && hasOptionalArguments()) {
+            for (PLSQLargument argument : this.arguments) {
+                DatabaseField queryArgument = new DatabaseField(argument.name);
+                if (this.optionalArguments.contains(queryArgument) && (row.get(queryArgument) == null)) {
+                    if (specifiedArguments == this.arguments) {
+                        specifiedArguments = new ArrayList<PLSQLargument>(this.arguments);
+                    }
+                    specifiedArguments.remove(argument);
+                }
+            }
+        }
+        List<PLSQLargument> inArguments = getArguments(specifiedArguments, ParameterType.IN);
+        inArguments.addAll(getArguments(specifiedArguments, ParameterType.INOUT));
+        Collections.sort(inArguments, new Comparator<PLSQLargument>() {
+            @Override
+            public int compare(PLSQLargument o1, PLSQLargument o2) {
+                return o1.inIndex - o2.inIndex;
+            }
+        });
+        for (Iterator<PLSQLargument> i = inArguments.iterator(); i.hasNext();) {
+            PLSQLargument inArg = i.next();
+            inArg.databaseType.logParameter(sb, ParameterType.IN, inArg, translationRow,
+                getQuery().getSession().getPlatform());
+            if (i.hasNext()) {
+                sb.append(", ");
+            }
+        }
+        List<PLSQLargument> outArguments = getArguments(specifiedArguments, ParameterType.OUT);
+        outArguments.addAll(getArguments(specifiedArguments, ParameterType.INOUT));
+        Collections.sort(outArguments, new Comparator<PLSQLargument>() {
+            @Override
+            public int compare(PLSQLargument o1, PLSQLargument o2) {
+                return o1.outIndex - o2.outIndex;
+            }
+        });
+        if (!inArguments.isEmpty() && !outArguments.isEmpty()) {
+            sb.append(", ");
+        }
+        for (Iterator<PLSQLargument> i = outArguments.iterator(); i.hasNext();) {
+            PLSQLargument outArg = i.next();
+            outArg.databaseType.logParameter(sb, ParameterType.OUT, outArg, translationRow,
+                getQuery().getSession().getPlatform());
+            if (i.hasNext()) {
+                sb.append(", ");
+            }
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    /**
+     * INTERNAL
+     *
+     * @param args
+     * @param direction
+     * @return list of arguments with the specified direction
+     */
+    protected static List<PLSQLargument> getArguments(List<PLSQLargument> args, Integer direction) {
+        return getArguments(args, ParameterType.valueOf(direction));
+    }
+
+    /**
+     * INTERNAL
+     *
+     * @param args
+     * @param direction
+     * @return list of arguments with the specified direction
+     */
+    protected static List<PLSQLargument> getArguments(List<PLSQLargument> args, ParameterType direction) {
+        List<PLSQLargument> inArgs = new ArrayList<PLSQLargument>();
+        for (PLSQLargument arg : args) {
+            if (arg.pdirection == direction) {
+                inArgs.add(arg);
+            }
+        }
+        return inArgs;
+    }
+
+    // Made static for performance reasons.
+    /**
+     * INTERNAL:
+     * Helper structure used to store the PLSQL type conversion routines.
+     */
+    static final class TypeInfo {
+        String sql2PlName;
+        String sql2PlConv;
+        String pl2SqlName;
+        String pl2SqlConv;
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder(NL);
+            sb.append(sql2PlName == null ? "" : sql2PlConv);
+            sb.append(pl2SqlName == null ? "" : pl2SqlConv);
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Return the conversion function name, generate the function if missing.
+     */
+    public String getSQL2PlName(ComplexDatabaseType type) {
+        if (typesInfo == null) {
+            return null;
+        }
+        TypeInfo info = typesInfo.get(type.getTypeName());
+        if (info == null) {
+            info = generateNestedFunction(type);
+        }
+        return info.sql2PlName;
+    }
+
+    @Override
+    public boolean isStoredPLSQLProcedureCall() {
+        return true;
+    }
+
+    /**
+     * Return the conversion function name, generate the function if missing.
+     */
+    public String getPl2SQLName(ComplexDatabaseType type) {
+        if (typesInfo == null) {
+            return null;
+        }
+        TypeInfo info = typesInfo.get(type.getTypeName());
+        if (info == null) {
+            info = generateNestedFunction(type);
+        }
+        return info.pl2SqlName;
+    }
+
+    @Override
+    public Object getOutputParameterValue(CallableStatement statement, int index, AbstractSession session) throws SQLException {
+        return session.getPlatform().getParameterValueFromDatabaseCall(statement, index + 1, session);
+    }
+
+    /**
+     * Return the PLSQL arguments.
+     */
+    public List<PLSQLargument> getArguments() {
+        return arguments;
+    }
+
+    /**
+     * Set the PLSQL arguments.
+     */
+    public void setArguments(List<PLSQLargument> arguments) {
+        this.arguments = arguments;
+    }
+
+    // Made static final for performance reasons.
+    /**
+     * Class responsible for comparing PLSQLargument instances based on
+     * the inIndex property.
+     *
+     */
+    static final class InArgComparer implements Comparator<PLSQLargument>, Serializable {
+        private static final long serialVersionUID = -4182293492217092689L;
+        @Override
+        public int compare(PLSQLargument arg0, PLSQLargument arg1) {
+            if (arg0.inIndex < arg1.inIndex) {
+                return -1;
+            }
+            if (arg0.inIndex > arg1.inIndex) {
+                return 1;
+            }
+            return 0;
+        }
+    }
+
+    // Made static final for performance reasons.
+    /**
+     * Class responsible for comparing PLSQLargument instances based on
+     * the outIndex property.
+     *
+     */
+    static final class OutArgComparer implements Comparator<PLSQLargument>, Serializable {
+        private static final long serialVersionUID = -4182293492217092689L;
+        @Override
+        public int compare(PLSQLargument arg0, PLSQLargument arg1) {
+            if (arg0.inIndex < arg1.outIndex) {
+                return -1;
+            }
+            if (arg0.inIndex > arg1.outIndex) {
+                return 1;
+            }
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Adding support for Oracle DB 23c (a.k.a 23ai) in JPA 2.1.
This would also likely fix RTC defect 299502.

For #28154