### PR TITLE
Detach entities after stateless repository operation

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
@@ -20,40 +20,46 @@ import com.ibm.websphere.ras.annotation.Trivial;
 @Trivial
 public enum QueryType {
     // query method count
-    COUNT(!Require.TX, !Require.RETURN_HIDDEN),
+    COUNT(!Require.TX, !Require.DETACH_ENTITIES, !Require.RETURN_HIDDEN),
 
     // query method exists
-    EXISTS(!Require.TX, !Require.RETURN_HIDDEN),
+    EXISTS(!Require.TX, !Require.DETACH_ENTITIES, !Require.RETURN_HIDDEN),
 
     // query method find/@Find/@Query(SELECT/FROM/WHERE)
-    FIND(!Require.TX, Require.RETURN_HIDDEN),
+    FIND(!Require.TX, Require.DETACH_ENTITIES, Require.RETURN_HIDDEN),
 
     // query method delete/@Delete with entity result
-    FIND_AND_DELETE(Require.TX, Require.RETURN_HIDDEN),
+    FIND_AND_DELETE(Require.TX, Require.DETACH_ENTITIES, Require.RETURN_HIDDEN),
 
     // life cycle @Insert
-    INSERT(Require.TX, Require.RETURN_HIDDEN),
+    INSERT(Require.TX, Require.DETACH_ENTITIES, Require.RETURN_HIDDEN),
 
     // life cycle @Delete
-    LC_DELETE(Require.TX, !Require.RETURN_HIDDEN),
+    LC_DELETE(Require.TX, !Require.DETACH_ENTITIES, !Require.RETURN_HIDDEN),
 
     // life cycle @Update
-    LC_UPDATE(Require.TX, !Require.RETURN_HIDDEN),
+    LC_UPDATE(Require.TX, !Require.DETACH_ENTITIES, !Require.RETURN_HIDDEN),
 
     // life cycle @Update often with entity result (find & merge)
-    LC_UPDATE_MERGE(Require.TX, Require.RETURN_HIDDEN),
+    LC_UPDATE_MERGE(Require.TX, Require.DETACH_ENTITIES, Require.RETURN_HIDDEN),
 
     // query method delete/@Delete/@Query(DELETE)
-    QM_DELETE(Require.TX, !Require.RETURN_HIDDEN),
+    QM_DELETE(Require.TX, !Require.DETACH_ENTITIES, !Require.RETURN_HIDDEN),
 
     // query method update/@Update/@Query(UPDATE)
-    QM_UPDATE(Require.TX, !Require.RETURN_HIDDEN),
+    QM_UPDATE(Require.TX, !Require.DETACH_ENTITIES, !Require.RETURN_HIDDEN),
 
     // resource accessor method
-    RESOURCE_ACCESS(!Require.TX, !Require.RETURN_HIDDEN),
+    RESOURCE_ACCESS(!Require.TX, !Require.DETACH_ENTITIES, !Require.RETURN_HIDDEN),
 
     // life cycle @Save
-    SAVE(Require.TX, Require.RETURN_HIDDEN);
+    SAVE(Require.TX, Require.DETACH_ENTITIES, Require.RETURN_HIDDEN);
+
+    /**
+     * Indicates that a stateless repository must clear the entity manager to
+     * detach entities after the operation.
+     */
+    public final boolean detachEntities;
 
     /**
      * Indicates if a return value from this type of method must be hidden from
@@ -70,11 +76,15 @@ public enum QueryType {
      * Internal constructor for enumeration values.
      *
      * @param requiresTransaction require a transaction for the operation.
+     * @param detachEntities      require a stateless repository to detach entities
+     *                                after the operation.
      * @param hideReturnValue     suppress logging/tracing of the method's return
      *                                value by default
      */
     private QueryType(boolean requiresTransaction,
+                      boolean detachEntities,
                       boolean hideReturnValue) {
+        this.detachEntities = detachEntities;
         this.hideReturnValue = hideReturnValue;
         this.requiresTransaction = requiresTransaction;
     }
@@ -86,6 +96,7 @@ public enum QueryType {
      * declared later in the file.
      */
     private static final class Require {
+        static final boolean DETACH_ENTITIES = true;
         static final boolean RETURN_HIDDEN = true;
         static final boolean TX = true;
     }


### PR DESCRIPTION
When an EntityManager is used for a stateless repository (which is always the case in Data 1.0), we need to ensure that entities have been detached before returning from a repository operation so that the behavior is consistent with stateless.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
