### PR TITLE
SpringBoot test application cleanup

### DIFF
--- a/dev/com.ibm.ws.springboot.fat20.actuator.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.actuator.app/build.gradle
@@ -13,10 +13,10 @@
 
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
-
-apply plugin: 'java'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/com.ibm.ws.springboot.fat20.aop.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.aop.app/build.gradle
@@ -11,6 +11,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 
@@ -25,14 +26,4 @@ dependencies {
   implementation('org.springframework.boot:spring-boot-starter-aop')
   implementation('org.aspectj:aspectjweaver:1.9.24')
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.jms.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.jms.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.app/build.gradle
@@ -13,6 +13,7 @@
 
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 def sv = springVersions[ '2.0' ]

--- a/dev/com.ibm.ws.springboot.fat20.concurrency.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.concurrency.app/build.gradle
@@ -12,6 +12,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 
@@ -24,14 +25,4 @@ java {
 dependencies {
   implementation('org.springframework.boot:spring-boot-starter-web')
   providedRuntime('org.springframework.boot:spring-boot-starter-tomcat')
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.data.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.data.app/build.gradle
@@ -12,6 +12,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 
@@ -29,12 +30,4 @@ dependencies {
   providedCompile 'org.hibernate:hibernate-core'
   providedCompile 'jakarta.transaction:jakarta.transaction-api'
   providedCompile 'jakarta.persistence:jakarta.persistence-api'
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.http.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.http.app/build.gradle
@@ -14,6 +14,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 
@@ -29,10 +30,4 @@ dependencies {
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
   providedCompile 'javax.servlet:jstl'
   providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.http.app/module/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.http.app/module/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'java'
+plugins {
+  id 'java'
+}
 
 group = 'com.ibm.ws.example'
 version = '0.0.1-SNAPSHOT'

--- a/dev/com.ibm.ws.springboot.fat20.http.contextroot.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.http.contextroot.app/build.gradle
@@ -14,6 +14,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 
@@ -29,10 +30,4 @@ dependencies {
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
   providedCompile 'javax.servlet:jstl'
   providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.http.contextroot.app/module/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.http.contextroot.app/module/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'java'
+plugins {
+  id 'java'
+}
 
 group = 'com.ibm.ws.example'
 version = '0.0.1-SNAPSHOT'

--- a/dev/com.ibm.ws.springboot.fat20.java.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.java.app/build.gradle
@@ -13,10 +13,10 @@
 
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
-
-apply plugin: 'java'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/com.ibm.ws.springboot.fat20.jms.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.jms.app/build.gradle
@@ -11,6 +11,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 
@@ -28,14 +29,4 @@ dependencies {
   implementation('org.springframework.boot:spring-boot-starter-jdbc')
   providedCompile('javax.jms:javax.jms-api:2.0.1')
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.jms.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.jms.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.mbean.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.mbean.app/build.gradle
@@ -14,6 +14,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 
@@ -26,14 +27,4 @@ java {
 dependencies {
   implementation('org.springframework.boot:spring-boot-starter-web')
   providedRuntime('org.springframework.boot:spring-boot-starter-tomcat')
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.multicontext.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.multicontext.app/build.gradle
@@ -13,10 +13,10 @@
 
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
-
-apply plugin: 'java'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/com.ibm.ws.springboot.fat20.programmatic.trans.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.programmatic.trans.app/build.gradle
@@ -12,6 +12,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 
@@ -26,14 +27,4 @@ dependencies {
   implementation('org.springframework.boot:spring-boot-starter-jdbc')
 
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.transactions.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.transactions.app/build.gradle
@@ -12,6 +12,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 
@@ -26,14 +27,4 @@ dependencies {
   implementation('org.springframework.boot:spring-boot-starter-data-jpa')
 
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.validation.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.validation.app/build.gradle
@@ -12,6 +12,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
@@ -29,12 +30,4 @@ dependencies {
     exclude group: 'org.hibernate.validator', module: 'hibernate-validator'
   }
   compileOnly 'jakarta.validation:jakarta.validation-api'
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.war.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.war.app/build.gradle
@@ -14,6 +14,7 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 
@@ -48,10 +49,4 @@ dependencies {
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
   providedCompile 'javax.servlet:jstl'
   providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/com.ibm.ws.springboot.fat20.war.app/module/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.war.app/module/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'java'
+plugins {
+  id 'java'
+}
 
 group = 'com.ibm.ws.example'
 version = '0.0.1-SNAPSHOT'

--- a/dev/com.ibm.ws.springboot.fat20.webanno.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.webanno.app/build.gradle
@@ -13,10 +13,10 @@
 
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
-
-apply plugin: 'java'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/com.ibm.ws.springboot.fat20.webflux.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.webflux.app/build.gradle
@@ -13,10 +13,10 @@
 
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
-
-apply plugin: 'java'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/com.ibm.ws.springboot.fat20.websocket.app/build.gradle
+++ b/dev/com.ibm.ws.springboot.fat20.websocket.app/build.gradle
@@ -13,11 +13,11 @@
 
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/springboot2.gradle'
 def sv = springVersions[ '2.0' ]
-
-apply plugin: 'java'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.checkpoint.springboot.fat30.app/build.gradle
+++ b/dev/io.openliberty.checkpoint.springboot.fat30.app/build.gradle
@@ -13,10 +13,9 @@
 
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.checkpoint.springboot.fat30.data.app/build.gradle
+++ b/dev/io.openliberty.checkpoint.springboot.fat30.data.app/build.gradle
@@ -13,9 +13,8 @@
 
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
-  id 'java'
   id 'org.springframework.boot' version '3.5.3'
-  id 'io.spring.dependency-management' version '1.1.4'
+  id 'io.spring.dependency-management' version '1.1.7'
   id 'war'
 }
 
@@ -65,8 +64,4 @@ bootWar {
       'Spring-Boot-Version': '3.2.4'
     )
   }
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
 }

--- a/dev/io.openliberty.checkpoint.springboot.fat30.webflux.app/build.gradle
+++ b/dev/io.openliberty.checkpoint.springboot.fat30.webflux.app/build.gradle
@@ -14,10 +14,9 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.actuator.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.actuator.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.aop.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.aop.app/build.gradle
@@ -12,10 +12,9 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -30,13 +29,4 @@ dependencies {
   implementation('org.springframework.boot:spring-boot-starter-aop')
   implementation('org.aspectj:aspectjweaver:1.9.24')
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
-}
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':io.openliberty.springboot.fat30.jms.app:module:compileTestJava' and 
-// ':io.openliberty.springboot.fat30.jms.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat30.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.app/build.gradle
@@ -14,11 +14,11 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
-apply from: '../wlp-gradle/subprojects/spring.gradle'
 
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
+apply from: '../wlp-gradle/subprojects/spring.gradle'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.concurrency.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.concurrency.app/build.gradle
@@ -12,10 +12,9 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -28,14 +27,4 @@ apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 dependencies {
   implementation('org.springframework.boot:spring-boot-starter-web')
   providedRuntime('org.springframework.boot:spring-boot-starter-tomcat')
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat30.data.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.data.app/build.gradle
@@ -12,11 +12,10 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -34,12 +33,4 @@ dependencies {
   providedCompile 'org.hibernate.orm:hibernate-core'
   providedCompile 'jakarta.transaction:jakarta.transaction-api'
   providedCompile 'jakarta.persistence:jakarta.persistence-api'
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat30.http.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.http.app/build.gradle
@@ -14,11 +14,9 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-def sv = springVersions[ '3.0' ]
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -28,17 +26,10 @@ java {
 
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
-
 dependencies {
-  implementation('org.springframework.boot:spring-boot-starter-web') // + ':' + sv['springBoot'])
+  implementation('org.springframework.boot:spring-boot-starter-web')
 
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
   providedCompile 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api'
   providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'
-}
-
-// Disable jar because it would need a dependency on ':io.openliberty.springboot.fat30.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat30.http.app/module/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.http.app/module/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'java'
+plugins {
+  id 'java'
+}
 
 group = 'com.ibm.ws.example'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.http.contextroot.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.http.contextroot.app/build.gradle
@@ -14,11 +14,9 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-def sv = springVersions[ '3.0' ]
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -28,17 +26,10 @@ java {
 
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
-
 dependencies {
-  implementation('org.springframework.boot:spring-boot-starter-web') // + ':' + sv['springBoot'])
+  implementation('org.springframework.boot:spring-boot-starter-web')
 
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
   providedCompile 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api'
   providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'
-}
-
-// Disable jar because it would need a dependency on ':io.openliberty.springboot.fat30.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat30.http.contextroot.app/module/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.http.contextroot.app/module/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'java'
+plugins {
+  id 'java'
+}
 
 group = 'com.ibm.ws.example'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.java.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.java.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.jms.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.jms.app/build.gradle
@@ -12,10 +12,9 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -33,13 +32,4 @@ dependencies {
   implementation('org.springframework.boot:spring-boot-starter-jdbc')
   providedCompile('jakarta.jms:jakarta.jms-api:3.1.0')
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
-}
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':io.openliberty.springboot.fat30.jms.app:module:compileTestJava' and 
-// ':io.openliberty.springboot.fat30.jms.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat30.mbean.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.mbean.app/build.gradle
@@ -14,11 +14,9 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-def sv = springVersions[ '3.0' ]
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -29,16 +27,6 @@ java {
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 dependencies {
-  implementation('org.springframework.boot:spring-boot-starter-web') // + ':' + sv['springBoot'])
+  implementation('org.springframework.boot:spring-boot-starter-web')
   providedRuntime('org.springframework.boot:spring-boot-starter-tomcat')
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':io.openliberty.springboot.fat30.war.app:module:compileTestJava' and 
-// ':io.openliberty.springboot.fat30.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat30.multicontext.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.multicontext.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.security.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.security.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.transactions.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.transactions.app/build.gradle
@@ -12,11 +12,9 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-def sv = springVersions[ '2.0' ]
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -30,14 +28,5 @@ dependencies {
   implementation('org.springframework.boot:spring-boot-starter-web')
   implementation('org.springframework.boot:spring-boot-starter-jdbc')
 
-  providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
+  providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
 }

--- a/dev/io.openliberty.springboot.fat30.validation.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.validation.app/build.gradle
@@ -12,11 +12,10 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -26,7 +25,6 @@ java {
 
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
-
 dependencies {
   implementation('org.springframework.boot:spring-boot-starter-web')
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
@@ -34,12 +32,4 @@ dependencies {
     exclude group: 'org.hibernate.validator', module: 'hibernate-validator'
   }
   compileOnly 'jakarta.validation:jakarta.validation-api'
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat30.war.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.war.app/build.gradle
@@ -15,10 +15,9 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -55,10 +54,4 @@ dependencies {
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
   providedCompile 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api'
   providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'
-}
-
-// Disable jar because it would need a dependency on ':io.openliberty.springboot.fat30.war.app:module:compileTestJava' and 
-// ':io.openliberty.springboot.fat30.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat30.war.app/module/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.war.app/module/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'java'
+plugins {
+  id 'java'
+}
 
 group = 'com.ibm.ws.example'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.webanno.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.webanno.app/build.gradle
@@ -13,11 +13,10 @@
 
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.webflux.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.webflux.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '3.5.3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat30.websocket.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.websocket.app/build.gradle
@@ -15,11 +15,9 @@
 plugins {
   id 'org.springframework.boot' version '3.5.3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat40.actuator.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.actuator.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat40.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat40.concurrency.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.concurrency.app/build.gradle
@@ -14,10 +14,9 @@
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -35,14 +34,4 @@ dependencies {
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-core')
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-el')
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-websocket')
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat40.data.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.data.app/build.gradle
@@ -12,11 +12,10 @@
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -40,12 +39,4 @@ dependencies {
   providedCompile 'org.hibernate.orm:hibernate-core:7.1.0.Final'
   providedCompile 'jakarta.transaction:jakarta.transaction-api'
   providedCompile 'jakarta.persistence:jakarta.persistence-api'
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat40.java.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.java.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat40.jms.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.jms.app/build.gradle
@@ -12,10 +12,9 @@
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -38,11 +37,4 @@ dependencies {
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-core')
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-el')
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-websocket')
-}
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat40.mbean.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.mbean.app/build.gradle
@@ -14,11 +14,9 @@
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-def sv = springVersions[ '4.0' ]
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -29,21 +27,11 @@ java {
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 dependencies {
-  implementation('org.springframework.boot:spring-boot-starter-web') // + ':' + sv['springBoot'])
+  implementation('org.springframework.boot:spring-boot-starter-web')
    // Should use spring-boot-starter-tomcat as provideCompile, but gradle plugin
   // is putting too much in lib-provided: see https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/409
   // providedCompile('org.springframework.boot:spring-boot-starter-tomcat')
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-core')
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-el')
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-websocket')
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':io.openliberty.springboot.fat30.war.app:module:compileTestJava' and 
-// ':io.openliberty.springboot.fat30.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat40.multicontext.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.multicontext.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat40.security.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.security.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat40.transactions.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.transactions.app/build.gradle
@@ -12,10 +12,9 @@
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -35,14 +34,4 @@ dependencies {
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-core')
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-el')
   providedRuntime('org.apache.tomcat.embed:tomcat-embed-websocket')
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-// Disable jar because it would need a dependency on ':com.ibm.ws.springboot.fat20.war.app:module:compileTestJava' and 
-// ':com.ibm.ws.springboot.fat20.war.app:module:processTestResources' which seems silly since we don't actually need a jar for this project.  We only need the war.
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat40.validation.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.validation.app/build.gradle
@@ -12,11 +12,10 @@
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'com.ibm.ws.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -25,7 +24,6 @@ java {
 }
 
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
-
 
 dependencies {
   implementation('org.springframework.boot:spring-boot-starter-web')
@@ -39,12 +37,4 @@ dependencies {
     exclude group: 'org.hibernate.validator', module: 'hibernate-validator'
   }
   compileOnly 'jakarta.validation:jakarta.validation-api'
-}
-
-bootJar {
-  duplicatesStrategy = 'warn'
-}
-
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat40.war.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.war.app/build.gradle
@@ -15,10 +15,9 @@
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'
@@ -35,8 +34,4 @@ dependencies {
   providedCompile 'org.springframework.boot:spring-boot-starter-tomcat'
   //providedCompile 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api'
   //providedCompile 'org.apache.tomcat.embed:tomcat-embed-jasper'
-}
-
-jar {
-  enabled = false
 }

--- a/dev/io.openliberty.springboot.fat40.war.app/module/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.war.app/module/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'java'
+plugins {
+  id 'java'
+}
 
 group = 'com.ibm.ws.example'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat40.webanno.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.webanno.app/build.gradle
@@ -13,11 +13,10 @@
 
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat40.webflux.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.webflux.app/build.gradle
@@ -14,11 +14,10 @@
 // https://plugins.gradle.org/plugin/org.springframework.boot
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
+  id 'java'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/io.openliberty.springboot.fat40.websocket.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat40.websocket.app/build.gradle
@@ -15,11 +15,9 @@
 plugins {
   id 'org.springframework.boot' version '4.0.0-M3'
   id 'war'
+  id 'io.spring.dependency-management' version '1.1.7'
 }
 apply from: '../wlp-gradle/subprojects/spring.gradle'
-
-apply plugin: 'java'
-apply plugin: 'io.spring.dependency-management'
 
 group = 'io.openliberty.example.spring'
 version = '0.0.1-SNAPSHOT'

--- a/dev/wlp-gradle/subprojects/spring.gradle
+++ b/dev/wlp-gradle/subprojects/spring.gradle
@@ -63,6 +63,11 @@ ext {
   ]
 }
 
+// disable the jar and war tasks since the spring plugin we only need the bootJar and bootWar tasks
+jar {
+  enabled = false
+}
+
 if (project.plugins.hasPlugin('war')) {
   // Do not also create the non boot war
   tasks.war.enabled = false

--- a/dev/wlp-gradle/subprojects/springboot2.gradle
+++ b/dev/wlp-gradle/subprojects/springboot2.gradle
@@ -10,15 +10,13 @@
 
 /**
  * This gradle file includes the updates needed to build a Spring Boot 2 application
- * using the Spring Boot 3 gradle plugin.  The Spring Boot 2 gradle plugin does not
+ * using the Spring Boot 3 gradle plugin. The Spring Boot 2 gradle plugin does not
  * work with Gradle 9 so we do this approach to be able to build Spring Boot 2
- * application using Gradle 9 still.
+ * applications using Gradle 9 still.
  */
 
 apply from: '../wlp-gradle/subprojects/spring.gradle'
 def sv = springVersions[ '2.0' ]
-
-apply plugin: 'io.spring.dependency-management'
 
 // Need to use the dependency manager as well because the implementation with the
 // enforcedPlatform below only works for implementation and we need to have the bom


### PR DESCRIPTION
- Switch from using `apply plugin` to putting the plugins into `plugins`
- Remove `bootJar` config from build.gradle files where a war is built
- Remove `jar` being disabled in build.gradle and put it into spring.gradle like what is done to disable `war`.
- Switch to using version 1.1.7 of the dependency-management plugin
- Clean up sv usage where it was commented out
- Update to not specify `java` plugin if the `war` plugin is specified


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
