### PR TITLE
wsSecurity-1.1: Re-add missing AlgorithmSuites

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/bnd.bnd
@@ -98,14 +98,19 @@ instrument.classesIncludes: \
   io.openliberty.org.apache.cxf:cxf-rt-ws-security;strategy=exact;version=${cxfVersion}, \
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest, \
   com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2;version=latest, \
+  com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2;version=latest, \
+  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2;version=latest, \
   com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2;version=latest, \
+  com.ibm.ws.org.apache.cxf.rt.ws.mex.3.4.1;version=latest, \
   com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2;version=latest, \
   com.ibm.ws.org.apache.cxf.rt.security.3.4.1;version=latest, \
   com.ibm.ws.org.apache.cxf.rt.security.saml.3.4.1;version=latest, \
   com.ibm.ws.org.apache.neethi.3.1.1;version=latest, \
+  com.ibm.ws.org.apache.wss4j.bindings;version=latest, \
   com.ibm.ws.org.apache.wss4j.policy;version=latest, \
   com.ibm.ws.org.apache.wss4j.ws.security.common;version=latest, \
   com.ibm.ws.org.apache.wss4j.ws.security.dom;version=latest, \
+  com.ibm.ws.org.apache.wss4j.ws.security.policy.stax;version=latest, \
   com.ibm.ws.org.apache.wss4j.ws.security.stax;version=latest, \
   com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest, \
   com.ibm.ws.org.ehcache.ehcache.107.3.8.1;version=latest, \
@@ -113,5 +118,7 @@ instrument.classesIncludes: \
   com.ibm.ws.org.slf4j.api;version=latest, \
   com.ibm.websphere.appserver.spi.logging, \
   com.ibm.websphere.javaee.jws.1.0;version=latest, \
+  com.ibm.websphere.javaee.wsdl4j.1.2;version=latest, \
   org.codehaus.woodstox:stax2-api;version='4.2', \
-  org.codehaus.woodstox:woodstox-core-asl;version='4.2.0'
+  org.codehaus.woodstox:woodstox-core-asl;version='4.2.0', \
+  com.ibm.websphere.javaee.jcache.1.1.core;version=latest

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/AbstractTokenInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/AbstractTokenInterceptor.java
@@ -174,7 +174,7 @@ public abstract class AbstractTokenInterceptor extends AbstractSoapInterceptor {
         boolean mustunderstand = true;
         mustunderstand = translateMustUnderstandProperty(message);
         sh.setMustUnderstand(mustunderstand);
-		// Liberty Change End
+        // Liberty Change End
         if (actor != null && actor.length() > 0) {
             sh.setActor(actor);
         }
@@ -182,7 +182,7 @@ public abstract class AbstractTokenInterceptor extends AbstractSoapInterceptor {
         return sh;
     }
     
-	// Liberty Change Start
+    // Liberty Change Start
     /**
      * @param message
      * @return
@@ -203,8 +203,7 @@ public abstract class AbstractTokenInterceptor extends AbstractSoapInterceptor {
         } 
         return true;
     }
-	
-		// Liberty Change End
+     // Liberty Change End
 
     protected String getPassword(String userName, AbstractToken info,
                                  int usage, SoapMessage message) {

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/AbstractWSS4JInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/AbstractWSS4JInterceptor.java
@@ -46,6 +46,8 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.dom.handler.RequestData;
 import org.apache.wss4j.dom.handler.WSHandler;
 
+import com.ibm.websphere.ras.annotation.Trivial; // Liberty Change
+
 public abstract class AbstractWSS4JInterceptor extends WSHandler implements SoapInterceptor,
     PhaseInterceptor<SoapMessage> {
 
@@ -90,6 +92,7 @@ public abstract class AbstractWSS4JInterceptor extends WSHandler implements Soap
         this.phase = phase;
     }
 
+    @Trivial // Liberty Change
     public Object getOption(String key) {
         return properties.get(key);
     }
@@ -211,6 +214,7 @@ public abstract class AbstractWSS4JInterceptor extends WSHandler implements Soap
         if (passwordEncryptor != null) {
             msg.put(ConfigurationConstants.PASSWORD_ENCRYPTOR_INSTANCE, passwordEncryptor);
         }
+
         // Liberty Change Start
         String mustunderstand = (String)msg.getContextualProperty("ws-security.must-understand");
         if (mustunderstand != null && !mustunderstand.isEmpty()) {
@@ -220,7 +224,7 @@ public abstract class AbstractWSS4JInterceptor extends WSHandler implements Soap
                 LOG.fine("AbstractWSS4JInterceptor: OLGH23255 - mustUnderstand is set = " + mustunderstand);
             }        
         }
-		// Liberty Change End
+        // Liberty Change End
     }
 
     @Override
@@ -236,4 +240,5 @@ public abstract class AbstractWSS4JInterceptor extends WSHandler implements Soap
                 message, propFilename, classLoader, passwordEncryptor
             );
     }
+
 }

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/PolicyBasedWSS4JStaxInInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/PolicyBasedWSS4JStaxInInterceptor.java
@@ -1,0 +1,471 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.ws.security.wss4j;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.xml.namespace.QName;
+
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.binding.soap.interceptor.SoapActionInInterceptor;
+import org.apache.cxf.binding.soap.model.SoapBindingInfo;
+import org.apache.cxf.binding.soap.model.SoapOperationInfo;
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.endpoint.Endpoint;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
+import org.apache.cxf.rt.security.utils.SecurityUtils;
+import org.apache.cxf.service.model.BindingInfo;
+import org.apache.cxf.service.model.BindingOperationInfo;
+import org.apache.cxf.service.model.EndpointInfo;
+import org.apache.cxf.service.model.MessageInfo;
+import org.apache.cxf.ws.policy.AssertionInfo;
+import org.apache.cxf.ws.policy.AssertionInfoMap;
+import org.apache.cxf.ws.policy.EffectivePolicy;
+import org.apache.cxf.ws.security.SecurityConstants;
+import org.apache.cxf.ws.security.policy.PolicyUtils;
+import org.apache.cxf.ws.security.policy.custom.DefaultAlgorithmSuiteLoader;
+import org.apache.wss4j.common.WSSPolicyException;
+import org.apache.wss4j.common.crypto.Crypto;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.policy.SP12Constants;
+import org.apache.wss4j.policy.SPConstants;
+import org.apache.wss4j.policy.model.AbstractBinding;
+import org.apache.wss4j.policy.model.AlgorithmSuite;
+import org.apache.wss4j.policy.stax.OperationPolicy;
+import org.apache.wss4j.policy.stax.enforcer.PolicyEnforcer;
+import org.apache.wss4j.policy.stax.enforcer.PolicyInputProcessor;
+import org.apache.wss4j.stax.ext.WSSConstants;
+import org.apache.wss4j.stax.ext.WSSSecurityProperties;
+import org.apache.wss4j.stax.impl.securityToken.HttpsSecurityTokenImpl;
+import org.apache.wss4j.stax.securityEvent.HttpsTokenSecurityEvent;
+import org.apache.wss4j.stax.securityToken.WSSecurityTokenConstants;
+import org.apache.xml.security.exceptions.XMLSecurityException;
+import org.apache.xml.security.stax.securityEvent.SecurityEvent;
+import org.apache.xml.security.stax.securityEvent.SecurityEventListener;
+
+/**
+ *
+ */
+public class PolicyBasedWSS4JStaxInInterceptor extends WSS4JStaxInInterceptor {
+    private static final Logger LOG = LogUtils.getL7dLogger(PolicyBasedWSS4JStaxInInterceptor.class);
+
+    public void handleMessage(SoapMessage msg) throws Fault {
+        AssertionInfoMap aim = msg.get(AssertionInfoMap.class);
+        boolean enableStax =
+            MessageUtils.getContextualBoolean(msg, SecurityConstants.ENABLE_STREAMING_SECURITY);
+        if (aim != null && enableStax) {
+            super.handleMessage(msg);
+        }
+    }
+
+    @Override
+    protected WSSSecurityProperties createSecurityProperties() {
+        WSSSecurityProperties securityProperties = new WSSSecurityProperties();
+        securityProperties.setSkipDocumentEvents(true);
+        return securityProperties;
+    }
+
+    private void checkAsymmetricBinding(
+        AssertionInfoMap aim, SoapMessage message, WSSSecurityProperties securityProperties
+    ) throws WSSecurityException {
+        AssertionInfo ais = PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.ASYMMETRIC_BINDING);
+        if (ais == null) {
+            return;
+        }
+
+        Object s = SecurityUtils.getSecurityPropertyValue(SecurityConstants.SIGNATURE_CRYPTO, message);
+        if (s == null) {
+            s = SecurityUtils.getSecurityPropertyValue(SecurityConstants.SIGNATURE_PROPERTIES, message);
+        }
+        Object e = SecurityUtils.getSecurityPropertyValue(SecurityConstants.ENCRYPT_CRYPTO, message);
+        if (e == null) {
+            e = SecurityUtils.getSecurityPropertyValue(SecurityConstants.ENCRYPT_PROPERTIES, message);
+        }
+
+        Crypto encrCrypto = getEncryptionCrypto(e, message, securityProperties);
+        final Crypto signCrypto;
+        if (e != null && e.equals(s)) {
+            signCrypto = encrCrypto;
+        } else {
+            signCrypto = getSignatureCrypto(s, message, securityProperties);
+        }
+
+        if (signCrypto != null) {
+            securityProperties.setDecryptionCrypto(signCrypto);
+        }
+
+        if (encrCrypto != null) {
+            securityProperties.setSignatureVerificationCrypto(encrCrypto);
+        } else if (signCrypto != null) {
+            securityProperties.setSignatureVerificationCrypto(signCrypto);
+        }
+    }
+
+    private void checkTransportBinding(
+        AssertionInfoMap aim, SoapMessage message, WSSSecurityProperties securityProperties
+    ) throws XMLSecurityException {
+        boolean transportPolicyInEffect =
+            PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.TRANSPORT_BINDING) != null;
+        if (!transportPolicyInEffect
+            && !(PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.SYMMETRIC_BINDING) == null
+                && PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.ASYMMETRIC_BINDING) == null)) {
+            return;
+        }
+
+        // Add a HttpsSecurityEvent so the policy verification code knows TLS is in use
+        if (isRequestor(message)) {
+            HttpsTokenSecurityEvent httpsTokenSecurityEvent = new HttpsTokenSecurityEvent();
+            httpsTokenSecurityEvent.setAuthenticationType(
+                HttpsTokenSecurityEvent.AuthenticationType.HttpsNoAuthentication
+            );
+            HttpsSecurityTokenImpl httpsSecurityToken = new HttpsSecurityTokenImpl();
+            try {
+                httpsSecurityToken.addTokenUsage(WSSecurityTokenConstants.TOKENUSAGE_MAIN_SIGNATURE);
+            } catch (XMLSecurityException e) {
+                LOG.fine(e.getMessage());
+            }
+            httpsTokenSecurityEvent.setSecurityToken(httpsSecurityToken);
+
+            List<SecurityEvent> securityEvents = getSecurityEventList(message);
+            securityEvents.add(httpsTokenSecurityEvent);
+        }
+
+        Object s = SecurityUtils.getSecurityPropertyValue(SecurityConstants.SIGNATURE_CRYPTO, message);
+        if (s == null) {
+            s = SecurityUtils.getSecurityPropertyValue(SecurityConstants.SIGNATURE_PROPERTIES, message);
+        }
+        Object e = SecurityUtils.getSecurityPropertyValue(SecurityConstants.ENCRYPT_CRYPTO, message);
+        if (e == null) {
+            e = SecurityUtils.getSecurityPropertyValue(SecurityConstants.ENCRYPT_PROPERTIES, message);
+        }
+
+        Crypto encrCrypto = getEncryptionCrypto(e, message, securityProperties);
+        final Crypto signCrypto;
+        if (e != null && e.equals(s)) {
+            signCrypto = encrCrypto;
+        } else {
+            signCrypto = getSignatureCrypto(s, message, securityProperties);
+        }
+
+        if (signCrypto != null) {
+            securityProperties.setDecryptionCrypto(signCrypto);
+        }
+
+        if (encrCrypto != null) {
+            securityProperties.setSignatureVerificationCrypto(encrCrypto);
+        } else if (signCrypto != null) {
+            securityProperties.setSignatureVerificationCrypto(signCrypto);
+        }
+    }
+
+    private List<SecurityEvent> getSecurityEventList(Message message) {
+        @SuppressWarnings("unchecked")
+        List<SecurityEvent> securityEvents =
+            (List<SecurityEvent>) message.getExchange().get(SecurityEvent.class.getName() + ".out");
+        if (securityEvents == null) {
+            securityEvents = new ArrayList<>();
+            message.getExchange().put(SecurityEvent.class.getName() + ".out", securityEvents);
+        }
+
+        return securityEvents;
+    }
+
+    private void checkSymmetricBinding(
+        AssertionInfoMap aim, SoapMessage message, WSSSecurityProperties securityProperties
+    ) throws WSSecurityException {
+        AssertionInfo ais = PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.SYMMETRIC_BINDING);
+        if (ais == null) {
+            return;
+        }
+
+        Object s = SecurityUtils.getSecurityPropertyValue(SecurityConstants.SIGNATURE_CRYPTO, message);
+        if (s == null) {
+            s = SecurityUtils.getSecurityPropertyValue(SecurityConstants.SIGNATURE_PROPERTIES, message);
+        }
+        Object e = SecurityUtils.getSecurityPropertyValue(SecurityConstants.ENCRYPT_CRYPTO, message);
+        if (e == null) {
+            e = SecurityUtils.getSecurityPropertyValue(SecurityConstants.ENCRYPT_PROPERTIES, message);
+        }
+
+        Crypto encrCrypto = getEncryptionCrypto(e, message, securityProperties);
+        final Crypto signCrypto;
+        if (e != null && e.equals(s)) {
+            signCrypto = encrCrypto;
+        } else {
+            signCrypto = getSignatureCrypto(s, message, securityProperties);
+        }
+
+        if (isRequestor(message)) {
+            Crypto crypto = encrCrypto;
+            if (crypto == null) {
+                crypto = signCrypto;
+            }
+            if (crypto != null) {
+                securityProperties.setSignatureCrypto(crypto);
+            }
+
+            crypto = signCrypto;
+            if (crypto == null) {
+                crypto = encrCrypto;
+            }
+            if (crypto != null) {
+                securityProperties.setDecryptionCrypto(crypto);
+            }
+        } else {
+            Crypto crypto = signCrypto;
+            if (crypto == null) {
+                crypto = encrCrypto;
+            }
+            if (crypto != null) {
+                securityProperties.setSignatureVerificationCrypto(crypto);
+            }
+
+            crypto = encrCrypto;
+            if (crypto == null) {
+                crypto = signCrypto;
+            }
+            if (crypto != null) {
+                securityProperties.setDecryptionCrypto(crypto);
+            }
+        }
+    }
+
+    @Override
+    protected void configureProperties(
+        SoapMessage msg, WSSSecurityProperties securityProperties
+    ) throws XMLSecurityException {
+        AssertionInfoMap aim = msg.get(AssertionInfoMap.class);
+        checkAsymmetricBinding(aim, msg, securityProperties);
+        checkSymmetricBinding(aim, msg, securityProperties);
+        checkTransportBinding(aim, msg, securityProperties);
+                // Liberty Change Start: Backport 4.x
+        AssertionInfo assertionInfo = PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.ASYMMETRIC_BINDING);
+        AbstractBinding abstractBinding = null;
+        if (assertionInfo == null) {
+            assertionInfo = PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.SYMMETRIC_BINDING);
+            if (assertionInfo == null) {
+                assertionInfo = PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.TRANSPORT_BINDING);
+            }
+        }
+        if (assertionInfo != null) {
+            abstractBinding = (AbstractBinding)assertionInfo.getAssertion();
+        }
+        AlgorithmSuite.AlgorithmSuiteType originalAlgSuite = null;
+        if (abstractBinding != null) {
+            originalAlgSuite = abstractBinding.getAlgorithmSuite().getAlgorithmSuiteType();
+        }
+
+        AlgorithmSuite.AlgorithmSuiteType customAlgSuite = DefaultAlgorithmSuiteLoader
+                .customize(originalAlgSuite, msg);
+
+        // Allow for setting non-standard signature algorithms
+        String asymSignatureAlgorithm =
+                msg.getContextualProperty(SecurityConstants.ASYMMETRIC_SIGNATURE_ALGORITHM) != null
+                        ? (String)msg.getContextualProperty(SecurityConstants.ASYMMETRIC_SIGNATURE_ALGORITHM)
+                        : (customAlgSuite != null ? customAlgSuite.getAsymmetricSignature() : null);
+        String symSignatureAlgorithm =
+                msg.getContextualProperty(SecurityConstants.SYMMETRIC_SIGNATURE_ALGORITHM) != null
+                        ? (String)msg.getContextualProperty(SecurityConstants.SYMMETRIC_SIGNATURE_ALGORITHM)
+                        : (customAlgSuite != null ? customAlgSuite.getSymmetricSignature() : null);
+        if (asymSignatureAlgorithm != null || symSignatureAlgorithm != null) {
+            Collection<AssertionInfo> algorithmSuites =
+                aim.get(SP12Constants.ALGORITHM_SUITE);
+            if (algorithmSuites != null && !algorithmSuites.isEmpty()) {
+                for (AssertionInfo algorithmSuite : algorithmSuites) {
+                    AlgorithmSuite algSuite = (AlgorithmSuite)algorithmSuite.getAssertion();
+                    //customize Alg suite (if possible)
+                    DefaultAlgorithmSuiteLoader.customize(algSuite.getAlgorithmSuiteType(), msg);
+                                        // Liberty Change End
+
+                    if (asymSignatureAlgorithm != null) {
+                        algSuite.getAlgorithmSuiteType().setAsymmetricSignature(asymSignatureAlgorithm);
+                    }
+                    if (symSignatureAlgorithm != null) {
+                        algSuite.getAlgorithmSuiteType().setSymmetricSignature(symSignatureAlgorithm);
+                    }
+                }
+            }
+        }
+
+        super.configureProperties(msg, securityProperties);
+    }
+
+    /**
+     * Is a Nonce Cache required, i.e. are we expecting a UsernameToken
+     */
+    @Override
+    protected boolean isNonceCacheRequired(SoapMessage msg, WSSSecurityProperties securityProperties) {
+        AssertionInfoMap aim = msg.get(AssertionInfoMap.class);
+        if (aim != null) {
+            AssertionInfo ais = PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.USERNAME_TOKEN);
+            if (ais != null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Is a Timestamp cache required, i.e. are we expecting a Timestamp
+     */
+    @Override
+    protected boolean isTimestampCacheRequired(SoapMessage msg, WSSSecurityProperties securityProperties) {
+        AssertionInfoMap aim = msg.get(AssertionInfoMap.class);
+        if (aim != null) {
+            AssertionInfo ais = PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.INCLUDE_TIMESTAMP);
+            if (ais != null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Is a SAML Cache required, i.e. are we expecting a SAML Token
+     */
+    @Override
+    protected boolean isSamlCacheRequired(SoapMessage msg, WSSSecurityProperties securityProperties) {
+        AssertionInfoMap aim = msg.get(AssertionInfoMap.class);
+        if (aim != null) {
+            AssertionInfo ais = PolicyUtils.getFirstAssertionByLocalname(aim, SPConstants.SAML_TOKEN);
+            if (ais != null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    protected List<SecurityEventListener> configureSecurityEventListeners(
+        SoapMessage msg, WSSSecurityProperties securityProperties
+    ) throws WSSPolicyException {
+        final List<SecurityEventListener> securityEventListeners = new ArrayList<>(2);
+        securityEventListeners.addAll(super.configureSecurityEventListeners(msg, securityProperties));
+
+        Endpoint endoint = msg.getExchange().getEndpoint();
+
+        PolicyEnforcer policyEnforcer = createPolicyEnforcer(endoint.getEndpointInfo(), msg);
+        securityProperties.addInputProcessor(new PolicyInputProcessor(policyEnforcer, securityProperties));
+        securityEventListeners.add(policyEnforcer);
+
+        return securityEventListeners;
+    }
+
+    private PolicyEnforcer createPolicyEnforcer(
+        EndpointInfo endpointInfo, SoapMessage msg
+    ) throws WSSPolicyException {
+        EffectivePolicy dispatchPolicy = null;
+        List<OperationPolicy> operationPolicies = new ArrayList<>();
+        Collection<BindingOperationInfo> bindingOperationInfos = endpointInfo.getBinding().getOperations();
+        for (Iterator<BindingOperationInfo> bindingOperationInfoIterator =
+                     bindingOperationInfos.iterator(); bindingOperationInfoIterator.hasNext();) {
+            BindingOperationInfo bindingOperationInfo = bindingOperationInfoIterator.next();
+            QName operationName = bindingOperationInfo.getName();
+
+            // todo: I'm not sure what the effectivePolicy exactly contains,
+            // a) only the operation policy,
+            // or b) all policies for the service,
+            // or c) all policies which applies for the current operation.
+            // c) is that what we need for stax.
+            EffectivePolicy policy =
+                (EffectivePolicy)bindingOperationInfo.getProperty("policy-engine-info-serve-request");
+            //PolicyEngineImpl.POLICY_INFO_REQUEST_SERVER);
+            if (MessageUtils.isRequestor(msg)) {
+                policy =
+                    (EffectivePolicy)bindingOperationInfo.getProperty("policy-engine-info-client-response");
+                // Save the Dispatch Policy as it may be used on another BindingOperationInfo
+                if (policy != null
+                    && "http://cxf.apache.org/jaxws/dispatch".equals(operationName.getNamespaceURI())) {
+                    dispatchPolicy = policy;
+                }
+                if (bindingOperationInfo.getOutput() != null) {
+                    MessageInfo messageInfo = bindingOperationInfo.getOutput().getMessageInfo();
+                    operationName = messageInfo.getName();
+                    if (messageInfo.getMessagePartsNumber() > 0) {
+                        QName cn = messageInfo.getFirstMessagePart().getConcreteName();
+                        if (cn != null) {
+                            operationName = cn;
+                        }
+                    }
+                }
+            } else {
+                if (bindingOperationInfo.getInput() != null) {
+                    MessageInfo messageInfo = bindingOperationInfo.getInput().getMessageInfo();
+                    operationName = messageInfo.getName();
+                    if (messageInfo.getMessagePartsNumber() > 0) {
+                        QName cn = messageInfo.getFirstMessagePart().getConcreteName();
+                        if (cn != null) {
+                            operationName = cn;
+                        }
+                    }
+                }
+            }
+
+            SoapOperationInfo soapOperationInfo = bindingOperationInfo.getExtensor(SoapOperationInfo.class);
+            if (soapOperationInfo != null && policy == null && dispatchPolicy != null) {
+                policy = dispatchPolicy;
+            }
+
+            if (policy != null && soapOperationInfo != null) {
+                String soapNS;
+                BindingInfo bindingInfo = bindingOperationInfo.getBinding();
+                if (bindingInfo instanceof SoapBindingInfo) {
+                    soapNS = ((SoapBindingInfo)bindingInfo).getSoapVersion().getNamespace();
+                } else {
+                    //no idea what todo here...
+                    //most probably throw an exception:
+                    throw new IllegalArgumentException("BindingInfo is not an instance of SoapBindingInfo");
+                }
+
+                OperationPolicy operationPolicy = new OperationPolicy(operationName);
+                operationPolicy.setPolicy(policy.getPolicy());
+                operationPolicy.setOperationAction(soapOperationInfo.getAction());
+                operationPolicy.setSoapMessageVersionNamespace(soapNS);
+
+                operationPolicies.add(operationPolicy);
+            }
+        }
+
+        String soapAction = SoapActionInInterceptor.getSoapAction(msg);
+        if (soapAction == null) {
+            soapAction = "";
+        }
+        String actor = (String)msg.getContextualProperty(SecurityConstants.ACTOR);
+        final Collection<org.apache.cxf.message.Attachment> attachments = msg.getAttachments();
+        int attachmentCount = 0;
+        if (attachments != null && !attachments.isEmpty()) {
+            attachmentCount = attachments.size();
+        }
+        return new PolicyEnforcer(operationPolicies, soapAction, isRequestor(msg),
+                                  actor, attachmentCount,
+                                  new WSS4JPolicyAsserter(msg.get(AssertionInfoMap.class)),
+                                  WSSConstants.NS_SOAP12.equals(msg.getVersion().getNamespace()));
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/UsernameTokenInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/UsernameTokenInterceptor.java
@@ -25,14 +25,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger; // Liberty Change
+
 import javax.security.auth.Subject;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import org.apache.cxf.binding.soap.SoapMessage;
-import org.apache.cxf.common.logging.LogUtils; // Liberty Change
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.headers.Header;
 import org.apache.cxf.helpers.CastUtils;
@@ -77,13 +76,14 @@ import org.apache.wss4j.policy.model.UsernameToken;
 import org.apache.xml.security.exceptions.Base64DecodingException;
 import org.apache.xml.security.utils.XMLUtils;
 
+
+import com.ibm.websphere.ras.annotation.Trivial; // Liberty Change
+
 /**
  *
  */
+@Trivial 
 public class UsernameTokenInterceptor extends AbstractTokenInterceptor {
-    //Liberty Change Start
-    private static final Logger LOG = LogUtils.getL7dLogger(UsernameTokenInterceptor.class);
-    //Liberty Change End
     public UsernameTokenInterceptor() {
         super();
     }

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/WSS4JUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/WSS4JUtils.java
@@ -350,11 +350,11 @@ public final class WSS4JUtils {
             Properties props = WSS4JUtils.getProps(s, propsURL);
             if (props == null) {
                 // Liberty Change Start
-                //LOG.fine("Cannot find Crypto Signature properties: " + s);
                 // Liberty Change End
                 Exception ex = new Exception("Cannot find Crypto Signature properties: " + s);
                 throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, ex);
             }
+
             signCrypto = CryptoFactory.getInstance(props, Loader.getClassLoader(CryptoFactory.class),
                                                    passwordEncryptor);
 

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/custom/DefaultAlgorithmSuiteLoader.java
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/custom/DefaultAlgorithmSuiteLoader.java
@@ -1,0 +1,343 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.ws.security.policy.custom;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import javax.xml.namespace.QName;
+
+import org.w3c.dom.Element;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.ws.policy.AssertionBuilderRegistry;
+import org.apache.cxf.ws.policy.builder.primitive.PrimitiveAssertion;
+import org.apache.cxf.ws.policy.builder.primitive.PrimitiveAssertionBuilder;
+import org.apache.cxf.ws.security.SecurityConstants;
+import org.apache.cxf.ws.security.wss4j.AlgorithmSuiteTranslater;
+import org.apache.neethi.Assertion;
+import org.apache.neethi.AssertionBuilderFactory;
+import org.apache.neethi.Policy;
+import org.apache.neethi.builders.xml.XMLPrimitiveAssertionBuilder;
+import org.apache.wss4j.policy.SPConstants;
+import org.apache.wss4j.policy.model.AbstractSecurityAssertion;
+import org.apache.wss4j.policy.model.AlgorithmSuite;
+
+/**
+ * This class retrieves the default AlgorithmSuites plus the CXF specific GCM AlgorithmSuites.
+ */
+public class DefaultAlgorithmSuiteLoader implements AlgorithmSuiteLoader {
+    private static final Logger LOG = LogUtils.getL7dLogger(AlgorithmSuiteTranslater.class); // Liberty Change
+
+    public AlgorithmSuite getAlgorithmSuite(Bus bus, SPConstants.SPVersion version, Policy nestedPolicy) {
+        AssertionBuilderRegistry reg = bus.getExtension(AssertionBuilderRegistry.class);
+        if (reg != null) {
+            String ns = "http://cxf.apache.org/custom/security-policy";
+            final Map<QName, Assertion> assertions = new HashMap<>();
+            QName qName = new QName(ns, "Basic128GCM");
+            assertions.put(qName, new PrimitiveAssertion(qName));
+            qName = new QName(ns, "Basic192GCM");
+            assertions.put(qName, new PrimitiveAssertion(qName));
+            qName = new QName(ns, "Basic256GCM");
+            assertions.put(qName, new PrimitiveAssertion(qName));
+			// Liberty Change Start: Backport 4.x
+            qName = new QName(ns, "Basic128GCMSha256ECDHES");
+            assertions.put(qName, new PrimitiveAssertion(qName));
+            qName = new QName(ns, "Basic192GCMSha256ECDHES");
+            assertions.put(qName, new PrimitiveAssertion(qName));
+            qName = new QName(ns, "Basic256GCMSha256ECDHES");
+            assertions.put(qName, new PrimitiveAssertion(qName));
+            qName = new QName(ns, "CustomAlgorithmSuite");
+            assertions.put(qName, new PrimitiveAssertion(qName));
+			// Liberty Change End
+            reg.registerBuilder(new PrimitiveAssertionBuilder(assertions.keySet()) {
+                public Assertion build(Element element, AssertionBuilderFactory fact) {
+                    if (XMLPrimitiveAssertionBuilder.isOptional(element)
+                        || XMLPrimitiveAssertionBuilder.isIgnorable(element)) {
+                        return super.build(element, fact);
+                    }
+                    QName q = new QName(element.getNamespaceURI(), element.getLocalName());
+                    return assertions.get(q);
+                }
+            });
+        }
+        return new GCMAlgorithmSuite(version, nestedPolicy);
+    }
+
+ 
+    public static class GCMAlgorithmSuite extends AlgorithmSuite {
+
+        static {
+            ALGORITHM_SUITE_TYPES.put(
+                "Basic128GCM",
+                new AlgorithmSuiteType(
+                    "Basic128GCM",
+                    SPConstants.SHA1,
+                    "http://www.w3.org/2009/xmlenc11#aes128-gcm",
+                    SPConstants.KW_AES128,
+                    SPConstants.KW_RSA_OAEP,
+                    SPConstants.P_SHA1_L128,
+                    SPConstants.P_SHA1_L128,
+                    128, 128, 128, 256, 1024, 4096
+                )
+            );
+
+            ALGORITHM_SUITE_TYPES.put(
+                "Basic192GCM",
+                new AlgorithmSuiteType(
+                    "Basic192GCM",
+                    SPConstants.SHA1,
+                    "http://www.w3.org/2009/xmlenc11#aes192-gcm",
+                    SPConstants.KW_AES192,
+                    SPConstants.KW_RSA_OAEP,
+                    SPConstants.P_SHA1_L192,
+                    SPConstants.P_SHA1_L192,
+                    192, 192, 192, 256, 1024, 4096
+                )
+            );
+
+            ALGORITHM_SUITE_TYPES.put(
+                "Basic256GCM",
+                new AlgorithmSuiteType(
+                    "Basic256GCM",
+                    SPConstants.SHA1,
+                    "http://www.w3.org/2009/xmlenc11#aes256-gcm",
+                    SPConstants.KW_AES256,
+                    SPConstants.KW_RSA_OAEP,
+                    SPConstants.P_SHA1_L256,
+                    SPConstants.P_SHA1_L192,
+                    256, 192, 256, 256, 1024, 4096
+                )
+            );
+            
+            
+            // Liberty Change Start: 
+            
+            ALGORITHM_SUITE_TYPES.put(
+                  "Basic128GCMSha256ECDHES",
+                  new AlgorithmSuiteType(
+                      "Basic128GCMSha256ECDHES",
+                      SPConstants.SHA256,
+                      "http://www.w3.org/2009/xmlenc11#aes128-gcm",
+                      SPConstants.KW_AES128,
+                      SPConstants.KW_RSA_OAEP,
+                      "http://www.w3.org/2021/04/xmldsig-more#hkdf",
+                      "http://www.w3.org/2021/04/xmldsig-more#hkdf",
+                      SPConstants.KA_ECDH_ES,
+                      128, 128, 128, 256, 1024, 4096, 160, 512
+                  )
+           );
+            
+            ALGORITHM_SUITE_TYPES.put(
+                  "Basic192GCMSha256ECDHES",
+                  new AlgorithmSuiteType(
+                      "Basic192GCMSha256ECDHES",
+                      SPConstants.SHA256,
+                      "http://www.w3.org/2009/xmlenc11#aes192-gcm",
+                      SPConstants.KW_AES192,
+                      SPConstants.KW_RSA_OAEP,
+                      "http://www.w3.org/2021/04/xmldsig-more#hkdf",
+                      "http://www.w3.org/2021/04/xmldsig-more#hkdf",
+                      SPConstants.KA_ECDH_ES,
+                      192, 192, 192, 256, 1024, 4096, 160, 512
+                  )
+           );
+
+            ALGORITHM_SUITE_TYPES.put(
+                  "Basic256GCMSha256ECDHES",
+                  new AlgorithmSuiteType(
+                      "Basic256GCMSha256ECDHES",
+                      SPConstants.SHA256,
+                      "http://www.w3.org/2009/xmlenc11#aes256-gcm",
+                      SPConstants.KW_AES256,
+                      SPConstants.KW_RSA_OAEP,
+                      "http://www.w3.org/2021/04/xmldsig-more#hkdf",
+                      "http://www.w3.org/2021/04/xmldsig-more#hkdf",
+                      SPConstants.KA_ECDH_ES,
+                      256, 192, 256, 256, 1024, 4096, 160, 512
+                  )
+           );
+		   
+            ALGORITHM_SUITE_TYPES.put(
+                    "CustomAlgorithmSuite",
+                    new AlgorithmSuiteType(
+                            "CustomAlgorithmSuite",
+                            SPConstants.SHA256,
+                            "http://www.w3.org/2009/xmlenc11#aes256-gcm",
+                            SPConstants.KW_AES256,
+                            SPConstants.KW_RSA15,
+                            SPConstants.P_SHA1_L256,
+                            SPConstants.P_SHA1_L192,
+                            256, 192, 256, 256, 1024, 4096
+                    )
+            );
+			
+           // Liberty Change End
+        }
+
+        GCMAlgorithmSuite(SPConstants.SPVersion version, Policy nestedPolicy) {
+            super(version, nestedPolicy);
+        }
+
+        @Override
+        protected AbstractSecurityAssertion cloneAssertion(Policy nestedPolicy) {
+            return new GCMAlgorithmSuite(getVersion(), nestedPolicy);
+        }
+
+        @Override
+        protected void parseCustomAssertion(Assertion assertion) {
+            String assertionName = assertion.getName().getLocalPart();
+            String assertionNamespace = assertion.getName().getNamespaceURI();
+            if (!"http://cxf.apache.org/custom/security-policy".equals(assertionNamespace)) {
+                return;
+            }
+
+            if ("Basic128GCM".equals(assertionName)) {
+                setAlgorithmSuiteType(ALGORITHM_SUITE_TYPES.get("Basic128GCM"));
+                getAlgorithmSuiteType().setNamespace(assertionNamespace);
+            } else if ("Basic192GCM".equals(assertionName)) {
+                setAlgorithmSuiteType(ALGORITHM_SUITE_TYPES.get("Basic192GCM"));
+                getAlgorithmSuiteType().setNamespace(assertionNamespace);
+            } else if ("Basic256GCM".equals(assertionName)) {
+                setAlgorithmSuiteType(ALGORITHM_SUITE_TYPES.get("Basic256GCM"));
+                getAlgorithmSuiteType().setNamespace(assertionNamespace);
+            // Liberty Change Start: Backport 4.x
+            } else if ("Basic128GCMSha256ECDHES".equals(assertionName)) {
+                setAlgorithmSuiteType(ALGORITHM_SUITE_TYPES.get("Basic128GCMSha256ECDHES"));
+                getAlgorithmSuiteType().setNamespace(assertionNamespace);
+            } else if ("Basic192GCMSha256ECDHES".equals(assertionName)) {
+                setAlgorithmSuiteType(ALGORITHM_SUITE_TYPES.get("Basic192GCMSha256ECDHES"));
+                getAlgorithmSuiteType().setNamespace(assertionNamespace);
+            } else if ("Basic256GCMSha256ECDHES".equals(assertionName)) {
+                setAlgorithmSuiteType(ALGORITHM_SUITE_TYPES.get("Basic256GCMSha256ECDHES"));
+                getAlgorithmSuiteType().setNamespace(assertionNamespace);
+            }else if ("CustomAlgorithmSuite".equals(assertionName)) {
+                setAlgorithmSuiteType(ALGORITHM_SUITE_TYPES.get("CustomAlgorithmSuite"));
+                getAlgorithmSuiteType().setNamespace(assertionNamespace);
+            }
+        }
+    }
+
+
+    public static AlgorithmSuite.AlgorithmSuiteType customize(AlgorithmSuite.AlgorithmSuiteType suiteType,
+                                                              Message message) {
+
+        Map<String, Object> values = message.getContextualPropertyKeys()
+                .stream()
+                .filter(k -> k.startsWith(SecurityConstants.CUSTOM_ALG_SUITE_PREFIX))
+                .collect(Collectors.toMap(Function.identity(), k -> message.getContextualProperty(k)));
+
+        return customize(suiteType, values);
+
+    }
+
+    public static AlgorithmSuite.AlgorithmSuiteType customize(AlgorithmSuite.AlgorithmSuiteType suiteType,
+                                                              Map<String, Object> values) {
+
+        //customization happens only for CustomAlgorithmSuite
+        if (suiteType == null
+                || (suiteType != null && !"CustomAlgorithmSuite".equals(suiteType.getName()))) {
+            return suiteType;
+        }
+
+        
+        AlgorithmSuite.AlgorithmSuiteType retVal = suiteType;
+
+        //if there is no custom values, return without customization
+        if (values == null || values.isEmpty()) {
+            return retVal;
+        }
+        //apply customization
+        customizeAlgSuiteType(retVal, suiteType, values);
+        
+        return retVal;
+    }
+
+    private static void customizeAlgSuiteType(AlgorithmSuite.AlgorithmSuiteType suiteType,
+                                              AlgorithmSuite.AlgorithmSuiteType defValue,
+                                              Map<String, Object> values) {
+
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_DIGEST_ALGORITHM, values,
+                suiteType::setDigest,
+                defValue != null ? defValue::getDigest : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_ENCRYPTION_ALGORITHM, values,
+                suiteType::setEncryption,
+                defValue != null ? defValue::getEncryption : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_SYMMETRIC_KEY_ENCRYPTION_ALGORITHM, values,
+                suiteType::setSymmetricKeyWrap,
+                defValue != null ? defValue::getSymmetricKeyWrap : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_ASYMMETRIC_KEY_ENCRYPTION_ALGORITHM, values,
+                suiteType::setAsymmetricKeyWrap,
+                defValue != null ? defValue::getAsymmetricKeyWrap : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_ENCRYPTION_KEY_DERIVATION, values,
+                suiteType::setEncryptionKeyDerivation,
+                defValue != null ? defValue::getEncryptionKeyDerivation : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_SIGNATURE_KEY_DERIVATION, values,
+                suiteType::setSignatureKeyDerivation,
+                defValue != null ? defValue::getSignatureKeyDerivation : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_SYMMETRIC_SIGNATURE, values,
+                suiteType::setSymmetricSignature,
+                defValue != null ? defValue::getSymmetricSignature : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_ASYMMETRIC_SIGNATURE, values,
+                suiteType::setAsymmetricSignature,
+                defValue != null ? defValue::getAsymmetricSignature : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_ENCRYPTION_DERIVED_KEY_LENGTH, values,
+                suiteType::getEncryptionDerivedKeyLength,
+                defValue != null ? defValue::getEncryptionDerivedKeyLength : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_SIGNATURE_DERIVED_KEY_LENGTH, values,
+                suiteType::setSignatureDerivedKeyLength,
+                defValue != null ? defValue::getSignatureDerivedKeyLength : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_MINIMUM_SYMMETRIC_KEY_LENGTH, values,
+                suiteType::setMinimumSymmetricKeyLength,
+                defValue != null ? defValue::getMinimumSymmetricKeyLength : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_MAXIMUM_SYMMETRIC_KEY_LENGTH, values,
+                suiteType::setMaximumSymmetricKeyLength,
+                defValue != null ? defValue::getMaximumSymmetricKeyLength : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_MINIMUM_ASYMMETRIC_KEY_LENGTH, values,
+                suiteType::setMinimumAsymmetricKeyLength,
+                defValue != null ? defValue::getMinimumAsymmetricKeyLength : null);
+        setValue(SecurityConstants.CUSTOM_ALG_SUITE_MAXIMUM_ASYMMETRIC_KEY_LENGTH, values,
+                suiteType::setMaximumAsymmetricKeyLength,
+                defValue != null ? defValue::getMaximumAsymmetricKeyLength : null);
+    }
+
+    private static <T> void setValue(String key, Map<String, Object> values,
+                                     Consumer<T> customValueSetter,
+                                     Supplier<T> defaultValueGetter) {
+
+        //get custom value
+        T value = (T)values.get(key);
+        //use default value if null
+        if (value == null && defaultValueGetter != null) {
+            value = defaultValueGetter.get();
+        }
+        //set value
+        if (value != null) {
+            customValueSetter.accept(value);
+        }
+    }
+	// Liberty Change End
+}

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/policyhandlers/AsymmetricBindingHandler.java
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/policyhandlers/AsymmetricBindingHandler.java
@@ -239,8 +239,8 @@ public class AsymmetricBindingHandler extends AbstractBindingBuilder {
             }
 
             if (encToken != null) {
-                WSSecBase encr = null;
                 if (encToken.getToken() != null && !enc.isEmpty()) {
+                    final WSSecBase encr; // Liberty Change: Backport 4.x
                     if (encToken.getToken().getDerivedKeys() == DerivedKeys.RequireDerivedKeys) {
                         encr = doEncryptionDerived(encToken, enc);
                     } else {
@@ -783,7 +783,7 @@ public class AsymmetricBindingHandler extends AbstractBindingBuilder {
             }
 
             List<Reference> referenceList = sig.addReferencesToSign(sigParts);
-            if (!referenceList.isEmpty()) {
+            if (!referenceList.isEmpty()) { 
                 //Do signature
                 if (bottomUpElement == null) {
                     sig.computeSignature(referenceList, false, null);

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/policyhandlers/TransportBindingHandler.java
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/policyhandlers/TransportBindingHandler.java
@@ -29,11 +29,11 @@ import java.util.logging.Level;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.xml.crypto.dsig.Reference;
-import javax.xml.soap.SOAPException;
-import javax.xml.soap.SOAPMessage;
 
 import org.w3c.dom.Element;
 
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPMessage;
 import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.DOMUtils;
@@ -86,6 +86,7 @@ import org.apache.wss4j.policy.model.TransportBinding;
 import org.apache.wss4j.policy.model.TransportToken;
 import org.apache.wss4j.policy.model.UsernameToken;
 import org.apache.wss4j.policy.model.X509Token;
+
 
 /**
  *
@@ -341,7 +342,9 @@ public class TransportBindingHandler extends AbstractBindingBuilder {
         } else if (token instanceof UsernameToken) {
             // Create a UsernameToken object for derived keys and store the security token
             byte[] salt = UsernameTokenUtil.generateSalt(true);
-            WSSecUsernameToken usernameToken = addDKUsernameToken((UsernameToken)token, salt, true);
+            // Liberty Change Start: keep 3.5.5 method signature
+            WSSecUsernameToken usernameToken = addDKUsernameToken((UsernameToken) token, salt, true);
+            // Liberty Change End
             String id = usernameToken.getId();
             byte[] secret = usernameToken.getDerivedKey(salt);
             Arrays.fill(salt, (byte)0);

--- a/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/src/org/apache/xml/security/utils/KeyUtils.java
+++ b/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/src/org/apache/xml/security/utils/KeyUtils.java
@@ -1,0 +1,313 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.xml.security.utils;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Arrays;
+
+import javax.crypto.KeyAgreement;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.xml.security.algorithms.implementations.ECDSAUtils;
+import org.apache.xml.security.encryption.XMLEncryptionException;
+import org.apache.xml.security.encryption.keys.content.derivedKey.ConcatKDF;
+import org.apache.xml.security.encryption.keys.content.derivedKey.HKDF;
+import org.apache.xml.security.encryption.params.ConcatKDFParams;
+import org.apache.xml.security.encryption.params.HKDFParams;
+import org.apache.xml.security.encryption.params.KeyAgreementParameters;
+import org.apache.xml.security.encryption.params.KeyDerivationParameters;
+import org.apache.xml.security.exceptions.DERDecodingException;
+import org.apache.xml.security.exceptions.XMLSecurityException;
+
+/**
+ * A set of utility methods to handle keys.
+ */
+public class KeyUtils {
+
+    /**
+     * Enumeration of Supported key algorithm types.
+     */
+    public enum KeyAlgorithmType {
+        EC("EC", "1.2.840.10045.2.1"),
+        DSA("DSA", "1.2.840.10040.4.1"),
+        RSA("RSA", "1.2.840.113549.1.1.1"),
+        RSASSA_PSS("RSASSA-PSS", "1.2.840.113549.1.1.10"),
+        DH("DiffieHellman", "1.2.840.113549.1.3.1"),
+        XDH("XDH", null),
+        EdDSA("EdDSA", null);
+
+        private final String jceName;
+        private final String oid;
+
+        KeyAlgorithmType(String jceName, String oid) {
+            this.jceName = jceName;
+            this.oid = oid;
+        }
+
+        public String getJceName() {
+            return jceName;
+        }
+
+        public String getOid() {
+            return oid;
+        }
+
+    }
+
+    /**
+     * Enumeration of specific key types.
+     */
+    public enum KeyType {
+        DSA("DSA", "RFC 8017", KeyAlgorithmType.DSA, "1.2.840.10040.4.1"),
+        RSA("RSA", "RFC 8017", KeyAlgorithmType.RSA, "1.2.840.113549.1.1.1"),
+        RSASSA_PSS("RSASSA-PSS", "RFC 3447", KeyAlgorithmType.RSASSA_PSS, "1.2.840.113549.1.1.10"),
+        SECT163K1("sect163k1", "NIST K-163", KeyAlgorithmType.EC, "1.3.132.0.1"),
+        SECT163R1("sect163r1", "", KeyAlgorithmType.EC, "1.3.132.0.2"),
+        SECT163R2("sect163r2", "NIST B-163", KeyAlgorithmType.EC, "1.3.132.0.15"),
+        SECT193R1("sect193r1", "", KeyAlgorithmType.EC, "1.3.132.0.24"),
+        SECT193R2("sect193r2", "", KeyAlgorithmType.EC, "1.3.132.0.25"),
+        SECT233K1("sect233k1", "NIST K-233", KeyAlgorithmType.EC, "1.3.132.0.26"),
+        SECT233R1("sect233r1", "NIST B-233", KeyAlgorithmType.EC, "1.3.132.0.27"),
+        SECT239K1("sect239k1", "", KeyAlgorithmType.EC, "1.3.132.0.3"),
+        SECT283K1("sect283k1", "NIST K-283", KeyAlgorithmType.EC, "1.3.132.0.16"),
+        SECT283R1("sect283r1", "", KeyAlgorithmType.EC, "1.3.132.0.17"),
+        SECT409K1("sect409k1", "NIST K-409", KeyAlgorithmType.EC, "1.3.132.0.36"),
+        SECT409R1("sect409r1", "NIST B-409", KeyAlgorithmType.EC, "1.3.132.0.37"),
+        SECT571K1("sect571k1", "NIST K-571", KeyAlgorithmType.EC, "1.3.132.0.38"),
+        SECT571R1("sect571r1", "NIST B-571", KeyAlgorithmType.EC, "1.3.132.0.39"),
+        SECP160K1("secp160k1", "", KeyAlgorithmType.EC, "1.3.132.0.9"),
+        SECP160R1("secp160r1", "", KeyAlgorithmType.EC, "1.3.132.0.8"),
+        SECP160R2("secp160r2", "", KeyAlgorithmType.EC, "1.3.132.0.30"),
+        SECP192K1("secp192k1", "", KeyAlgorithmType.EC, "1.3.132.0.31"),
+        SECP192R1("secp192r1", "NIST P-192,X9.62 prime192v1", KeyAlgorithmType.EC, "1.2.840.10045.3.1.1"),
+        SECP224K1("secp224k1", "", KeyAlgorithmType.EC, "1.3.132.0.32"),
+        SECP224R1("secp224r1", "NIST P-224", KeyAlgorithmType.EC, "1.3.132.0.33"),
+        SECP256K1("secp256k1", "", KeyAlgorithmType.EC, "1.3.132.0.10"),
+        SECP256R1("secp256r1", "NIST P-256,X9.62 prime256v1", KeyAlgorithmType.EC, "1.2.840.10045.3.1.7"),
+        SECP384R1("secp384r1", "NIST P-384", KeyAlgorithmType.EC, "1.3.132.0.34"),
+        SECP521R1("secp521r1", "NIST P-521", KeyAlgorithmType.EC, "1.3.132.0.35"),
+        BRAINPOOLP256R1("brainpoolP256r1", "RFC 5639", KeyAlgorithmType.EC, "1.3.36.3.3.2.8.1.1.7"),
+        BRAINPOOLP384R1("brainpoolP384r1", "RFC 5639", KeyAlgorithmType.EC, "1.3.36.3.3.2.8.1.1.11"),
+        BRAINPOOLP512R1("brainpoolP512r1", "RFC 5639", KeyAlgorithmType.EC, "1.3.36.3.3.2.8.1.1.13"),
+        X25519("x25519", "RFC 7748", KeyAlgorithmType.XDH, "1.3.101.110"),
+        X448("x448", "RFC 7748", KeyAlgorithmType.XDH, "1.3.101.111"),
+        ED25519("ed25519", "RFC 8032", KeyAlgorithmType.EdDSA, "1.3.101.112"),
+        ED448("ed448", "RFC 8032", KeyAlgorithmType.EdDSA, "1.3.101.113");
+
+        private final String name;
+        private final String origin;
+        private final KeyAlgorithmType algorithm;
+        private final String oid;
+
+        KeyType(String name, String origin, KeyAlgorithmType algorithm, String oid) {
+            this.name = name;
+            this.origin = origin;
+            this.algorithm = algorithm;
+            this.oid = oid;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public KeyAlgorithmType getAlgorithm() {
+            return algorithm;
+        }
+
+        public String getOid() {
+            return oid;
+        }
+
+        public String getOrigin() {
+            return origin;
+        }
+
+        public static KeyType getByOid(String oid) {
+            return Arrays.stream(KeyType.values()).filter(keyType -> keyType.getOid().equals(oid)).findFirst().orElse(null);
+        }
+    }
+
+    /**
+     * Method generates DH keypair which match the type of given public key type.
+     *
+     * @param recipientPublicKey public key of recipient
+     * @param provider provider to use for key generation
+     * @return generated keypair
+     * @throws XMLEncryptionException if the keys cannot be generated
+     */
+    public static KeyPair generateEphemeralDHKeyPair(PublicKey recipientPublicKey, Provider provider) throws XMLEncryptionException {
+        String algorithm = recipientPublicKey.getAlgorithm();
+        KeyPairGenerator keyPairGenerator;
+        try {
+
+            if (recipientPublicKey instanceof ECPublicKey) {
+                keyPairGenerator = createKeyPairGenerator(algorithm, provider);
+                ECPublicKey exchangePublicKey = (ECPublicKey) recipientPublicKey;
+                String keyOId = ECDSAUtils.getOIDFromPublicKey(exchangePublicKey);
+                if (keyOId == null) {
+                    keyOId = DERDecoderUtils.getAlgorithmIdFromPublicKey(recipientPublicKey);
+                }
+                ECGenParameterSpec kpgparams = new ECGenParameterSpec(keyOId);
+                keyPairGenerator.initialize(kpgparams);
+            } else {
+                String keyOId = DERDecoderUtils.getAlgorithmIdFromPublicKey(recipientPublicKey);
+                KeyType keyType = KeyType.getByOid(keyOId);
+                keyPairGenerator = createKeyPairGenerator(keyType == null ? keyOId : keyType.getName(), provider);
+            }
+            return keyPairGenerator.generateKeyPair();
+        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException | DERDecodingException e) {
+            throw new XMLEncryptionException(e);
+        }
+    }
+
+    /**
+     * Create a KeyPairGenerator for the given algorithm and provider.
+     *
+     * @param algorithm the key JCE algorithm name
+     * @param provider the provider to use or null if default JCE provider should be used
+     * @return the KeyPairGenerator
+     * @throws NoSuchAlgorithmException if the algorithm is not supported
+     */
+    public static KeyPairGenerator createKeyPairGenerator(String algorithm, Provider provider) throws NoSuchAlgorithmException {
+        return provider == null ? KeyPairGenerator.getInstance(algorithm) : KeyPairGenerator.getInstance(algorithm, provider);
+    }
+
+    /**
+     * Method generates a secret key for given KeyAgreementParameterSpec.
+     *
+     * @param parameterSpec KeyAgreementParameterSpec which defines algorithm to derive key
+     * @return generated secret key
+     * @throws XMLEncryptionException if the secret key cannot be generated as: Key agreement is not supported,
+     *             wrong key types, etc.
+     */
+    public static SecretKey aesWrapKeyWithDHGeneratedKey(KeyAgreementParameters parameterSpec) throws XMLEncryptionException {
+        try {
+            PublicKey publicKey = parameterSpec.getAgreementPublicKey();
+            PrivateKey privateKey = parameterSpec.getAgreementPrivateKey();
+
+            String keyAlgorithm = publicKey.getAlgorithm();
+            String keyAgreementAlgorithm = keyAlgorithm + ("EC".equalsIgnoreCase(keyAlgorithm) ? "DH" : "");
+            KeyAgreement keyAgreement = KeyAgreement.getInstance(keyAgreementAlgorithm);
+            keyAgreement.init(privateKey);
+            keyAgreement.doPhase(publicKey, true);
+            byte[] secret = keyAgreement.generateSecret();
+            byte[] kek = deriveKeyEncryptionKey(secret, parameterSpec.getKeyDerivationParameter());
+            return new SecretKeySpec(kek, "AES");
+        } catch (XMLSecurityException | NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new XMLEncryptionException(e);
+        }
+    }
+
+    /**
+     * Defines the key size for the encrypting algorithm.
+     *
+     * @param keyWrapAlg the key wrap algorithm URI
+     * @return the key size in bits
+     * @throws XMLEncryptionException if the key wrap algorithm is not supported
+     */
+    public static int getAESKeyBitSizeForWrapAlgorithm(String keyWrapAlg) throws XMLEncryptionException {
+        switch (keyWrapAlg) {
+            case EncryptionConstants.ALGO_ID_KEYWRAP_AES128:
+                return 128;
+            case EncryptionConstants.ALGO_ID_KEYWRAP_AES192:
+                return 192;
+            case EncryptionConstants.ALGO_ID_KEYWRAP_AES256:
+                return 256;
+            default:
+                throw new XMLEncryptionException("Unsupported KeyWrap Algorithm");
+        }
+    }
+
+    /**
+     * Derive a key encryption key from a shared secret and keyDerivationParameter.
+     * Currently only the ConcatKDF and HMAC-base Extract-and-Expand Key Derivation
+     * Function (HKDF) are supported.
+     *
+     * @param sharedSecret the shared secret
+     * @param keyDerivationParameter the key derivation parameters
+     * @return the derived key encryption key
+     * @throws IllegalArgumentException if the keyDerivationParameter is null
+     * @throws XMLSecurityException if the key derivation algorithm is not supported
+     */
+    public static byte[] deriveKeyEncryptionKey(byte[] sharedSecret, KeyDerivationParameters keyDerivationParameter) throws XMLSecurityException {
+
+        if (keyDerivationParameter == null) {
+            throw new IllegalArgumentException(I18n.translate("KeyDerivation.MissingParameters"));
+        }
+
+        String keyDerivationAlgorithm = keyDerivationParameter.getAlgorithm();
+        if (keyDerivationParameter instanceof HKDFParams) {
+            return deriveKeyWithHKDF(sharedSecret, (HKDFParams) keyDerivationParameter);
+        } else if (keyDerivationParameter instanceof ConcatKDFParams) {
+            return deriveKeyWithConcatKDF(sharedSecret, (ConcatKDFParams) keyDerivationParameter);
+        }
+
+        throw new XMLEncryptionException("KeyDerivation.UnsupportedAlgorithm", keyDerivationAlgorithm, keyDerivationParameter.getClass().getName());
+    }
+
+    /**
+     * Derive a key using the HMAC-based Extract-and-Expand Key Derivation
+     * Function (HKDF) with implementation instance {@link HKDFParams}.
+     *
+     * @param sharedSecret the shared secret
+     * @param hkdfParameter the HKDF parameters
+     * @return the derived key encryption key.
+     * @throws XMLSecurityException if the key derivation parameters are invalid or
+     *             the hmac algorithm is not supported.
+     */
+    public static byte[] deriveKeyWithHKDF(byte[] sharedSecret, HKDFParams hkdfParameter) throws XMLSecurityException {
+
+        if (!EncryptionConstants.ALGO_ID_KEYDERIVATION_HKDF.equals(hkdfParameter.getAlgorithm())) {
+            throw new XMLEncryptionException("KeyDerivation.UnsupportedAlgorithm", hkdfParameter.getAlgorithm(), HKDFParams.class.getName());
+        }
+
+        HKDF kdf = new HKDF();
+        return kdf.deriveKey(sharedSecret, hkdfParameter);
+    }
+
+    /**
+     * Derive a key using the Concatenation Key Derivation Function (ConcatKDF)
+     * with implementation instance {@link ConcatKDFParams}.
+     *
+     * @param sharedSecret the shared secret/ input keying material
+     * @param ckdfParameter the ConcatKDF parameters
+     * @return the derived key
+     * @throws XMLSecurityException if the key derivation parameters are invalid or
+     *             the hash algorithm is not supported.
+     */
+    public static byte[] deriveKeyWithConcatKDF(byte[] sharedSecret, ConcatKDFParams ckdfParameter) throws XMLSecurityException {
+
+        if (!EncryptionConstants.ALGO_ID_KEYDERIVATION_CONCATKDF.equals(ckdfParameter.getAlgorithm())) {
+            throw new XMLEncryptionException("KeyDerivation.UnsupportedAlgorithm", ckdfParameter.getAlgorithm(), HKDFParams.class.getName());
+        }
+
+        ConcatKDF concatKDF = new ConcatKDF();
+        return concatKDF.deriveKey(sharedSecret, ckdfParameter);
+    }
+}

--- a/dev/com.ibm.ws.org.apache.wss4j.policy/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.wss4j.policy/bnd.bnd
@@ -20,7 +20,6 @@ wss4jVersion=2.4.4.1
  @\${repo;io.openliberty.org.apache.wss4j:wss4j-policy;${wss4jVersion}}!/schemas/**,\
  @\${repo;io.openliberty.org.apache.wss4j:wss4j-policy;${wss4jVersion}}!/*xml, \
  
-
 -buildpath: \
  io.openliberty.org.apache.wss4j:wss4j-policy;version=${wss4jVersion}, \
  com.ibm.ws.org.apache.neethi.3.1.1;version=latest

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/bnd.bnd
@@ -31,4 +31,3 @@ instrument.classesExcludes:\
    com.ibm.websphere.appserver.spi.logging;version=latest, \
    com.ibm.ws.org.ehcache.ehcache.107.3.8.1;version=latest, \
    com.ibm.ws.kernel.service;version=latest
-   com.ibm.ws.org.joda.time.2.9.9;version=latest

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/crypto/AlgorithmSuiteValidator.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/crypto/AlgorithmSuiteValidator.java
@@ -1,0 +1,387 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wss4j.common.crypto;
+
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.*;
+import java.util.Set;
+
+import javax.xml.crypto.dsig.Reference;
+import javax.xml.crypto.dsig.Transform;
+import javax.xml.crypto.dsig.XMLSignature;
+
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.xml.security.exceptions.DERDecodingException;
+import org.apache.xml.security.utils.DERDecoderUtils;
+import org.apache.xml.security.utils.KeyUtils;
+
+/**
+ * Validate signature/encryption/etc. algorithms against an AlgorithmSuite policy.
+ */
+public class AlgorithmSuiteValidator {
+
+    private static final org.slf4j.Logger LOG =
+        org.slf4j.LoggerFactory.getLogger(AlgorithmSuiteValidator.class);
+
+    private final AlgorithmSuite algorithmSuite;
+
+    public AlgorithmSuiteValidator(
+        AlgorithmSuite algorithmSuite
+    ) {
+        this.algorithmSuite = algorithmSuite;
+    }
+
+    /**
+     * Check the Signature Method
+     */
+    public void checkSignatureMethod(
+        String signatureMethod
+    ) throws WSSecurityException {
+        Set<String> allowedSignatureMethods = algorithmSuite.getSignatureMethods();
+        if (!allowedSignatureMethods.isEmpty()
+            && !allowedSignatureMethods.contains(signatureMethod)) {
+            LOG.warn(
+                "SignatureMethod " + signatureMethod + " does not match required values"
+            );
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+    }
+
+    /**
+     * Check the C14n Algorithm
+     */
+    public void checkC14nAlgorithm(
+        String c14nAlgorithm
+    ) throws WSSecurityException {
+        Set<String> allowedC14nAlgorithms = algorithmSuite.getC14nAlgorithms();
+        if (!allowedC14nAlgorithms.isEmpty() && !allowedC14nAlgorithms.contains(c14nAlgorithm)) {
+            LOG.warn(
+                "C14nMethod " + c14nAlgorithm + " does not match required value"
+            );
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+    }
+
+    /**
+     * Check the Signature Algorithms
+     */
+    public void checkSignatureAlgorithms(
+        XMLSignature xmlSignature
+    ) throws WSSecurityException {
+        // Signature Algorithm
+        String signatureMethod =
+            xmlSignature.getSignedInfo().getSignatureMethod().getAlgorithm();
+        checkSignatureMethod(signatureMethod);
+
+        // C14n Algorithm
+        String c14nMethod =
+            xmlSignature.getSignedInfo().getCanonicalizationMethod().getAlgorithm();
+        checkC14nAlgorithm(c14nMethod);
+
+        for (Object refObject : xmlSignature.getSignedInfo().getReferences()) {
+            Reference reference = (Reference)refObject;
+            // Digest Algorithm
+            String digestMethod = reference.getDigestMethod().getAlgorithm();
+            Set<String> allowedDigestAlgorithms = algorithmSuite.getDigestAlgorithms();
+            if (!allowedDigestAlgorithms.isEmpty()
+                    && !allowedDigestAlgorithms.contains(digestMethod)) {
+                LOG.warn(
+                    "DigestMethod " + digestMethod + " does not match required value"
+                );
+                throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+            }
+
+            // Transform Algorithms
+            for (int i = 0; i < reference.getTransforms().size(); i++) {
+                Transform transform = (Transform)reference.getTransforms().get(i);
+                String algorithm = transform.getAlgorithm();
+                Set<String> allowedTransformAlgorithms =
+                        algorithmSuite.getTransformAlgorithms();
+                if (!allowedTransformAlgorithms.isEmpty()
+                        && !allowedTransformAlgorithms.contains(algorithm)) {
+                    LOG.warn(
+                        "Transform method " + algorithm + " does not match required value"
+                    );
+                    throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+                }
+            }
+        }
+    }
+
+    public void checkEncryptionKeyWrapAlgorithm(
+        String keyWrapAlgorithm
+    ) throws WSSecurityException {
+        Set<String> keyWrapAlgorithms = algorithmSuite.getKeyWrapAlgorithms();
+        if (!keyWrapAlgorithms.isEmpty()
+            && !keyWrapAlgorithms.contains(keyWrapAlgorithm)) {
+            LOG.warn(
+                "The Key transport method does not match the requirement"
+            );
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+    }
+    // Liberty Change Start: Backport 4.x
+    public void checkKeyAgreementMethodAlgorithm(
+            String keyAgreementMethodAlgorithm
+    ) throws WSSecurityException {
+        Set<String> keyAgreementMethodAlgorithms = algorithmSuite.getKeyAgreementMethodAlgorithms();
+        if (!keyAgreementMethodAlgorithms.isEmpty()
+                && !keyAgreementMethodAlgorithms.contains(keyAgreementMethodAlgorithm)) {
+            LOG.warn(
+                    "The Key agreement method does not match the requirement"
+            );
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+    }
+
+    /**
+     * Method to check the Key Derivation algorithm is on the approved list  of the
+     * AlgorithmSuite configuration.
+     * @param keyDerivationFunction the key derivation function to be validated
+     * @throws WSSecurityException if the approved list is not empty and the key
+     * derivation function is not on the list
+     */
+    public void checkKeyDerivationFunction(
+            String keyDerivationFunction
+    ) throws WSSecurityException {
+        Set<String> keyDerivationFunctions = algorithmSuite.getDerivedKeyAlgorithms();
+        
+        for (String function : keyDerivationFunctions) {
+            // Process each string element in the set
+        }
+        if (!keyDerivationFunctions.isEmpty()
+                && !keyDerivationFunctions.contains(keyDerivationFunction)) {
+            LOG.warn(
+                    "The Key derivation function does not match the requirement"
+            );
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+    }
+    // Liberty Change End
+
+    public void checkSymmetricEncryptionAlgorithm(
+        String symmetricAlgorithm
+    ) throws WSSecurityException {
+        Set<String> encryptionMethods = algorithmSuite.getEncryptionMethods();
+        if (!encryptionMethods.isEmpty()
+            && !encryptionMethods.contains(symmetricAlgorithm)) {
+            LOG.warn(
+                "The encryption algorithm does not match the requirement"
+            );
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+    }
+
+    /**
+     * Check the asymmetric key length
+     */
+    public void checkAsymmetricKeyLength(
+        X509Certificate[] x509Certificates
+    ) throws WSSecurityException {
+        if (x509Certificates == null) {
+            return;
+        }
+
+        for (X509Certificate cert : x509Certificates) {
+            checkAsymmetricKeyLength(cert.getPublicKey());
+        }
+    }
+
+    /**
+     * Check the asymmetric key length
+     */
+    public void checkAsymmetricKeyLength(
+        X509Certificate x509Certificate
+    ) throws WSSecurityException {
+        if (x509Certificate == null) {
+            return;
+        }
+
+        checkAsymmetricKeyLength(x509Certificate.getPublicKey());
+    }
+
+    /**
+     * Check the asymmetric key length
+     */
+    public void checkAsymmetricKeyLength(
+        PublicKey publicKey
+    ) throws WSSecurityException {
+        if (publicKey == null) {
+            return;
+        }
+        if (publicKey instanceof RSAPublicKey) {
+            int modulus = ((RSAPublicKey)publicKey).getModulus().bitLength();
+            if (modulus < algorithmSuite.getMinimumAsymmetricKeyLength()
+                || modulus > algorithmSuite.getMaximumAsymmetricKeyLength()) {
+                LOG.warn(
+                    "The asymmetric key length does not match the requirement"
+                );
+                throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+            }
+        } else if (publicKey instanceof DSAPublicKey) {
+            int length = ((DSAPublicKey)publicKey).getParams().getP().bitLength();
+            if (length < algorithmSuite.getMinimumAsymmetricKeyLength()
+                || length > algorithmSuite.getMaximumAsymmetricKeyLength()) {
+                LOG.warn(
+                    "The asymmetric key length does not match the requirement"
+                );
+                throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+            }
+        } else if (publicKey instanceof ECPublicKey) {
+            final ECPublicKey ecpriv = (ECPublicKey) publicKey;
+            final java.security.spec.ECParameterSpec spec = ecpriv.getParams();
+            int length = spec.getOrder().bitLength();
+            if (length < algorithmSuite.getMinimumEllipticCurveKeyLength()
+                    || length > algorithmSuite.getMaximumEllipticCurveKeyLength()) {
+                LOG.warn("The elliptic curve key length does not match the requirement");
+                throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+            }
+        } else {
+            // Liberty Change Start: Backport 4.x
+            // Try with last supported key types EdEC and XDH
+            int keySize = getEdECndXDHKeyLength(publicKey);
+            if (keySize < algorithmSuite.getMinimumEllipticCurveKeyLength()
+                    || keySize > algorithmSuite.getMaximumEllipticCurveKeyLength()) {
+                LOG.warn(
+                        "The asymmetric key length does not match the requirement"
+                );
+                throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+            }
+        }
+    }
+
+    /**
+     * A generic method to determinate key length for keys x25519, x448, ed25519 and ed448 keys. Method does not rely on
+     * any specific implementation of the key, but uses OID to determine the key type.
+     *
+     * @param publicKey the public key to check the key length
+     * @return the key length in bits
+     * @throws WSSecurityException if the key is not  EdEC or XDH or if length can not be determined
+     */
+    private int getEdECndXDHKeyLength(PublicKey publicKey) throws  WSSecurityException {
+        String keyAlgorithmOId;
+        try {
+            keyAlgorithmOId = DERDecoderUtils.getAlgorithmIdFromPublicKey(publicKey);
+        } catch (DERDecodingException e) {
+            LOG.warn("Can not parse the public key to determine key size!", e);
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+        KeyUtils.KeyType keyType = KeyUtils.KeyType.getByOid(keyAlgorithmOId);
+        if (keyType == null) {
+            LOG.warn("An unknown public key was provided");
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+
+        int edECndXDHKeyLength = 0;
+
+        switch (keyType) {
+        case ED25519:
+            edECndXDHKeyLength = 256;
+            break;
+        case X25519:
+            edECndXDHKeyLength = 256;
+            break;
+        case ED448:
+            edECndXDHKeyLength = 456;
+            break;
+        case X448:
+            edECndXDHKeyLength = 456;
+            break;
+        default:
+            LOG.warn("An unknown public key was provided");
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+
+        return edECndXDHKeyLength;
+        // return switch (keyType) {
+        //     case ED25519, X25519 -> 256;
+        //     case ED448, X448 -> 456;
+        //     default -> {
+        //         LOG.warn(
+        //                 "An unknown public key was provided"
+        //         );
+        //         throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        //     }
+        // };
+    }
+    // Liberty Change End
+    /**
+     * Check the symmetric key length
+     */
+    public void checkSymmetricKeyLength(
+        int secretKeyLength
+    ) throws WSSecurityException {
+        if (secretKeyLength < (algorithmSuite.getMinimumSymmetricKeyLength() / 8)
+            || secretKeyLength > (algorithmSuite.getMaximumSymmetricKeyLength() / 8)) {
+            LOG.warn(
+                "The symmetric key length does not match the requirement"
+            );
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+    }
+
+    /**
+     * Check Signature Derived Key length (in bytes)
+     */
+    public void checkSignatureDerivedKeyLength(
+        int derivedKeyLength
+    ) throws WSSecurityException {
+        int requiredKeyLength = algorithmSuite.getSignatureDerivedKeyLength();
+        if (requiredKeyLength > 0 && (derivedKeyLength / 8) != requiredKeyLength) {
+            LOG.warn(
+                "The signature derived key length of " + derivedKeyLength + " does not match"
+                + " the requirement of " + requiredKeyLength
+            );
+        }
+    }
+
+    /**
+     * Check Encryption Derived Key length (in bytes)
+     */
+    public void checkEncryptionDerivedKeyLength(
+        int derivedKeyLength
+    ) throws WSSecurityException {
+        int requiredKeyLength = algorithmSuite.getEncryptionDerivedKeyLength();
+        if (requiredKeyLength > 0 && (derivedKeyLength / 8) != requiredKeyLength) {
+            LOG.warn(
+                "The encryption derived key length of " + derivedKeyLength + " does not match"
+                + " the requirement of " + requiredKeyLength
+            );
+        }
+    }
+
+    /**
+     * Check Derived Key algorithm
+     */
+    public void checkDerivedKeyAlgorithm(
+        String algorithm
+    ) throws WSSecurityException {
+        Set<String> derivedKeyAlgorithms = algorithmSuite.getDerivedKeyAlgorithms();
+        if (!derivedKeyAlgorithms.isEmpty()
+            && !derivedKeyAlgorithms.contains(algorithm)) {
+            LOG.warn(
+                "The Derived Key Algorithm does not match the requirement"
+            );
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/src/org/apache/wss4j/dom/message/WSSecEncryptedKey.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/src/org/apache/wss4j/dom/message/WSSecEncryptedKey.java
@@ -1,0 +1,1013 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wss4j.dom.message;
+
+import org.apache.wss4j.common.WSS4JConstants;
+import org.apache.wss4j.common.crypto.Crypto;
+import org.apache.wss4j.common.crypto.CryptoType;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.common.token.*;
+import org.apache.wss4j.common.util.AttachmentUtils;
+import org.apache.wss4j.common.util.KeyUtils;
+import org.apache.wss4j.dom.WSConstants;
+import org.apache.wss4j.dom.util.WSSecurityUtil;
+import org.apache.xml.security.encryption.XMLCipherUtil;
+import org.apache.xml.security.encryption.XMLEncryptionException;
+import org.apache.xml.security.encryption.keys.content.AgreementMethodImpl;
+import org.apache.xml.security.encryption.params.ConcatKDFParams;
+import org.apache.xml.security.encryption.params.HKDFParams;
+import org.apache.xml.security.encryption.params.KeyAgreementParameters;
+import org.apache.xml.security.encryption.params.KeyDerivationParameters;
+import org.apache.xml.security.exceptions.XMLSecurityException;
+import org.apache.xml.security.stax.ext.XMLSecurityConstants;
+import org.apache.xml.security.stax.impl.util.IDGenerator;
+import org.apache.xml.security.utils.Constants;
+import org.apache.xml.security.utils.XMLUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Text;
+
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.xml.crypto.MarshalException;
+import javax.xml.crypto.dom.DOMStructure;
+import javax.xml.crypto.dsig.XMLSignatureFactory;
+import javax.xml.crypto.dsig.keyinfo.KeyInfo;
+import javax.xml.crypto.dsig.keyinfo.KeyInfoFactory;
+import javax.xml.crypto.dsig.keyinfo.KeyValue;
+import java.security.*;
+import java.security.cert.X509Certificate;
+
+/**
+ * Builder class to build an EncryptedKey.
+ *
+ * This is especially useful in the case where the same
+ * <code>EncryptedKey</code> has to be used to sign and encrypt the message In
+ * such a situation this builder will add the <code>EncryptedKey</code> to the
+ * security header and we can use the information form the builder to provide to
+ * other builders to reference to the token
+ */
+public class WSSecEncryptedKey extends WSSecBase {
+
+    private static final org.slf4j.Logger LOG =
+        org.slf4j.LoggerFactory.getLogger(WSSecEncryptedKey.class);
+
+    /**
+     * Algorithm used to encrypt the ephemeral key
+     */
+    private String keyEncAlgo = WSConstants.KEYTRANSPORT_RSAOAEP;
+    // Liberty Change Start: Backport 4.x
+    /**
+     * Key agreement method algorithm used to encrypt the transport key.
+     * Example for ECDH-ES: http://www.w3.org/2009/xmlenc11#ECDH-ES
+     * and xec example: X25519: http://www.w3.org/2021/04/xmldsig-more#x25519,
+     *  x448: http://www.w3.org/2021/04/xmldsig-more#x448
+     */
+    private String keyAgreementMethod;
+
+    /**
+     * Method to derive the key to be used to encrypt the data with the Key keyAgreementMethod
+     *
+     */
+    private String keyDerivationMethod = WSS4JConstants.KEYDERIVATION_HKDF;
+
+
+    /**
+     * The Key Derivation Parameters for the with the Key keyAgreementMethod
+     */
+    private KeyDerivationParameters keyDerivationParameters;
+    // Liberty Change End
+    /**
+     * Digest Algorithm to be used with RSA-OAEP. The default is SHA-1 (which is not
+     * written out unless it is explicitly configured).
+     */
+    private String digestAlgo;
+
+    /**
+     * MGF Algorithm to be used with RSA-OAEP. The default is MGF-SHA-1 (which is not
+     * written out unless it is explicitly configured).
+     */
+    private String mgfAlgo;
+
+    /**
+     * xenc:EncryptedKey element
+     */
+    private Element encryptedKeyElement;
+
+    /**
+     * The Token identifier of the token that the <code>DerivedKeyToken</code>
+     * is (or to be) derived from.
+     */
+    private String encKeyId;
+
+    /**
+     * BinarySecurityToken to be included in the case where BST_DIRECT_REFERENCE
+     * is used to refer to the asymmetric encryption cert
+     */
+    private BinarySecurity bstToken;
+
+    private X509Certificate useThisCert;
+
+    private PublicKey useThisPublicKey;
+
+    /**
+     * Custom token value
+     */
+    private String customEKTokenValueType;
+
+    /**
+     * Custom token id
+     */
+    private String customEKTokenId;
+
+    private boolean bstAddedToSecurityHeader;
+    private boolean includeEncryptionToken;
+    private Element customEKKeyInfoElement;
+    private Provider provider;
+
+    private String encryptedKeySHA1;
+
+    public WSSecEncryptedKey(WSSecHeader securityHeader) {
+        super(securityHeader);
+    }
+
+    public WSSecEncryptedKey(Document doc) {
+        this(doc, null);
+    }
+
+    public WSSecEncryptedKey(Document doc, Provider provider) {
+        super(doc);
+        this.provider = provider;
+    }
+
+    /**
+     * Set the user name to get the encryption certificate.
+     *
+     * The public key of this certificate is used, thus no password necessary.
+     * The user name is a keystore alias usually.
+     *
+     * @param user
+     */
+    public void setUserInfo(String user) {
+        this.user = user;
+    }
+
+    /**
+     * Get the id generated during <code>prepare()</code>.
+     *
+     * Returns the the value of wsu:Id attribute of the EncryptedKey element.
+     *
+     * @return Return the wsu:Id of this token or null if <code>prepare()</code>
+     *         was not called before.
+     */
+    public String getId() {
+        return encKeyId;
+    }
+
+    /**
+     * Create the EncryptedKey Element for inclusion in the security header, by encrypting the
+     * symmetricKey parameter using either a public key or certificate that is set on the class,
+     * and adding the encrypted bytes as the CipherValue of the EncryptedKey element. The KeyInfo
+     * is constructed according to the keyIdentifierType and also the type of the encrypting
+     * key
+     *
+     * @param crypto An instance of the Crypto API to handle keystore and certificates
+     * @param symmetricKey The symmetric key to encrypt and insert into the EncryptedKey
+     * @throws WSSecurityException
+     */
+    public void prepare(Crypto crypto, SecretKey symmetricKey) throws WSSecurityException {
+
+        if (useThisPublicKey != null) {
+            createEncryptedKeyElement(useThisPublicKey);
+            byte[] encryptedEphemeralKey = encryptSymmetricKey(useThisPublicKey, symmetricKey);
+            addCipherValueElement(encryptedEphemeralKey);
+        } else {
+            //
+            // Get the certificate that contains the public key for the public key
+            // algorithm that will encrypt the generated symmetric (session) key.
+            //
+            X509Certificate remoteCert = useThisCert;
+            if (remoteCert == null) {
+                CryptoType cryptoType = new CryptoType(CryptoType.TYPE.ALIAS);
+                cryptoType.setAlias(user);
+                if (crypto == null) {
+                    throw new WSSecurityException(
+                                                  WSSecurityException.ErrorCode.FAILURE,
+                                                  "noUserCertsFound",
+                                                  new Object[] {user, "encryption"});
+                }
+                X509Certificate[] certs = crypto.getX509Certificates(cryptoType);
+                if (certs == null || certs.length <= 0) {
+                    throw new WSSecurityException(
+                                                  WSSecurityException.ErrorCode.FAILURE,
+                                                  "noUserCertsFound",
+                                                  new Object[] {user, "encryption"});
+                }
+                remoteCert = certs[0];
+            }
+
+            Key kek;
+            KeyAgreementParameters dhSpec = null;
+            if (isKeyAgreementConfigured(keyAgreementMethod)) {
+                // generate ephemeral keys the key must match receivers keys
+                dhSpec = buildKeyAgreementParameter(remoteCert.getPublicKey());
+                kek = generateEncryptionKey(dhSpec);
+            } else {
+                kek = remoteCert.getPublicKey();
+            }
+
+            createEncryptedKeyElement(remoteCert, crypto, dhSpec);
+            byte[] encryptedEphemeralKey = encryptSymmetricKey(kek, symmetricKey);
+            addCipherValueElement(encryptedEphemeralKey);
+        }
+    }
+
+    /**
+     * Create and add the CipherValue Element to the EncryptedKey Element.
+     */
+    protected void addCipherValueElement(byte[] encryptedEphemeralKey) throws WSSecurityException {
+        Element xencCipherValue = createCipherValue(getDocument(), encryptedKeyElement);
+        if (storeBytesInAttachment) {
+            final String attachmentId = getIdAllocator().createId("", getDocument());
+            AttachmentUtils.storeBytesInAttachment(xencCipherValue, getDocument(), attachmentId,
+                                                  encryptedEphemeralKey, attachmentCallbackHandler);
+        } else {
+            Text keyText =
+                WSSecurityUtil.createBase64EncodedTextNode(getDocument(), encryptedEphemeralKey);
+            xencCipherValue.appendChild(keyText);
+        }
+
+        setEncryptedKeySHA1(encryptedEphemeralKey);
+    }
+
+    /**
+     * Now we need to set up the EncryptedKey header block:
+     *  1) create a EncryptedKey element and set a wsu:Id for it
+     *  2) Generate ds:KeyInfo element
+     *  3) Create and set up the ds:KeyInfo child element - this can either be a SecurityTokenReference or X509Data/X509SKI
+     *  4) Create the CipherValue element structure and insert the encrypted session key
+     */
+    protected void createEncryptedKeyElement(X509Certificate remoteCert, Crypto crypto, KeyAgreementParameters dhSpec)
+            throws WSSecurityException {
+        encryptedKeyElement = createEncryptedKey(getDocument(), keyEncAlgo);
+        if (encKeyId == null || encKeyId.isEmpty()) {
+            encKeyId = IDGenerator.generateID("EK-");
+        }
+        encryptedKeyElement.setAttributeNS(null, "Id", encKeyId);
+
+        if (customEKKeyInfoElement != null) {
+            encryptedKeyElement.appendChild(getDocument().adoptNode(customEKKeyInfoElement));
+        } else if (keyIdentifierType == WSConstants.X509_SKI) {
+            DOMX509SKI x509SKI = new DOMX509SKI(getDocument(), remoteCert);
+            DOMX509Data x509Data = new DOMX509Data(getDocument(), x509SKI);
+
+            Element keyInfoElement = createKeyInfoElement(x509Data.getElement(), dhSpec);
+            encryptedKeyElement.appendChild(keyInfoElement);
+        } else {
+            SecurityTokenReference secToken = new SecurityTokenReference(getDocument());
+            if (addWSUNamespace) {
+                secToken.addWSUNamespace();
+            }
+
+            switch (keyIdentifierType) {
+            case WSConstants.X509_KEY_IDENTIFIER:
+                secToken.setKeyIdentifier(remoteCert);
+                break;
+
+            case WSConstants.SKI_KEY_IDENTIFIER:
+                secToken.setKeyIdentifierSKI(remoteCert, crypto);
+
+                if (includeEncryptionToken) {
+                    addBST(remoteCert);
+                }
+                break;
+
+            case WSConstants.THUMBPRINT_IDENTIFIER:
+            case WSConstants.ENCRYPTED_KEY_SHA1_IDENTIFIER:
+                //
+                // This identifier is not applicable for this case, so fall back to
+                // ThumbprintRSA.
+                //
+                secToken.setKeyIdentifierThumb(remoteCert);
+
+                if (includeEncryptionToken) {
+                    addBST(remoteCert);
+                }
+                break;
+
+            case WSConstants.ISSUER_SERIAL:
+                addIssuerSerial(remoteCert, secToken, false);
+                break;
+
+            case WSConstants.ISSUER_SERIAL_QUOTE_FORMAT:
+                addIssuerSerial(remoteCert, secToken,true);
+                break;
+
+            case WSConstants.BST_DIRECT_REFERENCE:
+                Reference ref = new Reference(getDocument());
+                String certUri = IDGenerator.generateID(null);
+                ref.setURI("#" + certUri);
+                bstToken = new X509Security(getDocument());
+                ((X509Security) bstToken).setX509Certificate(remoteCert);
+                bstToken.setID(certUri);
+                ref.setValueType(bstToken.getValueType());
+                secToken.setReference(ref);
+                break;
+
+            case WSConstants.CUSTOM_SYMM_SIGNING :
+                Reference refCust = new Reference(getDocument());
+                if (WSConstants.WSS_SAML_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                    secToken.addTokenType(WSConstants.WSS_SAML_TOKEN_TYPE);
+                    refCust.setValueType(customEKTokenValueType);
+                } else if (WSConstants.WSS_SAML2_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                    secToken.addTokenType(WSConstants.WSS_SAML2_TOKEN_TYPE);
+                } else if (WSConstants.WSS_ENC_KEY_VALUE_TYPE.equals(customEKTokenValueType)) {
+                    secToken.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                    refCust.setValueType(customEKTokenValueType);
+                } else {
+                    refCust.setValueType(customEKTokenValueType);
+                }
+                refCust.setURI("#" + customEKTokenId);
+                secToken.setReference(refCust);
+                break;
+
+            case WSConstants.CUSTOM_SYMM_SIGNING_DIRECT :
+                Reference refCustd = new Reference(getDocument());
+                if (WSConstants.WSS_SAML_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                    secToken.addTokenType(WSConstants.WSS_SAML_TOKEN_TYPE);
+                    refCustd.setValueType(customEKTokenValueType);
+                } else if (WSConstants.WSS_SAML2_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                    secToken.addTokenType(WSConstants.WSS_SAML2_TOKEN_TYPE);
+                } else if (WSConstants.WSS_ENC_KEY_VALUE_TYPE.equals(customEKTokenValueType)) {
+                    secToken.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                    refCustd.setValueType(customEKTokenValueType);
+                } else {
+                    refCustd.setValueType(customEKTokenValueType);
+                }
+                refCustd.setURI(customEKTokenId);
+                secToken.setReference(refCustd);
+                break;
+
+            case WSConstants.CUSTOM_KEY_IDENTIFIER:
+                secToken.setKeyIdentifier(customEKTokenValueType, customEKTokenId);
+                if (WSConstants.WSS_SAML_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                    secToken.addTokenType(WSConstants.WSS_SAML_TOKEN_TYPE);
+                } else if (WSConstants.WSS_SAML2_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                    secToken.addTokenType(WSConstants.WSS_SAML2_TOKEN_TYPE);
+                } else if (WSConstants.WSS_ENC_KEY_VALUE_TYPE.equals(customEKTokenValueType)) {
+                    secToken.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                } else if (SecurityTokenReference.ENC_KEY_SHA1_URI.equals(customEKTokenValueType)) {
+                    secToken.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                }
+                break;
+
+            default:
+                throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, "unsupportedKeyId",
+                                              new Object[] {keyIdentifierType});
+            }
+
+            Element keyInfoElement = createKeyInfoElement(secToken.getElement(), dhSpec);
+            encryptedKeyElement.appendChild(keyInfoElement);
+        }
+    }
+
+    /**
+     * Method builds and returns a ds:KeyInfo element wrapping the provided child element.
+     */
+    private Element createKeyInfoElement(Element childElement, KeyAgreementParameters dhSpec) throws WSSecurityException {
+        Element keyInfoElement =
+                getDocument().createElementNS(
+                        WSConstants.SIG_NS, WSConstants.SIG_PREFIX + ":" + WSConstants.KEYINFO_LN
+                );
+        keyInfoElement.setAttributeNS(
+                WSConstants.XMLNS_NS, "xmlns:" + WSConstants.SIG_PREFIX, WSConstants.SIG_NS
+        );
+        if (isKeyAgreementConfigured(keyAgreementMethod)) {
+            try {
+                AgreementMethodImpl agreementMethod = new AgreementMethodImpl(getDocument(), dhSpec);
+                agreementMethod.getRecipientKeyInfo().addUnknownElement(childElement);
+                Element agreementMethodElement = agreementMethod.getElement();
+                keyInfoElement.appendChild(agreementMethodElement);
+            } catch (XMLSecurityException e) {
+                throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, "unsupportedKeyId",
+                                              new Object[] {keyIdentifierType});
+            }
+
+        } else {
+            keyInfoElement.appendChild(childElement);
+        }
+        return keyInfoElement;
+    }
+
+    /**
+     * Method verifies is the key agreement method is configured(not empty)
+     * @param keyAgreementMethod the key agreement method
+     * @return true if the key agreement method is not empty else false
+     */
+    private boolean isKeyAgreementConfigured(String keyAgreementMethod) {
+         return keyAgreementMethod != null && !keyAgreementMethod.isEmpty();
+    }
+
+    private void addIssuerSerial(X509Certificate remoteCert, SecurityTokenReference secToken, boolean isCommaDelimited)
+            throws WSSecurityException {
+        String issuer = remoteCert.getIssuerX500Principal().getName();
+        java.math.BigInteger serialNumber = remoteCert.getSerialNumber();
+        DOMX509IssuerSerial domIssuerSerial =
+                new DOMX509IssuerSerial(getDocument(), issuer, serialNumber, isCommaDelimited);
+        DOMX509Data domX509Data = new DOMX509Data(getDocument(), domIssuerSerial);
+        secToken.setUnknownElement(domX509Data.getElement());
+
+        if (includeEncryptionToken) {
+            addBST(remoteCert);
+        }
+    }
+
+    /**
+     * Now we need to setup the EncryptedKey header block:
+     *  1) create a EncryptedKey element and set a wsu:Id for it
+     *  2) Generate ds:KeyInfo element, this wraps the wsse:SecurityTokenReference
+     *  3) Create and set up the SecurityTokenReference according to the keyIdentifier parameter
+     *  4) Create the CipherValue element structure and insert the encrypted session key
+     */
+    protected void createEncryptedKeyElement(Key key) throws WSSecurityException {
+        encryptedKeyElement = createEncryptedKey(getDocument(), keyEncAlgo);
+        if (encKeyId == null || encKeyId.isEmpty()) {
+            encKeyId = IDGenerator.generateID("EK-");
+        }
+        encryptedKeyElement.setAttributeNS(null, "Id", encKeyId);
+
+        if (customEKKeyInfoElement != null) {
+            encryptedKeyElement.appendChild(getDocument().adoptNode(customEKKeyInfoElement));
+        } else {
+            SecurityTokenReference secToken = new SecurityTokenReference(getDocument());
+            if (addWSUNamespace) {
+                secToken.addWSUNamespace();
+            }
+
+            switch (keyIdentifierType) {
+
+                case WSConstants.CUSTOM_SYMM_SIGNING :
+                    Reference refCust = new Reference(getDocument());
+                    if (WSConstants.WSS_SAML_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                        secToken.addTokenType(WSConstants.WSS_SAML_TOKEN_TYPE);
+                        refCust.setValueType(customEKTokenValueType);
+                    } else if (WSConstants.WSS_SAML2_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                        secToken.addTokenType(WSConstants.WSS_SAML2_TOKEN_TYPE);
+                    } else if (WSConstants.WSS_ENC_KEY_VALUE_TYPE.equals(customEKTokenValueType)) {
+                        secToken.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                        refCust.setValueType(customEKTokenValueType);
+                    } else {
+                        refCust.setValueType(customEKTokenValueType);
+                    }
+                    refCust.setURI("#" + customEKTokenId);
+                    secToken.setReference(refCust);
+                    break;
+
+                case WSConstants.CUSTOM_SYMM_SIGNING_DIRECT :
+                    Reference refCustd = new Reference(getDocument());
+                    if (WSConstants.WSS_SAML_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                        secToken.addTokenType(WSConstants.WSS_SAML_TOKEN_TYPE);
+                        refCustd.setValueType(customEKTokenValueType);
+                    } else if (WSConstants.WSS_SAML2_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                        secToken.addTokenType(WSConstants.WSS_SAML2_TOKEN_TYPE);
+                    } else if (WSConstants.WSS_ENC_KEY_VALUE_TYPE.equals(customEKTokenValueType)) {
+                        secToken.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                        refCustd.setValueType(customEKTokenValueType);
+                    } else {
+                        refCustd.setValueType(customEKTokenValueType);
+                    }
+                    refCustd.setURI(customEKTokenId);
+                    secToken.setReference(refCustd);
+                    break;
+
+                case WSConstants.CUSTOM_KEY_IDENTIFIER:
+                    secToken.setKeyIdentifier(customEKTokenValueType, customEKTokenId);
+                    if (WSConstants.WSS_SAML_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                        secToken.addTokenType(WSConstants.WSS_SAML_TOKEN_TYPE);
+                    } else if (WSConstants.WSS_SAML2_KI_VALUE_TYPE.equals(customEKTokenValueType)) {
+                        secToken.addTokenType(WSConstants.WSS_SAML2_TOKEN_TYPE);
+                    } else if (WSConstants.WSS_ENC_KEY_VALUE_TYPE.equals(customEKTokenValueType)) {
+                        secToken.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                    } else if (SecurityTokenReference.ENC_KEY_SHA1_URI.equals(customEKTokenValueType)) {
+                        secToken.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                    }
+                    break;
+
+                case WSConstants.KEY_VALUE:
+                    // This is only applicable for the PublicKey case
+                    if (!(key instanceof PublicKey)) {
+                        throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, "unsupportedKeyId",
+                                                      new Object[] {keyIdentifierType});
+                    }
+                    try {
+                        XMLSignatureFactory signatureFactory;
+                        if (provider == null) {
+                            // Try to install the Santuario Provider - fall back to the JDK provider if this does
+                            // not work
+                            try {
+                                signatureFactory = XMLSignatureFactory.getInstance("DOM", "ApacheXMLDSig");
+                            } catch (NoSuchProviderException ex) {
+                                signatureFactory = XMLSignatureFactory.getInstance("DOM");
+                            }
+                        } else {
+                            signatureFactory = XMLSignatureFactory.getInstance("DOM", provider);
+                        }
+
+                        KeyInfoFactory keyInfoFactory = signatureFactory.getKeyInfoFactory();
+                        KeyValue keyValue = keyInfoFactory.newKeyValue((PublicKey)key);
+                        String keyInfoUri = getIdAllocator().createSecureId("KI-", null);
+                        KeyInfo keyInfo =
+                            keyInfoFactory.newKeyInfo(
+                                java.util.Collections.singletonList(keyValue), keyInfoUri
+                            );
+
+                        keyInfo.marshal(new DOMStructure(encryptedKeyElement), null);
+                    } catch (KeyException | MarshalException ex) {
+                        LOG.error("", ex);
+                        throw new WSSecurityException(
+                            WSSecurityException.ErrorCode.FAILED_ENCRYPTION, ex
+                        );
+                    }
+                    break;
+
+                default:
+                    throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, "unsupportedKeyId",
+                                                  new Object[] {keyIdentifierType});
+            }
+
+            if (WSConstants.KEY_VALUE != keyIdentifierType) {
+                Element keyInfoElement =
+                    getDocument().createElementNS(
+                        WSConstants.SIG_NS, WSConstants.SIG_PREFIX + ":" + WSConstants.KEYINFO_LN
+                    );
+                keyInfoElement.setAttributeNS(
+                    WSConstants.XMLNS_NS, "xmlns:" + WSConstants.SIG_PREFIX, WSConstants.SIG_NS
+                );
+                keyInfoElement.appendChild(secToken.getElement());
+                encryptedKeyElement.appendChild(keyInfoElement);
+            }
+        }
+    }
+
+    /**
+     * Method builds the KeyAgreementParameterSpec for the ECDH-ES, X25519 or X448
+     * Key Agreement Method using the recipient's public key and preconfigured values:
+     * keyEncAlgo, digestAlgo and keyAgreementMethod. If the keyDerivationParameters
+     * are not set, the default values for the key derivation method are used.
+     *
+     * @param recipientPublicKey the recipient's public key
+     * @return KeyAgreementParameterSpec the {@link java.security.spec.AlgorithmParameterSpec} for generating the
+     * key for encrypting transport key and generating XML elements.
+     *
+     * @throws WSSecurityException if the KeyAgreementParameterSpec cannot be created due to
+     * invalid key agreement method or key derivation method and wrap algorithm not supported
+     */
+    private KeyAgreementParameters buildKeyAgreementParameter(PublicKey recipientPublicKey)
+            throws WSSecurityException {
+        KeyAgreementParameters dhSpec;
+        try {
+            int keyBitLength = org.apache.xml.security.utils.KeyUtils.getAESKeyBitSizeForWrapAlgorithm(keyEncAlgo);
+            KeyDerivationParameters kdf = keyDerivationParameters;
+            if (keyDerivationParameters == null) {
+                LOG.debug("Set default KeyDerivationParameters for key derivation method: [{}]",
+                        keyDerivationMethod);
+                kdf = buildDefaultKeyDerivationParameters(keyBitLength);
+            }
+            KeyPair dhKeyPair = org.apache.xml.security.utils.KeyUtils.generateEphemeralDHKeyPair(recipientPublicKey, null);
+            dhSpec = XMLCipherUtil.constructAgreementParameters(keyAgreementMethod,
+                    KeyAgreementParameters.ActorType.ORIGINATOR, kdf, null, recipientPublicKey);
+            dhSpec.setOriginatorKeyPair(dhKeyPair);
+        } catch (XMLEncryptionException e) {
+            throw new WSSecurityException(
+                    WSSecurityException.ErrorCode.FAILED_ENCRYPTION, e
+            );
+        }
+        return dhSpec;
+    }
+
+    /**
+     * Method builds the KeyDerivationParameters for keyDerivationMethod with default values.
+     * The default values for the key derivation method are:
+     * <ul>
+     *   <li>ConcatKDF
+     *     <ul>
+     *       <li> DigestAlgorithm: "http://www.w3.org/2001/04/xmlenc#sha256"</li>
+     *       <li> AlgorithmID: "0000"</li>
+     *       <li> PartyUInfo: ""</li>
+     *       <li> PartyVInfo: ""</li>
+     *       <li> SuppPubInfo: null</li>
+     *       <li> SuppPrivInfo: null</li>
+     *     </ul>
+     *   <li>HKDF: SHA-256
+     *     <ul>
+     *       <li> PRF: http://www.w3.org/2001/04/xmldsig-more#hmac-sha256 </li>
+     *       <li> Salt: random 256 bit value</li>
+     *       <li> Info: null</li>
+     *     </ul>
+     *   </li>
+     * </ul>
+     *
+     * @param keyBitLength the length of the derived key in bits
+     * @return KeyDerivationParameters the {@link KeyDerivationParameters} for generating the
+     * key for encrypting transport key and generating XML elements.
+     * @throws WSSecurityException if the KeyDerivationParameters cannot be created
+     */
+    private KeyDerivationParameters buildDefaultKeyDerivationParameters(int keyBitLength) throws WSSecurityException {
+
+        switch (keyDerivationMethod) {
+            case WSS4JConstants.KEYDERIVATION_CONCATKDF:
+                return ConcatKDFParams.createBuilder(keyBitLength, WSConstants.SHA256)
+                        .algorithmID("0000")
+                        .partyUInfo("")
+                        .partyVInfo("")
+                        .build();
+            case WSS4JConstants.KEYDERIVATION_HKDF:
+                // use semi random value for salt.
+                // rfc5869: Yet, even a salt value of less quality (shorter in
+                //   size or with limited entropy) may still make a significant
+                //   contribution to the security of the output keying material
+                byte[] semiRandom;
+                try { 
+                    int length = keyBitLength / 8;
+                    semiRandom = XMLSecurityConstants.generateBytes(length);
+                } catch (Exception ex) {
+                    throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, ex,
+                            "empty", new Object[] {"Error in generating secret bytes " }
+                    );
+                }
+                return HKDFParams.createBuilder(keyBitLength, WSS4JConstants.HMAC_SHA256)
+                        .salt(semiRandom)
+                        .info(null)
+                        .build();
+            default:
+                throw new WSSecurityException(
+                        WSSecurityException.ErrorCode.FAILED_ENCRYPTION, "unsupportedKeyDerivationMethod",
+                        new Object[]{keyDerivationMethod}
+                );
+        }
+    }
+
+
+    /**
+     * Method generates the key for encrypting the transport key using the KeyAgreementParameterSpec
+     *
+     * @param keyAgreementParameter the {@link KeyAgreementParameters} for generating the secret key
+     * @return SecretKey the secret key for encrypting the transport key
+     * @throws WSSecurityException if the secret key cannot be generated
+     */
+    private SecretKey generateEncryptionKey(KeyAgreementParameters keyAgreementParameter) throws WSSecurityException {
+        try {
+            // derive the key for encryption of the transport key
+            return org.apache.xml.security.utils.KeyUtils.aesWrapKeyWithDHGeneratedKey(keyAgreementParameter);
+        } catch (XMLEncryptionException e) {
+            throw new WSSecurityException(
+                    WSSecurityException.ErrorCode.FAILED_ENCRYPTION, e
+            );
+        }
+    }
+
+    private byte[] encryptSymmetricKey(Key encryptingKey, SecretKey keyToBeEncrypted)
+        throws WSSecurityException {
+        Cipher cipher = KeyUtils.getCipherInstance(keyEncAlgo);
+        try {
+            OAEPParameterSpec oaepParameterSpec = null;
+            if (WSConstants.KEYTRANSPORT_RSAOAEP.equals(keyEncAlgo)
+                    || WSConstants.KEYTRANSPORT_RSAOAEP_XENC11.equals(keyEncAlgo)) {
+                oaepParameterSpec = XMLCipherUtil.constructOAEPParameters(keyEncAlgo, digestAlgo, mgfAlgo, null);
+            }
+            
+            if (oaepParameterSpec == null) {
+                cipher.init(Cipher.WRAP_MODE, encryptingKey);
+            } else {
+                cipher.init(Cipher.WRAP_MODE, encryptingKey, oaepParameterSpec);
+            }
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
+            throw new WSSecurityException(
+                WSSecurityException.ErrorCode.FAILED_ENCRYPTION, e
+            );
+        }
+        int blockSize = cipher.getBlockSize();
+        LOG.debug("cipher blksize: {}", blockSize);
+
+        try {
+            return cipher.wrap(keyToBeEncrypted);
+        } catch (IllegalStateException | IllegalBlockSizeException | InvalidKeyException ex) {
+            throw new WSSecurityException(
+                WSSecurityException.ErrorCode.FAILED_ENCRYPTION, ex
+            );
+        }
+    }
+
+    /**
+     * Add a BinarySecurityToken
+     */
+    private void addBST(X509Certificate cert) throws WSSecurityException {
+        bstToken = new X509Security(getDocument());
+        ((X509Security) bstToken).setX509Certificate(cert);
+
+        bstAddedToSecurityHeader = false;
+        bstToken.setID(IDGenerator.generateID(null));
+        if (addWSUNamespace) {
+            bstToken.addWSUNamespace();
+        }
+    }
+
+    /**
+     * Create DOM subtree for <code>xenc:EncryptedKey</code>
+     *
+     * @param doc the SOAP envelope parent document
+     * @param keyTransportAlgo specifies which algorithm to use to encrypt the symmetric key
+     * @return an <code>xenc:EncryptedKey</code> element
+     */
+    private Element createEncryptedKey(Document doc, String keyTransportAlgo) {
+        Element encryptedKey =
+            doc.createElementNS(WSConstants.ENC_NS, WSConstants.ENC_PREFIX + ":EncryptedKey");
+
+        org.apache.wss4j.common.util.XMLUtils.setNamespace(encryptedKey, WSConstants.ENC_NS, WSConstants.ENC_PREFIX);
+        Element encryptionMethod =
+            doc.createElementNS(WSConstants.ENC_NS, WSConstants.ENC_PREFIX + ":EncryptionMethod");
+        encryptionMethod.setAttributeNS(null, "Algorithm", keyTransportAlgo);
+
+        if ((WSConstants.KEYTRANSPORT_RSAOAEP_XENC11.equals(keyEncAlgo) || WSConstants.KEYTRANSPORT_RSAOAEP.equals(
+                keyEncAlgo)) && digestAlgo != null) {
+            Element digestElement =
+                XMLUtils.createElementInSignatureSpace(doc, Constants._TAG_DIGESTMETHOD);
+            digestElement.setAttributeNS(null, "Algorithm", digestAlgo);
+            encryptionMethod.appendChild(digestElement);
+        }
+        if (WSConstants.KEYTRANSPORT_RSAOAEP_XENC11.equals(keyEncAlgo) && mgfAlgo != null) {
+            Element mgfElement =
+                doc.createElementNS(WSConstants.ENC11_NS, WSConstants.ENC11_PREFIX + ":MGF");
+            mgfElement.setAttributeNS(null, "Algorithm", mgfAlgo);
+            encryptionMethod.appendChild(mgfElement);
+        }
+
+        encryptedKey.appendChild(encryptionMethod);
+        return encryptedKey;
+    }
+
+    protected Element createCipherValue(Document doc, Element encryptedKey) {
+        Element cipherData =
+            doc.createElementNS(WSConstants.ENC_NS, WSConstants.ENC_PREFIX + ":CipherData");
+        Element cipherValue =
+            doc.createElementNS(WSConstants.ENC_NS, WSConstants.ENC_PREFIX + ":CipherValue");
+        cipherData.appendChild(cipherValue);
+        encryptedKey.appendChild(cipherData);
+        return cipherValue;
+    }
+
+    /**
+     * Prepend the EncryptedKey element to the elements already in the Security
+     * header.
+     *
+     * The method can be called any time after <code>prepare()</code>. This
+     * allows to insert the EncryptedKey element at any position in the Security
+     * header.
+     */
+    public void prependToHeader() {
+        Element secHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+        WSSecurityUtil.prependChildElement(secHeaderElement, encryptedKeyElement);
+    }
+
+    /**
+     * Append the EncryptedKey element to the elements already in the Security
+     * header.
+     *
+     * The method can be called any time after <code>prepare()</code>. This
+     * allows to insert the EncryptedKey element at any position in the Security
+     * header.
+     */
+    public void appendToHeader() {
+        Element secHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+        secHeaderElement.appendChild(encryptedKeyElement);
+    }
+
+    /**
+     * Prepend the BinarySecurityToken to the elements already in the Security
+     * header.
+     *
+     * The method can be called any time after <code>prepare()</code>. This
+     * allows to insert the BST element at any position in the Security header.
+     */
+    public void prependBSTElementToHeader() {
+        if (bstToken != null && !bstAddedToSecurityHeader) {
+            Element secHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+            WSSecurityUtil.prependChildElement(secHeaderElement, bstToken.getElement());
+            bstAddedToSecurityHeader = true;
+        }
+    }
+
+    /**
+     * Append the BinarySecurityToken to the elements already in the Security
+     * header.
+     *
+     * The method can be called any time after <code>prepare()</code>. This
+     * allows to insert the BST element at any position in the Security header.
+     */
+    public void appendBSTElementToHeader() {
+        if (bstToken != null && !bstAddedToSecurityHeader) {
+            Element secHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+            secHeaderElement.appendChild(bstToken.getElement());
+            bstAddedToSecurityHeader = true;
+        }
+    }
+
+    /**
+     * Set the X509 Certificate to use for encryption.
+     *
+     * If this is set <b>and</b> the key identifier is set to
+     * <code>DirectReference</code> then use this certificate to get the
+     * public key for encryption.
+     *
+     * @param cert is the X509 certificate to use for encryption
+     */
+    public void setUseThisCert(X509Certificate cert) {
+        useThisCert = cert;
+    }
+
+    public X509Certificate getUseThisCert() {
+        return useThisCert;
+    }
+
+    /**
+     * Set the PublicKey to use for encryption.
+     * @param key the PublicKey instance to use for encryption
+     */
+    public void setUseThisPublicKey(PublicKey key) {
+        useThisPublicKey = key;
+    }
+
+    public PublicKey getUseThisPublicKey() {
+        return useThisPublicKey;
+    }
+
+    /**
+     * @return Returns the encryptedKeyElement.
+     */
+    public Element getEncryptedKeyElement() {
+        return encryptedKeyElement;
+    }
+
+    /**
+     * Set the encrypted key element when a pre prepared encrypted key is used
+     * @param encryptedKeyElement EncryptedKey element of the encrypted key used
+     */
+    public void setEncryptedKeyElement(Element encryptedKeyElement) {
+        this.encryptedKeyElement = encryptedKeyElement;
+    }
+
+    /**
+     * @return Returns the BinarySecurityToken element.
+     */
+    public Element getBinarySecurityTokenElement() {
+        if (bstToken != null) {
+            return bstToken.getElement();
+        }
+        return null;
+    }
+
+    public void setKeyEncAlgo(String keyEncAlgo) {
+        this.keyEncAlgo = keyEncAlgo;
+    }
+
+    public String getKeyEncAlgo() {
+        return keyEncAlgo;
+    }
+
+    public String getKeyAgreementMethod() {
+        return keyAgreementMethod;
+    }
+
+    public void setKeyAgreementMethod(String keyAgreementMethod) {
+        this.keyAgreementMethod = keyAgreementMethod;
+    }
+
+    public String getKeyDerivationMethod() {
+        return keyDerivationMethod;
+    }
+
+    public void setKeyDerivationMethod(String keyDerivationMethod) {
+        this.keyDerivationMethod = keyDerivationMethod;
+    }
+
+    public KeyDerivationParameters getKeyDerivationParameters() {
+        return keyDerivationParameters;
+    }
+
+    public void setKeyDerivationParameters(KeyDerivationParameters keyDerivationParameters) {
+        this.keyDerivationParameters = keyDerivationParameters;
+    }
+
+    /**
+     * Get the id of the BSt generated during <code>prepare()</code>.
+     *
+     * @return Returns the the value of wsu:Id attribute of the
+     * BinaruSecurityToken element.
+     */
+    public String getBSTTokenId() {
+        if (bstToken == null) {
+            return null;
+        }
+
+        return bstToken.getID();
+    }
+
+    /**
+     * @param encKeyId The encKeyId to set.
+     */
+    public void setEncKeyId(String encKeyId) {
+        this.encKeyId = encKeyId;
+    }
+
+    public boolean isCertSet() {
+        return useThisCert != null;
+    }
+
+    public void setCustomEKTokenValueType(String customEKTokenValueType) {
+        this.customEKTokenValueType = customEKTokenValueType;
+    }
+
+    public void setCustomEKTokenId(String customEKTokenId) {
+        this.customEKTokenId = customEKTokenId;
+    }
+
+    /**
+     * Set the digest algorithm to use with the RSA-OAEP key transport algorithm. The
+     * default is SHA-1.
+     *
+     * @param digestAlgorithm the digest algorithm to use with the RSA-OAEP key transport algorithm
+     */
+    public void setDigestAlgorithm(String digestAlgorithm) {
+        this.digestAlgo = digestAlgorithm;
+    }
+
+    /**
+     * Get the digest algorithm to use with the RSA-OAEP key transport algorithm. The
+     * default is SHA-1.
+     */
+    public String getDigestAlgorithm() {
+        return digestAlgo;
+    }
+
+    /**
+     * Set the MGF algorithm to use with the RSA-OAEP key transport algorithm. The
+     * default is MGF-SHA-1.
+     *
+     * @param mgfAlgorithm the MGF algorithm to use with the RSA-OAEP key transport algorithm
+     */
+    public void setMGFAlgorithm(String mgfAlgorithm) {
+        this.mgfAlgo = mgfAlgorithm;
+    }
+
+    /**
+     * Get the MGF algorithm to use with the RSA-OAEP key transport algorithm. The
+     * default is MGF-SHA-1.
+     */
+    public String getMGFAlgorithm() {
+        return mgfAlgo;
+    }
+
+    public boolean isIncludeEncryptionToken() {
+        return includeEncryptionToken;
+    }
+
+    public void setIncludeEncryptionToken(boolean includeEncryptionToken) {
+        this.includeEncryptionToken = includeEncryptionToken;
+    }
+
+    public Element getCustomEKKeyInfoElement() {
+        return customEKKeyInfoElement;
+    }
+
+    public void setCustomEKKeyInfoElement(Element customEKKeyInfoElement) {
+        this.customEKKeyInfoElement = customEKKeyInfoElement;
+    }
+
+    protected void setEncryptedKeySHA1(byte[] encryptedEphemeralKey) throws WSSecurityException {
+        byte[] encodedBytes = KeyUtils.generateDigest(encryptedEphemeralKey);
+        encryptedKeySHA1 = XMLUtils.encodeToString(encodedBytes);
+    }
+
+    public String getEncryptedKeySHA1() {
+        return encryptedKeySHA1;
+    }
+}

--- a/dev/com.ibm.ws.wssecurity.example.cbh/test-bundles/com.ibm.ws.wssecurity.cbh/src/com/ibm/ws/wssecurity/example/cbh/CommonPasswordCallback.java
+++ b/dev/com.ibm.ws.wssecurity.example.cbh/test-bundles/com.ibm.ws.wssecurity.cbh/src/com/ibm/ws/wssecurity/example/cbh/CommonPasswordCallback.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -91,6 +91,7 @@ public class CommonPasswordCallback implements CallbackHandler {
             userPasswords.put("alice", "password");
             userPasswords.put("bob", "password");
             userPasswords.put("cxfca", "password");
+            userPasswords.put("secp256r1", "security");
 
             // do not distinguish encrypt or signature for now
             signaturePasswords.put("x509ClientDefault", "KLibertyX509Client");
@@ -105,6 +106,7 @@ public class CommonPasswordCallback implements CallbackHandler {
             signaturePasswords.put("soaprequester", "client");
             signaturePasswords.put("bob", "keypass");
             signaturePasswords.put("alice", "keypass");
+            signaturePasswords.put("secp256r1", "security");
 
             encryptPasswords.put("x509ClientDefault", "KLibertyX509Client");
             encryptPasswords.put("x509clientdefault", "KLibertyX509Client");
@@ -116,6 +118,7 @@ public class CommonPasswordCallback implements CallbackHandler {
             encryptPasswords.put("x509serversecond", "KLibertyX509Server2");
             encryptPasswords.put("bob", "keypass");
             encryptPasswords.put("alice", "keypass");
+            encryptPasswords.put("secp256r1", "security");
 
         }
 
@@ -135,7 +138,7 @@ public class CommonPasswordCallback implements CallbackHandler {
             String pass = null;
 
             switch (pwcb.getUsage()) {
-                //2/2021    
+                //2/2021
                 //case WSPasswordCallback.USERNAME_TOKEN_UNKNOWN:  // deprecated
                 case WSPasswordCallback.UNKNOWN:
                 case WSPasswordCallback.USERNAME_TOKEN:

--- a/dev/com.ibm.ws.wssecurity.example.cbh/test-bundles/com.ibm.ws.wssecurity.cbh/src/com/ibm/ws/wssecurity/example/cbh/CommonPasswordCallback.java
+++ b/dev/com.ibm.ws.wssecurity.example.cbh/test-bundles/com.ibm.ws.wssecurity.cbh/src/com/ibm/ws/wssecurity/example/cbh/CommonPasswordCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.wssecurity.example.cbhwss4j/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity.example.cbhwss4j/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2024 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.wssecurity.example.cbhwss4j/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity.example.cbhwss4j/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2023 IBM Corporation and others.
+# Copyright (c) 2020, 2024 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.wssecurity.example.cbhwss4j/bnd.bnd
+++ b/dev/com.ibm.ws.wssecurity.example.cbhwss4j/bnd.bnd
@@ -38,4 +38,5 @@ test.project: true
 
 -buildpath: \
   com.ibm.ws.org.apache.wss4j.ws.security.common;version=latest,\
+  com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest,\
   com.ibm.ws.wssecurity.fat.utils.common;version=latest

--- a/dev/com.ibm.ws.wssecurity.example.cbhwss4j/test-bundles/com.ibm.ws.wssecurity.cbhwss4j/src/com/ibm/ws/wssecurity/example/cbhwss4j/CommonPasswordCallbackWss4j.java
+++ b/dev/com.ibm.ws.wssecurity.example.cbhwss4j/test-bundles/com.ibm.ws.wssecurity.cbhwss4j/src/com/ibm/ws/wssecurity/example/cbhwss4j/CommonPasswordCallbackWss4j.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -111,6 +111,7 @@ public class CommonPasswordCallbackWss4j implements CallbackHandler {
             userPasswords.put("alice", "password");
             userPasswords.put("bob", "password");
             userPasswords.put("cxfca", "password");
+            userPasswords.put("secp256r1", "security");
 
             // do not distinguish encrypt or signature for now
             signaturePasswords.put("x509ClientDefault", "KLibertyX509Client");
@@ -125,6 +126,7 @@ public class CommonPasswordCallbackWss4j implements CallbackHandler {
             signaturePasswords.put("soaprequester", "client");
             signaturePasswords.put("bob", "keypass");
             signaturePasswords.put("alice", "keypass");
+            signaturePasswords.put("secp256r1", "security");
 
             encryptPasswords.put("x509ClientDefault", "KLibertyX509Client");
             encryptPasswords.put("x509clientdefault", "KLibertyX509Client");
@@ -136,6 +138,7 @@ public class CommonPasswordCallbackWss4j implements CallbackHandler {
             encryptPasswords.put("x509serversecond", "KLibertyX509Server2");
             encryptPasswords.put("bob", "keypass");
             encryptPasswords.put("alice", "keypass");
+            encryptPasswords.put("secp256r1", "security");
 
         }
 


### PR DESCRIPTION
This PR addresses two issues:

1. It restores missing updates to `wsSecurity-1.1` from previous commits
2. This functionality is to allow non WS-SecurityPolicy AlgorithmSuites to be defined for specific ECDH-ES encryption combinations. 


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
