### PR TITLE
Update to not release test bundles that are in multiple projects (try 2)

### DIFF
--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -220,7 +220,9 @@ task createGradleBootstrap {
         def depsList = []
         gradleBndProjects.each { projectName ->
             def bndProject = bndWorkspace.getProject(projectName)
-            if (!bndProject.isNoBundles()) {
+            // If the project doesn't have any bundles or if the bundles are not
+            // released, then skip the project
+            if (!bndProject.isNoBundles() && !bndProject.get('-releaserepo').isEmpty()) {
                 String org
                 if ('true'.equals(bndProject.get('test.project', bndProject.get('fat.project', 'false')))) {
                     org = 'test'

--- a/dev/cnf/resources/bnd/anttaskdefs.bnd
+++ b/dev/cnf/resources/bnd/anttaskdefs.bnd
@@ -9,73 +9,73 @@
 #*******************************************************************************
 
 repo.rasInstrumentation.path: ${path;\
-    ${repo;wlp-rasInstrumentation}}
+    \${repo;wlp-rasInstrumentation}}
     
 repo.generateChecksums.path: ${path;\
-    ${repo;wlp-generateChecksums},\
-    ${repo;com.ibm.ws.kernel.boot.core},\
-    ${repo;com.ibm.ws.org.apache.ant},\
-    ${repo;com.ibm.ws.org.apache.aries.util},\
-    ${repo;com.ibm.websphere.org.osgi.core}}
+    \${repo;wlp-generateChecksums},\
+    \${repo;com.ibm.ws.kernel.boot.core},\
+    \${repo;com.ibm.ws.org.apache.ant},\
+    \${repo;com.ibm.ws.org.apache.aries.util},\
+    \${repo;com.ibm.websphere.org.osgi.core}}
     
 repo.nlsTasks.path: ${path;\
-    ${repo;commons-io:commons-io;2.19.0},\
-    ${repo;commons-lang:commons-lang;2.4},\
-    ${repo;org.apache.commons:commons-math;2.2},\
-    ${repo;com.ibm.ws.componenttest:mantis-collections;2.5.0},\
-    ${repo;com.ibm.ws.componenttest:mantis-nls-standalone;2.5.0}}
+    \${repo;commons-io:commons-io;2.19.0},\
+    \${repo;commons-lang:commons-lang;2.4},\
+    \${repo;org.apache.commons:commons-math;2.2},\
+    \${repo;com.ibm.ws.componenttest:mantis-collections;2.5.0},\
+    \${repo;com.ibm.ws.componenttest:mantis-nls-standalone;2.5.0}}
 
 repo.portSelector.path: ${path;\
-    ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;7.0.2}}
+    \${repo;com.ibm.ws.componenttest:infra.buildtasks-core;7.0.2}}
 
 repo.featureTasks.path: ${path;\
-    ${repo;wlp-featureTasks},\
-    ${repo;com.ibm.ws.kernel.boot.core},\
-    ${repo;com.ibm.ws.logging.core},\
-    ${repo;biz.aQute.bnd:biz.aQute.bnd;7.0.0},\
-    ${repo;com.ibm.ws.org.apache.ant},\
-    ${repo;com.ibm.ws.componenttest:infra.buildtasks-core;7.0.2},\
-    ${repo;org.jsoup:jsoup;1.7.2},\
-    ${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
-    ${repo;org.osgi:org.osgi.core;6.0.0}}
+    \${repo;wlp-featureTasks},\
+    \${repo;com.ibm.ws.kernel.boot.core},\
+    \${repo;com.ibm.ws.logging.core},\
+    \${repo;biz.aQute.bnd:biz.aQute.bnd;7.0.0},\
+    \${repo;com.ibm.ws.org.apache.ant},\
+    \${repo;com.ibm.ws.componenttest:infra.buildtasks-core;7.0.2},\
+    \${repo;org.jsoup:jsoup;1.7.2},\
+    \${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
+    \${repo;org.osgi:org.osgi.core;6.0.0}}
 
 repo.generateRepositoryContent.path: ${path;\
-    ${repo;wlp-generateRepositoryContent},\
-    ${repo;com.ibm.json4j},\
-    ${repo;com.ibm.ws.kernel.boot.core},\
-    ${repo;com.ibm.ws.kernel.feature.core},\
-    ${repo;com.ibm.ws.logging.core},\
-    ${repo;wlp-generateChecksums},\
-    ${repo;com.ibm.ws.org.apache.ant},\
-    ${repo;org.jsoup:jsoup;1.7.2},\
-    ${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
-    ${repo;org.osgi:org.osgi.core;6.0.0}}
+    \${repo;wlp-generateRepositoryContent},\
+    \${repo;com.ibm.json4j},\
+    \${repo;com.ibm.ws.kernel.boot.core},\
+    \${repo;com.ibm.ws.kernel.feature.core},\
+    \${repo;com.ibm.ws.logging.core},\
+    \${repo;wlp-generateChecksums},\
+    \${repo;com.ibm.ws.org.apache.ant},\
+    \${repo;org.jsoup:jsoup;1.7.2},\
+    \${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
+    \${repo;org.osgi:org.osgi.core;6.0.0}}
 
 repo.repositoryGenerator.path: ${path;\
-    ${repo;com.ibm.ws.repository.generator},\
-    ${repo;com.ibm.ws.repository},\
-    ${repo;com.ibm.ws.repository.parsers},\
-    ${repo;com.ibm.ws.kernel.boot.core},\
-    ${repo;com.ibm.ws.kernel.feature.core},\
-    ${repo;com.ibm.ws.logging.core},\
-    ${repo;com.ibm.ws.org.apache.ant},\
-    ${repo;javax.json:javax.json-api;1.1.2},\
-    ${repo;org.glassfish:javax.json;1.1.2},\
-    ${repo;org.jsoup:jsoup;1.7.2},\
-    ${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
-    ${repo;org.osgi:org.osgi.core;6.0.0}}
+    \${repo;com.ibm.ws.repository.generator},\
+    \${repo;com.ibm.ws.repository},\
+    \${repo;com.ibm.ws.repository.parsers},\
+    \${repo;com.ibm.ws.kernel.boot.core},\
+    \${repo;com.ibm.ws.kernel.feature.core},\
+    \${repo;com.ibm.ws.logging.core},\
+    \${repo;com.ibm.ws.org.apache.ant},\
+    \${repo;javax.json:javax.json-api;1.1.2},\
+    \${repo;org.glassfish:javax.json;1.1.2},\
+    \${repo;org.jsoup:jsoup;1.7.2},\
+    \${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
+    \${repo;org.osgi:org.osgi.core;6.0.0}}
 
 repo.mavenRepoTasks.path: ${path;\
-    ${repo;wlp-mavenRepoTasks},\
-    ${repo;com.ibm.ws.org.apache.ant},\
-    ${repo;commons-io:commons-io;2.19.0},\
-    ${repo;commons-lang:commons-lang;2.4},\
-    ${repo;javax.json:javax.json-api;1.1.2},\
-    ${repo;org.glassfish:javax.json;1.1.2},\
-    ${repo;org.apache.maven:maven-model;3.5.0},\
-    ${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
+    \${repo;wlp-mavenRepoTasks},\
+    \${repo;com.ibm.ws.org.apache.ant},\
+    \${repo;commons-io:commons-io;2.19.0},\
+    \${repo;commons-lang:commons-lang;2.4},\
+    \${repo;javax.json:javax.json-api;1.1.2},\
+    \${repo;org.glassfish:javax.json;1.1.2},\
+    \${repo;org.apache.maven:maven-model;3.5.0},\
+    \${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
     ${workspace}/cnf/mavenlibs/plexus-utils-3.0.24.jar}
-#    ${repo;org.codehaus.plexus:plexus-utils;3.0.24}}
+#    \${repo;org.codehaus.plexus:plexus-utils;3.0.24}}
 
 repo.junitReportTask.path: ${path;\
-    ${repo;com.ibm.ws.org.apache.ant-junit}}
+    \${repo;com.ibm.ws.org.apache.ant-junit}}

--- a/dev/com.ibm.ws.collector/bnd.bnd
+++ b/dev/com.ibm.ws.collector/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2016, 2024 IBM Corporation and others.
+# Copyright (c) 2016, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,10 +14,6 @@
 bVersion=1.0
 
 -sub: *.bnd
-
-Bundle-Name: Collector
-Bundle-SymbolicName: com.ibm.ws.collector
-Bundle-Description: Generic Collector: Defines the framework for a collector; version=${bVersion}
 
 WS-TraceGroup: collector
 

--- a/dev/com.ibm.ws.jmx_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jmx_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -18,6 +18,12 @@ src: \
 	test-bundles/test-mbeans/src
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 -buildpath: \
 	com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/com.ibm.ws.jpa_testframework/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_testframework/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -15,11 +15,6 @@
 -sub: *.bnd
 
 bVersion=1.0
-
-
-Bundle-Name: JPA Test Tools
-Bundle-SymbolicName: com.ibm.ws.jpa_testframework
-Bundle-Description: JPA Test Tools; version=${bVersion}
 
 test.project: true
 publish.wlp.jar.disabled: true

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2019 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,12 @@ src: \
 -sub: *.bnd
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 tested.features: opentracing-1.1
 

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,12 @@ src: \
 -sub: *.bnd
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 tested.features: opentracing-1.2
 

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2020 IBM Corporation and others.
+# Copyright (c) 2019, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,12 @@ src: \
 -sub: *.bnd
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 tested.features: opentracing-1.3, mprestclient-1.4
 

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2019 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,12 @@ src: \
 -sub: *.bnd
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 tested.features: opentracing-1.0
 

--- a/dev/com.ibm.ws.opentracing.1.x_fat/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,12 @@ src: \
 -sub: *.bnd
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 tested.features: mpOpenTracing-1.1, mpOpenTracing-1.2, mpOpenTracing-1.3, jsonb-1.0, microProfile-2.1
 

--- a/dev/com.ibm.ws.opentracing_fat/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,12 @@ src: \
 -sub: *.bnd
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 tested.features: opentracing-1.0
 

--- a/dev/com.ibm.ws.transaction.hadb_fat.db2.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.db2.1/bnd.bnd
@@ -21,6 +21,12 @@ src: \
 
 fat.project: true
 
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
+
 tested.features:\
   cdi-3.0, cdi-4.0,\
   servlet-5.0, servlet-6.0

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/bnd.bnd
@@ -22,6 +22,12 @@ src: \
 
 fat.project: true
 
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
+
 tested.features:\
   cdi-3.0, cdi-4.0,\
   servlet-5.0, servlet-6.0

--- a/dev/com.ibm.ws.transaction.hadb_fat.oracle.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.oracle.1/bnd.bnd
@@ -21,6 +21,12 @@ src: \
 
 fat.project: true
 
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
+
 tested.features:\
   cdi-3.0, cdi-4.0,\
   servlet-5.0, servlet-6.0

--- a/dev/com.ibm.ws.transaction.hadb_fat.postgresql.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.postgresql.1/bnd.bnd
@@ -21,6 +21,12 @@ src: \
 
 fat.project: true
 
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
+
 tested.features:\
   cdi-3.0, cdi-4.0,\
   servlet-5.0, servlet-6.0

--- a/dev/com.ibm.ws.transaction.hadb_fat.sqlserver.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.sqlserver.1/bnd.bnd
@@ -23,6 +23,12 @@ src: \
 
 fat.project: true
 
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
+
 tested.features:\
   cdi-3.0, cdi-4.0,\
   servlet-5.0, servlet-6.0

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -44,6 +44,12 @@ src: \
 
 fat.project: true
 
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
+
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, osgiConsole-1.0 is added programmatically at runtime.
 tested.features: \

--- a/dev/io.openliberty.checkpoint_fat_mp/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_mp/bnd.bnd
@@ -29,6 +29,12 @@ fat.project: true
 
 fat.test.container.images: kyleaure/db2-ssl:3.0
 
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
+
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, osgiConsole-1.0 is added programmatically at runtime.
 tested.features: \

--- a/dev/io.openliberty.http.monitor/bnd.bnd
+++ b/dev/io.openliberty.http.monitor/bnd.bnd
@@ -15,10 +15,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.http.monitor
-Bundle-SymbolicName: io.openliberty.http.monitor
-Bundle-Description: io.openliberty.http.monitor; version=${bVersion}
-
 src: src
 
 -dsannotations: \

--- a/dev/io.openliberty.http.monitor/original.bnd
+++ b/dev/io.openliberty.http.monitor/original.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -13,4 +13,4 @@
 
 Bundle-Name: io.openliberty.http.monitor
 Bundle-SymbolicName: io.openliberty.http.monitor
-
+Bundle-Description: io.openliberty.http.monitor; version=${bVersion}

--- a/dev/io.openliberty.http.monitor/transformed.bnd
+++ b/dev/io.openliberty.http.monitor/transformed.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,4 +14,4 @@
 
 Bundle-Name: io.openliberty.http.monitor.jakarta
 Bundle-SymbolicName: io.openliberty.http.monitor.jakarta
-
+Bundle-Description: io.openliberty.http.monitor.jakarta; version=${bVersion}

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,12 @@ src: \
 -sub: *.bnd
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 tested.features: opentracing-2.0, mprestclient-1.4
 

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,12 @@ src: \
 -sub: *.bnd
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 tested.features: mpOpenTracing-3.0, mprestclient-3.0
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.config_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.config_fat/bnd.bnd
@@ -19,6 +19,12 @@ src: \
 	
 fat.project: true
 
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
+
 tested.features:\
   jsonp-1.1,\
   mprestclient-1.2,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
@@ -19,6 +19,12 @@ src: \
 	
 fat.project: true
 
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
+
 tested.features:\
   jsonp-1.1,\
   mprestclient-1.2,\

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2023, 2024 IBM Corporation and others.
+# Copyright (c) 2023, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,8 +12,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.microprofile.telemetry.1.1.internal
-Bundle-SymbolicName: io.openliberty.microprofile.telemetry.1.1.internal
 Bundle-Activator: io.openliberty.microprofile.telemetry11.internal.helper.InstrumenterActivator
 Bundle-Description: MicroProfile.telemetry, version 1.1
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,8 +12,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.microprofile.telemetry.2.0.internal
-Bundle-SymbolicName: io.openliberty.microprofile.telemetry.2.0.internal
 Bundle-Activator: io.openliberty.microprofile.telemetry20.internal.helper.InstrumenterActivator
 Bundle-Description: MicroProfile.telemetry, version 2.0
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal/bnd.bnd
@@ -12,8 +12,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.microprofile.telemetry.2.0.logging.internal
-Bundle-SymbolicName: io.openliberty.microprofile.telemetry.2.0.logging.internal
 Bundle-Description: MicroProfile.telemetry.logging, version 2.0
 WS-TraceGroup: TELEMETRY
 

--- a/dev/io.openliberty.microprofile.telemetry.2.1.logging.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.1.logging.internal/bnd.bnd
@@ -12,8 +12,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.microprofile.telemetry.2.1.logging.internal
-Bundle-SymbolicName: io.openliberty.microprofile.telemetry.2.1.logging.internal
 Bundle-Description: MicroProfile.telemetry.logging, version 2.1
 WS-TraceGroup: TELEMETRY
 

--- a/dev/io.openliberty.microprofile.telemetry.logging.internal.common/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.logging.internal.common/bnd.bnd
@@ -12,8 +12,6 @@ bVersion=1.0
 
 -sub: *.bnd
 
-Bundle-Name: io.openliberty.microprofile.telemetry.logging.internal.common
-Bundle-SymbolicName: io.openliberty.microprofile.telemetry.logging.internal.common
 Bundle-Description: MicroProfile.telemetry.logging, common code
 WS-TraceGroup: TELEMETRY
 

--- a/dev/io.openliberty.opentracing.2.x_fat/bnd.bnd
+++ b/dev/io.openliberty.opentracing.2.x_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,12 @@ src: \
 -sub: *.bnd
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 tested.features: mpOpenTracing-2.0
 

--- a/dev/io.openliberty.opentracing.3.x_fat/bnd.bnd
+++ b/dev/io.openliberty.opentracing.3.x_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2021 IBM Corporation and others.
+# Copyright (c) 2021, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,12 @@ src: \
 -sub: *.bnd
 
 fat.project: true
+
+# Do not release this project's bundles to the bnd repository.
+# If has a test bundle whose name is shared with another project.
+# Because of that you can get a build error that the bundle
+# is already published when doing parallel builds in gradle.
+-releaserepo:
 
 tested.features: mpOpenTracing-3.0
 

--- a/dev/wlp-jakartaee-transform/notes.txt
+++ b/dev/wlp-jakartaee-transform/notes.txt
@@ -302,8 +302,8 @@ dev/wlp-gradle/subprojects/tasks.gradle
 
 dev/wlp-jakartaee-transform/bnd.bnd
 
--include= jar:${fileuri;${repo;org.eclipse.transformer:org.eclipse.transformer.cli;0.2.0}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;\${repo;org.eclipse.transformer:org.eclipse.transformer.cli;0.2.0}}!/META-INF/MANIFEST.MF,bnd.overrides
 -includeresource: \
-    @${repo;org.eclipse.transformer:org.eclipse.transformer.cli;0.2.0}!/!META-INF/maven/*
+    @\${repo;org.eclipse.transformer:org.eclipse.transformer.cli;0.2.0}!/!META-INF/maven/*
     org.eclipse.transformer:org.eclipse.transformer.cli;version=0.2.0,\
     org.eclipse.transformer:org.eclipse.transformer;version=0.2.0,\


### PR DESCRIPTION
- This is attempt 2 to deliver this change.  It was originally done with #33217.  `-releaserepo` needs to be in the bnd.bnd file, not in a the sub bundle's bnd file.
- When 2 or more test projects end up having test bundles with the same name, there can be errors during the build when both projects try to release the same bundle name and it already was released. There is no need to actually release test bundles to the bnd repository. This PR updates to not release the bundles for projects that have bundles with names that are shared across multiple test projects.
- In the future it would be good to not release any fat project bundles unless required, but this is a stop gap in order to prevent people from getting build errors when doing gradle with parallel enabled.
- Also updated bnd.bnd files to remove SymbolicName settings when the project has sub bundles and the symbolic name is set in the sub bundles' bnd files.
- Added some updates to escape the dollar sign for `${repo;` calls that I missed in #33266 


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
