### PR TITLE
Updates to be able to build Open Liberty with Java 25

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_postgresql/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -27,4 +27,5 @@ fat.project: true
 	software.amazon.jdbc:aws-advanced-jdbc-wrapper;version=2.2.3,\
 	com.ibm.ws.jca.cm;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
-	io.openliberty.org.testcontainers;version=latest
+	io.openliberty.org.testcontainers;version=latest,\
+	org.jetbrains:annotations;version=13.0

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DerbyClientContainer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DerbyClientContainer.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -30,15 +30,21 @@ class DerbyClientContainer extends JdbcDatabaseContainer<DerbyClientContainer> {
     private String dbname = "memory:testdb";
 
     public DerbyClientContainer(DockerImageName image) {
-        super("");
+        // Calling super constructor like this since super("") doesn't compile with
+        // Java 25 due to stricter annotation checking rules
+        super(DockerImageName.parse(""));
     }
 
     public DerbyClientContainer(String image) {
-        super("");
+        // Calling super constructor like this since super("") doesn't compile with
+        // Java 25 due to stricter annotation checking rules
+        super(DockerImageName.parse(""));
     }
 
     public DerbyClientContainer() {
-        super("");
+        // Calling super constructor like this since super("") doesn't compile with
+        // Java 25 due to stricter annotation checking rules
+        super(DockerImageName.parse(""));
     }
 
     @Override

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DerbyNoopContainer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DerbyNoopContainer.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -26,15 +26,21 @@ import org.testcontainers.utility.DockerImageName;
 class DerbyNoopContainer extends JdbcDatabaseContainer<DerbyNoopContainer> {
 
     public DerbyNoopContainer(DockerImageName image) {
-        super("");
+        // Calling super constructor like this since super("") doesn't compile with
+        // Java 25 due to stricter annotation checking rules
+        super(DockerImageName.parse(""));
     }
 
     public DerbyNoopContainer(String image) {
-        super("");
+        // Calling super constructor like this since super("") doesn't compile with
+        // Java 25 due to stricter annotation checking rules
+        super(DockerImageName.parse(""));
     }
 
     public DerbyNoopContainer() {
-        super("");
+        // Calling super constructor like this since super("") doesn't compile with
+        // Java 25 due to stricter annotation checking rules
+        super(DockerImageName.parse(""));
     }
 
     @Override

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/PostgreSQLContainer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/PostgreSQLContainer.java
@@ -41,12 +41,9 @@ public class PostgreSQLContainer extends JdbcDatabaseContainer<PostgreSQLContain
                     .withStartupTimeout(Duration.of(60, ChronoUnit.SECONDS));
 
     public PostgreSQLContainer(String img) {
-        super(img);
-        this.waitStrategy = defaultWaitStrategy; //can be overwritten by calling waitingFor or setWaitStrategy
-    }
-
-    public PostgreSQLContainer(final Future<String> image) {
-        super(image);
+        // Calling super constructor like this since super(img) doesn't compile with
+        // Java 25 due to stricter annotation checking rules
+        super(DockerImageName.parse(img));
         this.waitStrategy = defaultWaitStrategy; //can be overwritten by calling waitingFor or setWaitStrategy
     }
 


### PR DESCRIPTION
- Switch from using the String constructor to using the DockerImageName constructor to avoid the `@NotNull` annotation needing to be on the buildpath.  
- Add jetbrains annotations to the buildpath where we can't avoid the `@NotNull` annotation compile dependency

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
