### PR TITLE
SendRedirect throws IAE if relative location cannot be converted to valid URL.

### DIFF
--- a/dev/com.ibm.ws.webcontainer/resources/com/ibm/ws/webcontainer/resources/Messages.nlsprops
+++ b/dev/com.ibm.ws.webcontainer/resources/com/ibm/ws/webcontainer/resources/Messages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 1997, 2024 IBM Corporation and others.
+# Copyright (c) 1997, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -1643,3 +1643,7 @@ read.write.bytebuffer.null.useraction=Modify the application code to create a no
 read.write.failed.isReady.false=CWWWC0011E: An attempt to read from an InputStream operation or write to an OutputStream operation failed because the isReady API returns false.
 read.write.failed.isReady.false.explanation=If the isReady API returns false, you cannot call a read or write method.
 read.write.failed.isReady.false.useraction=Modify the application logic to make sure that the stream is ready for an InputStream or OutputStream operation.
+
+sendRedirect.cannot.convert.relative.url=CWWWC0012E: The sendRedirect relative URL in the application cannot be converted into a valid URL.
+sendRedirect.cannot.convert.relative.url.explanation=The relative URL given might contain invalid path traversal characters or indexes.
+sendRedirect.cannot.convert.relative.url.useraction=Verify the sendRedirect location URL in the application before calling the response.sendRedirect() method

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppDispatcherContext.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppDispatcherContext.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2024 IBM Corporation and others.
+ * Copyright (c) 1997, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.webcontainer.webapp;
 
@@ -16,8 +13,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.MessageFormat;
-import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -767,6 +762,9 @@ public abstract class WebAppDispatcherContext implements Cloneable, IWebAppDispa
             String redirectURL = null;
             if (relativeToRootURI)
             {
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {
+                    logger.logp(Level.FINE, CLASS_NAME,"convertRelativeURIToURL", "relative to context root");
+                }
                 // 115010 - begin
                 // if the relative URI begins with '/' and we're in sendRedirect compatibility mode, then make uri 
                 // relative to the context root...otherwise, make it relative to the server (no context root)
@@ -785,6 +783,9 @@ public abstract class WebAppDispatcherContext implements Cloneable, IWebAppDispa
             }
             else
             {
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {
+                    logger.logp(Level.FINE, CLASS_NAME,"convertRelativeURIToURL", "relative to current request URL");
+                }
                 // not relative to webapp context root, but relative to the presently
                 // invoked URL
 
@@ -821,6 +822,11 @@ public abstract class WebAppDispatcherContext implements Cloneable, IWebAppDispa
                     redirectURL = requestString.substring(0, requestString.lastIndexOf('/') + 1) + relativeURI;
                 }
             }
+
+            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {
+                logger.logp(Level.FINE, CLASS_NAME,"convertRelativeURIToURL", "before normalize redirectURL [" + redirectURL + "]");
+            }
+            
             if (redirectURL.indexOf("..") > -1)
             { // only normalize where required.. this is expensive.
                 int skip = new String(urlScheme + "://").length();
@@ -844,9 +850,14 @@ public abstract class WebAppDispatcherContext implements Cloneable, IWebAppDispa
             com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(ex, "com.ibm.ws.webcontainer.webapp.WebAppDispatcherResponse.convertRelativeURIToURL", "256", this);
         }
 
-        // Could not convert
         logger.logp(Level.FINE, CLASS_NAME,"convertRelativeURIToURL", "could not convert [" + location + "]");
-        return location;
+        
+        String message = nls.getString("sendRedirect.cannot.convert.relative.url", "SendRedirect relative URL cannot be converted into a valid URL.");
+        
+        if (WebContainer.isServlet61orAbove())
+            throw new IllegalArgumentException(message);
+        else
+            return location;
     }
 
     public void callPage(String fileName, javax.servlet.http.HttpServletRequest hreq) throws IOException, ServletException

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/fat/src/io/openliberty/webcontainer/servlet61/fat/tests/Servlet61ResponseSendRedirectTest.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/fat/src/io/openliberty/webcontainer/servlet61/fat/tests/Servlet61ResponseSendRedirectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,8 @@ import componenttest.topology.impl.LibertyServer;
  * These tests will just verify the response status code, Location header, and response's body without follow up with the redirect.
  *
  * Location is a fix location "https://github.com/OpenLiberty"
+ *
+ * Test IllegalArgumentException - If a relative URL is given and cannot be converted into an absolute URL
  */
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
@@ -372,6 +374,32 @@ public class Servlet61ResponseSendRedirectTest {
                     }
                 }
                 assertTrue("Expecting body not found ", responseText.equalsIgnoreCase(RESP_DEFAULT_HYPER_TEXT_URL_BODY));
+            }
+        }
+    }
+
+    /*
+     * Test IllegalArgumentException - If a relative URL is given and cannot be converted into an absolute URL
+     */
+    @Test
+    public void test_sendRedirect_throws_IllegalArgumentException() throws Exception {
+        LOG.info("====== <test_sendRedirect_throws_IllegalArgumentException> ======");
+
+        String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + TEST_APP_NAME + "/" + SERVLET_MAPPING;
+        HttpGet getMethod = new HttpGet(url);
+        getMethod.addHeader("runTest", "testSendRedirect_throws_IllegalArgumentException");
+
+        LOG.info("Send request [" + url + "]");
+        try (final CloseableHttpClient client = HttpClientBuilder.create().disableRedirectHandling().build()) {
+            try (final CloseableHttpResponse response = client.execute(getMethod)) {
+                int sc = response.getCode();
+                String responseText = (EntityUtils.toString(response.getEntity()).trim());
+
+                LOG.info("\n" + "Response Status: [" + sc + "]");
+                LOG.info("\n" + "Response Text: \n[" + responseText + "]");
+
+                assertTrue("Not expect 302 status code. Found [" + sc + "]", sc != 302);
+                assertTrue("Cannot find PASSES result from response.", responseText.contains("PASSES"));
             }
         }
     }

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/test-applications/ResponseSendRedirectTest.war/src/sendredirect/servlets/TestResponseSendRedirectServlet.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/test-applications/ResponseSendRedirectTest.war/src/sendredirect/servlets/TestResponseSendRedirectServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@ package sendredirect.servlets;
 
 import java.io.IOException;
 
-import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -19,12 +18,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
- * Test HTTP response sendRedirect methods: 
+ * Test HTTP response sendRedirect methods:
  *
  * sendRedirect(String location)                        => sendRedirect(location, 302, true)
  * sendRedirect(String location, int status_code)       => sendRedirect(location, status_code, true)
  * sendRedirect(String location, boolean clearBuffer)   => sendRedirect(location, 302, clearBuffer)
- * 
+ *
  * sendRedirect(String location, int status_code, boolean clearBuffer)
  */
 @WebServlet("/TestResponseSendRedirect")
@@ -57,15 +56,17 @@ public class TestResponseSendRedirectServlet extends HttpServlet {
         else if (runTestMethod.equalsIgnoreCase("testSendRedirect_301"))
             testSendRedirect_301();
         else if (runTestMethod.equalsIgnoreCase("testSendRedirect_303"))
-            testSendRedirect_303(); 
+            testSendRedirect_303();
         if (runTestMethod.equalsIgnoreCase("testSendRedirect_writer"))
             testSendRedirect_writer();
         else if (runTestMethod.equalsIgnoreCase("testSendRedirect_clearBuffer_false"))
-            testSendRedirect_clearBuffer_false(); 
+            testSendRedirect_clearBuffer_false();
         else if (runTestMethod.equalsIgnoreCase("testSendRedirect_301_clearBuffer_false"))
-            testSendRedirect_301_clearBuffer_false(); 
+            testSendRedirect_301_clearBuffer_false();
         else if (runTestMethod.equalsIgnoreCase("testSendRedirect_303_clearBuffer_true"))
-            testSendRedirect_303_clearBuffer_true(); 
+            testSendRedirect_303_clearBuffer_true();
+        else if (runTestMethod.equalsIgnoreCase("testSendRedirect_throws_IllegalArgumentException"))
+            testSendRedirect_throws_IllegalArgumentException();
 
         LOG("EXIT doGet");
     }
@@ -87,11 +88,11 @@ public class TestResponseSendRedirectServlet extends HttpServlet {
         LOG("<<< Testing testSendRedirect");
 
     }
-    
+
     /*
      * sendRedirect(String Location) with the default 302 status code
-     * 
-     * Provide a body using PrinterWriter.  
+     *
+     * Provide a body using PrinterWriter.
      * Server's sendRedirect will replace the body and also switch b/w outputStream and Writer to accommodate the correct output type.
      */
     private void testSendRedirect_writer() throws IOException{
@@ -111,7 +112,7 @@ public class TestResponseSendRedirectServlet extends HttpServlet {
 
     /*
      * sendRedirect(String Location, int status_code)
-     * 
+     *
      * with status code 301 and OutputStream body
      * Server will replace the body.
      */
@@ -164,12 +165,12 @@ public class TestResponseSendRedirectServlet extends HttpServlet {
         }
         LOG("<<< Testing testSendRedirect_clearBuffer_false");
     }
-    
+
     /*
      * sendRedirect(String Location, int sc, boolean clearBuffer)
      * with status code 301, using writer to write a body, and without reset the current buffer.
      */
-    
+
     private void testSendRedirect_301_clearBuffer_false() throws IOException{
         LOG(">>> Testing testSendRedirect_301_clearBuffer_false");
 
@@ -183,14 +184,14 @@ public class TestResponseSendRedirectServlet extends HttpServlet {
         }
         LOG("<<< Testing testSendRedirect_301_clearBuffer_false");
     }
-    
+
     /*
      * sendRedirect(String Location, int sc, boolean clearBuffer)
      * with status code 303, using writer to write a body, and explicitly clearBuffer = true
      * App's body will be reset and replaced with default hypertext URL
      * Server will switch dynamically b/w outputStream and Writer to write out the default hypertext
      */
-    
+
     private void testSendRedirect_303_clearBuffer_true() throws IOException{
         LOG(">>> Testing testSendRedirect_303_clearBuffer_true");
 
@@ -203,6 +204,29 @@ public class TestResponseSendRedirectServlet extends HttpServlet {
             throw e;
         }
         LOG("<<< Testing testSendRedirect_303_clearBuffer_true");
+    }
+
+    /*
+     * sendRedirect throws IllegalArguementException if a relative URL is given and cannot be converted into an absolute URL
+     */
+    private void testSendRedirect_throws_IllegalArgumentException() throws IOException{
+        LOG(">>> Testing testSendRedirect_cannot_convert_URL");
+        String badURL = "https%E5%98%BA/../.../../../../../..../../www.sendRedirect.IllegalArguementException.com";
+        try {
+            response.sendRedirect(badURL);
+        }
+        catch (Exception e){
+            LOG("Exception during sendRedirect [" + e + "]");
+            if (e.getMessage().contains("CWWWC0012E")) {
+                LOG("Exception CWWWC0012E found. Test PASSES");
+                response.getOutputStream().println("Test sendRedirect cannot convert to a valid URL. Test PASSES");
+            }
+            else {
+                LOG(" cannot find the expected exception CWWWC0012E. Test FAILS");
+                throw e;
+            }
+        }
+        LOG("<<< Testing testSendRedirect");
     }
 
     public static void LOG(String s) {


### PR DESCRIPTION
Servlet 61: sendRedirect throws IllegalArgumentException if a relative URL is given and cannot be converted into an absolute URL

Fixes #https://github.com/OpenLiberty/open-liberty/issues/33156