### PR TITLE
Update to not release test bundles that are in multiple projects

### DIFF
--- a/dev/com.ibm.ws.collector/bnd.bnd
+++ b/dev/com.ibm.ws.collector/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2016, 2024 IBM Corporation and others.
+# Copyright (c) 2016, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,10 +14,6 @@
 bVersion=1.0
 
 -sub: *.bnd
-
-Bundle-Name: Collector
-Bundle-SymbolicName: com.ibm.ws.collector
-Bundle-Description: Generic Collector: Defines the framework for a collector; version=${bVersion}
 
 WS-TraceGroup: collector
 

--- a/dev/com.ibm.ws.jmx_fat/com.ibm.ws.jmx.fat.jmxtest.bnd
+++ b/dev/com.ibm.ws.jmx_fat/com.ibm.ws.jmx.fat.jmxtest.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0.0
 Bundle-Name: JMX Test bundle
 Bundle-SymbolicName: com.ibm.ws.jmx.fat.jmxtest
 Bundle-Description: Test bundle for the jmx project
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 # optional... 
 WS-TraceGroup: projectExample

--- a/dev/com.ibm.ws.jpa_testframework/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_testframework/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -15,11 +15,6 @@
 -sub: *.bnd
 
 bVersion=1.0
-
-
-Bundle-Name: JPA Test Tools
-Bundle-SymbolicName: com.ibm.ws.jpa_testframework
-Bundle-Description: JPA Test Tools; version=${bVersion}
 
 test.project: true
 publish.wlp.jar.disabled: true

--- a/dev/com.ibm.ws.kernel.boot_test/simple.bnd
+++ b/dev/com.ibm.ws.kernel.boot_test/simple.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -19,6 +19,12 @@ Bundle-Name: simple bundle
 Bundle-SymbolicName: simple
 Bundle-Version: ${bVersion}
 Bundle-Description: simple, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 #include the real property file resources
 Include-Resource: \

--- a/dev/com.ibm.ws.kernel.boot_test/simple2.bnd
+++ b/dev/com.ibm.ws.kernel.boot_test/simple2.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -21,6 +21,12 @@ Bundle-SymbolicName: simple
 Bundle-Version: ${bVersion}
 Bundle-Description: simple, version ${bVersion}
 WebSphere-DefaultKernel: test-kernel-2.0
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 # For each exported package, create (in that package) a package-info.java
 # file, and place an @version javadoc tag in package-level javadoc. 

--- a/dev/com.ibm.ws.kernel.boot_test/simple3.bnd
+++ b/dev/com.ibm.ws.kernel.boot_test/simple3.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,12 @@ Bundle-SymbolicName: simple
 Bundle-Version: ${bVersion}
 Bundle-Description: simple, version ${bVersion}
 WebSphere-DefaultKernel: test-kernel-2.0
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 ## It is important that the pacakges.list file does not actually exist in the generated bundle..
 # because this is testing missing system packages so we don't include them here!

--- a/dev/com.ibm.ws.kernel.boot_test/simple4.bnd
+++ b/dev/com.ibm.ws.kernel.boot_test/simple4.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,12 @@ Bundle-SymbolicName: simple
 Bundle-Version: ${bVersion}
 Bundle-Description: simple, version ${bVersion}
 WebSphere-DefaultKernel: test-kernel-2.0
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 #mock up a 1.6.0 package list from the package.list with a bad property
 Include-Resource: OSGI-OPT/websphere/system-packages_1.6.0.properties=resources/packages.list

--- a/dev/com.ibm.ws.kernel.boot_test/simple5.bnd
+++ b/dev/com.ibm.ws.kernel.boot_test/simple5.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -19,6 +19,12 @@ Bundle-Name: simple bundle
 Bundle-SymbolicName: simple
 Bundle-Version: ${bVersion}
 Bundle-Description: simple, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 #Include dummy resources for system-packages
 Include-Resource: \

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/opentracing.mock11.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/opentracing.mock11.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2024 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: com.ibm.ws.opentracing.mock-1.1
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.1
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory
 

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/opentracing.mock12.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/opentracing.mock12.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2024 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: com.ibm.ws.opentracing.mock-1.2
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.2
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory
 

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/opentracing.mock13.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/opentracing.mock13.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2024 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: com.ibm.ws.opentracing.mock-1.3
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.3
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory
 

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/opentracing.mock.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2024 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: com.ibm.ws.opentracing.mock
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock
 Bundle-Description:Opentracing mock Tracer, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory
 

--- a/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock11.bnd
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock11.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2024 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: com.ibm.ws.opentracing.mock-1.1
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.1
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory
 

--- a/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock12.bnd
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock12.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2024 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: com.ibm.ws.opentracing.mock-1.2
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.2
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory
 

--- a/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock13.bnd
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/opentracing.mock13.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2024 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: com.ibm.ws.opentracing.mock-1.3
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock-1.3
 Bundle-Description:Opentracing mock Tracer 0.31.0, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory
 

--- a/dev/com.ibm.ws.opentracing_fat/opentracing.mock.bnd
+++ b/dev/com.ibm.ws.opentracing_fat/opentracing.mock.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2024 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: com.ibm.ws.opentracing.mock
 Bundle-SymbolicName: com.ibm.ws.opentracing.mock
 Bundle-Description:Opentracing mock Tracer, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: com.ibm.ws.opentracing.mock.OpentracingMockTracerFactory
 

--- a/dev/com.ibm.ws.transaction.hadb_fat.db2.1/ifxjdbc.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.db2.1/ifxjdbc.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0.0
 Bundle-Name: Test JDBC Extension 
 Bundle-SymbolicName: ifxjdbc
 Bundle-Description: This bundle tests HADB; version=${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 Export-Package: \
   com.informix.jdbcx;version=1.0.0, \

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/ifxjdbc.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/ifxjdbc.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0.0
 Bundle-Name: Test JDBC Extension 
 Bundle-SymbolicName: ifxjdbc
 Bundle-Description: This bundle tests HADB; version=${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 Export-Package: \
   com.informix.jdbcx;version=1.0.0, \

--- a/dev/com.ibm.ws.transaction.hadb_fat.oracle.1/ifxjdbc.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.oracle.1/ifxjdbc.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0.0
 Bundle-Name: Test JDBC Extension 
 Bundle-SymbolicName: ifxjdbc
 Bundle-Description: This bundle tests HADB; version=${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 Export-Package: \
   com.informix.jdbcx;version=1.0.0, \

--- a/dev/com.ibm.ws.transaction.hadb_fat.postgresql.1/ifxjdbc.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.postgresql.1/ifxjdbc.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0.0
 Bundle-Name: Test JDBC Extension 
 Bundle-SymbolicName: ifxjdbc
 Bundle-Description: This bundle tests HADB; version=${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 Export-Package: \
   com.informix.jdbcx;version=1.0.0, \

--- a/dev/com.ibm.ws.transaction.hadb_fat.sqlserver.1/ifxjdbc.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.sqlserver.1/ifxjdbc.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0.0
 Bundle-Name: Test JDBC Extension 
 Bundle-SymbolicName: ifxjdbc
 Bundle-Description: This bundle tests HADB; version=${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 Export-Package: \
   com.informix.jdbcx;version=1.0.0, \

--- a/dev/io.openliberty.checkpoint_fat/com.ibm.ws.jmx.fat.jmxtest.bnd
+++ b/dev/io.openliberty.checkpoint_fat/com.ibm.ws.jmx.fat.jmxtest.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0.0
 Bundle-Name: JMX Test bundle
 Bundle-SymbolicName: com.ibm.ws.jmx.fat.jmxtest
 Bundle-Description: Test bundle for the jmx project
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 # optional... 
 WS-TraceGroup: projectExample

--- a/dev/io.openliberty.checkpoint_fat/test.checkpoint.config.bundle.bnd
+++ b/dev/io.openliberty.checkpoint_fat/test.checkpoint.config.bundle.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2024 IBM Corporation and others.
+# Copyright (c) 2019, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,12 @@ bVersion=1.0.0
 
 Bundle-Name: test.checkpoint.config.bundle
 Bundle-SymbolicName: test.checkpoint.config.bundle
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 # hide the implementation packages
 Private-Package: \

--- a/dev/io.openliberty.checkpoint_fat_mp/com.ibm.ws.jmx.fat.jmxtest.bnd
+++ b/dev/io.openliberty.checkpoint_fat_mp/com.ibm.ws.jmx.fat.jmxtest.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0.0
 Bundle-Name: JMX Test bundle
 Bundle-SymbolicName: com.ibm.ws.jmx.fat.jmxtest
 Bundle-Description: Test bundle for the jmx project
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 # optional... 
 WS-TraceGroup: projectExample

--- a/dev/io.openliberty.checkpoint_fat_mp/test.checkpoint.config.bundle.bnd
+++ b/dev/io.openliberty.checkpoint_fat_mp/test.checkpoint.config.bundle.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2024 IBM Corporation and others.
+# Copyright (c) 2019, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,12 @@ bVersion=1.0.0
 
 Bundle-Name: test.checkpoint.config.bundle
 Bundle-SymbolicName: test.checkpoint.config.bundle
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 # hide the implementation packages
 Private-Package: \

--- a/dev/io.openliberty.http.monitor/bnd.bnd
+++ b/dev/io.openliberty.http.monitor/bnd.bnd
@@ -15,10 +15,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.http.monitor
-Bundle-SymbolicName: io.openliberty.http.monitor
-Bundle-Description: io.openliberty.http.monitor; version=${bVersion}
-
 src: src
 
 -dsannotations: \

--- a/dev/io.openliberty.http.monitor/original.bnd
+++ b/dev/io.openliberty.http.monitor/original.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,4 +13,4 @@
 
 Bundle-Name: io.openliberty.http.monitor
 Bundle-SymbolicName: io.openliberty.http.monitor
-
+Bundle-Description: io.openliberty.http.monitor; version=${bVersion}

--- a/dev/io.openliberty.http.monitor/transformed.bnd
+++ b/dev/io.openliberty.http.monitor/transformed.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,4 +14,4 @@
 
 Bundle-Name: io.openliberty.http.monitor.jakarta
 Bundle-SymbolicName: io.openliberty.http.monitor.jakarta
-
+Bundle-Description: io.openliberty.http.monitor.jakarta; version=${bVersion}

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/opentracing.mock.2.0.bnd
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/opentracing.mock.2.0.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: io.openliberty.opentracing.mock-2.0
 Bundle-SymbolicName: io.openliberty.opentracing.mock-2.0
 Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: io.openliberty.opentracing.internal.mock.OpentracingMockTracerFactory
 

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/opentracing.mock.3.0.bnd
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/opentracing.mock.3.0.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: io.openliberty.opentracing.mock-3.0
 Bundle-SymbolicName: io.openliberty.opentracing.mock-3.0
 Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: io.openliberty.opentracing.internal.mock.OpentracingMockTracerFactory
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.config_fat/user-feature.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.config_fat/user-feature.bnd
@@ -14,6 +14,12 @@ Bundle-Name:  User Feature To Test Open Telemetry SPI
 Bundle-SymbolicName: telemetry.user.feature
 Bundle-Description: This bundle tests the telemetry spi; version=${bVersion}
 
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
+
 Import-Package: \
   javax.ws.rs.ext;version="[2.0,3)",\
   *

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.config_fat/user-wab.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.config_fat/user-wab.bnd
@@ -14,6 +14,12 @@ Bundle-Name: User WAB To Test Open Telemetry SPI
 Bundle-SymbolicName: telemetry.user.wab
 Bundle-Description: This bundle tests the telemetry spi; version=${bVersion}
 
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
+
 Import-Package: \
   javax.ws.rs.ext;version="[2.0,3)",\
   *

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/user-feature.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/user-feature.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,6 +13,12 @@ bVersion=1.0.0
 Bundle-Name:  User Feature To Test Open Telemetry SPI 
 Bundle-SymbolicName: telemetry.user.feature
 Bundle-Description: This bundle tests the telemetry spi; version=${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 Import-Package: \
   javax.ws.rs.ext;version="[2.0,3)",\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/user-wab.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/user-wab.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,6 +13,12 @@ bVersion=1.0.0
 Bundle-Name: User WAB To Test Open Telemetry SPI 
 Bundle-SymbolicName: telemetry.user.wab
 Bundle-Description: This bundle tests the telemetry spi; version=${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 Import-Package: \
   javax.ws.rs.ext;version="[2.0,3)",\

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2023, 2024 IBM Corporation and others.
+# Copyright (c) 2023, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,8 +12,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.microprofile.telemetry.1.1.internal
-Bundle-SymbolicName: io.openliberty.microprofile.telemetry.1.1.internal
 Bundle-Activator: io.openliberty.microprofile.telemetry11.internal.helper.InstrumenterActivator
 Bundle-Description: MicroProfile.telemetry, version 1.1
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,8 +12,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.microprofile.telemetry.2.0.internal
-Bundle-SymbolicName: io.openliberty.microprofile.telemetry.2.0.internal
 Bundle-Activator: io.openliberty.microprofile.telemetry20.internal.helper.InstrumenterActivator
 Bundle-Description: MicroProfile.telemetry, version 2.0
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/bnd.bnd
@@ -12,8 +12,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.microprofile.telemetry.2.0.logging.internal
-Bundle-SymbolicName: io.openliberty.microprofile.telemetry.2.0.logging.internal
 Bundle-Description: MicroProfile.telemetry.logging, version 2.0
 WS-TraceGroup: TELEMETRY
 

--- a/dev/io.openliberty.microprofile.telemetry.2.1.logging.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.1.logging.internal/bnd.bnd
@@ -12,8 +12,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.microprofile.telemetry.2.1.logging.internal
-Bundle-SymbolicName: io.openliberty.microprofile.telemetry.2.1.logging.internal
 Bundle-Description: MicroProfile.telemetry.logging, version 2.1
 WS-TraceGroup: TELEMETRY
 

--- a/dev/io.openliberty.microprofile.telemetry.logging.internal.common/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.logging.internal.common/bnd.bnd
@@ -12,8 +12,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.microprofile.telemetry.logging.internal.common
-Bundle-SymbolicName: io.openliberty.microprofile.telemetry.logging.internal.common
 Bundle-Description: MicroProfile.telemetry.logging, common code
 WS-TraceGroup: TELEMETRY
 

--- a/dev/io.openliberty.opentracing.2.x_fat/opentracing.mock20.bnd
+++ b/dev/io.openliberty.opentracing.2.x_fat/opentracing.mock20.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: io.openliberty.opentracing.mock-2.0
 Bundle-SymbolicName: io.openliberty.opentracing.mock-2.0
 Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: io.openliberty.opentracing.internal.mock.OpentracingMockTracerFactory
 

--- a/dev/io.openliberty.opentracing.3.x_fat/opentracing.mock30.bnd
+++ b/dev/io.openliberty.opentracing.3.x_fat/opentracing.mock30.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021, 2024 IBM Corporation and others.
+# Copyright (c) 2021, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,12 @@ bVersion=1.0
 Bundle-Name: io.openliberty.opentracing.mock-3.0
 Bundle-SymbolicName: io.openliberty.opentracing.mock-3.0
 Bundle-Description: Opentracing mock Tracer 0.33.0, version ${bVersion}
+
+# Do not release this test bundle to the bnd repository.
+# It is only needed internally and is not needed for other projects.
+# If another project has a bundle with the same SymbolicName, you can get
+# a build error that the bundle is already published.
+-releaserepo:
 
 -dsannotations: io.openliberty.opentracing.internal.mock.OpentracingMockTracerFactory
 


### PR DESCRIPTION
- When 2 or more test projects end up having test bundles with the same name, there can be errors during the build when both projects try to release the same bundle name and it already was released.  There is no need to actually release test bundles to the bnd repository.  This PR updates to not release the bundles whose names are shared across multiple test projects. 
- In the future it would be good to update all test bundle bnd files to not release, but this is a stop gap in order to prevent people from getting build errors when doing gradle with parallel enabled.
- Also updated bnd.bnd files to remove SymbolicName settings when the projects has sub bundles and set the symbolic name in the sub bundles.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
