### PR TITLE
Specify default value for attribute webModuleClassPathLoader

### DIFF
--- a/dev/com.ibm.ws.app.manager.war/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.app.manager.war/resources/OSGI-INF/metatype/metatype.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2024 IBM Corporation and others.
+    Copyright (c) 2017, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -33,7 +33,8 @@
         <AD name="%earapp.addWebModuleClassPathTo.name" description="%earapp.addWebModuleClassPathTo.desc"
             id="webModuleClassPathLoader"
             required="false"
-            type="String" >
+            type="String"
+            default="war" >
             <Option label="%earapp.addWebModuleClassPathTo.warLoader" value="war"/>
             <Option label="%earapp.addWebModuleClassPathTo.earLoader" value="ear"/>
         </AD>


### PR DESCRIPTION
Formally specify `war` as the default value for `<enterpriseApplication/>` attribute `webModuleClassPathLoader`. This will effectively publish the default setting to user documentation.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
