### PR TITLE
Reversing the comparison to avoid NPE in CacheMap

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/CacheMap.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/CacheMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corporation and others.
+ * Copyright (c) 2001, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -263,7 +263,7 @@ public class CacheMap {
         // Look through the entries in the bucket to find one that matches for removal.
 
         for (int i = bucketSize - 1; i >= 0; i--) {
-            if (bucketKeys[i].equals(key)) {
+            if (key.equals(bucketKeys[i])) {
                 // If we emptied the bucket then remove its MRU/LRU entry.
 
                 if ((bucketSizes[bucketIndex] = --bucketSize) == 0) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Avoiding possible NPE that can occur when tried to remove a cache entry using a key, but the entry is missing.