### PR TITLE
fixing invalid argument bug

### DIFF
--- a/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityMessages.nlsprops
+++ b/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityMessages.nlsprops
@@ -154,7 +154,7 @@ to your server.xml file:\n\
 \t<include location=\"{0}\" />
 generateaeskey.failFileExists=\
 The {0} file exists and will not be overwritten. Either specify a \n\
-different file name, or remove the existing file before you try again.\n\
+different file name, or remove the existing file before you try again.
 generateaeskey.failFileIsDirectory=\
 The {0} value specified for the file name is a directory. Specify the \n\
 full file name and try again.

--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/GenerateAesKeyTask.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/GenerateAesKeyTask.java
@@ -41,7 +41,7 @@ public class GenerateAesKeyTask extends BaseCommandTask {
     private static final List<String> VALID_ARGUMENTS = Collections.unmodifiableList(
                                                                                      Arrays.asList(BaseCommandTask.ARG_KEY, ARG_FILE));
 
-    private static final String TASK_NAME = "generateAESKey";
+    protected static final String TASK_NAME = "generateAESKey";
     private final IFileUtility fileUtil;
 
     /**
@@ -125,9 +125,10 @@ public class GenerateAesKeyTask extends BaseCommandTask {
         String keyPhrase = null;
         String filePath = null;
 
-        for (String arg : args) {
+        for (int i = 1; i < args.length; i++) {
+            String arg = args[i];
             if (!arg.startsWith("--")) {
-                continue;
+                throw new IllegalArgumentException(getMessage("invalidArg", arg));
             }
 
             int index = arg.indexOf('=');


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

In testing, Niya found the argument parser for generateAESKey was allowing invalid arguments without outputting an error. The invalid arguments  were ignored but the proper response would be to throw an error. 