### PR TITLE
Do not release test bundles unless generating replacement

### DIFF
--- a/dev/cnf/build.bnd
+++ b/dev/cnf/build.bnd
@@ -65,7 +65,7 @@ instrument.taskInjection: false
 
 -releaserepo: Release
 -baselinerepo: Release
--buildrepo: Local
+-buildrepo: ${if;${fat.project};;Local}
 
 # Don't upload sources or javadoc unless bundle overrides
 -maven-release: ${if;${driver;gradle};remote;local}, sources;path=NONE, javadoc;path=NONE

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -220,15 +220,13 @@ task createGradleBootstrap {
         def depsList = []
         gradleBndProjects.each { projectName ->
             def bndProject = bndWorkspace.getProject(projectName)
-            // If the project doesn't have any bundles or if the bundles are not
-            // released, then skip the project
-            if (!bndProject.isNoBundles() && !bndProject.get('-releaserepo').isEmpty()) {
-                String org
-                if ('true'.equals(bndProject.get('test.project', bndProject.get('fat.project', 'false')))) {
-                    org = 'test'
-                } else {
-                    org = 'dev'
-                }
+            // Only add the bundle to the gradle bootstrap if there are bundles in
+            // the project and it is not a test project or we are generating
+            // replacement if it is a test project.
+            boolean testProject = 'true'.equals(bndProject.get('test.project', bndProject.get('fat.project', 'false')))
+            boolean generateReplacement = 'true'.equals(bndProject.get('generate.replacement', testProject ? 'false' : 'true'))
+            if (!bndProject.isNoBundles() && generateReplacement) {
+                String org = testProject ? 'test' : 'dev'
                 for (String bsn : bndProject.getBsns()) {
                     String version = null
                     try {
@@ -313,12 +311,7 @@ task createGeneratedReplacementProjects {
             if (!generateReplacement) {
                 return
             }
-            String org
-            if (testProject) {
-                org = 'test'
-            } else {
-                org = 'dev'
-            }
+            String org = testProject ? 'test' : 'dev'
             List bsns = bndProject.getBsns()
             int bsnCount = bndProject.isNoBundles() ? 0 : bsns.size()
             String classpathEntries = ""

--- a/dev/cnf/resources/bnd/repos.bnd
+++ b/dev/cnf/resources/bnd/repos.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2019, 2022 IBM Corporation and others.
+# Copyright (c) 2019, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -83,4 +83,4 @@ push.ibm.repository:
 
 -releaserepo: Release
 -baselinerepo: Release
--buildrepo: Local
+-buildrepo: ${if;${fat.project};;Local}

--- a/dev/com.ibm.ws.componenttest/bnd.bnd
+++ b/dev/com.ibm.ws.componenttest/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -51,6 +51,7 @@ DynamicImport-Package: \
 publish.wlp.jar.disabled: false
 
 test.project: true
+generate.replacement: true
 
 #This really really needs org.hamcrest since otherwise an older version of Matcher
 #gets put on the classpath and causes unfortunate issues.

--- a/dev/com.ibm.ws.jmx_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jmx_fat/bnd.bnd
@@ -19,12 +19,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 -buildpath: \
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.kernel.feature.resolver/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.feature.resolver/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2023 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -45,7 +45,7 @@ instrument.ffdc: false
 
 publish.wlp.jar.disabled: true
 
-generate.replacement: false
+generate.replacement: true
 
 src: build/src, src
 

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/bnd.bnd
@@ -21,12 +21,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features: opentracing-1.1
 
 -buildpath: \

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/bnd.bnd
@@ -21,12 +21,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features: opentracing-1.2
 
 -buildpath: \

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/bnd.bnd
@@ -21,12 +21,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features: opentracing-1.3, mprestclient-1.4
 
 -buildpath: \

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/bnd.bnd
@@ -21,12 +21,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features: opentracing-1.0
 
 -buildpath: \

--- a/dev/com.ibm.ws.opentracing.1.x_fat/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/bnd.bnd
@@ -24,12 +24,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features: mpOpenTracing-1.1, mpOpenTracing-1.2, mpOpenTracing-1.3, jsonb-1.0, microProfile-2.1
 
 -buildpath: \

--- a/dev/com.ibm.ws.opentracing_fat/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing_fat/bnd.bnd
@@ -24,12 +24,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features: opentracing-1.0
 
 -buildpath: \

--- a/dev/com.ibm.ws.org.slf4j.simple/bnd.bnd
+++ b/dev/com.ibm.ws.org.slf4j.simple/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -18,3 +18,4 @@
 -buildpath: org.slf4j:slf4j-simple;version=1.7.36
 
 test.project: true
+generate.replacement: true

--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -20,6 +20,7 @@ src: \
 	test-resourceadapter/src
 
 fat.project: true
+generate.replacement: true
 
 tested.features: mpOpenApi-2.0,\
                  mpOpenApi-3.0,\

--- a/dev/com.ibm.ws.security.social_fat.delegated/bnd.bnd
+++ b/dev/com.ibm.ws.security.social_fat.delegated/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2023 IBM Corporation and others.
+# Copyright (c) 2022, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -17,6 +17,7 @@ src: \
         fat/src
 
 fat.project: true
+generate.replacement: true
 
 tested.features: appsecurity-4.0, appsecurity-5.0, cdi-3.0, cdi-4.0, concurrent-2.0, el-3.0, expressionlanguage-4.0, expressionlanguage-5.0, jsonp-2.0, jsonp-2.1, jsp-2.3, pages-3.0, pages-3.1, restfulws-3.0, restfulws-3.1, restfulwsclient-3.0, restfulwsclient-3.1, servlet-5.0, servlet-6.0, transportsecurity-1.0
 

--- a/dev/com.ibm.ws.security.social_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.social_fat/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -17,6 +17,7 @@ src: \
     fat/src
 
 test.project: true
+generate.replacement: true
 
 
 -buildpath: \

--- a/dev/com.ibm.ws.transaction.hadb_fat.db2.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.db2.1/bnd.bnd
@@ -21,12 +21,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features:\
   cdi-3.0, cdi-4.0,\
   servlet-5.0, servlet-6.0

--- a/dev/com.ibm.ws.transaction.hadb_fat.derby.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.derby.1/bnd.bnd
@@ -22,12 +22,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features:\
   cdi-3.0, cdi-4.0,\
   servlet-5.0, servlet-6.0

--- a/dev/com.ibm.ws.transaction.hadb_fat.oracle.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.oracle.1/bnd.bnd
@@ -21,12 +21,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features:\
   cdi-3.0, cdi-4.0,\
   servlet-5.0, servlet-6.0

--- a/dev/com.ibm.ws.transaction.hadb_fat.postgresql.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.postgresql.1/bnd.bnd
@@ -21,12 +21,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features:\
   cdi-3.0, cdi-4.0,\
   servlet-5.0, servlet-6.0

--- a/dev/com.ibm.ws.transaction.hadb_fat.sqlserver.1/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.hadb_fat.sqlserver.1/bnd.bnd
@@ -23,12 +23,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features:\
   cdi-3.0, cdi-4.0,\
   servlet-5.0, servlet-6.0

--- a/dev/io.openliberty.checkpoint_fat/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat/bnd.bnd
@@ -44,12 +44,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, osgiConsole-1.0 is added programmatically at runtime.
 tested.features: \

--- a/dev/io.openliberty.checkpoint_fat_mp/bnd.bnd
+++ b/dev/io.openliberty.checkpoint_fat_mp/bnd.bnd
@@ -29,12 +29,6 @@ fat.project: true
 
 fat.test.container.images: kyleaure/db2-ssl:3.0
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 # Define additional tested features that are NOT present in any XML files in this bucket.
 # In this case, osgiConsole-1.0 is added programmatically at runtime.
 tested.features: \

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/bnd.bnd
@@ -21,12 +21,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features: opentracing-2.0, mprestclient-1.4
 
 -buildpath: \

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/bnd.bnd
@@ -21,12 +21,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features: mpOpenTracing-3.0, mprestclient-3.0
 
 -buildpath: \

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.config_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.config_fat/bnd.bnd
@@ -19,12 +19,6 @@ src: \
 	
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features:\
   jsonp-1.1,\
   mprestclient-1.2,\

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat/bnd.bnd
@@ -19,12 +19,6 @@ src: \
 	
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features:\
   jsonp-1.1,\
   mprestclient-1.2,\

--- a/dev/io.openliberty.opentracing.2.x_fat/bnd.bnd
+++ b/dev/io.openliberty.opentracing.2.x_fat/bnd.bnd
@@ -24,12 +24,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features: mpOpenTracing-2.0
 
 -buildpath: \

--- a/dev/io.openliberty.opentracing.3.x_fat/bnd.bnd
+++ b/dev/io.openliberty.opentracing.3.x_fat/bnd.bnd
@@ -24,12 +24,6 @@ src: \
 
 fat.project: true
 
-# Do not release this project's bundles to the bnd repository.
-# If has a test bundle whose name is shared with another project.
-# Because of that you can get a build error that the bundle
-# is already published when doing parallel builds in gradle.
--releaserepo:
-
 tested.features: mpOpenTracing-3.0
 
 -buildpath: \

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -25,12 +25,13 @@ task cleanFat(type: Delete) {
 }
 
 if (isAutomatedBuild && project.file('fat').exists()) {
-  release {
+  task cleanupAfterRelease {
     doLast {
       delete autoFvtDir
       delete layout.buildDirectory.dir("distributions")
     }
   }
+  release.finalizedBy(cleanupAfterRelease)
 }
 
 task cleanBeforeRun(type: Delete) {

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -243,6 +243,13 @@ task buildfat {
   group = "build"
 }
 
+// Only release bundles that are non test projects unless the project is explicitly
+// marked to generate a replacement which means we need to release the bundle(s).
+release {
+  def testProject = 'true'.equals(bnd.get('test.project', bnd.get('fat.project', 'false')))
+  enabled = (!testProject || bnd.is('generate.replacement'))
+}
+
 if (bnd.get('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd.get('publish.wlp.jar.suffix', 'lib').contains('spi/ibm')) {
   task apiSpiJavadoc(type: Javadoc) {
     dependsOn jar

--- a/dev/wlp-mavenRepoTasks/bnd.bnd
+++ b/dev/wlp-mavenRepoTasks/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -25,7 +25,7 @@ publish.wlp.jar.disabled: true
 
 tool.project: true
 
-generate.replacement: false
+generate.replacement: true
 
 -buildpath: \
 	com.ibm.ws.org.apache.commons.io;version=latest, \


### PR DESCRIPTION
- Does the complete solution to not release bundles for test projects unless `generate.replacement: true` is set in the bnd.bnd file
- Undoes `-releaserepo` changes from PR #33275
- Sets `-buildrepo` to empty string for fat projects so we don't collide in that repo as well
- Updates some build / fat / test components to add `generate.replacement: true` since they are needed by WebSphere Liberty repository

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
