### PR TITLE
Reduce access to DataProvider where possible

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1518,7 +1518,7 @@ public class QueryInfo {
      */
     @Trivial
     private RuntimeException excMissingParamAnno(int p) {
-        DataVersionCompatibility compat = producer.provider().compat;
+        DataVersionCompatibility compat = producer.compat();
 
         switch (type) {
             case FIND:
@@ -4608,7 +4608,7 @@ public class QueryInfo {
 
             if (findQueryStartsWithSelect == Boolean.TRUE) {
                 countMustOmitSelect = countPages;
-                if (producer.provider().compat.atLeast(1, 1) &&
+                if (producer.compat().atLeast(1, 1) &&
                     singleType.isRecord()) {
                     while (i < length && Character.isWhitespace(ql.charAt(i)))
                         i++;
@@ -5287,7 +5287,7 @@ public class QueryInfo {
     void setParameters(jakarta.persistence.Query query, Object... args) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
-        DataVersionCompatibility compat = producer.provider().compat;
+        DataVersionCompatibility compat = producer.compat();
         Iterator<String> namedParams = jpqlParamNames.iterator();
         for (int i = 0, p = 0; i < jpqlParamCount; i++) {
             Object[] values = compat.toConstraintValues(args[i]);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -294,7 +294,7 @@ public class Util {
     @Trivial
     static final boolean hasOperationAnno(Method method,
                                           RepositoryProducer<?> producer) {
-        DataVersionCompatibility compat = producer.provider().compat;
+        DataVersionCompatibility compat = producer.compat();
         Set<Class<? extends Annotation>> statefulAnnos = compat.operationAnnoTypes(true);
         Set<Class<? extends Annotation>> statelessAnnos = compat.operationAnnoTypes(false);
 
@@ -344,7 +344,7 @@ public class Util {
      */
     @Trivial
     static String lifeCycleAnnoNames(RepositoryProducer<?> producer) {
-        Set<Class<? extends Annotation>> annoClasses = producer.provider().compat //
+        Set<Class<? extends Annotation>> annoClasses = producer.compat() //
                         .lifeCycleAnnoTypes(producer.stateful());
 
         return annoClasses.stream() //
@@ -413,7 +413,7 @@ public class Util {
      */
     @Trivial
     static String operationAnnoNames(RepositoryProducer<?> producer) {
-        Set<Class<? extends Annotation>> annoClasses = producer.provider().compat //
+        Set<Class<? extends Annotation>> annoClasses = producer.compat() //
                         .operationAnnoTypes(producer.stateful());
 
         return annoClasses.stream() //
@@ -496,7 +496,7 @@ public class Util {
      */
     @Trivial
     static String resourceAccessorTypeNames(RepositoryProducer<?> producer) {
-        Set<Class<?>> types = producer.provider().compat //
+        Set<Class<?>> types = producer.compat() //
                         .resourceAccessorTypes(producer.stateful());
 
         return types.stream() //

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/DataExtension.java
@@ -166,6 +166,9 @@ public class DataExtension implements Extension {
 
                 producer.setFutureEMBuilder(futureEMBuilder);
 
+                provider.producerCreated(futureEMBuilder.jeeName.getApplication(),
+                                         producer);
+
                 @SuppressWarnings("unchecked")
                 Bean<Object> bean = beanMgr.createBean(producer, (Class<Object>) repositoryInterface, producer);
                 event.addBean(bean);
@@ -232,7 +235,7 @@ public class DataExtension implements Extension {
             Find find = method.getAnnotation(Find.class);
             Class<?> entityClass = find == null //
                             ? void.class //
-                            : provider.compat.getEntityClass(find);
+                            : producer.compat().getEntityClass(find);
             Class<?> returnArrayComponentType = null;
             List<Class<?>> returnTypeAtDepth = new ArrayList<>(5);
             Type type = method.getGenericReturnType();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/FutureEMBuilder.java
@@ -130,7 +130,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         this.provider = provider;
         this.repositoryClassLoader = repositoryClassLoader;
         this.dataStore = dataStore;
-        this.jeeName = getArtifactName(repositoryInterface, repositoryClassLoader, provider);
+        this.jeeName = getArtifactName(repositoryInterface, repositoryClassLoader);
         this.namespace = Namespace.of(dataStore);
 
         if (Namespace.APP.isMoreGranularThan(namespace)) { // java:global or none
@@ -652,14 +652,12 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
      *
      * @param repositoryInterface   the repository interface.
      * @param repositoryClassLoader class loader of the repository interface.
-     * @param provider              OSGi service that provides the CDI extension.
      * @return AppName[#ModuleName] with only the application name if not defined
      *         in a module.
      * @throws IllegalStateException if not running on an application thread.
      */
     private J2EEName getArtifactName(Class<?> repositoryInterface,
-                                     ClassLoader repositoryClassLoader,
-                                     DataProvider provider) {
+                                     ClassLoader repositoryClassLoader) {
         J2EEName artifactName;
 
         Optional<J2EEName> moduleNameOptional = //

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/cdi/RepositoryProducer.java
@@ -45,6 +45,7 @@ import io.openliberty.data.internal.persistence.EntityManagerBuilder;
 import io.openliberty.data.internal.persistence.QueryInfo;
 import io.openliberty.data.internal.persistence.RepositoryImpl;
 import io.openliberty.data.internal.persistence.Util;
+import io.openliberty.data.internal.version.DataVersionCompatibility;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.repository.Repository;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -402,13 +403,14 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
     }
 
     /**
-     * Returns the Jakarta Data provider.
+     * Obtains version-dependent capability for the supported Jakarta Data
+     * version.
      *
-     * @return the Jakarta Data provider.
+     * @return version-dependent capability.
      */
     @Trivial
-    public DataProvider provider() {
-        return provider;
+    public DataVersionCompatibility compat() {
+        return provider.compat;
     }
 
     /**
@@ -422,8 +424,6 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
             Tr.debug(this, tc, "setFutureEMBuilder", futureEMBuilder);
 
         this.futureEMBuilder = futureEMBuilder;
-
-        provider.producerCreated(futureEMBuilder.jeeName.getApplication(), this);
     }
 
     /**


### PR DESCRIPTION
Refactoring step to reduce access to DataProvider (which currently has Liberty-specific code) and instead access the DataVersionCompatibility code. Currently the latter does come from DataProvider as well, but a later step will be to change that.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

