### PR TITLE
Adding beta fence message for log throttling

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -313,7 +313,7 @@ public class BaseTraceService implements TrService {
     public static boolean isStackTraceSingleEntryEnabled = false;
 
     private static volatile Boolean isBetaEdition = null;
-    private static volatile boolean issuedBetaMessageAccess = false;
+    private static final AtomicBoolean betaCheckInitializing = new AtomicBoolean(false);
 
     /**
      * Called from Tr.getDelegate when BaseTraceService delegate is created
@@ -366,14 +366,8 @@ public class BaseTraceService implements TrService {
         if (isBetaEdition != null)
             return isBetaEdition;
 
-        if (issuedBetaMessageAccess) {
-            return false;
-        }
-
-        issuedBetaMessageAccess = true;
-
-        try {
-            synchronized (BaseTraceService.class) {
+        if (betaCheckInitializing.compareAndSet(false, true)) {
+            try {
                 if (isBetaEdition == null) {
                     if (Boolean.getBoolean("com.ibm.ws.beta.edition")) {
                         Tr.info(tc, "BETA: A beta method has been invoked for the class BaseTraceService for the first time.");
@@ -381,13 +375,15 @@ public class BaseTraceService implements TrService {
                     } else {
                         isBetaEdition = false;
                     }
-                }
-            }
 
-            return isBetaEdition;
-        } finally {
-            issuedBetaMessageAccess = false;
+                }
+
+                return isBetaEdition;
+            } finally {
+                betaCheckInitializing.set(false);
+            }
         }
+        return isBetaEdition != null ? isBetaEdition : false;
     }
 
     /**

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -366,6 +366,7 @@ public class BaseTraceService implements TrService {
         if (isBetaEdition != null)
             return isBetaEdition;
 
+        //To prevent a StackOverflow error, we need to ensure only one thread runs the beta check block, otherwise the tr.info will be stuck in an infinite loop.
         if (betaCheckInitializing.compareAndSet(false, true)) {
             try {
                 if (isBetaEdition == null) {

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -312,7 +312,7 @@ public class BaseTraceService implements TrService {
     protected final static int BYTE_ARRAY_OUTPUT_BUFFER_THRESHOLD = ThreadLocalByteArrayOutputStream.getByteArrayOutputThreshold();
     public static boolean isStackTraceSingleEntryEnabled = false;
 
-    private static Boolean isBetaEdition = null;
+    private static volatile Boolean isBetaEdition = null;
     private static volatile boolean issuedBetaMessageAccess = false;
 
     /**
@@ -373,14 +373,17 @@ public class BaseTraceService implements TrService {
         issuedBetaMessageAccess = true;
 
         try {
-            if (isBetaEdition == null) {
-                if (Boolean.getBoolean("com.ibm.ws.beta.edition")) {
-                    Tr.info(tc, "BETA: A beta method has been invoked for the class BaseTraceService for the first time.");
-                    isBetaEdition = true;
-                } else {
-                    isBetaEdition = false;
+            synchronized (BaseTraceService.class) {
+                if (isBetaEdition == null) {
+                    if (Boolean.getBoolean("com.ibm.ws.beta.edition")) {
+                        Tr.info(tc, "BETA: A beta method has been invoked for the class BaseTraceService for the first time.");
+                        isBetaEdition = true;
+                    } else {
+                        isBetaEdition = false;
+                    }
                 }
             }
+
             return isBetaEdition;
         } finally {
             issuedBetaMessageAccess = false;

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -312,7 +312,8 @@ public class BaseTraceService implements TrService {
     protected final static int BYTE_ARRAY_OUTPUT_BUFFER_THRESHOLD = ThreadLocalByteArrayOutputStream.getByteArrayOutputThreshold();
     public static boolean isStackTraceSingleEntryEnabled = false;
 
-    private static Boolean isBetaEdition;
+    private static Boolean isBetaEdition = null;
+    private static volatile boolean issuedBetaMessageAccess = false;
 
     /**
      * Called from Tr.getDelegate when BaseTraceService delegate is created
@@ -362,14 +363,28 @@ public class BaseTraceService implements TrService {
     }
 
     public Boolean betaFenceCheck() {
-        if (isBetaEdition == null) {
-            if (Boolean.getBoolean("com.ibm.ws.beta.edition")) {
-                isBetaEdition = true;
-            } else {
-                isBetaEdition = false;
-            }
+        if (isBetaEdition != null)
+            return isBetaEdition;
+
+        if (issuedBetaMessageAccess) {
+            return false;
         }
-        return isBetaEdition;
+
+        issuedBetaMessageAccess = true;
+
+        try {
+            if (isBetaEdition == null) {
+                if (Boolean.getBoolean("com.ibm.ws.beta.edition")) {
+                    Tr.info(tc, "BETA: A beta method has been invoked for the class BaseTraceService for the first time.");
+                    isBetaEdition = true;
+                } else {
+                    isBetaEdition = false;
+                }
+            }
+            return isBetaEdition;
+        } finally {
+            issuedBetaMessageAccess = false;
+        }
     }
 
     /**
@@ -482,15 +497,13 @@ public class BaseTraceService implements TrService {
             collectorMgrPipelineUtils = CollectorManagerPipelineUtils.getInstance();
         }
 
-        if (betaFenceCheck()) {
-            throttleMaxMessagesPerWindow = trConfig.getThrottleMaxMessagesPerWindow();
-            throttleMapSize = trConfig.getThrottleMapSize();
+        throttleMaxMessagesPerWindow = trConfig.getThrottleMaxMessagesPerWindow();
+        throttleMapSize = trConfig.getThrottleMapSize();
 
-            if (throttleType != trConfig.getThrottleType()) {
-                throttleType = trConfig.getThrottleType();
-                resetLogThrottling(); //We need to reset the throttleStates map when switching between throttleTypes.
+        if (throttleType != trConfig.getThrottleType()) {
+            throttleType = trConfig.getThrottleType();
+            resetLogThrottling(); //We need to reset the throttleStates map when switching between throttleTypes.
 
-            }
         }
 
         //Sources


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Due to this project being responsible for logging, if the regular betaFenceCheck is used, the warning causes StackOverflow errors. The flow ends up being betaFenceCheck -> warning -> Log -> betaFenceCheck -> warning...

So betaCheckInitializing is used to stop this loop and allow us to print the warning once.