### PR TITLE
Adding 3.1 schemas as part of the Hibernate Validator 9.0 Final upgrade

### DIFF
--- a/dev/io.openliberty.org.hibernate.validator.9.0/bnd.overrides
+++ b/dev/io.openliberty.org.hibernate.validator.9.0/bnd.overrides
@@ -8,7 +8,7 @@ Bundle-SymbolicName: io.openliberty.org.hibernate.validator.9.0
 Bundle-Description: Hibernate's Jakarta Validation 3.1 reference implementation; version=9.0.0.Final
 
 # Provide these as resources to applications
-#TODO add the 3.1 schemas when upgrading to the final Hibernate Validator 9.0
+
 app-resources= \
   META-INF/services/jakarta.validation.spi.ValidationProvider | \
   META-INF/validation-mapping-1.0.xsd | \
@@ -17,8 +17,8 @@ app-resources= \
   META-INF/validation-configuration-1.1.xsd | \
   META-INF/validation-mapping-2.0.xsd | \
   META-INF/validation-configuration-2.0.xsd | \
-  META-INF/validation-mapping-3.0.xsd | \
-  META-INF/validation-configuration-3.0.xsd
+  META-INF/validation-mapping-3.1.xsd | \
+  META-INF/validation-configuration-3.1.xsd
 
 Export-Package: \
   org.hibernate.validator.*;version="9.0.0.Final";thread-context=true

--- a/dev/io.openliberty.org.hibernate.validator.9.0/bnd.overrides
+++ b/dev/io.openliberty.org.hibernate.validator.9.0/bnd.overrides
@@ -17,6 +17,8 @@ app-resources= \
   META-INF/validation-configuration-1.1.xsd | \
   META-INF/validation-mapping-2.0.xsd | \
   META-INF/validation-configuration-2.0.xsd | \
+  META-INF/validation-mapping-3.0.xsd | \
+  META-INF/validation-configuration-3.0.xsd
   META-INF/validation-mapping-3.1.xsd | \
   META-INF/validation-configuration-3.1.xsd
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Adding 3.1 schemas as part of the upgrade from Hibernate Validator 9.0.0.Beta3 to the 9.0 Final release.

Fixes #29998
