### PR TITLE
Skipping Jakarta Validation FAT TCK in Windows OS

### DIFF
--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/fat/src/io/openliberty/jakarta/validation/tck/ValidationTckLauncher.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.Assume;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.OperatingSystem;
@@ -56,6 +57,12 @@ public class ValidationTckLauncher {
 
         final OperatingSystem os = server.getMachine().getOperatingSystem();
 
+        /**
+         * Existing issue with the liberty Arquillian plugin running on windows: https://github.com/OpenLiberty/liberty-arquillian/issues/25
+         * Hence skipping the test if the OS is Windows.
+         */
+        Assume.assumeTrue(os != OperatingSystem.WINDOWS);
+        
         /*
          * Server config:
          * - Path that jimage will output modules for signature testing

--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -30,7 +30,7 @@
 		<jakarta.validation.tck.version>3.1.1</jakarta.validation.tck.version>
 		<jakarta.validation.version>3.1.0</jakarta.validation.version>
 		<arquillian.version>1.9.1.Final</arquillian.version>
-		<arquillian.liberty.managed.jakarta.version>2.1.3</arquillian.liberty.managed.jakarta.version>
+		<arquillian.liberty.managed.jakarta.version>2.1.1</arquillian.liberty.managed.jakarta.version>
 		<testng.version>7.9.0</testng.version>
 		<slf4j.version>2.0.6</slf4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -30,7 +30,7 @@
 		<jakarta.validation.tck.version>3.1.1</jakarta.validation.tck.version>
 		<jakarta.validation.version>3.1.0</jakarta.validation.version>
 		<arquillian.version>1.9.1.Final</arquillian.version>
-		<arquillian.liberty.managed.jakarta.version>2.1.1</arquillian.liberty.managed.jakarta.version>
+		<arquillian.liberty.managed.jakarta.version>2.1.3</arquillian.liberty.managed.jakarta.version>
 		<testng.version>7.9.0</testng.version>
 		<slf4j.version>2.0.6</slf4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
Existing issue with the liberty Arquillian plugin running on windows: https://github.com/OpenLiberty/liberty-arquillian/issues/25

Tried to upgrade to iberty arquillian 2.1.3, but it didn't work. https://github.com/OpenLiberty/open-liberty/pull/33063

Skipping running on windows as TCKs are not certified on Windows.

