### PR TITLE
Override write(byte[],int,int) to avoid single byte writes

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -1628,8 +1628,7 @@ public class BaseTraceService implements TrService {
                     if (LogTraceList.contains(entry[0])) {
                         messageMap.put(entry[0], entry[1]);
                     }
-                } 
-                else if (entry.length == 3) {
+                } else if (entry.length == 3) {
                     entry[1] = entry[1].trim();
                     entry[2] = entry[2].trim();
                     //add properties to their respective hashmaps and trim whitespaces
@@ -1637,7 +1636,7 @@ public class BaseTraceService implements TrService {
                         if (LogTraceList.contains(entry[1]) || entry[1].startsWith("ext_")) {
                             messageMap.put(entry[1], entry[2]);
                         }
-                    } 
+                    }
                 }
             }
         }
@@ -1651,7 +1650,7 @@ public class BaseTraceService implements TrService {
                    .addField(LogTraceData.getDatetimeKey(jsonKey, true), datetime, false, true)
                    .addField(LogTraceData.getSequenceKey(jsonKey, true), sequenceNumber, false, true);
         //@formatter:on
-        
+
         return jsonBuilder.build().toString().concat("\n");
     }
 
@@ -2038,7 +2037,11 @@ public class BaseTraceService implements TrService {
         @Override
         public void write(int b) throws IOException {
             threadLocal.get().write(b);
+        }
 
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            threadLocal.get().write(b, off, len);
         }
 
         public void reset() {


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

