### PR TITLE
Improving ambiguous exception message for bad header names

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
@@ -424,8 +424,18 @@ public class HttpHeaderKeys extends HeaderKeys {
                 if (returnFalseForInvalidName) {
                     return false;
                 }
-                IllegalArgumentException iae = new IllegalArgumentException("Header name contained an invalid character " + i);
-                FFDCFilter.processException(iae, HttpHeaderKeys.class.getName() + ".validateHeaderName(String)", "1", name);
+                final String msg = "Header name contained an invalid character " + i 
+                                   + " | char=" + toPrintable(c)
+                                   + " code=" + (int) c + "(0x" + Integer.toHexString(c) + ")"
+                                   + " pos=" + (i + 1)
+                                   + " name=\"" + name + "\"";
+
+                final IllegalArgumentException iae = new IllegalArgumentException(msg);
+                FFDCFilter.processException(
+                                            iae,
+                                            HttpHeaderKeys.class.getName() + ".validateHeaderName(String)",
+                                            "1",
+                                            name);
                 throw iae;
             }
         }
@@ -446,6 +456,25 @@ public class HttpHeaderKeys extends HeaderKeys {
                         (c == '~');
 
         return valid;
+    }
+
+    /**
+     * Returns a compact representation of a header-name character
+     * suitable for diagnostics. This is for header name, not values.
+     *
+     * @param c the character from the header name being validated
+     * @return a short printable form of {@code c} for logging
+     */
+    private static String toPrintable(char c) {
+        if (c == ' ')
+            return "\\u0020(SPACE)";
+        if (c == '\t')
+            return "\\u0009(TAB)";
+        if (c == '\r')
+            return "\\u000D(CR)";
+        if (c == '\n')
+            return "\\u000A(LF)";
+        return Character.isISOControl(c) ? String.format("\\u%04x", (int) c) : String.valueOf(c);
     }
 
     /** private headers defined as sensitive */

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/channel/test/api/HttpHeaderKeysTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/channel/test/api/HttpHeaderKeysTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.http.channel.test.api;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class HttpHeaderKeysTest {
+
+    private static Class<?> clazz;
+    private static Method validateHeaderName;
+
+    @BeforeClass
+    public static void reflect() throws Exception {
+        clazz = Class.forName("com.ibm.wsspi.http.channel.values.HttpHeaderKeys");
+        validateHeaderName = clazz.getDeclaredMethod("validateHeaderName", String.class, boolean.class);
+        validateHeaderName.setAccessible(true);
+    }
+
+    private static Object callValidate(String name, boolean returnFalseForInvalid) throws Throwable {
+        try {
+            return validateHeaderName.invoke(null, name, returnFalseForInvalid);
+        } catch (InvocationTargetException ite) {
+            throw ite.getCause();
+        }
+    }
+
+    /**
+     * Ensures an invalid header name ending with a space throws {@link IllegalArgumentException},
+     * preserves the original prefix, and includes new diagnostics (char, codes, pos, name).
+     */
+    @Test
+    public void zeroMigration_testValidateHeaderName_originalAndNewDiagnostic() throws Throwable {
+        String bad = "User-Agent "; // SPACE at end makes header name invalid
+        try {
+            callValidate(bad, false);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
+            String message = iae.getMessage();
+            assertNotNull(message);
+
+            // Legacy-compatible start:
+            assertTrue("Message must start with original prefix",
+                    message.startsWith("Header name contained an invalid character "));
+
+            assertTrue("Should include offending char escape", message.contains("char=\\u0020(SPACE)"));
+            assertTrue("Should include decimal code", message.contains("code=32("));
+            assertTrue("Should include hex code", message.contains("(0x20)"));
+            assertTrue("Should include 1-based position", message.contains(" pos="));
+            assertTrue("Should include header name", message.contains("name=\"User-Agent \""));
+        }
+    }
+
+    /**
+     * Validates TAB within the header name is reported with the complete diagnostic format.
+     */
+    @Test
+    public void invalidHeaderName_tabInName_hasCompactDetails() throws Throwable {
+        String bad = "X\tBad";
+        try {
+            callValidate(bad, false);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
+            String message = iae.getMessage();
+            assertTrue(message.startsWith("Header name contained an invalid character "));
+            assertTrue(message.contains("char=\\u0009(TAB)"));
+            assertTrue(message.contains("name=\"X\tBad\""));
+        }
+    }
+
+    @Test
+    public void returnFalseForInvalidName_suppressesException() throws Throwable {
+        String bad = "Bad Name"; // SPACE invalid
+        Object result = callValidate(bad, true);
+        assertEquals("Expected boolean false when returnFalseForInvalidName=true", Boolean.FALSE, result);
+    }
+
+    @Test
+    public void validHeaderName_withDigitPasses() throws Throwable {
+        Object result = callValidate("ValidHeaderName6", false);
+        assertEquals(Boolean.TRUE, result);
+    }
+
+    @Test
+    public void isValidTchar_acceptsDigitAndRejectsSpace() throws Exception {
+        Method isValidTchar = clazz.getDeclaredMethod("isValidTchar", char.class);
+        assertEquals(Boolean.TRUE, isValidTchar.invoke(null, '6'));
+        assertEquals(Boolean.FALSE, isValidTchar.invoke(null, ' '));
+    }
+
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #33209 
