### PR TITLE
reproduce setCacheRetrieveMode bug

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -123,7 +123,7 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
             if (cursor.isPresent())
                 queryInfo.setParametersFromCursor(query, cursor.get());
 
-            // TODO why are EntityManager.setCacheRetrieveMode and
+            // TODO #33189 why are EntityManager.setCacheRetrieveMode and
             // Query.setCacheRetrieveMode unable to set this instead?
             query.setHint("jakarta.persistence.cache.retrieveMode",
                           CacheRetrieveMode.BYPASS);
@@ -182,7 +182,7 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
             TypedQuery<Long> query = em.createQuery(queryInfo.jpqlCount, Long.class);
             queryInfo.setParameters(query, args);
 
-            // TODO why are EntityManager.setCacheRetrieveMode and
+            // TODO #33189 why are EntityManager.setCacheRetrieveMode and
             // Query.setCacheRetrieveMode unable to set this instead?
             query.setHint("jakarta.persistence.cache.retrieveMode",
                           CacheRetrieveMode.BYPASS);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -102,7 +102,7 @@ public class PageImpl<T> implements Page<T> {
             jakarta.persistence.Query query = em.createQuery(queryInfo.jpql);
             queryInfo.setParameters(query, args);
 
-            // TODO why are EntityManager.setCacheRetrieveMode and
+            // TODO #33189 why are EntityManager.setCacheRetrieveMode and
             // Query.setCacheRetrieveMode unable to set this instead?
             query.setHint("jakarta.persistence.cache.retrieveMode",
                           CacheRetrieveMode.BYPASS);
@@ -158,7 +158,7 @@ public class PageImpl<T> implements Page<T> {
             TypedQuery<Long> query = em.createQuery(queryInfo.jpqlCount, Long.class);
             queryInfo.setParameters(query, args);
 
-            // TODO why are EntityManager.setCacheRetrieveMode and
+            // TODO #33189 why are EntityManager.setCacheRetrieveMode and
             // Query.setCacheRetrieveMode unable to set this instead?
             query.setHint("jakarta.persistence.cache.retrieveMode",
                           CacheRetrieveMode.BYPASS);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -910,7 +910,7 @@ public class QueryInfo {
         TypedQuery<Long> query = em.createQuery(jpql, Long.class);
         setParameters(query, args);
 
-        // TODO why are EntityManager.setCacheRetrieveMode and
+        // TODO #33189 why are EntityManager.setCacheRetrieveMode and
         // Query.setCacheRetrieveMode unable to set this instead?
         query.setHint("jakarta.persistence.cache.retrieveMode",
                       CacheRetrieveMode.BYPASS);
@@ -1698,7 +1698,7 @@ public class QueryInfo {
         query.setMaxResults(1);
         setParameters(query, args);
 
-        // TODO why are EntityManager.setCacheRetrieveMode and
+        // TODO #33189 why are EntityManager.setCacheRetrieveMode and
         // Query.setCacheRetrieveMode unable to set this instead?
         query.setHint("jakarta.persistence.cache.retrieveMode",
                       CacheRetrieveMode.BYPASS);
@@ -1906,7 +1906,7 @@ public class QueryInfo {
             jakarta.persistence.Query query = em.createQuery(jpql);
             setParameters(query, args);
 
-            // TODO why are EntityManager.setCacheRetrieveMode and
+            // TODO #33189 why are EntityManager.setCacheRetrieveMode and
             // Query.setCacheRetrieveMode unable to set this instead?
             query.setHint("jakarta.persistence.cache.retrieveMode",
                           CacheRetrieveMode.BYPASS);

--- a/dev/io.openliberty.data.internal_fat_datastore/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_datastore/bnd.bnd
@@ -31,12 +31,12 @@ tested.features=connectors-2.1
 -buildpath: \
 	com.ibm.ws.componenttest.2.0;version=latest,\
 	io.openliberty.data,\
-	io.openliberty.jakarta.annotation.2.1,\
-	io.openliberty.jakarta.cdi.4.0,\
+	io.openliberty.jakarta.annotation.3.0,\
+	io.openliberty.jakarta.cdi.4.1,\
 	io.openliberty.jakarta.data.1.0,\
 	io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\
-	io.openliberty.jakarta.interceptor.2.1,\
-	io.openliberty.jakarta.persistence.3.1,\
-	io.openliberty.jakarta.servlet.6.0;version=latest,\
+	io.openliberty.jakarta.interceptor.2.2,\
+	io.openliberty.jakarta.persistence.3.2,\
+	io.openliberty.jakarta.servlet.6.1;version=latest,\
 	io.openliberty.jakarta.transaction.2.0;version=latest,\
 	io.openliberty.org.testcontainers;version=latest

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/PersistenceUnitRepo.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/PersistenceUnitRepo.java
@@ -14,7 +14,9 @@ package test.jakarta.data.datastore.web;
 
 import java.sql.Connection;
 import java.util.List;
+import java.util.Optional;
 
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.persistence.EntityManager;
@@ -30,6 +32,8 @@ public interface PersistenceUnitRepo {
 
     Connection connection();
 
+    int countByIdStartsWith(String pattern);
+
     DataSource dataSource();
 
     EntityManager entityManager();
@@ -39,5 +43,9 @@ public interface PersistenceUnitRepo {
     @Save
     List<PersistenceUnitEntity> save(List<PersistenceUnitEntity> e);
 
-    int countByIdStartsWith(String pattern);
+    @Query("WHERE id = ?1")
+    Optional<PersistenceUnitEntity> singleItem(String id);
+
+    @Query("UPDATE PersistenceUnitEntity SET value = value * 3 WHERE id = ?1")
+    boolean triple(String id);
 }


### PR DESCRIPTION
Automated test (with workarounds) to cover EcilpseLink bug #33189 with not honoring EntityManager/Query.setCacheRetrieveMode(BYPASS)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
