### PR TITLE
fixing NPE when createConfigFile doesn't have a value set

### DIFF
--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/GenerateAesKeyTask.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/GenerateAesKeyTask.java
@@ -150,6 +150,9 @@ public class GenerateAesKeyTask extends BaseCommandTask {
                 }
                 keyPhrase = value;
             } else if (ARG_FILE.equals(option)) {
+                if (value == null) {
+                    throw new IllegalArgumentException(getMessage("missingValue", option));
+                }
                 File file = new File(value);
                 if (fileUtil.isDirectory(file)) {
                     throw new IllegalArgumentException(getMessage("generateaeskey.failFileIsDirectory", value));

--- a/dev/com.ibm.ws.security.utility/test/com/ibm/ws/security/utility/tasks/GenerateAesKeyTest.java
+++ b/dev/com.ibm.ws.security.utility/test/com/ibm/ws/security/utility/tasks/GenerateAesKeyTest.java
@@ -120,6 +120,18 @@ public class GenerateAesKeyTest {
     }
 
     @Test
+    public void testEmptyConfigFile() throws Exception {
+
+        try (MockedStatic<PasswordEncryptionConfigBuilder> xmlBuilder = Mockito.mockStatic(PasswordEncryptionConfigBuilder.class, Mockito.CALLS_REAL_METHODS)) {
+            generate.handleTask(stdin, stdout, stderr, new String[] { GenerateAesKeyTask.TASK_NAME, "--createConfigFile=" });
+            fail("task should throw an exception if config file isn't specified");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("Wrong message returned when specifying an empty value for --createConfigFile.", BaseCommandTask.getMessage("missingValue", "--createConfigFile"),
+                         iae.getMessage());
+        }
+    }
+
+    @Test
     public void testUnknownArg() {
         String unknownArg = "testarg=abc";
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
