### PR TITLE
fix: avoid reserved keyword when using EclipseLink and Oracle

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/CreditCard.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/models/CreditCard.java
@@ -1,0 +1,69 @@
+
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.data.tests.models;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+@Entity
+@IdClass(CreditCard.CardId.class)
+public class CreditCard {
+    public static enum Issuer {
+        AmericanExtravagance, Discrooger, MonsterCard, Feesa
+    }
+
+    public static record CardId(Issuer issuer, long number) {
+        @Override
+        public String toString() {
+            return issuer + " card #" + number;
+        }
+    }
+
+    @Column
+    public LocalDate expiresOn;
+
+    @Column
+    public LocalDate issuedOn;
+
+    @Id
+    public Issuer issuer;
+
+    @Id
+    public long number;
+
+    @Column
+    public int securityCode;
+
+    public CreditCard() {
+    }
+
+    public static CreditCard of(long number, int securityCode, LocalDate issuedOn, LocalDate expiresOn, Issuer issuer) {
+        CreditCard inst = new CreditCard();
+
+        inst.issuer = issuer;
+        inst.number = number;
+        inst.securityCode = securityCode;
+        inst.issuedOn = issuedOn;
+        inst.expiresOn = expiresOn;
+
+        return inst;
+    }
+
+    @Override
+    public String toString() {
+        return issuer + " card #" + number + " (" + securityCode + ") " +
+               " valid from " + issuedOn + " to " + expiresOn;
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -57,6 +57,8 @@ import io.openliberty.jpa.data.tests.models.City;
 import io.openliberty.jpa.data.tests.models.CityId;
 import io.openliberty.jpa.data.tests.models.Coordinate;
 import io.openliberty.jpa.data.tests.models.County;
+import io.openliberty.jpa.data.tests.models.CreditCard;
+import io.openliberty.jpa.data.tests.models.CreditCard.Issuer;
 import io.openliberty.jpa.data.tests.models.DemographicInfo;
 import io.openliberty.jpa.data.tests.models.DemographicInformation;
 import io.openliberty.jpa.data.tests.models.Door;
@@ -2513,6 +2515,23 @@ public class JakartaDataRecreateServlet extends FATServlet {
 
         assertEquals(1, showtimesTodayList.size());
         assertEquals(t1.movie, showtimesTodayList.get(0).movie);
+    }
+
+    @Test
+    @SkipIfSysProp(DB_Oracle) // Reference Issue: https://github.com/OpenLiberty/open-liberty/issues/33246
+    public void testOLGH33246() throws Exception {
+//        deleteAllEntities(CreditCard.class);
+
+        CreditCard c1 = CreditCard.of(1000921011110001L, 101, LocalDate.of(2021, 1, 10), LocalDate.of(2025, 1, 10), Issuer.AmericanExtravagance);
+
+        tx.begin();
+        try {
+            em.merge(c1);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e; // Rethrows PersistenceException during failure
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_jpa/build.gradle
@@ -44,87 +44,11 @@ task addHibernateJPA32(type: Copy) {
   into new File(autoFvtDir, 'publish/shared/resources/jpa32_hibernate_orm')
 }
 
-/*
- * Add Hibernate and transitive dependencies into the permissions section of server.xml(s)
- */
-task addHibernatePermissions() {
-  // Do not execute this task during our builds
-  onlyIf {
-    !isAutomatedBuild
-  }
-
-  // Find server.xml files
-  def serverConfigs = []
-  fileTree(project.file('publish/servers')).visit { FileVisitDetails d ->
-    if(d.file.name == "server.xml") {
-      serverConfigs << d.file.path
-    }
-  }
-  
-  println "serverConfigs: "
-  serverConfigs.sort()
-  serverConfigs.each { serverConfig -> println "- " + serverConfig }
-
-  // Generate permissions
-  def permissions = []
-  configurations.hibernateJPA32.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact a ->
-    permissions << "<javaPermission className=\"java.security.AllPermission\" codebase=\"\${shared.resource.dir}/jpa32_hibernate_orm/${a.file.name}\"/>"
-  }
-  
-  println "permissions: "
-  permissions.sort()
-  permissions.each { permission -> println "- " + permission }
-
-  // Replace existing permissions
-  serverConfigs.each { String p ->
-    String START_TAG = "<!-- START:"
-    String END_TAG   = "<!-- END:"
-    
-    java.nio.file.Path path = java.nio.file.Paths.get(p)
-
-    List<String> original = java.nio.file.Files.readAllLines(path)
-    List<String> updated  = new ArrayList<>(original.size())
-
-    boolean inSection = false
-    for (String line : original) {
-      // Keep start tag, mark in section, and add in all new permissions
-      if (line.contains(START_TAG)) {
-        updated.add(line)
-        inSection = true
-        String whitespace = line.substring(0, line.indexOf(START_TAG));
-        for (String permission : permissions) {
-            updated.add(whitespace + permission)
-        }
-        continue;
-      }
-      
-      // Keep end tag, mark out of section
-      if (line.contains(END_TAG)) {
-        inSection = false
-        updated.add(line)
-        continue
-      }
-      
-      // Keep all lines outside the tagged section
-      if (!inSection) {
-        updated.add(line)
-      }
-      
-      // Ignore all lines inside the tagged section
-    }
-
-    // overwrite the file with the updated lines
-    java.nio.file.Files.write(path, updated)
-  }
-}
-
 addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn copyJdbcDrivers
 
 addRequiredLibraries.dependsOn addDerby
 addRequiredLibraries.dependsOn addHibernateJPA32
-
-jar.dependsOn addHibernatePermissions
 
 apply plugin: 'java'
 

--- a/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate/server.xml
+++ b/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate/server.xml
@@ -21,7 +21,6 @@
     
     <!-- Features required by Hibernate -->
     <feature>xmlBinding-4.0</feature>
-    <feature>cdi-4.1</feature>
     
     <feature>servlet-6.1</feature>
   </featureManager>

--- a/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate/server.xml
+++ b/dev/io.openliberty.data.internal_fat_jpa/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate/server.xml
@@ -47,21 +47,4 @@
   </library>
 
   <javaPermission codeBase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
-
-  <!-- START: Hibernate permissions -->
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/angus-activation-2.0.2.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/antlr4-runtime-4.13.2.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/byte-buddy-1.17.5.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/classmate-1.7.0.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/hibernate-community-dialects-7.0.9.Final.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/hibernate-core-7.0.9.Final.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/hibernate-models-1.0.1.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/hibernate-scan-jandex-7.0.9.Final.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/istack-commons-runtime-4.1.2.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/jandex-3.3.0.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/jaxb-core-4.0.5.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/jaxb-runtime-4.0.5.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/jboss-logging-3.6.1.Final.jar"/>
-  <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa32_hibernate_orm/txw2-4.0.5.jar"/>
-  <!-- END: Hibernate permissions -->
 </server>

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCard.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/CreditCard.java
@@ -49,6 +49,7 @@ public class CreditCard {
     public Issuer issuer;
 
     @Id
+    @Column(name = "ccnumber") //Avoid reserved keyword on oracle: https://github.com/OpenLiberty/open-liberty/issues/33246
     public long number;
 
     @Column

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -171,6 +171,16 @@ public class DataJPATestServlet extends FATServlet {
     Triangles triangles;
 
     /**
+     * Indicates if testing with the Hibernate Persistence provider
+     * rather than EclipseLink.
+     *
+     * @return true if testing with the Hibernate Persistence provider.
+     */
+    public static final boolean isHibernate() {
+        return Boolean.valueOf(System.getenv("TEST_HIBERNATE"));
+    }
+
+    /**
      * Temporary method to allow skipping tests for tests that
      * fail due to incompatibilities between our Jakarta Data provider
      * and Hibernate's Jakarta Persistence provider.
@@ -180,16 +190,15 @@ public class DataJPATestServlet extends FATServlet {
      * @return boolean - if we need to skip the test, false otherwise.
      */
     public static boolean skipForHibernate(String... issues) {
-        boolean testingHibernate = Boolean.valueOf(System.getenv("TEST_HIBERNATE"));
-        if (testingHibernate) {
-            System.out.println("Skipping test because: " + issues);
+        if (isHibernate()) {
+            System.out.println("Skipping test because: " + Arrays.asList(issues));
 
             // FIXME - this is the proper way to skip a test via junit
             // however, our FATServlet does not support catching an
             // AssumptionViolatedException and serializing it back to the client.
-//            assumeTrue(!testingHibernate);
+//            assumeTrue(!isHibernate());
         }
-        return testingHibernate;
+        return isHibernate();
     }
 
     @Override
@@ -287,16 +296,6 @@ public class DataJPATestServlet extends FATServlet {
         testLiteralDouble();
         // To quickly try reproducing the issue, remove the above line and add the following line to tearDown,
         // runTest(server, "DataJPATestApp", "testLiteralDouble");
-    }
-
-    /**
-     * Indicates if testing with the Hibernate Persistence provider
-     * rather than EclipseLink.
-     *
-     * @return true if testing with the Hibernate Persistence provider.
-     */
-    public static final boolean isHibernate() {
-        return Boolean.valueOf(System.getenv("TEST_HIBERNATE"));
     }
 
     /**


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Remove cdi-4.1 as it is not necessary
- Remove security permissions as they are not necessary
- recreate reserved keyword issue
- avoid using a reserved keyword in Jakarta Data testing

