### PR TITLE
JPQL UPDATE requires setting version explicitly if versioned

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -209,6 +209,7 @@ public abstract class EntityManagerBuilder {
                                 idType = singleAttr.getJavaType();
                             } else if (singleAttr != null && singleAttr.isVersion()) {
                                 versionAttrName = attributeName;
+                                attributeNamesForUpdate = null;
                             } else if (Collection.class.isAssignableFrom(attr.getJavaType())) {
                                 // collection attribute that is not annotated with ElementCollection
                                 collectionElementTypes.put(attributeName, Object.class);
@@ -307,6 +308,7 @@ public abstract class EntityManagerBuilder {
                                     idType = singleAttr.getJavaType();
                                 } else if (singleAttr.isVersion()) {
                                     versionAttrName = relationAttributeName_; // to be suitable for query-by-method
+                                    attributeNamesForUpdate = null;
                                 }
                             }
                         }
@@ -318,8 +320,6 @@ public abstract class EntityManagerBuilder {
                         attributeNamesForUpdate.remove(ID);
                         if (idAttrName != null)
                             attributeNamesForUpdate.remove(idAttrName);
-                        if (versionAttrName != null)
-                            attributeNamesForUpdate.remove(versionAttrName);
                     }
 
                     if (!entityType.hasSingleIdAttribute()) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -560,7 +560,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     case QM_UPDATE, QM_DELETE -> queryInfo.execute(em, args);
                     case LC_DELETE -> queryInfo.delete(args[0], em);
                     case LC_UPDATE -> queryInfo.update(args[0], em);
-                    case LC_UPDATE_RET_ENTITY -> queryInfo.findAndUpdate(args[0], em);
+                    case LC_UPDATE_MERGE -> queryInfo.findAndUpdate(args[0], em);
                     case RESOURCE_ACCESS -> getResource(method);
                 };
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
@@ -40,8 +40,8 @@ public enum QueryType {
     // life cycle @Update
     LC_UPDATE(Require.TX, !Require.RETURN_HIDDEN),
 
-    // life cycle @Update with entity result
-    LC_UPDATE_RET_ENTITY(Require.TX, Require.RETURN_HIDDEN),
+    // life cycle @Update often with entity result (find & merge)
+    LC_UPDATE_MERGE(Require.TX, Require.RETURN_HIDDEN),
 
     // query method delete/@Delete/@Query(DELETE)
     QM_DELETE(Require.TX, !Require.RETURN_HIDDEN),


### PR DESCRIPTION
JPQL UPDATE statements must explicitly update the version attribute per the Jakarta Persistence specification.  The Persistence provider is not required to update it automatically.  EclipseLink was doing it for us, but not Hibernate.

We need to cover this in two places:
* Life cycle update - in this case, we send the code down the path to use EntityManager.merge rather than JPQL, as is already done in some other cases.  This required various updates to code.
* Parameter-based updates - in this case, we need to check whether any parameter already covers the version update, and if not, add a version attribute update to the generated query.

This PR adds a test case of versioned updates across multiple threads that now passes on Hibernate with these changes.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
