### PR TITLE
step 2 main bucket with persistence unit refs

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -37,6 +37,7 @@ import jakarta.data.exceptions.DataException;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Cursor;
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
@@ -122,6 +123,11 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
             if (cursor.isPresent())
                 queryInfo.setParametersFromCursor(query, cursor.get());
 
+            // TODO why are EntityManager.setCacheRetrieveMode and
+            // Query.setCacheRetrieveMode unable to set this instead?
+            query.setHint("jakarta.persistence.cache.retrieveMode",
+                          CacheRetrieveMode.BYPASS);
+
             query.setFirstResult(firstResult);
             query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1)); // extra position is for knowing whether to expect another page
 
@@ -175,6 +181,11 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
                 Tr.debug(this, tc, "query for count: " + queryInfo.jpqlCount);
             TypedQuery<Long> query = em.createQuery(queryInfo.jpqlCount, Long.class);
             queryInfo.setParameters(query, args);
+
+            // TODO why are EntityManager.setCacheRetrieveMode and
+            // Query.setCacheRetrieveMode unable to set this instead?
+            query.setHint("jakarta.persistence.cache.retrieveMode",
+                          CacheRetrieveMode.BYPASS);
 
             return query.getSingleResult();
         } catch (Exception x) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -30,6 +30,7 @@ import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Mode;
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
@@ -101,6 +102,11 @@ public class PageImpl<T> implements Page<T> {
             jakarta.persistence.Query query = em.createQuery(queryInfo.jpql);
             queryInfo.setParameters(query, args);
 
+            // TODO why are EntityManager.setCacheRetrieveMode and
+            // Query.setCacheRetrieveMode unable to set this instead?
+            query.setHint("jakarta.persistence.cache.retrieveMode",
+                          CacheRetrieveMode.BYPASS);
+
             int maxPageSize = pageRequest.size();
             query.setFirstResult(queryInfo.computeOffset(pageRequest));
             query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1));
@@ -151,6 +157,11 @@ public class PageImpl<T> implements Page<T> {
                 Tr.debug(this, tc, "query for count: " + queryInfo.jpqlCount);
             TypedQuery<Long> query = em.createQuery(queryInfo.jpqlCount, Long.class);
             queryInfo.setParameters(query, args);
+
+            // TODO why are EntityManager.setCacheRetrieveMode and
+            // Query.setCacheRetrieveMode unable to set this instead?
+            query.setHint("jakarta.persistence.cache.retrieveMode",
+                          CacheRetrieveMode.BYPASS);
 
             return query.getSingleResult();
         } catch (Exception x) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -93,6 +93,7 @@ import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.TypedQuery;
@@ -909,6 +910,11 @@ public class QueryInfo {
         TypedQuery<Long> query = em.createQuery(jpql, Long.class);
         setParameters(query, args);
 
+        // TODO why are EntityManager.setCacheRetrieveMode and
+        // Query.setCacheRetrieveMode unable to set this instead?
+        query.setHint("jakarta.persistence.cache.retrieveMode",
+                      CacheRetrieveMode.BYPASS);
+
         Long count = query.getSingleResult();
 
         Object returnValue;
@@ -1692,6 +1698,11 @@ public class QueryInfo {
         query.setMaxResults(1);
         setParameters(query, args);
 
+        // TODO why are EntityManager.setCacheRetrieveMode and
+        // Query.setCacheRetrieveMode unable to set this instead?
+        query.setHint("jakarta.persistence.cache.retrieveMode",
+                      CacheRetrieveMode.BYPASS);
+
         List<?> results = query.getResultList();
         boolean found = !results.isEmpty();
 
@@ -1894,6 +1905,11 @@ public class QueryInfo {
 
             jakarta.persistence.Query query = em.createQuery(jpql);
             setParameters(query, args);
+
+            // TODO why are EntityManager.setCacheRetrieveMode and
+            // Query.setCacheRetrieveMode unable to set this instead?
+            query.setHint("jakarta.persistence.cache.retrieveMode",
+                          CacheRetrieveMode.BYPASS);
 
             if (type == FIND_AND_DELETE)
                 query.setLockMode(LockModeType.PESSIMISTIC_WRITE);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -53,6 +53,7 @@ import jakarta.data.repository.Insert;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 import jakarta.persistence.AttributeConverter;
+import jakarta.transaction.Status;
 
 /**
  * A location for helper methods that do not require any state.
@@ -654,6 +655,29 @@ public class Util {
             }
             b.append(EOLN);
         }
+    }
+
+    /**
+     * Readable value to log to trace for a transaction status constant.
+     *
+     * @param status constant value from jakarta.transaction.Status.
+     * @return a more readable value to log to trace.
+     */
+    @Trivial
+    static final String txStatusToString(int status) {
+        return switch (status) {
+            case Status.STATUS_ACTIVE -> "STATUS_ACTIVE (0)";
+            case Status.STATUS_MARKED_ROLLBACK -> "STATUS_MARKED_ROLLBACK (1)";
+            case Status.STATUS_PREPARED -> "STATUS_PREPARED (2)";
+            case Status.STATUS_COMMITTED -> "STATUS_COMMITTED (3)";
+            case Status.STATUS_ROLLEDBACK -> "STATUS_ROLLEDBACK (4)";
+            case Status.STATUS_UNKNOWN -> "STATUS_UNKNOWN (5)";
+            case Status.STATUS_NO_TRANSACTION -> "STATUS_NO_TRANSACTION (6)";
+            case Status.STATUS_PREPARING -> "STATUS_PREPARING (7)";
+            case Status.STATUS_COMMITTING -> "STATUS_COMMITTING (8)";
+            case Status.STATUS_ROLLING_BACK -> "STATUS_ROLLING_BACK (9)";
+            default -> "unrecognized value (" + status + ")";
+        };
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataPersistenceTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataPersistenceTest.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.spi.Extension;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.database.container.DatabaseContainerFactory;
+import componenttest.topology.database.container.DatabaseContainerType;
+import componenttest.topology.database.container.DatabaseContainerUtil;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import test.jakarta.data.inmemory.web.ProviderTestServlet;
+import test.jakarta.data.web.DataTestServlet;
+
+/**
+ * Runs the tests with a third-party Persistence provider (Hibernate)
+ * instead of the built-in Persistence provider (EclipseLink).
+ * TODO actually use Hibernate instead of EclipseLink
+ */
+@RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 17)
+public class DataPersistenceTest extends FATServletClient {
+    /**
+     * Error messages, typically for invalid repository methods, that are
+     * intentionally caused by tests to cover error paths.
+     * These are ignored when checking the messages.log file for errors.
+     */
+    static final String[] EXPECTED_ERROR_MESSAGES = //
+                    new String[] {
+                                   "CWWKD1075E.*Apartment2",
+                                   "CWWKD1075E.*Apartment3",
+                                   // work around to prevent bad behavior from EclipseLink (see #30575)
+                                   "CWWKD1103E.*romanNumeralSymbolsAsListOfArrayList",
+                                   // work around to prevent bad behavior from EclipseLink (see #30575)
+                                   "CWWKD1103E.*romanNumeralSymbolsAsSetOfArrayList",
+                                   "CWWKD1119E.*minNumberOfEachNameLength", // cannot infer count for GROUP BY
+                                   "CWWJP9991W.*DatabaseException", // various intentional error paths
+                                   // TODO the following works around warnings from EclipseLink:
+                                   // W CWWJP9991W: [eclipselink.weaver] Weaver encountered an exception
+                                   // while trying to weave class test.jakarta.data.web.Participant$Name.
+                                   // The exception was: Cannot invoke "String.hashCode()" because "value"
+                                   // is null
+                                   // W CWWJP9991W: [eclipselink.weaver] Weaver encountered an exception
+                                   // while trying to weave class test.jakarta.data.web.Receipt.
+                                   // The exception was: Cannot invoke "String.hashCode()" because "value"
+                                   // is null
+                                   "CWWJP9991W.*Participant",
+                                   "CWWJP9991W.*Receipt"
+                    };
+
+    @ClassRule
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+
+    @Server("io.openliberty.data.internal.fat.persistence")
+    @TestServlets({ @TestServlet(servlet = DataTestServlet.class,
+                                 contextRoot = "DataPersistenceApp"),
+                    @TestServlet(servlet = ProviderTestServlet.class,
+                                 contextRoot = "ProviderTestApp") })
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Get driver type
+        DatabaseContainerType type = DatabaseContainerType.valueOf(testContainer);
+        server.addEnvVar("DB_DRIVER", type.getDriverName());
+
+        // Set up server DataSource properties
+        DatabaseContainerUtil.setupDataSourceDatabaseProperties(server, testContainer);
+
+        WebArchive war = ShrinkHelper.buildDefaultApp("DataPersistenceApp",
+                                                      "test.jakarta.data.web");
+        ShrinkHelper.exportAppToServer(server, war);
+
+        JavaArchive providerJar = ShrinkWrap.create(JavaArchive.class,
+                                                    "palindrome-data-provider.jar")
+                        .addPackage("test.jakarta.data.inmemory.provider")
+                        .addAsServiceProvider(BuildCompatibleExtension.class.getName(),
+                                              "test.jakarta.data.inmemory.provider.CompositeBuildCompatibleExtension")
+                        .addAsServiceProvider(Extension.class.getName(),
+                                              "test.jakarta.data.inmemory.provider.PalindromeExtension");
+
+        WebArchive providerWar = ShrinkHelper.buildDefaultApp("ProviderTestApp",
+                                                              "test.jakarta.data.inmemory.web")
+                        .addAsLibrary(providerJar);
+        ShrinkHelper.exportAppToServer(server, providerWar);
+
+        server.startServerAndValidate(LibertyServer.DEFAULT_PRE_CLEAN,
+                                      LibertyServer.DEFAULT_CLEANSTART,
+                                      true);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer(EXPECTED_ERROR_MESSAGES);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 @SuiteClasses({
                 AlwaysPassesTest.class,
                 DataTest.class,
+                DataPersistenceTest.class,
                 DataTestCheckpoint.class
 })
 public class FATSuite extends TestContainerSuite {

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat.persistence/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat.persistence/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat.persistence/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat.persistence/server.xml
@@ -1,0 +1,61 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <featureManager>
+    <feature>componenttest-2.0</feature>
+    <feature>concurrent-3.1</feature> <!-- for @Asynchronous -->
+    <feature>data-1.0</feature>
+    <feature>jdbc-4.3</feature>
+    <feature>jndi-1.0</feature>
+    <feature>persistence-3.2</feature>
+    <feature>servlet-6.1</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+  <application location="DataPersistenceApp.war"/>
+  
+  <application location="ProviderTestApp.war"/>
+
+  <authData id="auth1" user="user1" password="pwd1"/>
+  <authData id="auth2" user="user2" password="pwd2"/>
+
+  <data logValues="test.jakarta.data.web"/>
+
+  <dataSource id="DefaultDataSource" fat.modify="true">
+    <jdbcDriver libraryRef="JDBCLibrary"/>
+    <properties.derby.embedded
+      createDatabase="create"
+      databaseName="memory:testdb"
+      user="dbuser1"
+      password="dbpwd1"/>
+  </dataSource>
+
+  <library id="JDBCLibrary">
+    <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
+  </library>
+
+  <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar"
+                  className="java.security.AllPermission"/>
+  <javaPermission codeBase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}"
+                  className="java.security.AllPermission"/>
+
+  <javaPermission codeBase="${server.config.dir}/apps/ProviderTestApp.war"
+                  className="java.lang.RuntimePermission"
+                  name="accessDeclaredMembers"/>
+  <javaPermission codeBase="${server.config.dir}/apps/ProviderTestApp.war"
+                  className="java.lang.RuntimePermission"
+                  name="getClassLoader"/>
+
+</server>

--- a/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
+++ b/dev/io.openliberty.data.internal_fat/publish/servers/io.openliberty.data.internal.fat/server.xml
@@ -36,7 +36,7 @@
   <authData id="auth1" user="user1" password="pwd1"/>
   <authData id="auth2" user="user2" password="pwd2"/>
 
-  <data logValues="test.jakarta.data.web"/>
+  <data logValues="test.jakarta.data.web,test.jakarta.data.web.eclipselink"/>
 
   <!-- For DataSourceDefinition java:app/jdbc/DerbyDataSource which is used by the Vehicles repository -->
   <library id="DerbyLib">

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataPersistenceApp/resources/WEB-INF/classes/META-INF/orm.xml
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataPersistenceApp/resources/WEB-INF/classes/META-INF/orm.xml
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<entity-mappings
+    xmlns="https://jakarta.ee/xml/ns/persistence/orm"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm https://jakarta.ee/xml/ns/persistence/orm/orm_3_2.xsd"
+    version="3.2">
+
+ <entity class="test.jakarta.data.web.Apartment">
+  <table name="Apartment"/>
+  <attributes>
+   <id name="APTID">
+    <column nullable="false"/>
+   </id>
+   <basic name="isOccupied">
+    <column nullable="false"/>
+   </basic>
+   <embedded name="occupant">
+    <attribute-override name="firstName">
+     <column name="OCCUPANT_FIRSTNAME"/>
+    </attribute-override>
+    <attribute-override name="lastName">
+     <column name="OCCUPANT_LASTNAME"/>
+    </attribute-override>
+   </embedded>
+   <embedded name="quarters">
+    <attribute-override name="length">
+     <column name="QUARTERS_LENGTH"/>
+    </attribute-override>
+    <attribute-override name="width">
+     <column name="QUARTERS_WIDTH"/>
+    </attribute-override>
+   </embedded>
+   <basic name="quartersWidth">
+    <column nullable="false"/>
+   </basic>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.Apartment2">
+  <table name="Apartment2"/>
+  <attributes>
+   <id name="aptId">
+    <column nullable="false"/>
+   </id>
+   <basic name="isOccupied">
+    <column nullable="false"/>
+   </basic>
+   <embedded name="occupant">
+    <attribute-override name="firstName">
+     <column name="OCCUPANT_FIRSTNAME"/>
+    </attribute-override>
+    <attribute-override name="lastName">
+     <column name="OCCUPANT_LASTNAME"/>
+    </attribute-override>
+   </embedded>
+   <embedded name="quarters">
+    <attribute-override name="length">
+     <column name="QUARTERS_LENGTH"/>
+    </attribute-override>
+    <attribute-override name="width">
+     <column name="QUARTERS_WIDTH"/>
+    </attribute-override>
+   </embedded>
+   <basic name="quarters_width">
+    <column nullable="false"/>
+   </basic>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.Apartment3">
+  <table name="Apartment3"/>
+  <attributes>
+   <id name="aptId">
+    <column nullable="false"/>
+   </id>
+   <basic name="isOccupied">
+    <column nullable="false"/>
+   </basic>
+   <embedded name="occupant">
+    <attribute-override name="firstName">
+     <column name="OCCUPANT_FIRSTNAME"/>
+    </attribute-override>
+    <attribute-override name="lastName">
+     <column name="OCCUPANT_LASTNAME"/>
+    </attribute-override>
+   </embedded>
+   <basic name="occupant_firstName">
+    <column nullable="false"/>
+   </basic>
+   <embedded name="quarters">
+    <attribute-override name="length">
+     <column name="QUARTERS_LENGTH"/>
+    </attribute-override>
+    <attribute-override name="width">
+     <column name="QUARTERS_WIDTH"/>
+    </attribute-override>
+   </embedded>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.House">
+  <table name="House"/>
+  <attributes>
+   <basic name="area">
+    <column nullable="false"/>
+   </basic>
+   <embedded name="garage">
+    <attribute-override name="area">
+     <column name="GARAGE_AREA"/>
+    </attribute-override>
+    <attribute-override name="type">
+     <column name="GARAGE_TYPE"/>
+    </attribute-override>
+    <attribute-override name="door.height">
+     <column name="GARAGE_DOOR_HEIGHT"/>
+    </attribute-override>
+    <attribute-override name="door.width">
+     <column name="GARAGE_DOOR_WIDTH"/>
+    </attribute-override>
+   </embedded>
+   <embedded name="kitchen">
+    <attribute-override name="length">
+     <column name="KITCHEN_LENGTH"/>
+    </attribute-override>
+    <attribute-override name="width">
+     <column name="KITCHEN_WIDTH"/>
+    </attribute-override>
+   </embedded>
+   <basic name="lotSize">
+    <column nullable="false"/>
+   </basic>
+   <basic name="numBedrooms">
+    <column nullable="false"/>
+   </basic>
+   <id name="parcelId">
+   </id>
+   <basic name="purchasePrice">
+    <column nullable="false"/>
+   </basic>
+   <basic name="sold">
+   </basic>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.Package">
+  <table name="Package"/>
+  <attributes>
+   <basic name="description">
+   </basic>
+   <basic name="height">
+    <column nullable="false"/>
+   </basic>
+   <id name="id">
+    <column nullable="false"/>
+   </id>
+   <basic name="length">
+    <column nullable="false"/>
+   </basic>
+   <basic name="width">
+    <column nullable="false"/>
+   </basic>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.Participant">
+  <table name="Participant"/>
+  <attributes>
+   <embedded name="name">
+    <attribute-override name="first">
+     <column name="NAME_FIRST"/>
+    </attribute-override>
+    <attribute-override name="last">
+     <column name="NAME_LAST"/>
+    </attribute-override>
+   </embedded>
+   <id name="pID">
+   </id>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.Person">
+  <table name="Person"/>
+  <attributes>
+   <basic name="firstName">
+   </basic>
+   <basic name="lastName">
+   </basic>
+   <id name="ssn_id">
+    <column nullable="false"/>
+   </id>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.Prime">
+  <table name="Prime"/>
+  <attributes>
+   <basic name="binaryDigits">
+   </basic>
+   <basic name="even">
+    <column nullable="false"/>
+   </basic>
+   <basic name="hex">
+   </basic>
+   <basic name="name">
+   </basic>
+   <id name="numberId">
+    <column nullable="false"/>
+   </id>
+   <basic name="romanNumeral">
+   </basic>
+   <element-collection name="romanNumeralSymbols" fetch="EAGER">
+   </element-collection>
+   <basic name="sumOfBits">
+    <column nullable="false"/>
+   </basic>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.Product">
+  <table name="Product"/>
+  <attributes>
+   <basic name="description">
+   </basic>
+   <basic name="name">
+   </basic>
+   <id name="pk">
+   </id>
+   <basic name="price">
+    <column nullable="false"/>
+   </basic>
+   <version name="version">
+    <column nullable="false"/>
+   </version>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.Purchase">
+  <table name="Purchase"/>
+  <attributes>
+   <basic name="customer">
+   </basic>
+   <id name="purchaseId">
+    <column nullable="false"/>
+   </id>
+   <embedded name="receipt">
+    <attribute-override name="customer">
+     <column name="RECEIPT_CUSTOMER"/>
+    </attribute-override>
+    <attribute-override name="purchaseId">
+     <column name="RECEIPT_PURCHASEID"/>
+    </attribute-override>
+    <attribute-override name="total">
+     <column name="RECEIPT_TOTAL"/>
+    </attribute-override>
+   </embedded>
+   <basic name="total">
+    <column nullable="false"/>
+   </basic>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.Thing">
+  <table name="Thing"/>
+  <attributes>
+   <basic name="a">
+   </basic>
+   <basic name="alike">
+   </basic>
+   <basic name="android">
+    <column nullable="false"/>
+   </basic>
+   <basic name="brand">
+   </basic>
+   <basic name="description">
+   </basic>
+   <basic name="floor">
+   </basic>
+   <basic name="info">
+   </basic>
+   <basic name="notes">
+   </basic>
+   <basic name="orderNumber">
+    <column nullable="false"/>
+   </basic>
+   <basic name="purchaseOrder">
+    <column nullable="false"/>
+   </basic>
+   <id name="thingId">
+    <column nullable="false"/>
+   </id>
+  </attributes>
+ </entity>
+
+ <entity class="test.jakarta.data.web.Vehicle">
+  <table name="Vehicle"/>
+  <attributes>
+   <basic name="make">
+   </basic>
+   <basic name="model">
+   </basic>
+   <basic name="numSeats">
+    <column nullable="false"/>
+   </basic>
+   <basic name="price">
+    <column nullable="false"/>
+   </basic>
+   <id name="vinId">
+   </id>
+  </attributes>
+ </entity>
+ 
+ <embeddable class="test.jakarta.data.web.Bedroom">
+  <attributes>
+   <basic name="length">
+   </basic>
+   <basic name="width">
+   </basic>
+  </attributes>
+ </embeddable>
+
+ <embeddable class="test.jakarta.data.web.Garage">
+  <attributes>
+   <basic name="area">
+   </basic>
+   <embedded name="door">
+   </embedded>
+   <basic name="type">
+   </basic>
+  </attributes>
+ </embeddable>
+
+ <embeddable class="test.jakarta.data.web.GarageDoor">
+  <attributes>
+   <basic name="height">
+   </basic>
+   <basic name="width">
+   </basic>
+  </attributes>
+ </embeddable>
+
+ <embeddable class="test.jakarta.data.web.Kitchen">
+  <attributes>
+   <basic name="length">
+   </basic>
+   <basic name="width">
+   </basic>
+  </attributes>
+ </embeddable>
+
+ <embeddable class="test.jakarta.data.web.Participant$Name">
+  <attributes>
+   <basic name="first">
+   </basic>
+   <basic name="last">
+   </basic>
+  </attributes>
+ </embeddable>
+
+ <embeddable class="test.jakarta.data.web.Receipt">
+  <attributes>
+   <basic name="customer">
+   </basic>
+   <basic name="purchaseId">
+   </basic>
+   <basic name="total">
+   </basic>
+  </attributes>
+ </embeddable>
+
+ <embeddable class="test.jakarta.data.web.Residence$Occupant">
+  <attributes>
+   <basic name="firstName">
+   </basic>
+   <basic name="lastName">
+   </basic>
+  </attributes>
+ </embeddable>
+
+</entity-mappings>
+

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataPersistenceApp/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataPersistenceApp/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -20,18 +20,7 @@
 
     <persistence-unit name="MyPersistenceUnit">
         <jta-data-source>java:comp/DefaultDataSource</jta-data-source>
-        <class>test.jakarta.data.web.Apartment</class>
-        <class>test.jakarta.data.web.Apartment2</class>
-        <class>test.jakarta.data.web.Apartment3</class>
-        <class>test.jakarta.data.web.House</class>
-        <class>test.jakarta.data.web.Package</class>
-        <class>test.jakarta.data.web.Participant</class>
-        <class>test.jakarta.data.web.Person</class>
-        <class>test.jakarta.data.web.Prime</class>
-        <class>test.jakarta.data.web.Product</class>
-        <class>test.jakarta.data.web.Purchase</class>
-        <class>test.jakarta.data.web.Thing</class>
-        <class>test.jakarta.data.web.Vehicle</class>
+        <mapping-file>META-INF/orm.xml</mapping-file>
         <properties>
             <property name="eclipselink.logging.parameters" value="true"/>
             <property name="jakarta.persistence.schema-generation.database.action" value="create"/>

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataPersistenceApp/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataPersistenceApp/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -13,11 +13,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 -->
-<persistence 
-    xmlns="http://java.sun.com/xml/ns/persistence"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
-    version="1.0">
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd"
+             version="3.2">
 
     <persistence-unit name="MyPersistenceUnit">
         <jta-data-source>java:comp/DefaultDataSource</jta-data-source>

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataPersistenceApp/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataPersistenceApp/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence 
+    xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+    version="1.0">
+
+    <persistence-unit name="MyPersistenceUnit">
+        <jta-data-source>java:comp/DefaultDataSource</jta-data-source>
+        <class>test.jakarta.data.web.Apartment</class>
+        <class>test.jakarta.data.web.Apartment2</class>
+        <class>test.jakarta.data.web.Apartment3</class>
+        <class>test.jakarta.data.web.House</class>
+        <class>test.jakarta.data.web.Package</class>
+        <class>test.jakarta.data.web.Participant</class>
+        <class>test.jakarta.data.web.Person</class>
+        <class>test.jakarta.data.web.Prime</class>
+        <class>test.jakarta.data.web.Product</class>
+        <class>test.jakarta.data.web.Purchase</class>
+        <class>test.jakarta.data.web.Thing</class>
+        <class>test.jakarta.data.web.Vehicle</class>
+        <properties>
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataPersistenceApp/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataPersistenceApp/resources/WEB-INF/web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-app version="6.1" 
+	xmlns="https://jakarta.ee/xml/ns/jakartaee" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd">
+
+  <!-- This is only used in server configurations where the
+       persistence feature is enabled -->
+  <persistence-unit-ref>
+    <persistence-unit-ref-name>java:module/env/data/DataStoreRef</persistence-unit-ref-name>
+    <persistence-unit-name>MyPersistenceUnit</persistence-unit-name>
+  </persistence-unit-ref>
+
+</web-app>


### PR DESCRIPTION
Step 2: before being able to run with Hibernate, the main test bucket needs to be able to run in a mode that has the repositories using persistence units rather than data sources, also supplying orm.xml to define the Java classes as entities.
An unexpected difference with the persistence service was found related to reading stale cached data, and a query hint is added to prevent that. Some comments/TODOs are left in the code in that area because it seems like a better approach should have been possible at the EntityManager level using Jakarta Persistence API to set the same thing for the whole EntityManager, but that isn't working.  It will need separate investigation.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
