### PR TITLE
Resolve 31559 and tests for Empty and NotEmpty

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1720,6 +1720,56 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
+     * Tests the Empty (and NotEmpty) Query by Method Name keyword.
+     */
+    @Test
+    public void testEmptyAndNotEmpty() {
+        mobilePhones.removeAll();
+
+        Mobile m1 = mobilePhones.insert(Mobile.of(OS.ANDROID,
+                                                  List.of("Camera",
+                                                          "Photos",
+                                                          "Email"),
+                                                  List.of()));
+
+        Mobile m2 = mobilePhones.insert(Mobile.of(OS.IOS,
+                                                  List.of(),
+                                                  List.of("email1@openliberty.io",
+                                                          "email2@openliberty.io",
+                                                          "email3@openliberty.io")));
+
+        List<Mobile> list = mobilePhones.findByEmailsEmpty();
+        assertEquals(list.toString(), 1, list.size());
+        Mobile m = list.get(0);
+        assertEquals(OS.ANDROID,
+                     m.operatingSystem);
+        assertEquals(m1.deviceId,
+                     m.deviceId);
+        assertEquals(List.of("Camera",
+                             "Photos",
+                             "Email"),
+                     m.apps);
+        assertEquals(List.of(),
+                     m.emails);
+
+        list = mobilePhones.findByEmailsNotEmpty();
+        assertEquals(list.toString(), 1, list.size());
+        m = list.get(0);
+        assertEquals(OS.IOS,
+                     m.operatingSystem);
+        assertEquals(m2.deviceId,
+                     m.deviceId);
+        assertEquals(List.of(),
+                     m.apps);
+        assertEquals(List.of("email1@openliberty.io",
+                             "email2@openliberty.io",
+                             "email3@openliberty.io"),
+                     m.emails);
+
+        mobilePhones.removeAll();
+    }
+
+    /**
      * Tests CrudRepository methods that supply entities as parameters.
      * Also tests compatibility with Converters using OffsetDateTimeToStringConverter
      */

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1322,34 +1322,6 @@ public class DataJPATestServlet extends FATServlet {
                                              .map(a -> a.houseNumber + " " + a.streetName)
                                              .collect(Collectors.toList()));
 
-        List<ShippingAddress> found = shippingAddresses
-                        .findByStreetAddressRecipientInfoNotEmpty();
-        ShippingAddress a = null;
-        for (ShippingAddress s : found) {
-            if (a1.id.equals(s.id))
-                a = s;
-        }
-        // TODO Replace above for loop with the following once EclipseLink bug #31559 is fixed
-        // assertEquals(1, found.size());
-        // a = found.get(0);
-        assertEquals(a1.id, a.id);
-        assertEquals(a1.city, a.city);
-        assertEquals(a1.state, a.state);
-        assertEquals(a1.zipCode, a.zipCode);
-        assertEquals(a1.streetAddress.houseNumber, a.streetAddress.houseNumber);
-        assertEquals(a1.streetAddress.streetName, a.streetAddress.streetName);
-        assertEquals(a1.streetAddress.recipientInfo, a.streetAddress.recipientInfo);
-
-        long count = shippingAddresses.countByStreetAddressRecipientInfoEmpty();
-        // TODO Enable once EclipseLink bug #31559 is fixed:
-        // assertEquals(3L, count);
-
-        // [EclipseLink-4002] Internal Exception: java.sql.SQLIntegrityConstraintViolationException:
-        //                    DELETE on table 'SHIPPINGADDRESS' caused a violation of foreign key constraint 'SHPPNGSHPPNGDDRSSD' for key (1001)
-        // TODO Entity removal fails without the above error unless we add the following lines to first remove the rows from the collection attribute's table,
-        a1.streetAddress.recipientInfo = new ArrayList<>();
-        shippingAddresses.save(a1);
-
         assertEquals(4, shippingAddresses.removeAll());
     }
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MobilePhones.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/MobilePhones.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
+import java.util.List;
 import java.util.UUID;
 
 import jakarta.data.repository.CrudRepository;
@@ -23,6 +24,10 @@ import jakarta.data.repository.Repository;
  */
 @Repository(dataStore = "java:app/env/data/DataStoreRef")
 public interface MobilePhones extends CrudRepository<Mobile, UUID> {
+
+    List<Mobile> findByEmailsEmpty();
+
+    List<Mobile> findByEmailsNotEmpty();
 
     @Delete
     public long removeAll();

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ShippingAddresses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ShippingAddresses.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.web;
 
-import java.util.List;
 import java.util.Set;
 
 import jakarta.data.repository.Delete;
@@ -25,13 +24,8 @@ import jakarta.data.repository.Save;
  */
 @Repository(dataStore = "java:app/env/data/DataStoreRef")
 public interface ShippingAddresses {
-    long countByStreetAddressRecipientInfoEmpty();
-
-    List<ShippingAddress> findByStreetAddressRecipientInfoNotEmpty();
 
     StreetAddress[] findByStreetAddress_houseNumberBetweenOrderByStreetAddress_streetNameAscStreetAddress_houseNumber(int minHouseNumber, int maxHouseNumber);
-
-    List<ShippingAddress> findByStreetAddress_recipientInfoNotEmpty();
 
     WorkAddress[] findByStreetAddress_streetNameAndFloorNumber(String streetName, int floorNumber);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/StreetAddress.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/StreetAddress.java
@@ -15,7 +15,6 @@ package test.jakarta.data.jpa.web;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
 
 /**
@@ -23,8 +22,7 @@ import jakarta.persistence.Embeddable;
  */
 @Embeddable
 public class StreetAddress {
-    // TODO enable once EclipseLink bug #31559 is fixed
-    //@ElementCollection
+
     public ArrayList<String> recipientInfo = new ArrayList<String>();
 
     public int houseNumber;


### PR DESCRIPTION
Remove TODOs for 31559 given that EclipseLink clarified it is unsupported despite the error that makes it look like they tried to implement it.  Add different tests for Empty and NotEmpty on list typed entity attributes.

Closes #31559

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
