### PR TITLE
Do not skip EE9 repeat on Windows now that JSF 2.3 bucket is split

### DIFF
--- a/dev/com.ibm.ws.jsf.2.3_fat.2/fat/src/com/ibm/ws/jsf23/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat.2/fat/src/com/ibm/ws/jsf23/fat/FATSuite.java
@@ -9,8 +9,6 @@
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat;
 
-import java.util.Locale;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -63,30 +61,15 @@ import componenttest.rules.repeater.RepeatTests;
 
 public class FATSuite extends TestContainerSuite {
 
+    // EE10 requires Java 11.
+    // EE11 requires Java 17
+    // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
+    // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
     @ClassRule
-    public static RepeatTests repeat;
-
-    private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
-
-    static {
-        // EE10 requires Java 11.
-        // EE11 requires Java 17
-        // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
-        if (isWindows && !FATRunner.FAT_TEST_LOCALRUN) {
-            // Repeating the full fat for all features may exceed the 3 hour limit on Fyre Windows and causes random build breaks.
-            // Skip EE9 on the windows platform when not running locally.
-            // If we are running with a Java version less than 11, have EE8 (EmptyAction) be the lite mode test to run.
-            repeat = RepeatTests.with(new EmptyAction().conditionalFullFATOnly(EmptyAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                            .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                            .andWith(FeatureReplacementAction.EE11_FEATURES());
-        } else {
-            // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
-            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                            .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                            .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                            .andWith(FeatureReplacementAction.EE11_FEATURES());
-        }
-    }
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     public static DockerImageName getChromeImage() {
         if (FATRunner.ARM_ARCHITECTURE) {

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/FATSuite.java
@@ -9,8 +9,6 @@
  *******************************************************************************/
 package com.ibm.ws.jsf23.fat;
 
-import java.util.Locale;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -86,30 +84,15 @@ import componenttest.rules.repeater.RepeatTests;
 
 public class FATSuite extends TestContainerSuite {
 
+    // EE10 requires Java 11.
+    // EE11 requires Java 17
+    // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
+    // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
     @ClassRule
-    public static RepeatTests repeat;
-
-    private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
-
-    static {
-        // EE10 requires Java 11.
-        // EE11 requires Java 17
-        // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
-        if (isWindows && !FATRunner.FAT_TEST_LOCALRUN) {
-            // Repeating the full fat for all features may exceed the 3 hour limit on Fyre Windows and causes random build breaks.
-            // Skip EE9 on the windows platform when not running locally.
-            // If we are running with a Java version less than 11, have EE8 (EmptyAction) be the lite mode test to run.
-            repeat = RepeatTests.with(new EmptyAction().conditionalFullFATOnly(EmptyAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                            .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                            .andWith(FeatureReplacementAction.EE11_FEATURES());
-        } else {
-            // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
-            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                            .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                            .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                            .andWith(FeatureReplacementAction.EE11_FEATURES());
-        }
-    }
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     public static DockerImageName getChromeImage() {
         if (FATRunner.ARM_ARCHITECTURE) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #33243