### PR TITLE
Support for Annotations when returning Content objects in MCP

### DIFF
--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolContents.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolContents.java
@@ -13,36 +13,207 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import org.junit.Test;
 
+import io.openliberty.mcp.content.AudioContent;
+import io.openliberty.mcp.content.Content.Annotations;
+import io.openliberty.mcp.content.ImageContent;
+import io.openliberty.mcp.content.Role;
 import io.openliberty.mcp.content.TextContent;
 import io.openliberty.mcp.meta.MetaKey;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
 
 public class ToolContents {
 
+    // Text Content
     @Test
-    public void testTextContentConstructorAndFields() {
+    public void testTextConvenienceConstructor() {
         TextContent content = new TextContent("Hello world");
 
         assertEquals("Hello world", content.text());
         assertNull(content._meta());
+        assertNull(content.annotations());
         assertEquals(TextContent.Type.TEXT, content.type());
         assertSame(content, content.asText());
     }
 
     @Test
-    public void testTextContentWithMeta() {
-        Map<MetaKey, Object> meta = Map.of();
-        TextContent content = new TextContent("Text with meta", meta);
+    public void testTextContentWithNullMetaAndAnnotation() {
+        TextContent content = new TextContent("Hello world", null, null);
 
-        assertEquals("Text with meta", content.text());
+        assertEquals("Hello world", content.text());
+        assertNull(content._meta());
+        assertNull(content.annotations());
+        assertEquals(TextContent.Type.TEXT, content.type());
+        assertSame(content, content.asText());
+    }
+
+    @Test
+    public void testTextContentWithMetaAndAnnotation() {
+        Map<MetaKey, Object> meta = Map.of();
+        Annotations annotations = new Annotations(Role.USER, ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                          .format(DateTimeFormatter.ISO_INSTANT),
+                                                  0.5);
+        TextContent content = new TextContent("Hello world", meta, annotations);
+
+        assertEquals("Hello world", content.text());
         assertEquals(meta, content._meta());
+        assertEquals(annotations, content.annotations());
+        assertEquals(TextContent.Type.TEXT, content.type());
+        assertSame(content, content.asText());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testTextContentNullTextThrowsException() {
         new TextContent(null);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTextContentNullWithMetaThrowsException() {
+        Map<MetaKey, Object> meta = Map.of();
+        Annotations annotations = new Annotations(Role.USER, ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                          .format(DateTimeFormatter.ISO_INSTANT),
+                                                  0.5);
+        new TextContent(null, meta, annotations);
+    }
+
+    // Audio Content
+    @Test
+    public void testAudioContentConvienienceConstructor() {
+        AudioContent content = new AudioContent("base64-encoded-audio", "audio/mpeg");
+
+        assertEquals("base64-encoded-audio", content.data());
+        assertEquals("audio/mpeg", content.mimeType());
+        assertNull(content._meta());
+        assertNull(content.annotations());
+        assertEquals(AudioContent.Type.AUDIO, content.type());
+        assertSame(content, content.asAudio());
+    }
+
+    @Test
+    public void testAudioContentWithNullMetaAndAnnotation() {
+        AudioContent content = new AudioContent("base64-encoded-audio", "audio/mpeg", null, null);
+
+        assertEquals("base64-encoded-audio", content.data());
+        assertEquals("audio/mpeg", content.mimeType());
+        assertNull(content._meta());
+        assertNull(content.annotations());
+        assertEquals(TextContent.Type.AUDIO, content.type());
+        assertSame(content, content.asAudio());
+    }
+
+    @Test
+    public void testAudioContentWithMetaAndAnnotation() {
+        Map<MetaKey, Object> meta = Map.of();
+        Annotations annotations = new Annotations(Role.USER, ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                          .format(DateTimeFormatter.ISO_INSTANT),
+                                                  0.5);
+        AudioContent content = new AudioContent("base64-encoded-audio", "audio/mpeg", meta, annotations);
+
+        assertEquals("base64-encoded-audio", content.data());
+        assertEquals("audio/mpeg", content.mimeType());
+        assertEquals(meta, content._meta());
+        assertEquals(annotations, content.annotations());
+        assertEquals(TextContent.Type.AUDIO, content.type());
+        assertSame(content, content.asAudio());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAudioContentNullDataThrowsException() {
+        new AudioContent(null, "audio/mpeg");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAudioContentNullMimeThrowsException() {
+        new AudioContent("base64-encoded-audio", null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAudioContentNullDataAndMimeWithMetaThrowsException() {
+        Map<MetaKey, Object> meta = Map.of();
+        Annotations annotations = new Annotations(Role.USER, ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                          .format(DateTimeFormatter.ISO_INSTANT),
+                                                  0.5);
+        new AudioContent(null, null, meta, annotations);
+    }
+
+    // Image Content
+    @Test
+    public void testImageContentConvienienceConstructor() {
+        ImageContent content = new ImageContent("base64-encoded-image", "image/png");
+
+        assertEquals("base64-encoded-image", content.data());
+        assertEquals("image/png", content.mimeType());
+        assertNull(content._meta());
+        assertNull(content.annotations());
+        assertEquals(AudioContent.Type.IMAGE, content.type());
+        assertSame(content, content.asImage());
+    }
+
+    @Test
+    public void testImageContentWithNullMetaAndAnnotation() {
+        ImageContent content = new ImageContent("base64-encoded-image", "image/png", null, null);
+
+        assertEquals("base64-encoded-image", content.data());
+        assertEquals("image/png", content.mimeType());
+        assertNull(content._meta());
+        assertNull(content.annotations());
+        assertEquals(AudioContent.Type.IMAGE, content.type());
+        assertSame(content, content.asImage());
+    }
+
+    @Test
+    public void testImageContentWithMetaAndAnnotation() {
+        Map<MetaKey, Object> meta = Map.of();
+        Annotations annotations = new Annotations(Role.ASSISTANT, ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                               .format(DateTimeFormatter.ISO_INSTANT),
+                                                  0.5);
+        ImageContent content = new ImageContent("base64-encoded-image", "image/png", meta, annotations);
+
+        assertEquals("base64-encoded-image", content.data());
+        assertEquals("image/png", content.mimeType());
+        assertEquals(meta, content._meta());
+        assertEquals(annotations, content.annotations());
+        assertEquals(AudioContent.Type.IMAGE, content.type());
+        assertSame(content, content.asImage());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testImageContentNullDataThrowsException() {
+        new ImageContent(null, "image/png");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testImageContentNullMimeThrowsException() {
+        new ImageContent("base64-encoded-image", null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testImageContentNullDataAndMimeWithMetaThrowsException() {
+        Map<MetaKey, Object> meta = Map.of();
+        Annotations annotations = new Annotations(Role.ASSISTANT, ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                               .format(DateTimeFormatter.ISO_INSTANT),
+                                                  0.5);
+        new ImageContent(null, null, meta, annotations);
+    }
+
+    // Role Enum Serialization Test
+    @Test
+    public void testRoleEnumSerialization() {
+        Jsonb jsonb = JsonbBuilder.create();
+
+        Role role = Role.ASSISTANT;
+        String roleEnumJSON = jsonb.toJson(role);
+        assertEquals("\"assistant\"", roleEnumJSON);
+
+        Role assistantRole = jsonb.fromJson("\"assistant\"", Role.class);
+        assertEquals(Role.ASSISTANT, assistantRole);
+    }
+
 }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
@@ -320,6 +320,47 @@ public class ToolTest extends FATServletClient {
     }
 
     @Test
+    public void testToolReturnsListOfContentWithAnnotations() throws Exception {
+        String request = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "textContentToolWithContentAnnotation",
+                            "arguments": {
+                              "input": "hello"
+                            }
+                          }
+                        }
+                        """;
+        String response = client.callMCP(request);
+
+        String expectedResponseString = """
+                        {
+                          "id": 1,
+                          "jsonrpc": "2.0",
+                          "result": {
+                            "content": [
+                              {
+                                "annotations": {
+                                  "audience": "assistant",
+                                  "lastModified": "2025-08-26T08:40:00Z",
+                                  "priority": 0.5
+                                },
+                                "text": "Echo: hello",
+                                "type": "text"
+                              }
+                            ],
+                            "isError": false
+                          }
+                        }
+                        """;
+
+        JSONAssert.assertEquals(expectedResponseString, response, true);
+    }
+
+    @Test
     public void testToolReturnsImageContentList() throws Exception {
         String request = """
                         {
@@ -358,6 +399,49 @@ public class ToolTest extends FATServletClient {
     }
 
     @Test
+    public void testToolReturnsImageContentListWithAnnotations() throws Exception {
+        String request = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "imageContentToolWithContentAnnotation",
+                            "arguments": {
+                              "imageData": "base64-encoded-image"
+                            }
+                          }
+                        }
+                        """;
+
+        String response = client.callMCP(request);
+
+        String expectedResponseString = """
+                        {
+                            "id": 1,
+                            "jsonrpc": "2.0",
+                            "result": {
+                              "content": [
+                                {
+                                  "annotations": {
+                                    "audience": "user",
+                                    "lastModified": "2025-08-26T08:40:00Z",
+                                    "priority": 0.8
+                                  },
+                                  "data": "base64-encoded-image",
+                                  "mimeType": "image/png",
+                                  "type": "image"
+                                }
+                              ],
+                              "isError": false
+                            }
+                         }
+                         """;
+
+        JSONAssert.assertEquals(expectedResponseString, response, true);
+    }
+
+    @Test
     public void testToolReturnsAudioContentList() throws Exception {
         String request = """
                         {
@@ -375,12 +459,54 @@ public class ToolTest extends FATServletClient {
         String response = client.callMCP(request);
 
         String expectedResponseString = """
+                        {
+                           "id": 1,
+                           "jsonrpc": "2.0",
+                           "result": {
+                             "content": [
+                               {
+                                 "data": "base64-encoded-audio",
+                                 "mimeType": "audio/mpeg",
+                                 "type": "audio"
+                               }
+                             ],
+                             "isError": false
+                           }
+                         }
+                         """;
+
+        JSONAssert.assertEquals(expectedResponseString, response, true);
+    }
+
+    @Test
+    public void testToolReturnsAudioContentListWithAnnotations() throws Exception {
+        String request = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "audioContentToolWithContentAnnotation",
+                            "arguments": {
+                              "audioData": "base64-encoded-audio"
+                            }
+                          }
+                        }
+                        """;
+        String response = client.callMCP(request);
+
+        String expectedResponseString = """
                                                 {
                           "id": 1,
                           "jsonrpc": "2.0",
                           "result": {
                             "content": [
                               {
+                                "annotations": {
+                                  "audience": "assistant",
+                                  "lastModified": "2025-08-26T08:40:00Z",
+                                  "priority": 0.3
+                                },
                                 "data": "base64-encoded-audio",
                                 "mimeType": "audio/mpeg",
                                 "type": "audio"
@@ -1105,6 +1231,23 @@ public class ToolTest extends FATServletClient {
                                       "inputSchema": {
                                         "type": "object",
                                         "properties": {
+                                          "input": {
+                                            "description": "input string to echo back as content",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "input"
+                                        ]
+                                      },
+                                      "name": "textContentToolWithContentAnnotation",
+                                      "description": "Returns text content object with annotation",
+                                      "title": "Text Content Tool With Content Annotation"
+                                    },
+                                    {
+                                      "inputSchema": {
+                                        "type": "object",
+                                        "properties": {
                                           "imageData": {
                                             "description": "Base64-encoded image",
                                             "type": "string"
@@ -1122,6 +1265,23 @@ public class ToolTest extends FATServletClient {
                                       "inputSchema": {
                                         "type": "object",
                                         "properties": {
+                                          "imageData": {
+                                            "description": "Base64-encoded image",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "imageData"
+                                        ]
+                                      },
+                                      "name": "imageContentToolWithContentAnnotation",
+                                      "description": "Returns image content object with annotation",
+                                      "title": "Image Content Tool With Content Annotation"
+                                    },
+                                    {
+                                      "inputSchema": {
+                                        "type": "object",
+                                        "properties": {
                                           "audioData": {
                                             "description": "Base64-encoded audio",
                                             "type": "string"
@@ -1134,6 +1294,23 @@ public class ToolTest extends FATServletClient {
                                       "name": "audioContentTool",
                                       "description": "Returns audio content object",
                                       "title": "Audio Content Tool"
+                                    },
+                                    {
+                                      "inputSchema": {
+                                        "type": "object",
+                                        "properties": {
+                                          "audioData": {
+                                            "description": "Base64-encoded audio",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "audioData"
+                                        ]
+                                      },
+                                      "name": "audioContentToolWithContentAnnotation",
+                                      "description": "Returns audio content object with annotation",
+                                      "title": "Audio Content Tool With Content Annotation"
                                     },
                                     {
                                         "outputSchema": {

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/basicToolApp/BasicTools.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/basicToolApp/BasicTools.java
@@ -9,6 +9,9 @@
  *******************************************************************************/
 package io.openliberty.mcp.internal.fat.tool.basicToolApp;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +23,7 @@ import io.openliberty.mcp.annotations.ToolArg;
 import io.openliberty.mcp.content.AudioContent;
 import io.openliberty.mcp.content.Content;
 import io.openliberty.mcp.content.ImageContent;
+import io.openliberty.mcp.content.Role;
 import io.openliberty.mcp.content.TextContent;
 import io.openliberty.mcp.tools.ToolResponse;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -60,13 +64,11 @@ public class BasicTools {
 
         ImageContent image = new ImageContent(
                                               "base64-encoded-image",
-                                              "image/png",
-                                              null);
+                                              "image/png");
 
         AudioContent audio = new AudioContent(
                                               "base64-encoded-audio",
-                                              "audio/mpeg",
-                                              null);
+                                              "audio/mpeg");
 
         return ToolResponse.success(List.of(text, image, audio));
 
@@ -79,13 +81,11 @@ public class BasicTools {
 
                        new ImageContent(
                                         "base64-encoded-image",
-                                        "image/png",
-                                        null),
+                                        "image/png"),
 
                        new AudioContent(
                                         "base64-encoded-audio",
-                                        "audio/mpeg",
-                                        null));
+                                        "audio/mpeg"));
     }
 
     @Tool(name = "textContentTool", title = "Text Content Tool", description = "Returns text content object")
@@ -94,13 +94,35 @@ public class BasicTools {
         return new TextContent("Echo: " + input);
     }
 
+    @Tool(name = "textContentToolWithContentAnnotation", title = "Text Content Tool With Content Annotation", description = "Returns text content object with annotation")
+    public TextContent textContentToolWithContentAnnotation(
+                                                            @ToolArg(name = "input", description = "input string to echo back as content") String input) {
+        Content.Annotations annotations = new Content.Annotations(Role.ASSISTANT, ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                                               .format(DateTimeFormatter.ISO_INSTANT),
+                                                                  0.5);
+        return new TextContent("Echo: " + input, null, annotations);
+    }
+
     @Tool(name = "imageContentTool", title = "Image Content Tool", description = "Returns image content object")
     public ImageContent imageContentTool(
                                          @ToolArg(name = "imageData", description = "Base64-encoded image") String imageData) {
         return new ImageContent(
                                 imageData,
+                                "image/png");
+    }
+
+    @Tool(name = "imageContentToolWithContentAnnotation", title = "Image Content Tool With Content Annotation", description = "Returns image content object with annotation")
+    public ImageContent imageContentToolWithContentAnnotation(
+                                                              @ToolArg(name = "imageData", description = "Base64-encoded image") String imageData) {
+        Content.Annotations annotations = new Content.Annotations(Role.USER,
+                                                                  ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                               .format(DateTimeFormatter.ISO_INSTANT),
+                                                                  0.8);
+        return new ImageContent(
+                                imageData,
                                 "image/png",
-                                null);
+                                null,
+                                annotations);
     }
 
     @Tool(name = "audioContentTool", title = "Audio Content Tool", description = "Returns audio content object")
@@ -108,8 +130,20 @@ public class BasicTools {
                                          @ToolArg(name = "audioData", description = "Base64-encoded audio") String audioData) {
         return new AudioContent(
                                 audioData,
+                                "audio/mpeg");
+    }
+
+    @Tool(name = "audioContentToolWithContentAnnotation", title = "Audio Content Tool With Content Annotation", description = "Returns audio content object with annotation")
+    public AudioContent audioContentToolWithContentAnnotation(
+                                                              @ToolArg(name = "audioData", description = "Base64-encoded audio") String audioData) {
+        Content.Annotations annotations = new Content.Annotations(Role.ASSISTANT, ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                                               .format(DateTimeFormatter.ISO_INSTANT),
+                                                                  0.3);
+        return new AudioContent(
+                                audioData,
                                 "audio/mpeg",
-                                null);
+                                null,
+                                annotations);
     }
 
     //tool name is not present -> use method name

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/basicToolApp/BasicTools.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/basicToolApp/BasicTools.java
@@ -89,31 +89,28 @@ public class BasicTools {
     }
 
     @Tool(name = "textContentTool", title = "Text Content Tool", description = "Returns text content object")
-    public TextContent textContentTool(
-                                       @ToolArg(name = "input", description = "input string to echo back as content") String input) {
+    public TextContent textContentTool(@ToolArg(name = "input", description = "input string to echo back as content") String input) {
         return new TextContent("Echo: " + input);
     }
 
     @Tool(name = "textContentToolWithContentAnnotation", title = "Text Content Tool With Content Annotation", description = "Returns text content object with annotation")
-    public TextContent textContentToolWithContentAnnotation(
-                                                            @ToolArg(name = "input", description = "input string to echo back as content") String input) {
-        Content.Annotations annotations = new Content.Annotations(Role.ASSISTANT, ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
-                                                                                               .format(DateTimeFormatter.ISO_INSTANT),
+    public TextContent textContentToolWithContentAnnotation(@ToolArg(name = "input", description = "input string to echo back as content") String input) {
+        Content.Annotations annotations = new Content.Annotations(Role.ASSISTANT,
+                                                                  ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                               .format(DateTimeFormatter.ISO_INSTANT),
                                                                   0.5);
         return new TextContent("Echo: " + input, null, annotations);
     }
 
     @Tool(name = "imageContentTool", title = "Image Content Tool", description = "Returns image content object")
-    public ImageContent imageContentTool(
-                                         @ToolArg(name = "imageData", description = "Base64-encoded image") String imageData) {
+    public ImageContent imageContentTool(@ToolArg(name = "imageData", description = "Base64-encoded image") String imageData) {
         return new ImageContent(
                                 imageData,
                                 "image/png");
     }
 
     @Tool(name = "imageContentToolWithContentAnnotation", title = "Image Content Tool With Content Annotation", description = "Returns image content object with annotation")
-    public ImageContent imageContentToolWithContentAnnotation(
-                                                              @ToolArg(name = "imageData", description = "Base64-encoded image") String imageData) {
+    public ImageContent imageContentToolWithContentAnnotation(@ToolArg(name = "imageData", description = "Base64-encoded image") String imageData) {
         Content.Annotations annotations = new Content.Annotations(Role.USER,
                                                                   ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
                                                                                .format(DateTimeFormatter.ISO_INSTANT),
@@ -126,18 +123,17 @@ public class BasicTools {
     }
 
     @Tool(name = "audioContentTool", title = "Audio Content Tool", description = "Returns audio content object")
-    public AudioContent audioContentTool(
-                                         @ToolArg(name = "audioData", description = "Base64-encoded audio") String audioData) {
+    public AudioContent audioContentTool(@ToolArg(name = "audioData", description = "Base64-encoded audio") String audioData) {
         return new AudioContent(
                                 audioData,
                                 "audio/mpeg");
     }
 
     @Tool(name = "audioContentToolWithContentAnnotation", title = "Audio Content Tool With Content Annotation", description = "Returns audio content object with annotation")
-    public AudioContent audioContentToolWithContentAnnotation(
-                                                              @ToolArg(name = "audioData", description = "Base64-encoded audio") String audioData) {
-        Content.Annotations annotations = new Content.Annotations(Role.ASSISTANT, ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
-                                                                                               .format(DateTimeFormatter.ISO_INSTANT),
+    public AudioContent audioContentToolWithContentAnnotation(@ToolArg(name = "audioData", description = "Base64-encoded audio") String audioData) {
+        Content.Annotations annotations = new Content.Annotations(Role.ASSISTANT,
+                                                                  ZonedDateTime.of(2025, 8, 26, 8, 40, 0, 0, ZoneOffset.UTC)
+                                                                               .format(DateTimeFormatter.ISO_INSTANT),
                                                                   0.3);
         return new AudioContent(
                                 audioData,

--- a/dev/io.openliberty.mcp/bnd.bnd
+++ b/dev/io.openliberty.mcp/bnd.bnd
@@ -35,4 +35,4 @@ Export-Package: \
 	com.ibm.ws.logging;version=latest,\
 	io.openliberty.jakarta.cdi.4.0;version=latest,\
 	io.openliberty.jakarta.interceptor.2.1;version=latest,\
-	io.openliberty.jakarta.jsonb.3.0
+	io.openliberty.jakarta.jsonb.3.0;version=latest

--- a/dev/io.openliberty.mcp/bnd.bnd
+++ b/dev/io.openliberty.mcp/bnd.bnd
@@ -30,8 +30,9 @@ Export-Package: \
     io.openliberty.mcp.*
 
 -buildpath: \
-    com.ibm.websphere.org.osgi.core;version=latest,\
-    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-    com.ibm.ws.logging;version=latest,\
-    io.openliberty.jakarta.cdi.4.0;version=latest,\
-    io.openliberty.jakarta.interceptor.2.1;version=latest
+	com.ibm.websphere.org.osgi.core;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.logging;version=latest,\
+	io.openliberty.jakarta.cdi.4.0;version=latest,\
+	io.openliberty.jakarta.interceptor.2.1;version=latest,\
+	io.openliberty.jakarta.jsonb.3.0

--- a/dev/io.openliberty.mcp/src/io/openliberty/mcp/content/AudioContent.java
+++ b/dev/io.openliberty.mcp/src/io/openliberty/mcp/content/AudioContent.java
@@ -32,10 +32,10 @@ import io.openliberty.mcp.meta.MetaKey;
  * @param mimeType the mime type of the audio (must not be {@code null})
  * @param _meta the optional metadata
  */
-public record AudioContent(String data, String mimeType, Map<MetaKey, Object> _meta) implements Content {
+public record AudioContent(String data, String mimeType, Map<MetaKey, Object> _meta, Annotations annotations) implements Content {
 
     public AudioContent(String data, String mimeType) {
-        this(data, mimeType, null);
+        this(data, mimeType, null, null);
     }
 
     public AudioContent {

--- a/dev/io.openliberty.mcp/src/io/openliberty/mcp/content/Content.java
+++ b/dev/io.openliberty.mcp/src/io/openliberty/mcp/content/Content.java
@@ -33,6 +33,11 @@ public sealed interface Content permits TextContent, ImageContent, AudioContent 
     Type type();
 
     /**
+     * @return the optional annotations
+     */
+    Annotations annotations();
+
+    /**
      * Casts and returns this object as a text content, or throws an {@link IllegalArgumentException} if the content object does
      * not represent a {@link TextContent}.
      *
@@ -85,6 +90,13 @@ public sealed interface Content permits TextContent, ImageContent, AudioContent 
     default String getType() {
         return type().toString().toLowerCase();
     }
+
+    /**
+     * @param audience (may be {@code null})
+     * @param lastModified (may be {@code null})
+     * @param priority (may be {@code null})
+     */
+    public record Annotations(Role audience, String lastModified, Double priority) {}
 
     enum Type {
         TEXT,

--- a/dev/io.openliberty.mcp/src/io/openliberty/mcp/content/ImageContent.java
+++ b/dev/io.openliberty.mcp/src/io/openliberty/mcp/content/ImageContent.java
@@ -32,10 +32,10 @@ import io.openliberty.mcp.meta.MetaKey;
  * @param mimeType the mime type of the image (must not be {@code null})
  * @param _meta the optional metadata
  */
-public record ImageContent(String data, String mimeType, Map<MetaKey, Object> _meta) implements Content {
+public record ImageContent(String data, String mimeType, Map<MetaKey, Object> _meta, Annotations annotations) implements Content {
 
     public ImageContent(String data, String mimeType) {
-        this(data, mimeType, null);
+        this(data, mimeType, null, null);
     }
 
     public ImageContent {

--- a/dev/io.openliberty.mcp/src/io/openliberty/mcp/content/Role.java
+++ b/dev/io.openliberty.mcp/src/io/openliberty/mcp/content/Role.java
@@ -1,0 +1,31 @@
+package io.openliberty.mcp.content;
+
+import jakarta.json.bind.adapter.JsonbAdapter;
+import jakarta.json.bind.annotation.JsonbTypeAdapter;
+
+/**
+ * The sender or recipient of messages in a conversation.
+ */
+@JsonbTypeAdapter(Role.RoleAdapter.class)
+public enum Role {
+
+    ASSISTANT,
+    USER;
+
+    public String getName() {
+        return toString().toLowerCase();
+    }
+
+    public static class RoleAdapter implements JsonbAdapter<Role, String> {
+        @Override
+        public String adaptToJson(Role role) {
+            return role.toString().toLowerCase();
+        }
+
+        @Override
+        public Role adaptFromJson(String val) throws Exception {
+            return Role.valueOf(val.toUpperCase());
+        }
+    }
+
+}

--- a/dev/io.openliberty.mcp/src/io/openliberty/mcp/content/TextContent.java
+++ b/dev/io.openliberty.mcp/src/io/openliberty/mcp/content/TextContent.java
@@ -31,10 +31,10 @@ import io.openliberty.mcp.meta.MetaKey;
  * @param text (must not be {@code null})
  * @param _meta the optional metadata
  */
-public record TextContent(String text, Map<MetaKey, Object> _meta) implements Content {
+public record TextContent(String text, Map<MetaKey, Object> _meta, Annotations annotations) implements Content {
 
     public TextContent(String text) {
-        this(text, null);
+        this(text, null, null);
     }
 
     public TextContent {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Resolves #33139 

Includes changes from this [PR](https://github.com/quarkiverse/quarkus-mcp-server/commit/864961beedaa620068f58a4cdc65a84b158c5e82) from `quarkus-mcp-server` to allow Annotations to be added when returning MCP Content Objects