### PR TITLE
updating missing message reference

### DIFF
--- a/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityMessages.nlsprops
+++ b/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityMessages.nlsprops
@@ -33,8 +33,8 @@ missingArg=Missing argument {0}.
 missingValue=Missing value for argument {0}.
 missingArg2=Either the {0} argument or the {1} argument must be provided.
 exclusiveArg=The {0} argument or the {1} argument must be specified, but not both.
-serverNotFound=Specified server {0} could not be found at location {1}
-clientNotFound=Specified client {0} could not be found at location {1}
+serverNotFound=The {0} specified server was not found at the {1} location.
+clientNotFound=The {0} specified client was not found at the {1} location.
 
 
 encode.enterText=Enter text:

--- a/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityMessages.nlsprops
+++ b/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityMessages.nlsprops
@@ -34,6 +34,7 @@ missingValue=Missing value for argument {0}.
 missingArg2=Either the {0} argument or the {1} argument must be provided.
 exclusiveArg=The {0} argument or the {1} argument must be specified, but not both.
 serverNotFound=Specified server {0} could not be found at location {1}
+clientNotFound=Specified client {0} could not be found at location {1}
 
 
 encode.enterText=Enter text:
@@ -57,7 +58,6 @@ sslCert.createFailed=Unable to create default SSL certificate:\n{0}
 sslCert.errorEncodePassword=Error encoding password (certificate not created):\n{0}
 sslCert.createKeyStore=Creating keystore {0}\n
 sslCert.oneType=The {0} and {1} arguments can not be specified at the same time.
-sslCert.clientNotFound=Specified client {0} could not be found at location {1}
 
 #------------------------------\n at 72 chars -- leading tab-----------\n\#
 sslCert.serverXML=\

--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/CreateSSLCertificateTask.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/CreateSSLCertificateTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/CreateSSLCertificateTask.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/CreateSSLCertificateTask.java
@@ -155,7 +155,7 @@ public class CreateSSLCertificateTask extends BaseCommandTask {
             if (!fileUtility.exists(clientDir)) {
                 usrClients = fileUtility.resolvePath(usrClients);
                 stdout.println(getMessage("sslCert.abort"));
-                stdout.println(getMessage("sslCert.clientNotFound", clientName, usrClients));
+                stdout.println(getMessage("clientNotFound", clientName, usrClients));
                 return SecurityUtilityReturnCodes.ERR_CLIENT_NOT_FOUND;
             }
             dir = clientDir;


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


When user specifies `./securityUtility configureFIPS --client=client1` where `client1` doesn't exist the error message indicates our message isn't found:

```
java.util.MissingResourceException: Can't find resource for bundle com.ibm.ws.security.utility.resources.UtilityMessages, key clientNotFound
	at java.base/java.util.ResourceBundle.getObject(ResourceBundle.java:558)
	at java.base/java.util.ResourceBundle.getString(ResourceBundle.java:514)
	at com.ibm.ws.security.utility.utils.CommandUtils.getMessage(CommandUtils.java:27)
	at com.ibm.ws.security.utility.tasks.BaseCommandTask.getMessage(BaseCommandTask.java:81)
	at com.ibm.ws.security.utility.tasks.ConfigureFIPSTask.handleTask(ConfigureFIPSTask.java:222)
	at com.ibm.ws.security.utility.SecurityUtility.runProgram(SecurityUtility.java:137)
	at com.ibm.ws.security.utility.SecurityUtility.main(SecurityUtility.java:179)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:571)
	at com.ibm.ws.kernel.boot.cmdline.UtilityMain.internal_main(UtilityMain.java:175)
	at com.ibm.ws.kernel.boot.cmdline.UtilityMain.main(UtilityMain.java:55)
	at com.ibm.ws.kernel.boot.cmdline.Main.main(Main.java:54)

```