### PR TITLE
Fix unit test so that it works with Java 21

### DIFF
--- a/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/web/JavaScriptUtilsTest.java
+++ b/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/web/JavaScriptUtilsTest.java
@@ -219,13 +219,18 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "some prop";
             String value = "some value";
 
-            final String expectedCookieString = name + "=" + value + "; " +PARTITIONED_PROP+ " SameSite=None; secure;";
-
             getWebAppSecurityConfigCookiePropertiesExpectations(false, "None", "true");
 
             String result = utils.getJavaScriptHtmlCookieString(name, value);
 
-            verifyCaseInsensitiveQuotedPatternMatches(result, DOCUMENT_COOKIE_START + expectedCookieString + DOCUMENT_COOKIE_END, "Cookie string did not match expected pattern.");
+            final String expectedCookieString = name + "=" + value + ";";
+            verifyPattern(result, Pattern.quote(expectedCookieString), "Expected cookie name and value did not appear in the result.");
+
+            Map<String, String> cookieProps = new HashMap<String, String>();
+            cookieProps.put("Partitioned", null);
+            cookieProps.put("SameSite", "None");
+            cookieProps.put("secure", null);
+            verifyCookiePropertyStrings(result, cookieProps);
 
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName.getMethodName(), t);
@@ -265,13 +270,16 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String value = "some value";
             Map<String, String> cookieProps = new HashMap<String, String>();
 
-            final String expectedCookieString = name + "=" + value + "; " +PARTITIONED_PROP+ " SameSite=None; secure;";
-
             getWebAppSecurityConfigCookiePropertiesExpectations(false, "None", "true");
 
             String result = utils.getJavaScriptHtmlCookieString(name, value, cookieProps);
+            final String expectedCookieString = name + "=" + value + ";";
+            verifyPattern(result, Pattern.quote(expectedCookieString), "Expected cookie name and value did not appear in the result.");
 
-            verifyCaseInsensitiveQuotedPatternMatches(result, DOCUMENT_COOKIE_START + expectedCookieString + DOCUMENT_COOKIE_END, "Cookie string did not match expected pattern.");
+            cookieProps.put("Partitioned", null);
+            cookieProps.put("SameSite", "None");
+            cookieProps.put("secure", null);
+            verifyCookiePropertyStrings(result, cookieProps);
 
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName.getMethodName(), t);


### PR DESCRIPTION
- Test failed with Java 21 because it is expecting a specific order and map order is not guaranteed especially between different Java levels.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
