### PR TITLE
Classloader memory leak in sipcontainer when application is stopped

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/parser/ServletsInstanceHolder.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/parser/ServletsInstanceHolder.java
@@ -274,6 +274,8 @@ public class ServletsInstanceHolder implements ServletInstanceHolderInterface{
 				c_logger.traceDebug(this,"saveOnStartupServlet","members is null");	
 			}
 		}
+
+		//avoid classloader memory leak - see open-liberty issue #31839
 		sipServletThreadLocal.remove();
 	}
 }

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/parser/ServletsInstanceHolder.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/parser/ServletsInstanceHolder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003,2004 IBM Corporation and others.
+ * Copyright (c) 2003,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/parser/ServletsInstanceHolder.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/parser/ServletsInstanceHolder.java
@@ -245,7 +245,6 @@ public class ServletsInstanceHolder implements ServletInstanceHolderInterface{
 		
 		InitMembers members = new InitMembers(sipApp, sipServlet, sipletContext);
 		sipServletThreadLocal.set(members);
-		System.out.println("DEBUG: saveSipletReference" + sipServletThreadLocal);
 	}
 
 	/**
@@ -275,7 +274,6 @@ public class ServletsInstanceHolder implements ServletInstanceHolderInterface{
 				c_logger.traceDebug(this,"saveOnStartupServlet","members is null");	
 			}
 		}
-		System.out.println("DEBUG: saveOnStartupServlet called remove" );
 		sipServletThreadLocal.remove();
 	}
 }

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/parser/ServletsInstanceHolder.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/parser/ServletsInstanceHolder.java
@@ -245,6 +245,7 @@ public class ServletsInstanceHolder implements ServletInstanceHolderInterface{
 		
 		InitMembers members = new InitMembers(sipApp, sipServlet, sipletContext);
 		sipServletThreadLocal.set(members);
+		System.out.println("DEBUG: saveSipletReference" + sipServletThreadLocal);
 	}
 
 	/**
@@ -274,5 +275,7 @@ public class ServletsInstanceHolder implements ServletInstanceHolderInterface{
 				c_logger.traceDebug(this,"saveOnStartupServlet","members is null");	
 			}
 		}
+		System.out.println("DEBUG: saveOnStartupServlet called remove" );
+		sipServletThreadLocal.remove();
 	}
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

When an application is stopped there are leftover references in the SipThreadLocal object, resulting in a memory leak. We need to clean up those references.
