### PR TITLE
Remove calls to super ClassLoader findResource method.

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -1854,21 +1854,7 @@ abstract class ContainerClassLoader extends LibertyLoader implements Keyed<Class
 
     @Override
     public URL findResource(String name) {
-        //check super first, which checks parent, if any.
-        URL url = super.findResource(name);
-        if (url != null) {
-            return url;
-        }
-        url = smartClassPath.getResourceURL(name, jarProtocol);
-
-        //no need to retry smartClassPath with trailing / it already dealt with that.
-        if (url == null && !name.endsWith("/")) {
-            url = super.findResource(name);
-            if (url != null)
-                url = stripTrailingSlash(url);
-        }
-
-        return url;
+        return smartClassPath.getResourceURL(name, jarProtocol);
     }
 
     @Override


### PR DESCRIPTION
The ClassLoader findResource method returns null.  There is no reason to call it here.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
