### PR TITLE
Adds tests for setCacheRetrieveMode and setCacheStoreMode methods

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/PersistenceUnitEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/PersistenceUnitEntity.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jpa.persistence.tests.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class PersistenceUnitEntity {
+    @Id
+    public String id;
+    
+    public Integer value;
+
+    public PersistenceUnitEntity() {
+    }
+
+    public PersistenceUnitEntity(String id, Integer value) {
+        this.id = id;
+        this.value = value;
+    }
+
+    public static PersistenceUnitEntity of(String id, Integer value) {
+        return new PersistenceUnitEntity(id, value);
+    }
+
+    @Override
+    public String toString() {
+        return "PersistenceUnitEntity{id='" + id + "', value=" + value + "}";
+    }
+}

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -1746,6 +1746,124 @@ public class JakartaPersistenceServlet extends FATServlet {
         boolean inCache = em.getEntityManagerFactory().getCache().contains(PersistenceUnitEntity.class, id);
         assertFalse(inCache);
     }
+@Test
+    public void testCacheStoreMode_EMLevel_Refresh() throws Exception {
+        deleteAllEntities(PersistenceUnitEntity.class);
+        String id = "testCacheStoreMode_EMLevel_Refresh";
+
+        tx.begin();
+        em.persist(PersistenceUnitEntity.of(id, 222));
+        em.flush();
+        tx.commit();
+
+        em.setCacheStoreMode(CacheStoreMode.REFRESH);
+
+        PersistenceUnitEntity entity;
+        try {
+            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
+            query.setParameter(1, id);
+            entity = (PersistenceUnitEntity) query.getSingleResult();
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            resetCacheModes();
+        }
+
+        assertEquals(Integer.valueOf(222), entity.value);
+
+        boolean inCache = em.getEntityManagerFactory().getCache().contains(PersistenceUnitEntity.class, id);
+        assertTrue(inCache);
+    }
+
+    @Test
+    public void testCacheStoreMode_QueryLevel_Refresh() throws Exception {
+        deleteAllEntities(PersistenceUnitEntity.class);
+        String id = "testCacheStoreMode_QueryLevel_Refresh";
+
+        tx.begin();
+        em.persist(PersistenceUnitEntity.of(id, 222));
+        em.flush();
+        tx.commit();
+
+        PersistenceUnitEntity entity;
+        try {
+            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
+            query.setParameter(1, id);
+            query.setCacheStoreMode(CacheStoreMode.REFRESH);
+            entity = (PersistenceUnitEntity) query.getSingleResult();
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            resetCacheModes();
+        }
+
+        assertEquals(Integer.valueOf(222), entity.value);
+
+        boolean inCache = em.getEntityManagerFactory().getCache().contains(PersistenceUnitEntity.class, id);
+        assertTrue(inCache);
+    }
+
+    @Test
+    public void testCacheStoreMode_QueryOverridesEM_RefreshOverridesBypass() throws Exception {
+        deleteAllEntities(PersistenceUnitEntity.class);
+        String id = "testCacheStoreMode_QueryOverridesEM_RefreshOverridesBypass";
+
+        tx.begin();
+        em.persist(PersistenceUnitEntity.of(id, 222));
+        em.flush();
+        tx.commit();
+
+        em.getEntityManagerFactory().getCache().evict(PersistenceUnitEntity.class, id);
+        em.setCacheStoreMode(CacheStoreMode.BYPASS);
+
+        PersistenceUnitEntity entity;
+        try {
+            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
+            query.setParameter(1, id);
+            query.setCacheStoreMode(CacheStoreMode.REFRESH);
+            entity = (PersistenceUnitEntity) query.getSingleResult();
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            resetCacheModes();
+        }
+
+        assertEquals(Integer.valueOf(222), entity.value);
+
+        boolean inCache = em.getEntityManagerFactory().getCache().contains(PersistenceUnitEntity.class, id);
+        assertTrue(inCache);
+    }
+
+    @Test
+    public void testCacheStoreMode_QueryOverridesEM_BypassOverridesRefresh() throws Exception {
+        deleteAllEntities(PersistenceUnitEntity.class);
+        String id = "testCacheStoreMode_QueryOverridesEM_BypassOverridesRefresh";
+
+        tx.begin();
+        em.persist(PersistenceUnitEntity.of(id, 222));
+        em.flush();
+        tx.commit();
+
+        em.getEntityManagerFactory().getCache().evict(PersistenceUnitEntity.class, id);
+        em.setCacheStoreMode(CacheStoreMode.REFRESH);
+
+        PersistenceUnitEntity entity;
+        try {
+            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
+            query.setParameter(1, id);
+            query.setCacheStoreMode(CacheStoreMode.BYPASS);
+            entity = (PersistenceUnitEntity) query.getSingleResult();
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            resetCacheModes();
+        }
+
+        assertEquals(Integer.valueOf(222), entity.value);
+
+        boolean inCache = em.getEntityManagerFactory().getCache().contains(PersistenceUnitEntity.class, id);
+        assertFalse(inCache);
+    }
 
 
     /**

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -51,11 +51,14 @@ import io.openliberty.jpa.persistence.tests.models.Ticket;
 import io.openliberty.jpa.persistence.tests.models.TicketStatus;
 import io.openliberty.jpa.persistence.tests.models.User;
 import io.openliberty.jpa.persistence.tests.models.ConcatEntity;
+import io.openliberty.jpa.persistence.tests.models.PersistenceUnitEntity;
 import jakarta.annotation.Resource;
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -1360,6 +1363,205 @@ public class JakartaPersistenceServlet extends FATServlet {
         }
     }
 
+    @Test
+    public void testCacheRetrieveMode_EMLevel_Bypass() throws Exception {
+        deleteAllEntities(PersistenceUnitEntity.class);
+        String id = "testCacheRetrieveMode_EMLevel_Bypass";
+
+        tx.begin();
+        em.persist(PersistenceUnitEntity.of(id, 222));
+        em.flush();
+        tx.commit();
+
+        tx.begin();
+        PersistenceUnitEntity entity;
+
+        try {
+            em.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
+            
+            Query update = em.createQuery("UPDATE PersistenceUnitEntity SET value = value * 2 WHERE id = ?1");
+            update.setParameter(1, id);
+            update.executeUpdate();
+            
+            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
+            query.setParameter(1, id);
+            entity = (PersistenceUnitEntity) query.getSingleResult();
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            resetCacheModes();
+        }
+
+        assertEquals(Integer.valueOf(444), entity.value);
+    }
+    
+    @Test
+    public void testCacheRetrieveMode_EMLevel_Use_Default() throws Exception {
+        deleteAllEntities(PersistenceUnitEntity.class);
+        String id = "testCacheRetrieveMode_EMLevel_Use_Default";
+
+        tx.begin();
+        em.persist(PersistenceUnitEntity.of(id, 222));
+        em.flush();
+        tx.commit();
+
+        tx.begin();
+        PersistenceUnitEntity entity;
+
+        try {
+            //Default cache retrieve mode is USE — no  need to set explicitly
+            
+            Query update = em.createQuery("UPDATE PersistenceUnitEntity SET value = value * 2 WHERE id = ?1");
+            update.setParameter(1, id);
+            update.executeUpdate();
+            
+            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
+            query.setParameter(1, id);
+            entity = (PersistenceUnitEntity) query.getSingleResult();
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            resetCacheModes();
+        }
+
+        assertEquals(Integer.valueOf(222), entity.value);
+    }
+
+    @Test
+    public void testCacheRetrieveMode_QueryLevel_Bypass() throws Exception {
+        deleteAllEntities(PersistenceUnitEntity.class);
+        String id = "testCacheRetrieveMode_QueryLevel_Bypass";
+
+        tx.begin();
+        em.persist(PersistenceUnitEntity.of(id, 222));
+        em.flush();
+        tx.commit();
+
+        tx.begin();
+        PersistenceUnitEntity entity;
+        try {
+            Query update = em.createQuery("UPDATE PersistenceUnitEntity SET value = value * 2 WHERE id = ?1");
+            update.setParameter(1, id);
+            update.executeUpdate();
+
+            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
+            query.setParameter(1, id);
+            query.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
+
+            entity = (PersistenceUnitEntity) query.getSingleResult();
+
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        }
+        
+        assertEquals(Integer.valueOf(444), entity.value);
+    }
+    
+    @Test
+    public void testCacheRetrieveMode_QueryLevel_Use_Default() throws Exception {
+        deleteAllEntities(PersistenceUnitEntity.class);
+        String id = "testCacheRetrieveMode_QueryLevel_Use_Default";
+
+        tx.begin();
+        em.persist(PersistenceUnitEntity.of(id, 222));
+        em.flush();
+        tx.commit();
+
+        tx.begin();
+        PersistenceUnitEntity entity;
+        try {
+            Query update = em.createQuery("UPDATE PersistenceUnitEntity SET value = value * 2 WHERE id = ?1");
+            update.setParameter(1, id);
+            update.executeUpdate();
+
+            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
+            query.setParameter(1, id);
+            //Default cache retrieve mode is USE — no  need to set explicitly
+
+            entity = (PersistenceUnitEntity) query.getSingleResult();
+
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        }
+        
+        assertEquals(Integer.valueOf(222), entity.value);
+    }
+
+    @Test
+    public void testCacheRetrieveMode_QueryOverridesEM_UseOverridesBypass() throws Exception {
+        deleteAllEntities(PersistenceUnitEntity.class);
+        String id = "testCacheRetrieveMode_QueryOverridesEM_UseOverridesBypass";
+
+        tx.begin();
+        em.persist(PersistenceUnitEntity.of(id, 222));
+        em.flush();
+        tx.commit();
+
+        tx.begin();
+        PersistenceUnitEntity entity;
+        try {
+            em.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
+
+            Query update = em.createQuery("UPDATE PersistenceUnitEntity SET value = value * 2 WHERE id = ?1");
+            update.setParameter(1, id);
+            update.executeUpdate();
+
+            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
+            query.setParameter(1, id);
+            query.setCacheRetrieveMode(CacheRetrieveMode.USE);
+
+            entity = (PersistenceUnitEntity) query.getSingleResult();
+
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        } finally {
+            resetCacheModes();
+        }
+        
+        assertEquals(Integer.valueOf(222), entity.value);
+    }
+
+    @Test
+    public void testCacheRetrieveMode_QueryOverridesEM_BypassOverridesUse() throws Exception {
+        deleteAllEntities(PersistenceUnitEntity.class);
+        String id = "testCacheRetrieveMode_QueryOverridesEM_BypassOverridesUse";
+
+        tx.begin();
+        em.persist(PersistenceUnitEntity.of(id, 222));
+        em.flush();
+        tx.commit();
+
+        tx.begin();
+        PersistenceUnitEntity entity;
+        try {
+            em.setCacheRetrieveMode(CacheRetrieveMode.USE);
+
+            Query update = em.createQuery("UPDATE PersistenceUnitEntity SET value = value * 2 WHERE id = ?1");
+            update.setParameter(1, id);
+            update.executeUpdate();
+
+            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
+            query.setParameter(1, id);
+            query.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
+
+            entity = (PersistenceUnitEntity) query.getSingleResult();
+
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        }
+        
+        assertEquals(Integer.valueOf(444), entity.value);
+    }
+
+
     /**
      * Utility method to drop all entities from table.
      *
@@ -1373,5 +1575,14 @@ public class JakartaPersistenceServlet extends FATServlet {
         em.createQuery("DELETE FROM " + clazz.getSimpleName())
                         .executeUpdate();
         tx.commit();
+    }
+    
+    /**
+     * Helper method to reset EntityManager cache modes to defaults after tests.
+     * This ensures tests don't interfere with each other when using the same EM instance.
+     */
+    private void resetCacheModes() {
+        em.setCacheRetrieveMode(CacheRetrieveMode.USE);
+        em.setCacheStoreMode(CacheStoreMode.USE);
     }
 }

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -1428,8 +1428,6 @@ public class JakartaPersistenceServlet extends FATServlet {
         } catch (Exception e) {
             tx.rollback();
             throw e;
-        } finally {
-            resetCacheModes();
         }
 
         assertEquals(Integer.valueOf(222), entity.value);
@@ -1625,8 +1623,6 @@ public class JakartaPersistenceServlet extends FATServlet {
             entity = (PersistenceUnitEntity) query.getSingleResult();
         } catch (Exception e) {
             throw e;
-        } finally {
-            resetCacheModes();
         }
 
         assertEquals(Integer.valueOf(222), entity.value);
@@ -1656,8 +1652,6 @@ public class JakartaPersistenceServlet extends FATServlet {
             entity = (PersistenceUnitEntity) query.getSingleResult();
         } catch (Exception e) {
             throw e;
-        } finally {
-            resetCacheModes();
         }
 
         assertEquals(Integer.valueOf(222), entity.value);
@@ -1688,8 +1682,6 @@ public class JakartaPersistenceServlet extends FATServlet {
             entity = (PersistenceUnitEntity) query.getSingleResult();
         } catch (Exception e) {
             throw e;
-        } finally {
-            resetCacheModes();
         }
 
         assertEquals(Integer.valueOf(222), entity.value);
@@ -1752,8 +1744,6 @@ public class JakartaPersistenceServlet extends FATServlet {
             entity = (PersistenceUnitEntity) query.getSingleResult();
         } catch (Exception e) {
             throw e;
-        } finally {
-            resetCacheModes();
         }
 
         assertEquals(Integer.valueOf(222), entity.value);
@@ -1815,8 +1805,6 @@ public class JakartaPersistenceServlet extends FATServlet {
             entity = (PersistenceUnitEntity) query.getSingleResult();
         } catch (Exception e) {
             throw e;
-        } finally {
-            resetCacheModes();
         }
 
         assertEquals(Integer.valueOf(222), entity.value);

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -1365,6 +1365,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
     public void testCacheRetrieveMode_EMLevel_Bypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_EMLevel_Bypass";
@@ -1387,7 +1388,10 @@ public class JakartaPersistenceServlet extends FATServlet {
             Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
             query.setParameter(1, id);
             entity = (PersistenceUnitEntity) query.getSingleResult();
+
+            tx.commit();
         } catch (Exception e) {
+            tx.rollback();
             throw e;
         } finally {
             resetCacheModes();
@@ -1419,7 +1423,10 @@ public class JakartaPersistenceServlet extends FATServlet {
             Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
             query.setParameter(1, id);
             entity = (PersistenceUnitEntity) query.getSingleResult();
+
+            tx.commit();
         } catch (Exception e) {
+            tx.rollback();
             throw e;
         } finally {
             resetCacheModes();
@@ -1429,6 +1436,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
     public void testCacheRetrieveMode_QueryLevel_Bypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_QueryLevel_Bypass";
@@ -1493,6 +1501,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheRetrieveMode_QueryOverridesEM_UseOverridesBypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_QueryOverridesEM_UseOverridesBypass";
@@ -1529,6 +1538,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
     public void testCacheRetrieveMode_QueryOverridesEM_BypassOverridesUse() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_QueryOverridesEM_BypassOverridesUse";
@@ -1563,6 +1573,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
     public void testCacheStoreMode_EMLevel_Bypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_EMLevel_Bypass";
@@ -1593,6 +1604,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
     
     @Test
+    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_EMLevel_Use_Default() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_EMLevel_Use_Default";
@@ -1624,6 +1636,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
     public void testCacheStoreMode_QueryLevel_Bypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryLevel_Bypass";
@@ -1686,6 +1699,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryOverridesEM_UseOverridesBypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_UseOverridesBypass";
@@ -1717,6 +1731,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
     public void testCacheStoreMode_QueryOverridesEM_BypassOverridesUse() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_BypassOverridesUse";
@@ -1746,7 +1761,9 @@ public class JakartaPersistenceServlet extends FATServlet {
         boolean inCache = em.getEntityManagerFactory().getCache().contains(PersistenceUnitEntity.class, id);
         assertFalse(inCache);
     }
-@Test
+    
+    @Test
+    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_EMLevel_Refresh() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_EMLevel_Refresh";
@@ -1756,6 +1773,8 @@ public class JakartaPersistenceServlet extends FATServlet {
         em.flush();
         tx.commit();
 
+        em.getEntityManagerFactory().getCache().evict(PersistenceUnitEntity.class, id);
+        
         em.setCacheStoreMode(CacheStoreMode.REFRESH);
 
         PersistenceUnitEntity entity;
@@ -1776,6 +1795,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryLevel_Refresh() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryLevel_Refresh";
@@ -1784,6 +1804,8 @@ public class JakartaPersistenceServlet extends FATServlet {
         em.persist(PersistenceUnitEntity.of(id, 222));
         em.flush();
         tx.commit();
+
+        em.getEntityManagerFactory().getCache().evict(PersistenceUnitEntity.class, id);
 
         PersistenceUnitEntity entity;
         try {
@@ -1804,6 +1826,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryOverridesEM_RefreshOverridesBypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_RefreshOverridesBypass";
@@ -1814,6 +1837,7 @@ public class JakartaPersistenceServlet extends FATServlet {
         tx.commit();
 
         em.getEntityManagerFactory().getCache().evict(PersistenceUnitEntity.class, id);
+        
         em.setCacheStoreMode(CacheStoreMode.BYPASS);
 
         PersistenceUnitEntity entity;
@@ -1835,6 +1859,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
     public void testCacheStoreMode_QueryOverridesEM_BypassOverridesRefresh() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_BypassOverridesRefresh";
@@ -1845,6 +1870,7 @@ public class JakartaPersistenceServlet extends FATServlet {
         tx.commit();
 
         em.getEntityManagerFactory().getCache().evict(PersistenceUnitEntity.class, id);
+        
         em.setCacheStoreMode(CacheStoreMode.REFRESH);
 
         PersistenceUnitEntity entity;


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Adds tests for setCacheRetrieveMode() and setCacheStoreMode() methods introduced in Jakarta Persistence 3.2.
Recreates #33189 