### PR TITLE
Race condition on NettyChain stop/update

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyChain.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyChain.java
@@ -109,7 +109,7 @@ public class NettyChain extends HttpChain {
                 if (Objects.isNull(serverChannel)) {
                     // Found null channel while started/starting which shouldn't be the case!
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(this, tc, "Server Channel found to be null for a state where it should be assigned an object! Buggy implementation!!");
+                        Tr.debug(this, tc, "Server Channel found to be null for a state where it should be assigned an object!");
                     }
                     throw new IllegalStateException("Invalid chain state for stop: " + state.get());
                 }
@@ -163,7 +163,7 @@ public class NettyChain extends HttpChain {
             synchronized (stopLock) {
                 while (state.get() == ChainState.STOPPING) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(this, tc, "Waiting for chain on state: " + state.get() + " to be stopped..." + this);
+                        Tr.debug(this, tc, "Waiting for chain on state: " + state.get() + " to be stopped. " + this);
                     }
                     try {
                         stopLock.wait();

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyChain.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/NettyChain.java
@@ -56,6 +56,7 @@ public class NettyChain extends HttpChain {
     private final AtomicReference<ChainState> state = new AtomicReference<>(ChainState.UNINITIALIZED);
 
     private volatile boolean enabled = false;
+    private final Object stopLock = new Object();
 
     /**
      * Netty Http Chain constructor
@@ -99,41 +100,50 @@ public class NettyChain extends HttpChain {
             Tr.entry(this, tc, "Stopping Netty Chain: " + endpointName + ", Current state: " + state.get());
         }
 
-        if (state.get() == ChainState.STARTED || state.get() == ChainState.STARTING) {
+        ChainState currentState = state.get();
+        if (currentState == ChainState.STARTED || currentState == ChainState.STARTING) {
             endpointMgr.removeEndPoint(endpointName);
             state.set(ChainState.STOPPING);
 
             try {
-                if (Objects.nonNull(serverChannel) && serverChannel.isOpen()) {
-
+                if (Objects.isNull(serverChannel)) {
+                    // Found null channel while started/starting which shouldn't be the case!
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(this, tc, "Server Channel is open, attempting to close");
+                        Tr.debug(this, tc, "Server Channel found to be null for a state where it should be assigned an object! Buggy implementation!!");
                     }
-
-                    nettyFramework.stop(serverChannel, -1);
-                    ChannelFuture stopFuture = serverChannel.closeFuture().syncUninterruptibly();
-                    stopFuture.addListener(future -> {
-                    if (future.isSuccess()){
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(this, tc, "Server Channel was successfully closed");
-                        }
-                    } else {
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(this, tc, "Server Channel failed to close! Trying again...");
-                        }
-                        serverChannel.closeFuture().syncUninterruptibly();
-                    }});
-                    serverChannel = null;
+                    throw new IllegalStateException("Invalid chain state for stop: " + state.get());
                 }
-
+                else if (serverChannel.isActive()) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "Server Channel is active, attempting to close");
+                    }
+                    nettyFramework.stop(serverChannel, -1);
+                } else {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "Server Channel is NOT active while starting/started. Stopping will be left to the open future handler...");
+                    }
+                }
+                serverChannel.closeFuture().addListener(future -> {
+                    synchronized (stopLock) {
+                        if (future.isSuccess()) {
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                                Tr.debug(this, tc, "Server Channel was successfully closed");
+                            }
+                        } else {
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                                Tr.debug(this, tc, "Server Channel failed to close! Assuming no missing cleanup...");
+                            }
+                        }
+                        state.set(ChainState.STOPPED);
+                        stopLock.notifyAll();
+                    }
+                });
+                serverChannel = null;
             } finally {
-
                 VirtualHostMap.notifyStopped(owner, currentConfig.getResolvedHost(), currentConfig.getConfigPort(), isHttps);
                 currentConfig.clearActivePort();
                 String topic = owner.getEventTopic() + HttpServiceConstants.ENDPOINT_STOPPED;
                 postEvent(topic, currentConfig, null);
-
-                state.set(ChainState.STOPPED);
                 notifyAll();
             }
         } else {
@@ -150,6 +160,19 @@ public class NettyChain extends HttpChain {
     private void stopAndWait() {
         if (state.get() != ChainState.STOPPED && state.get() != ChainState.UNINITIALIZED) {
             stop();
+            synchronized (stopLock) {
+                while (state.get() == ChainState.STOPPING) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "Waiting for chain on state: " + state.get() + " to be stopped..." + this);
+                    }
+                    try {
+                        stopLock.wait();
+                    } catch (InterruptedException e) {
+                        // Assume if the thread was interrupted that the stop can proceed as expected
+                        break;
+                    }
+                }
+            }
         }
     }
 
@@ -260,9 +283,16 @@ public class NettyChain extends HttpChain {
     }
 
     private void channelFutureHandler(ChannelFuture future) {
-        if (state.get() == ChainState.STOPPING) {
+        if (state.get() == ChainState.STOPPING || state.get() == ChainState.STOPPED) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(this, tc, "Chain: " + endpointName + ", Current state: " + state.get() + ", is stopping so will not notify any virtual hosts and will just return");
+                Tr.debug(this, tc, "Chain: " + endpointName + ", Current state: " + state.get() + ", is not starting so will not notify any virtual hosts and will shutdown the channel if active");
+            }
+            if(future.channel().isActive()) {
+                // Found active channel when it should be stopped/stopping
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(this, tc, "Found active channel: " + future.channel() + ". Will attempt to stop it.");
+                }
+                nettyFramework.stop(future.channel());
             }
             return;
         }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

While running FAT tests we have seen an intermittent issue on servlet 4.0 samesite tests where the endpoint fails to start up after a server update and all tests after that fail with a port binding issue. The issue seems to be on the Netty Chain update logic where we attempt to stop an endpoint that is possibly not yet started and so this race condition seems to be causing that issue where we think the channel is stopped but is really started in the background. This attempts to fix that.

fixes #32755