### PR TITLE
add trace for when the interceptor is not a common bean

### DIFF
--- a/dev/com.ibm.ws.cdi.ejb.common/src/com/ibm/ws/cdi/ejb/impl/InterceptorChain.java
+++ b/dev/com.ibm.ws.cdi.ejb.common/src/com/ibm/ws/cdi/ejb/impl/InterceptorChain.java
@@ -131,6 +131,8 @@ public class InterceptorChain implements InvocationContext {
         if (interceptor instanceof CommonBean) {
             commonBean = (CommonBean<S>) interceptor;
             interceptorInstance = (S) this.activeInterceptors.get(commonBean.getIdentifier());
+        } else if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Interceptor " + interceptor.getName() + " : " + interceptor.getBeanClass() + " was not a CommonBean");
         }
 
         //TODO - investigate if we should use activeInterceptors for interceptors that are not CommonBean


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This is a follow up to https://github.com/OpenLiberty/open-liberty/pull/31562 that adds a little extra trace for the case that PR covers. 