### PR TITLE
Fix copy/paste error with NotLike

### DIFF
--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -553,7 +553,7 @@ public class Data_1_1 implements DataVersionCompatibility {
         else if (NotIn.class.equals(type))
             constraint = AttributeConstraint.NotIn;
         else if (NotLike.class.equals(type))
-            constraint = Like.class.equals(methodParamType) //
+            constraint = NotLike.class.equals(methodParamType) //
                             ? AttributeConstraint.NotLikeEscaped //
                             : AttributeConstraint.NotLike;
         else if (NotNull.class.equals(type))


### PR DESCRIPTION
Fix a copy/paste error that was handling NotLike improperly because it was looking for Like instead.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
