### PR TITLE
fix: hibernate lacks support for Java 26

### DIFF
--- a/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataPersistenceTest.java
+++ b/dev/io.openliberty.data.internal_fat/fat/src/test/jakarta/data/DataPersistenceTest.java
@@ -26,6 +26,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -43,10 +44,10 @@ import test.jakarta.data.web.hibernate.DataHibernateServlet;
 /**
  * Runs the tests with a third-party Persistence provider (Hibernate)
  * instead of the built-in Persistence provider (EclipseLink).
- * TODO actually use Hibernate instead of EclipseLink
  */
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
+@MaximumJavaLevel(javaLevel = 25) // TODO remove once Hibernate upgrades their ByteBuddy dependency to a version that supports java 26+
 public class DataPersistenceTest extends FATServletClient {
     /**
      * Error messages, typically for invalid repository methods, that are

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATestHibernate.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATestHibernate.java
@@ -21,6 +21,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -36,6 +37,7 @@ import test.jakarta.data.jpa.web.hibernate.DataJPAHibernateServlet;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
+@MaximumJavaLevel(javaLevel = 25) // TODO remove once Hibernate upgrades their ByteBuddy dependency to a version that supports java 26+
 public class DataJPATestHibernate extends FATServletClient {
     /**
      * Error messages, typically for invalid repository methods, that are

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/fat/src/test/jakarta/data/jpa/hibernate/DataJPAHibernateIntegrationTest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/fat/src/test/jakarta/data/jpa/hibernate/DataJPAHibernateIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -29,6 +30,7 @@ import test.jakarta.data.jpa.hibernate.integration.web.DataJPAHibernateIntegrati
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
+@MaximumJavaLevel(javaLevel = 25) // TODO remove once Hibernate upgrades their ByteBuddy dependency to a version that supports java 26+
 public class DataJPAHibernateIntegrationTest extends FATServletClient {
     private static final String APP_NAME = "DataJPAHibernateIntegrationApp";
 

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/fat/src/test/jakarta/data/jpa/hibernate/DataJPAHibernateTest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/fat/src/test/jakarta/data/jpa/hibernate/DataJPAHibernateTest.java
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -30,6 +31,7 @@ import test.jakarta.data.jpa.hibernate.web.DataJPAHibernateTestServlet;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
+@MaximumJavaLevel(javaLevel = 25) // TODO remove once Hibernate upgrades their ByteBuddy dependency to a version that supports java 26+
 public class DataJPAHibernateTest extends FATServletClient {
     private static final String APP_NAME = "DataJPAHibernateTestApp";
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Set maximum java level to 25 and add TODOs to remove maximum once Hibernate supports Java 26

