### PR TITLE
Do not skip EE9 repeat on Windows now that Servlet 3.1/4.0 buckets are split

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat.2/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat.2/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -50,23 +50,18 @@ import componenttest.topology.impl.LibertyServer;
 })
 public class FATSuite {
 
-    @ClassRule
-    public static RepeatTests repeat;
-
     public static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
 
-    static {
-        // EE10 requires Java 11.
-        // EE11 requires Java 17
-        // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
-        // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
-        repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                        .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
-                        .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                        .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                        .andWith(FeatureReplacementAction.EE11_FEATURES());
-
-    }
+    // EE10 requires Java 11.
+    // EE11 requires Java 17
+    // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
+    // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
+    @ClassRule
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     //Due to Fyre performance on Windows, use this method to set the server trace to the minimum
     public static void setDynamicTrace(LibertyServer server, String trace) throws Exception {

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -39,7 +39,6 @@ import com.ibm.ws.webcontainer.servlet31.fat.tests.WCServerHttpUnit;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.WCServerTest;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.WCServletContextUnsupportedOperationExceptionTest;
 
-import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
@@ -71,32 +70,18 @@ import componenttest.topology.impl.LibertyServer;
 })
 public class FATSuite {
 
-    @ClassRule
-    public static RepeatTests repeat;
-
     public static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
 
-    static {
-        // EE10 requires Java 11.
-        // EE11 requires Java 17
-        // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
-        if (isWindows && !FATRunner.FAT_TEST_LOCALRUN) {
-            // Repeating the full fat for all features may exceed the 3 hour limit on Fyre Windows and causes random build breaks.
-            // Skip EE9 on the windows platform when not running locally.
-            // If we are running with a Java version less than 11, have EE8 be the lite mode test to run.
-            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                            .andWith(FeatureReplacementAction.EE8_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                            .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                            .andWith(FeatureReplacementAction.EE11_FEATURES());
-        } else {
-            // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
-            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                            .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
-                            .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                            .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                            .andWith(FeatureReplacementAction.EE11_FEATURES());
-        }
-    }
+    // EE10 requires Java 11.
+    // EE11 requires Java 17
+    // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
+    // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
+    @ClassRule
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     //Due to Fyre performance on Windows, use this method to set the server trace to the minimum
     public static void setDynamicTrace(LibertyServer server, String trace) throws Exception {

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/FATSuite.java
@@ -9,8 +9,6 @@
  *******************************************************************************/
 package com.ibm.ws.fat.wc;
 
-import java.util.Locale;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -28,7 +26,6 @@ import com.ibm.ws.fat.wc.tests.WCSameSiteIncompatibleClientsTests;
 import com.ibm.ws.fat.wc.tests.WebSphereServletEventListenerTest;
 import com.ibm.ws.fat.wc.tests.WebSphereSpiHttpRequestURLTest;
 
-import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
@@ -64,30 +61,15 @@ import componenttest.rules.repeater.RepeatTests;
 
 public class FATSuite {
 
+    // EE10 requires Java 11.
+    // EE11 requires Java 17
+    // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
+    // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
     @ClassRule
-    public static RepeatTests repeat;
-
-    public static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
-
-    static {
-        // EE10 requires Java 11.
-        // EE11 requires Java 17
-        // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
-        if (isWindows && !FATRunner.FAT_TEST_LOCALRUN) {
-            // Repeating the full fat for all features may exceed the 3 hour limit on Fyre Windows and causes random build breaks.
-            // Skip EE9 on the windows platform when not running locally.
-            // If we are running with a Java version less than 11, have EE8 (EmptyAction) be the lite mode test to run.
-            repeat = RepeatTests.with(new EmptyAction().conditionalFullFATOnly(EmptyAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                            .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                            .andWith(FeatureReplacementAction.EE11_FEATURES());
-        } else {
-            // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
-            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                            .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                            .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                            .andWith(FeatureReplacementAction.EE11_FEATURES());
-        }
-    }
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     /**
      * @see {@link FatLogHandler#generateHelpFile()}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
@@ -9,8 +9,6 @@
  *******************************************************************************/
 package com.ibm.ws.fat.wc;
 
-import java.util.Locale;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -48,7 +46,6 @@ import com.ibm.ws.fat.wc.tests.WCServletPathForDefaultMappingFalse;
 import com.ibm.ws.fat.wc.tests.WCTestEncodedX590;
 import com.ibm.ws.fat.wc.tests.WCTrailersTest;
 
-import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
@@ -106,30 +103,15 @@ import componenttest.rules.repeater.RepeatTests;
 
 public class FATSuite {
 
+    // EE10 requires Java 11.
+    // EE11 requires Java 17
+    // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
+    // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
     @ClassRule
-    public static RepeatTests repeat;
-
-    public static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
-
-    static {
-        // EE10 requires Java 11.
-        // EE11 requires Java 17
-        // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
-        if (isWindows && !FATRunner.FAT_TEST_LOCALRUN) {
-            // Repeating the full fat for all features may exceed the 3 hour limit on Fyre Windows and causes random build breaks.
-            // Skip EE9 on the windows platform when not running locally.
-            // If we are running with a Java version less than 11, have EE8 (EmptyAction) be the lite mode test to run.
-            repeat = RepeatTests.with(new EmptyAction().conditionalFullFATOnly(EmptyAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                            .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                            .andWith(FeatureReplacementAction.EE11_FEATURES());
-        } else {
-            // If we are running with a Java version less than 11, have EE9 be the lite mode test to run.
-            repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
-                            .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
-                            .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
-                            .andWith(FeatureReplacementAction.EE11_FEATURES());
-        }
-    }
+    public static RepeatTests repeat = RepeatTests.with(new EmptyAction().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_11))
+                    .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
+                    .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     /**
      * @see {@link FatLogHandler#generateHelpFile()}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #33334