### PR TITLE
Get things building in eclipse again

### DIFF
--- a/dev/com.ibm.ws.org.opensaml.opensaml.core.3.4.5/.classpath
+++ b/dev/com.ibm.ws.org.opensaml.opensaml.core.3.4.5/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.opensaml.opensaml.core.3.4.5/bnd.overrides
+++ b/dev/com.ibm.ws.org.opensaml.opensaml.core.3.4.5/bnd.overrides
@@ -195,6 +195,5 @@ Include-Resource: \
   @\${repo;io.openliberty.org.opensaml:opensaml-xacml-api;4.3.2.1}!/!META-INF/MANIFEST.MF|META-INF/maven/*|META-INF/services/*, \
   @\${repo;io.openliberty.org.opensaml:opensaml-xacml-saml-impl;4.3.2.1}!/!META-INF/MANIFEST.MF|META-INF/maven/*|META-INF/services/*, \
  @\${repo;io.dropwizard.metrics:metrics-core;4.2.25}!/!META-INF/MANIFEST.MF|META-INF/maven/*|META-INF/services/*, \
- org/opensaml=${bin}/org/opensaml, \
  META-INF=resources/META-INF
 

--- a/dev/com.ibm.ws.org.opensaml.opensaml.messaging.api.3.4.5/.classpath
+++ b/dev/com.ibm.ws.org.opensaml.opensaml.messaging.api.3.4.5/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.security.mp.jwt.propagation/.classpath
+++ b/dev/com.ibm.ws.security.mp.jwt.propagation/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="bin" path="src"/>
-	<classpathentry kind="src" output="bin_test" path="test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
- Clean up src and test directories in .classpath that are empty
- Remove referencing ${bin} directory that isn't populated any longer since there is no source any longer for overlay classes

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
