### PR TITLE
Create load graph and use for find

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -123,6 +123,9 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
             if (cursor.isPresent())
                 queryInfo.setParametersFromCursor(query, cursor.get());
 
+            if (queryInfo.entityInfo.loadGraph != null)
+                query.setHint(Util.LOADGRAPH, queryInfo.entityInfo.loadGraph);
+
             // TODO #33189 why are EntityManager.setCacheRetrieveMode and
             // Query.setCacheRetrieveMode unable to set this instead?
             query.setHint("jakarta.persistence.cache.retrieveMode",

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 import jakarta.data.exceptions.MappingException;
+import jakarta.persistence.EntityGraph;
 import jakarta.persistence.Inheritance;
 
 /**
@@ -76,6 +77,8 @@ public class EntityInfo {
     final Class<?> idType; // type of the id, which could be a JPA IdClass for composite ids
     final SortedMap<String, Member> idClassAttributeAccessors; // null if no IdClass
     final boolean inheritance;
+    final EntityGraph<?> loadGraph; // null if all attributes automatically load eagerly
+    final Map<String, Object> loadGraphMap; // null if all attributes automatically load eagerly
     final String name; // entity name to use in query language. If a record, the name will be [RecordName]Entity.
     final Class<?> recordClass; // null if not a record
     final String versionAttributeName; // null if unversioned
@@ -94,6 +97,7 @@ public class EntityInfo {
                SortedMap<String, Class<?>> attributeTypes,
                Map<String, Class<?>> collectionElementTypes,
                Map<Class<?>, List<String>> relationAttributeNames,
+               EntityGraph<?> loadGraph,
                Class<?> idType,
                SortedMap<String, Member> idClassAttributeAccessors,
                String versionAttributeName,
@@ -107,6 +111,10 @@ public class EntityInfo {
         this.attributeTypes = attributeTypes;
         this.collectionElementTypes = collectionElementTypes;
         this.relationAttributeNames = relationAttributeNames;
+        this.loadGraph = loadGraph;
+        this.loadGraphMap = loadGraph == null //
+                        ? null //
+                        : Map.of(Util.LOADGRAPH, loadGraph);
         this.idType = idType;
         this.idClassAttributeAccessors = idClassAttributeAccessors;
         this.recordClass = recordClass;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -40,7 +40,6 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.sql.DataSource;
@@ -52,7 +51,10 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.MappingException;
+import jakarta.persistence.AttributeNode;
+import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Subgraph;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.Attribute.PersistentAttributeType;
 import jakarta.persistence.metamodel.EntityType;
@@ -61,6 +63,7 @@ import jakarta.persistence.metamodel.Metamodel;
 import jakarta.persistence.metamodel.PluralAttribute;
 import jakarta.persistence.metamodel.SingularAttribute;
 import jakarta.persistence.metamodel.Type;
+import jakarta.persistence.metamodel.Type.PersistenceType;
 
 /**
  * Creates EntityManager instances from an EntityManagerFactory (from a persistence unit reference)
@@ -141,6 +144,11 @@ public abstract class EntityManagerBuilder {
         this.convertibleTypes = convertibleTypes;
         EntityManager em = createEntityManager();
         try {
+            // TODO remove the following boolean once EclipseLink #33294 is fixed
+            // To temporarily reproduce the issue, set it to true below, then
+            // build this project and run the test bucket:
+            // ./gradlew io.openliberty.data.internal_fat_jpa:buildandrun
+            boolean loadSubgraphs = !em.getClass().getName().startsWith("org.eclipse.persistence");
             Set<Class<?>> missingEntityTypes = new HashSet<>(entityTypes);
             Metamodel model = em.getMetamodel();
             for (EntityType<?> entityType : model.getEntities()) {
@@ -154,11 +162,12 @@ public abstract class EntityManagerBuilder {
                 Queue<Attribute<?, ?>> relationships = new LinkedList<>();
                 Queue<String> relationPrefixes = new LinkedList<>();
                 Queue<List<Member>> relationAccessors = new LinkedList<>();
-                Class<?> recordClass = getRecordClass(entityType.getJavaType());
+                Queue<Boolean> relationEmbeddablesOnly = new LinkedList<>();
                 Class<?> idType = null;
                 String versionAttrName = null;
 
                 Class<?> jpaEntityClass = entityType.getJavaType();
+                Class<?> recordClass = getRecordClass(jpaEntityClass);
                 Class<?> userEntityClass = recordClass == null ? jpaEntityClass : recordClass;
                 missingEntityTypes.remove(userEntityClass);
 
@@ -166,7 +175,11 @@ public abstract class EntityManagerBuilder {
                     Tr.debug(this, tc, "collecting info for " +
                                        userEntityClass.getName());
 
+                Set<Class<?>> loadGraphPopulated = new HashSet<>();
+                loadGraphPopulated.add(jpaEntityClass);
                 try {
+                    EntityGraph<?> loadGraph = em.createEntityGraph(jpaEntityClass);
+
                     for (Attribute<?, ?> attr : entityType.getAttributes()) {
                         String attributeName = attr.getName();
                         PersistentAttributeType attributeType = attr.getPersistentAttributeType();
@@ -185,6 +198,7 @@ public abstract class EntityManagerBuilder {
                                 relationships.add(attr);
                                 relationPrefixes.add(attributeName);
                                 relationAccessors.add(Collections.singletonList(attr.getJavaMember()));
+                                relationEmbeddablesOnly.add(attributeType == PersistentAttributeType.EMBEDDED);
                                 break;
                             case ONE_TO_MANY:
                             case MANY_TO_MANY:
@@ -200,10 +214,28 @@ public abstract class EntityManagerBuilder {
                         attributeAccessors.put(attributeName, Collections.singletonList(accessor));
                         attributeTypes.put(attributeName, attr.getJavaType());
                         if (attr.isCollection()) {
-                            if (attr instanceof PluralAttribute)
-                                collectionElementTypes.put(attributeName, ((PluralAttribute<?, ?, ?>) attr).getElementType().getJavaType());
+                            if (attr instanceof PluralAttribute) {
+                                Type<?> elementType = ((PluralAttribute<?, ?, ?>) attr).getElementType();
+                                Class<?> elementClass = elementType.getJavaType();
+                                collectionElementTypes.put(attributeName,
+                                                           elementType.getJavaType());
+                                if (elementType.getPersistenceType() == PersistenceType.ENTITY) {
+                                    if (loadSubgraphs &&
+                                        loadGraphPopulated.add(elementClass)) {
+                                        populateSubgraph(loadGraph.addElementSubgraph(attributeName),
+                                                         elementClass,
+                                                         model,
+                                                         loadGraphPopulated);
+                                        loadGraphPopulated.remove(elementClass);
+                                    }
+                                } else {
+                                    loadGraph.addAttributeNodes(attributeName);
+                                }
+                            }
                         } else {
-                            SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute ? (SingularAttribute<?, ?>) attr : null;
+                            SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute //
+                                            ? (SingularAttribute<?, ?>) attr //
+                                            : null;
                             if (singleAttr != null && singleAttr.isId()) {
                                 attributeNames.put(ID, attributeName);
                                 idType = singleAttr.getJavaType();
@@ -213,6 +245,14 @@ public abstract class EntityManagerBuilder {
                             } else if (Collection.class.isAssignableFrom(attr.getJavaType())) {
                                 // collection attribute that is not annotated with ElementCollection
                                 collectionElementTypes.put(attributeName, Object.class);
+                            } else if (loadSubgraphs &&
+                                       singleAttr.isAssociation() &&
+                                       loadGraphPopulated.add(singleAttr.getJavaType())) {
+                                populateSubgraph(loadGraph.addSubgraph(attributeName),
+                                                 singleAttr.getJavaType(),
+                                                 model,
+                                                 loadGraphPopulated);
+                                loadGraphPopulated.remove(singleAttr.getJavaType());
                             }
                         }
                     }
@@ -225,6 +265,8 @@ public abstract class EntityManagerBuilder {
                     for (Attribute<?, ?> attr; (attr = relationships.poll()) != null;) {
                         String prefix = relationPrefixes.poll();
                         List<Member> accessors = relationAccessors.poll();
+                        boolean isEmbeddablesOnly = relationEmbeddablesOnly.poll();
+
                         ManagedType<?> relation = model.managedType(attr.getJavaType());
                         if (relation instanceof EntityType && !entityTypeClasses.add(attr.getJavaType()))
                             break;
@@ -252,6 +294,8 @@ public abstract class EntityManagerBuilder {
                                     relationships.add(relAttr);
                                     relationPrefixes.add(fullAttributeName);
                                     relationAccessors.add(relAccessors);
+                                    relationEmbeddablesOnly.add(isEmbeddablesOnly &&
+                                                                attributeType == PersistentAttributeType.EMBEDDED);
                                     break;
                                 case ONE_TO_MANY:
                                 case MANY_TO_MANY:
@@ -300,8 +344,25 @@ public abstract class EntityManagerBuilder {
 
                             attributeTypes.put(fullAttributeName, relAttr.getJavaType());
                             if (relAttr.isCollection()) {
-                                if (relAttr instanceof PluralAttribute)
-                                    collectionElementTypes.put(fullAttributeName, ((PluralAttribute<?, ?, ?>) relAttr).getElementType().getJavaType());
+                                if (relAttr instanceof PluralAttribute) {
+                                    Type<?> elementType = ((PluralAttribute<?, ?, ?>) relAttr).getElementType();
+                                    Class<?> elementClass = elementType.getJavaType();
+                                    collectionElementTypes.put(fullAttributeName,
+                                                               elementType.getJavaType());
+                                    if (isEmbeddablesOnly)
+                                        if (elementType.getPersistenceType() == PersistenceType.ENTITY) {
+                                            if (loadSubgraphs &&
+                                                loadGraphPopulated.add(elementClass)) {
+                                                populateSubgraph(loadGraph.addElementSubgraph(relationAttributeName),
+                                                                 elementClass,
+                                                                 model,
+                                                                 loadGraphPopulated);
+                                                loadGraphPopulated.remove(elementClass);
+                                            }
+                                        } else {
+                                            loadGraph.addAttributeNodes(relationAttributeName);
+                                        }
+                                }
                             } else if (relAttr instanceof SingularAttribute) {
                                 SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
                                 if (singleAttr.isId() && attributeNames.putIfAbsent(ID, fullAttributeName) == null) {
@@ -309,6 +370,15 @@ public abstract class EntityManagerBuilder {
                                 } else if (singleAttr.isVersion()) {
                                     versionAttrName = relationAttributeName_; // to be suitable for query-by-method
                                     attributeNamesForUpdate = null;
+                                } else if (loadSubgraphs &&
+                                           isEmbeddablesOnly &&
+                                           singleAttr.isAssociation() &&
+                                           loadGraphPopulated.add(singleAttr.getJavaType())) {
+                                    populateSubgraph(loadGraph.addSubgraph(relationAttributeName),
+                                                     singleAttr.getJavaType(),
+                                                     model,
+                                                     loadGraphPopulated);
+                                    loadGraphPopulated.remove(singleAttr.getJavaType());
                                 }
                             }
                         }
@@ -338,6 +408,12 @@ public abstract class EntityManagerBuilder {
                         }
                     }
 
+                    List<AttributeNode<?>> nodes = loadGraph.getAttributeNodes();
+                    if (trace && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "load graph for " + entityType.getName(), nodes);
+                    if (nodes.isEmpty())
+                        loadGraph = null; // avoid using a load graph
+
                     EntityInfo entityInfo = new EntityInfo( //
                                     entityType.getName(), //
                                     jpaEntityClass, //
@@ -348,6 +424,7 @@ public abstract class EntityManagerBuilder {
                                     attributeTypes, //
                                     collectionElementTypes, //
                                     relationAttributeNames, //
+                                    loadGraph, //
                                     idType, //
                                     idClassAttributeAccessors, //
                                     versionAttrName, //
@@ -356,7 +433,7 @@ public abstract class EntityManagerBuilder {
                     entityInfoMap.computeIfAbsent(userEntityClass, EntityInfo::newFuture).complete(entityInfo);
                 } catch (Throwable x) { // Ignored FFDC
                     if (!(x instanceof DataException))
-                        x = exc(CompletionException.class,
+                        x = exc(DataException.class,
                                 "CWWKD1081.entity.general.err",
                                 userEntityClass.getName(),
                                 getClassNames(repositoryInterfaces),
@@ -532,5 +609,51 @@ public abstract class EntityManagerBuilder {
         return cause instanceof SQLRecoverableException ||
                cause instanceof SQLNonTransientConnectionException ||
                cause instanceof SQLTransientConnectionException;
+    }
+
+    /**
+     * Populates the subgraph with attributes for which to force eager loading,
+     * which allows entities to be detached.
+     *
+     * @param subgraph           the subgraph.
+     * @param entityClass        the entity class to which the subgraph applies.
+     * @param model              the metamodel.
+     * @param loadGraphPopulated entity classes that have already been covered.
+     *                               This guards against infinite recursion in
+     *                               the case of cycles.
+     */
+    private void populateSubgraph(Subgraph<?> subgraph,
+                                  Class<?> entityClass,
+                                  Metamodel model,
+                                  Set<Class<?>> loadGraphPopulated) {
+        for (Attribute<?, ?> attr : model.entity(entityClass).getAttributes())
+            if (attr.isAssociation() &&
+                attr instanceof SingularAttribute &&
+                loadGraphPopulated.add(attr.getJavaType())) {
+
+                populateSubgraph(subgraph.addSubgraph(attr.getName()),
+                                 attr.getJavaType(),
+                                 model,
+                                 loadGraphPopulated);
+
+                // allow different subgraph to reuse:
+                loadGraphPopulated.remove(attr.getJavaType());
+            } else if (attr instanceof PluralAttribute plural) {
+                Type<?> elementType = plural.getElementType();
+                Class<?> elementClass = elementType.getJavaType();
+                if (elementType.getPersistenceType() == PersistenceType.ENTITY) {
+                    if (loadGraphPopulated.add(elementClass)) {
+                        populateSubgraph(subgraph.addElementSubgraph(attr.getName()),
+                                         elementClass,
+                                         model,
+                                         loadGraphPopulated);
+
+                        // allow different subgraph to reuse:
+                        loadGraphPopulated.remove(elementClass);
+                    }
+                } else {
+                    subgraph.addAttributeNodes(attr.getName());
+                }
+            }
     }
 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -102,6 +102,9 @@ public class PageImpl<T> implements Page<T> {
             jakarta.persistence.Query query = em.createQuery(queryInfo.jpql);
             queryInfo.setParameters(query, args);
 
+            if (queryInfo.entityInfo.loadGraph != null)
+                query.setHint(Util.LOADGRAPH, queryInfo.entityInfo.loadGraph);
+
             // TODO #33189 why are EntityManager.setCacheRetrieveMode and
             // Query.setCacheRetrieveMode unable to set this instead?
             query.setHint("jakarta.persistence.cache.retrieveMode",

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Util.java
@@ -80,6 +80,11 @@ public class Util {
                             Update.class.getSimpleName());
 
     /**
+     * Query hint and map key for a load graph.
+     */
+    static final String LOADGRAPH = "jakarta.persistence.loadgraph";
+
+    /**
      * List of valid prefixes for Query by Method Name methods of a stateful
      * repository.
      */

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1423,7 +1423,12 @@ public class DataJPATestServlet extends FATServlet {
                                      .map(t -> t.ssn)
                                      .collect(Collectors.toList()));
 
-        assertIterableEquals(List.of("AccountId:66320100:410224", "AccountId:77512000:705030", "AccountId:88191200:410224"),
+        if (!isHibernate())
+            return; // TODO enable once EclipseLink #33293 is fixed
+
+        assertIterableEquals(List.of("AccountId:66320100:410224",
+                                     "AccountId:77512000:705030",
+                                     "AccountId:88191200:410224"),
                              taxpayers.findAccountsBySSN(234002340L)
                                              .stream()
                                              .map(AccountId::toString)
@@ -1809,6 +1814,10 @@ public class DataJPATestServlet extends FATServlet {
                                                   List.of("email1@openliberty.io",
                                                           "email2@openliberty.io",
                                                           "email3@openliberty.io")));
+
+        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33290")) {
+            return; //TODO remove skip when fixed in Hibernate or Liberty
+        }
 
         List<Mobile> list = mobilePhones.findByEmailsEmpty();
         assertEquals(list.toString(), 1, list.size());
@@ -2373,6 +2382,10 @@ public class DataJPATestServlet extends FATServlet {
         // Populate database
         UUID id = mobilePhones.insert(Mobile.of(OS.ANDROID, apps, emails)).deviceId;
 
+        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33290")) {
+            return; //TODO remove skip when fixed in Hibernate or Liberty
+        }
+
         // Outside of transaction, returned entity should be detached
         Mobile johnsMobile = mobilePhones.findById(id).orElseThrow();
 
@@ -2391,9 +2404,6 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testForeignKey() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33178")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         Manufacturer toyota = new Manufacturer();
         toyota.setName("Toyota");
@@ -2427,6 +2437,7 @@ public class DataJPATestServlet extends FATServlet {
 
         Instant corollaLastMod;
         corollaLastMod = models.lastModified(corollaId).orElseThrow();
+
         List<Model> found = models.modifiedAt(corollaLastMod);
         assertEquals(false, found.isEmpty());
         corolla = null;
@@ -3245,9 +3256,6 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testManyToManyIncludedInResults() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33178")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         List<String> addresses = customers.findByPhoneIn(List.of(5075552444L,
                                                                  5075550101L))
@@ -3357,10 +3365,6 @@ public class DataJPATestServlet extends FATServlet {
                                              .map(cc -> cc.debtor)
                                              .map(c -> c.email)
                                              .collect(Collectors.toList()));
-
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33178")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         assertIterableEquals(List.of("MICHELLE@TESTS.OPENLIBERTY.IO",
                                      "Matthew@tests.openliberty.io",
@@ -4522,9 +4526,6 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Ignore("See comments ")
     public void testUpdateEntityWithIdClass() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33178")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         CreditCard original = creditCards
                         .findByIssuedOnWithMonthIn(Set.of(Month.MAY.getValue()))
@@ -4592,7 +4593,7 @@ public class DataJPATestServlet extends FATServlet {
         // for the following subsequent tests:
         // testCollectionAttribute, testIdClassOrderBySorts, testIdClassOrderByAnnotationWithCursorPagination,
         // testIdClassOrderByNamePatternWithCursorPagination, testIdClassOrderByAnnotationReverseDirection
-        if (true)
+        if (!isHibernate())
             return;
 
         City[] updated = cities.modifyData(City.of(mnId, 122413, Set.of(507, 924), mnVer),


### PR DESCRIPTION
Create a load graph for entities that can be used for find operations to retrieve entity attributes.
This PR is a first step and is not a complete solution, although it is already possible to enable several tests.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
