### PR TITLE
Wait for CWWKF0011I in Basic21Test

### DIFF
--- a/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/Basic21Test.java
+++ b/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/Basic21Test.java
@@ -12,6 +12,7 @@ package io.openliberty.wsoc.tests;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.logging.Logger;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -222,7 +223,13 @@ public class Basic21Test {
     @Mode(TestMode.LITE)
     @Test
     public void testUserPropertiesOnServer() throws Exception {
-        userprop.testUserPropertiesOnServer();
+        try { 
+            userprop.testUserPropertiesOnServer();
+        } catch(IOException ioe) {
+            // For defect 292475 -- java.io.IOException: Connection future timeout 5000 ms for ws://localhost:8010/basic21/userproperties
+             LOG.info(" Trying test again because IOException was caught: " + ioe.getMessage());
+             userprop.testUserPropertiesOnServer();
+        }
     }
 
     @Mode(TestMode.LITE)

--- a/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/Basic21Test.java
+++ b/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/Basic21Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -71,7 +71,6 @@ public class Basic21Test {
 
     @BeforeClass
     public static void setUp() throws Exception {
-
         // Build the war app and add the dependencies
         WebArchive BasicApp = ShrinkHelper.buildDefaultApp(BASIC_WAR_NAME + ".war",
                                                            "basic.war",
@@ -86,7 +85,10 @@ public class Basic21Test {
         ShrinkHelper.exportDropinAppToServer(LS, BasicApp);
 
         LS.startServer();
-        LS.waitForStringInLog("CWWKZ0001I.* " + BASIC_WAR_NAME);
+        //  CWWKZ0001I: Application basic21 started in ...
+        assertNotNull("Application did not start up!", LS.waitForStringInLog("CWWKZ0001I.* " + BASIC_WAR_NAME));
+        // CWWKF0011I: The basic21TestServer server is ready to run a smarter planet. The basic21TestServer server started in ...
+        assertNotNull("Server may not have started!", LS.waitForStringInLog("CWWKF0011I.*server started"));
         bwst = new WebServerSetup(LS);
         wt = new WsocTest(LS, false);
         timeout = new TimeOutTest(wt);
@@ -96,6 +98,8 @@ public class Basic21Test {
         wt_secure = new WsocTest(LS, true);
         ssl = new SSLTest(wt_secure);
         bwst.setUp();
+
+        Thread.sleep(500); // extra wait to allow server finish starting
     }
 
     @AfterClass


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

I'm thinking an extra wait to avoid the 5000 ms timeout? See defect for more info. 

#link 292475 (defect)