### PR TITLE
Update EclipseLink to support setCacheRetrieveMode and setCacheStoreMode methods

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -1365,7 +1365,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheRetrieveMode_EMLevel_Bypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_EMLevel_Bypass";
@@ -1434,7 +1434,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheRetrieveMode_QueryLevel_Bypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_QueryLevel_Bypass";
@@ -1499,7 +1499,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheRetrieveMode_QueryOverridesEM_UseOverridesBypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_QueryOverridesEM_UseOverridesBypass";
@@ -1536,7 +1536,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheRetrieveMode_QueryOverridesEM_BypassOverridesUse() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_QueryOverridesEM_BypassOverridesUse";
@@ -1571,7 +1571,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_EMLevel_Bypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_EMLevel_Bypass";
@@ -1602,7 +1602,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
     
     @Test
-    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_EMLevel_Use_Default() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_EMLevel_Use_Default";
@@ -1632,7 +1632,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryLevel_Bypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryLevel_Bypass";
@@ -1691,7 +1691,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryOverridesEM_UseOverridesBypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_UseOverridesBypass";
@@ -1723,7 +1723,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryOverridesEM_BypassOverridesUse() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_BypassOverridesUse";
@@ -1753,7 +1753,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
     
     @Test
-    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_EMLevel_Refresh() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_EMLevel_Refresh";
@@ -1785,7 +1785,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryLevel_Refresh() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryLevel_Refresh";
@@ -1814,7 +1814,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    //Test passes due to default behaviour but issue persists - Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryOverridesEM_RefreshOverridesBypass() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_RefreshOverridesBypass";
@@ -1847,7 +1847,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189")
+    //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryOverridesEM_BypassOverridesRefresh() throws Exception {
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_BypassOverridesRefresh";

--- a/dev/io.openliberty.persistence.3.2.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/bnd.bnd
@@ -130,7 +130,9 @@ Include-Resource: \
   @\${repo;org.eclipse.persistence:org.eclipse.persistence.jpa;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
   @\${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.jpql;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
   @\${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
-  @\${repo;org.eclipse.persistence:org.eclipse.persistence.json;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class)
+  @\${repo;org.eclipse.persistence:org.eclipse.persistence.json;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
+  org/eclipse/persistence/internal/jpa=${bin}/org/eclipse/persistence/internal/jpa,\
+  org/eclipse/persistence/queries=${bin}/org/eclipse/persistence/queries
 
 
 publish.wlp.jar.suffix: dev/api/third-party

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/internal/jpa/EJBQueryImpl.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/internal/jpa/EJBQueryImpl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 1998, 2025 IBM Corporation. All rights reserved.
+ * Copyright (c) 2025 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -383,6 +383,7 @@ public class EJBQueryImpl<X> extends QueryImpl implements JpaQuery<X> {
 
     @Override
     public TypedQuery<X> setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
+        FindOptionUtils.setCacheRetrieveMode(getDatabaseQuery().getProperties(), cacheRetrieveMode);
         setHint(QueryHints.CACHE_RETRIEVE_MODE, cacheRetrieveMode);
         return this;
     }
@@ -394,6 +395,7 @@ public class EJBQueryImpl<X> extends QueryImpl implements JpaQuery<X> {
 
     @Override
     public TypedQuery<X> setCacheStoreMode(CacheStoreMode cacheStoreMode) {
+        FindOptionUtils.setCacheStoreMode(getDatabaseQuery().getProperties(), cacheStoreMode);
         setHint(QueryHints.CACHE_STORE_MODE, cacheStoreMode);
         return this;
     }
@@ -405,6 +407,7 @@ public class EJBQueryImpl<X> extends QueryImpl implements JpaQuery<X> {
 
     @Override
     public TypedQuery<X> setTimeout(Integer timeout) {
+        FindOptionUtils.setTimeout(getDatabaseQuery().getProperties(), timeout);
         setHint(QueryHints.QUERY_TIMEOUT, timeout);
         return this;
     }
@@ -426,19 +429,19 @@ public class EJBQueryImpl<X> extends QueryImpl implements JpaQuery<X> {
         if (entityManager == null || entityManager.properties == null) {
             return;
         }
-        
+
         DatabaseQuery dbQuery = getDatabaseQuery();
         if (dbQuery == null) {
             return;
         }
-        
+
         Map<String, Object> emProperties = entityManager.properties;
-        
+
         // CACHE_RETRIEVE_MODE only applies to ObjectLevelReadQuery (SELECT queries)
         if (dbQuery.isObjectLevelReadQuery() && emProperties.containsKey(QueryHints.CACHE_RETRIEVE_MODE)) {
             setHint(QueryHints.CACHE_RETRIEVE_MODE, emProperties.get(QueryHints.CACHE_RETRIEVE_MODE));
         }
-        
+
         // CACHE_STORE_MODE applies to all query types:
         // - For ObjectLevelReadQuery: controls whether results are stored in cache after reading
         // - For ModifyQuery: controls whether cache is invalidated after UPDATE/DELETE

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
@@ -1,0 +1,2334 @@
+/*
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+//     07/13/2009-2.0 Guy Pelletier
+//       - 277039: JPA 2.0 Cache Usage Settings
+//     corteggiano, Frank Schwarz, Tom Ware - Fix for bug Bug 320254 - EL 2.1.0 JPA: Query with hint eclipselink.batch
+//              and org.eclipse.persistence.exceptions.QueryException.queryHintNavigatedNonExistantRelationship
+//     10/29/2010-2.2 Michael O'Brien
+//       - 325167: Make reserved # bind parameter char generic to enable native SQL pass through
+//     06/30/2011-2.3.1 Guy Pelletier
+//       - 341940: Add disable/enable allowing native queries
+//     06/30/2015-2.6.0 Will Dazey
+//       - 471487: Fixed eclipselink.jdbc.timeout hint not applying correctly to SQLCall
+//     09/03/2015 - Will Dazey
+//       - 456067 : Added support for defining query timeout units
+//     09/04/2018-3.0 Ravi Babu Tummuru
+//       - 538183: SETTING QUERYHINTS.CURSOR ON A NAMEDQUERY THROWS QUERYEXCEPTION
+//     09/02/2019-3.0 Alexandre Jacob
+//        - 527415: Fix code when locale is tr, az or lt
+//     12/14/2023: Tomas Kraus
+//       - New Jakarta Persistence 3.2 Features
+package org.eclipse.persistence.internal.jpa;
+
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.sql.Time;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.DescriptorException;
+import org.eclipse.persistence.exceptions.QueryException;
+
+
+import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.queries.ObjectLevelReadQuery;
+import org.eclipse.persistence.queries.ReadAllQuery;
+import org.eclipse.persistence.expressions.Expression;
+import org.eclipse.persistence.annotations.BatchFetchType;
+import org.eclipse.persistence.annotations.CacheType;
+import org.eclipse.persistence.config.*;
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.descriptors.invalidation.DailyCacheInvalidationPolicy;
+import org.eclipse.persistence.descriptors.invalidation.TimeToLiveCacheInvalidationPolicy;
+import org.eclipse.persistence.descriptors.partitioning.PartitioningPolicy;
+import org.eclipse.persistence.history.AsOfClause;
+import org.eclipse.persistence.history.AsOfSCNClause;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.internal.localization.ExceptionLocalization;
+import org.eclipse.persistence.internal.queries.ContainerPolicy;
+import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.internal.security.PrivilegedClassForName;
+import org.eclipse.persistence.internal.security.PrivilegedNewInstanceFromClass;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.mappings.ForeignReferenceMapping;
+import org.eclipse.persistence.mappings.DatabaseMapping;
+import org.eclipse.persistence.queries.AttributeGroup;
+import org.eclipse.persistence.queries.CursorPolicy;
+import org.eclipse.persistence.queries.CursoredStreamPolicy;
+import org.eclipse.persistence.queries.DataModifyQuery;
+import org.eclipse.persistence.queries.DataReadQuery;
+import org.eclipse.persistence.queries.DeleteAllQuery;
+import org.eclipse.persistence.queries.DirectReadQuery;
+import org.eclipse.persistence.queries.FetchGroup;
+import org.eclipse.persistence.queries.InMemoryQueryIndirectionPolicy;
+import org.eclipse.persistence.queries.LoadGroup;
+import org.eclipse.persistence.queries.ModifyAllQuery;
+import org.eclipse.persistence.queries.ModifyQuery;
+import org.eclipse.persistence.queries.ObjectBuildingQuery;
+import org.eclipse.persistence.queries.QueryRedirector;
+import org.eclipse.persistence.queries.ReadObjectQuery;
+import org.eclipse.persistence.queries.ReadQuery;
+import org.eclipse.persistence.queries.ReportQuery;
+import org.eclipse.persistence.queries.ResultSetMappingQuery;
+import org.eclipse.persistence.queries.ScrollableCursorPolicy;
+import org.eclipse.persistence.queries.UpdateAllQuery;
+import org.eclipse.persistence.queries.ValueReadQuery;
+
+/**
+ * The class processes query hints.
+ * <p>
+ * EclipseLink query hints and their values defined in org.eclipse.persistence.config package.
+ * <p>
+ * To add a new query hint:
+ *   Define a new hint in QueryHints;
+ *   Add a class containing hint's values if required to config package (like CacheUsage);
+ *      Alternatively values defined in HintValues may be used - Refresh and BindParameters hints do that.
+ *   Add an inner class to this class extending Hint corresponding to the new hint (like CacheUsageHint);
+ *      The first constructor parameter is hint name; the second is default value;
+ *      In constructor
+ *          provide 2-dimensional value array in case the values should be translated (currently all Hint classes do that);
+ *              in case translation is not required provide a single-dimension array (no such examples yet).
+ *   In inner class Hint static initializer addHint an instance of the new hint class (like addHint(new CacheUsageHint())).
+ *
+ * @see QueryHints
+ * @see HintValues
+ * @see CacheUsage
+ * @see PessimisticLock
+ */
+public class QueryHintsHandler {
+
+    public static final String QUERY_HINT_PROPERTY = "eclipselink.query.hints";
+
+    private QueryHintsHandler() {
+    }
+
+    /**
+     * Verifies the hints.
+     * <p>
+     * If session != null then logs a FINEST message for each hint.
+     * queryName parameter used only for identifying the query in messages,
+     * if it's null then "null" will be used.
+     * Throws IllegalArgumentException in case the hint value is illegal.
+     */
+    public static void verify(Map hints, String queryName, AbstractSession session) {
+        if(hints == null) {
+            return;
+        }
+        Iterator it = hints.entrySet().iterator();
+        while(it.hasNext()) {
+            Map.Entry entry = (Map.Entry)it.next();
+            String hintName = (String)entry.getKey();
+            verify(hintName, entry.getValue(), queryName, session);
+        }
+    }
+
+    /**
+     * Verifies the hint.
+     * <p>
+     * If session != null then logs a FINEST message.
+     * queryName parameter used only for identifying the query in messages,
+     * if it's null then "null" will be used.
+     * Throws IllegalArgumentException in case the hint value is illegal.
+     */
+    public static void verify(String hintName, Object hintValue, String queryName, AbstractSession session) {
+        Hint.verify(hintName, shouldUseDefault(hintValue), hintValue, queryName, session);
+    }
+
+    // Retrieve query hints Map from DatabaseQuery
+    @SuppressWarnings("unchecked")
+    static Map<String, Object> get(DatabaseQuery query) {
+        return (Map<String, Object>) query.getProperty(QUERY_HINT_PROPERTY);
+    }
+
+    /**
+     * Applies the hints to the query.
+     * Throws IllegalArgumentException in case the hint value is illegal.
+     */
+    public static DatabaseQuery apply(Map<String, Object> hints, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+        if (hints == null) {
+            return query;
+        }
+        DatabaseQuery hintQuery = query;
+        for (Map.Entry<String, Object> entry : hints.entrySet()) {
+            String hintName = entry.getKey();
+            if (entry.getValue() instanceof Object[] values) {
+                for (int index = 0; index < values.length; index++) {
+                    hintQuery = apply(hintName, values[index], hintQuery, loader, activeSession);
+                }
+            } else {
+                hintQuery = apply(hintName, entry.getValue(), hintQuery, loader, activeSession);
+            }
+        }
+        return hintQuery;
+    }
+
+    /**
+     * Applies the hint to the query.
+     * Throws IllegalArgumentException in case the hint value is illegal.
+     */
+    public static DatabaseQuery apply(String hintName, Object hintValue, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+        return Hint.apply(hintName, shouldUseDefault(hintValue), hintValue, query, loader, activeSession);
+    }
+
+    /**
+     * Common hint value processing into an boolean value. If the hint is
+     * null, false is returned. Those methods that need to handle a null hint
+     * to be something other than false should not call this method.
+     */
+    public static boolean parseBooleanHint(Object hint) {
+        if (hint == null) {
+            return false;
+        } else {
+            return Boolean.parseBoolean(hint.toString());
+        }
+    }
+
+    /**
+     * Common hint value processing into an integer value. If the hint is
+     * null, -1 is returned.
+     */
+    public static int parseIntegerHint(Object hint, String hintName) {
+        if (hint == null) {
+            return -1;
+        } else {
+            try {
+                return Integer.parseInt(hint.toString());
+            } catch (NumberFormatException e) {
+                throw QueryException.queryHintContainedInvalidIntegerValue(hintName, hint, e);
+            }
+        }
+    }
+
+    /**
+     * Empty String hintValue indicates that the default hint value
+     * should be used.
+     */
+    protected static boolean shouldUseDefault(Object hintValue) {
+        return (hintValue != null) &&  (hintValue instanceof String) && (((String) hintValue).isEmpty());
+    }
+
+    public static Set<String> getSupportedHints(){
+        return Hint.getSupportedHints();
+    }
+
+    /**
+     * Define a generic Hint.
+     * Hints should subclass this and override the applyToDatabaseQuery
+     * and set the valueArray if the set of valid values is finite.
+     */
+    protected static abstract class Hint {
+        static HashMap<String, Hint> mainMap = new HashMap<>();
+        Object[] valueArray;
+        HashMap<String, Object> valueMap;
+        String name;
+        String defaultValue;
+        Object defaultValueToApply;
+        boolean valueToApplyMayBeNull;
+
+        static {
+            addHint(new BindParametersHint());
+            addHint(new CacheUsageHint());
+            addHint(new CacheRetrieveModeHint());
+            addHint(new CacheRetrieveModeLegacyHint());
+            addHint(new CacheStoreModeHint());
+            addHint(new CacheStoreModeLegacyHint());
+            addHint(new QueryTypeHint());
+            addHint(new PessimisticLockHint());
+            addHint(new PessimisticLockScope());
+            addHint(new PessimisticLockTimeoutHint());
+            addHint(new PessimisticLockTimeoutUnitHint());
+            addHint(new RefreshHint());
+            addHint(new CascadePolicyHint());
+            addHint(new BatchHint());
+            addHint(new BatchTypeHint());
+            addHint(new BatchSizeHint());
+            addHint(new FetchHint());
+            addHint(new LeftFetchHint());
+            addHint(new ReadOnlyHint());
+            addHint(new JDBCTimeoutHint());
+            //Enhancement
+            addHint(new QueryTimeoutUnitHint());
+            //Enhancement
+            addHint(new QueryTimeoutHint());
+            addHint(new JDBCFetchSizeHint());
+            addHint(new JDBCMaxRowsHint());
+            addHint(new JDBCFirstResultHint());
+            addHint(new ResultCollectionTypeHint());
+            addHint(new RedirectorHint());
+            addHint(new PartitioningHint());
+            addHint(new QueryCacheHint());
+            addHint(new QueryCacheSizeHint());
+            addHint(new QueryCacheExpiryHint());
+            addHint(new QueryCacheExpiryTimeOfDayHint());
+            addHint(new MaintainCacheHint());
+            addHint(new PrepareHint());
+            addHint(new CacheStatementHint());
+            addHint(new FlushHint());
+            addHint(new HintHint());
+            addHint(new NativeConnectionHint());
+            addHint(new CursorHint());
+            addHint(new CursorInitialSizeHint());
+            addHint(new CursorPageSizeHint());
+            addHint(new ScrollableCursorHint());
+            addHint(new CursorSizeHint());
+            addHint(new FetchGroupHint());
+            addHint(new FetchGraphHint());
+            addHint(new FetchGroupNameHint());
+            addHint(new FetchGroupDefaultHint());
+            addHint(new FetchGroupAttributeHint());
+            addHint(new FetchGroupLoadHint());
+            addHint(new LoadGroupHint());
+            addHint(new LoadGroupAttributeHint());
+            addHint(new LoadGraphHint());
+            addHint(new ExclusiveHint());
+            addHint(new InheritanceJoinHint());
+            addHint(new AsOfHint());
+            addHint(new AsOfSCNHint());
+            addHint(new ResultTypeHint());
+            addHint(new ResultSetTypeHint());
+            addHint(new ResultSetConcurrencyHint());
+            addHint(new IndirectionPolicyHint());
+            addHint(new QueryCacheTypeHint());
+            addHint(new QueryCacheIgnoreNullHint());
+            addHint(new QueryCacheInvalidateOnChangeHint());
+            addHint(new QueryCacheRandomizedExpiryHint());
+            // 325167: Make reserved # bind parameter char generic to enable native SQL pass through
+            addHint(new ParameterDelimiterHint());
+            addHint(new CompositeMemberHint());
+            addHint(new AllowNativeSQLQueryHint());
+            addHint(new BatchWriteHint());
+            addHint(new ResultSetAccess());
+            addHint(new SerializedObject());
+            addHint(new ReturnNameValuePairsHint());
+            addHint(new PrintInnerJoinInWhereClauseHint());
+            addHint(new QueryResultsCacheValidation());
+        }
+
+        Hint(String name, String defaultValue) {
+            this.name = name;
+            this.defaultValue = defaultValue;
+        }
+
+        abstract DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession);
+
+        static void verify(String hintName, boolean shouldUseDefault, Object hintValue, String queryName, AbstractSession session) {
+            Hint hint = mainMap.get(hintName);
+            if(hint == null) {
+                if(session != null) {
+                    session.log(SessionLog.FINEST, SessionLog.QUERY, "unknown_query_hint", new Object[]{getPrintValue(queryName), hintName});
+                }
+                return;
+            }
+
+            hint.verify(hintValue, shouldUseDefault, queryName, session);
+        }
+
+        void verify(Object hintValue, boolean shouldUseDefault, String queryName, AbstractSession session) {
+            if(shouldUseDefault) {
+                hintValue = defaultValue;
+            }
+            if(session != null) {
+                session.log(SessionLog.FINEST, SessionLog.QUERY, "query_hint", new Object[]{getPrintValue(queryName), name, getPrintValue(hintValue)});
+            }
+            if(!shouldUseDefault && valueMap != null && !valueMap.containsKey(getUpperCaseString(hintValue))) {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-query-hint-value",new Object[]{getPrintValue(queryName), name, getPrintValue(hintValue)}));
+            }
+        }
+
+        static DatabaseQuery apply(String hintName, boolean shouldUseDefault, Object hintValue, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            Hint hint = mainMap.get(hintName);
+            if (hint == null) {
+                // unknown hint name - silently ignored.
+                return query;
+            }
+
+            Map<String, Object> existingHints = (Map<String, Object>)query.getProperty(QUERY_HINT_PROPERTY);
+            if (existingHints == null){
+                existingHints = new HashMap<>();
+                query.setProperty(QUERY_HINT_PROPERTY, existingHints);
+            }
+            existingHints.put(hintName, hintValue);
+
+            return hint.apply(hintValue, shouldUseDefault, query, loader, activeSession);
+        }
+
+        DatabaseQuery apply(Object hintValue, boolean shouldUseDefault, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            Object valueToApply = hintValue;
+            if (shouldUseDefault) {
+                valueToApply = defaultValueToApply;
+            } else {
+                if( valueMap != null) {
+                    String key = getUpperCaseString(hintValue);
+                    valueToApply = valueMap.get(key);
+                    if (valueToApply == null) {
+                        boolean wrongKey = true;
+                        if (valueToApplyMayBeNull) {
+                            wrongKey = !valueMap.containsKey(key);
+                        }
+                        if (wrongKey) {
+                            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-query-hint-value",new Object[]{getQueryId(query), name, getPrintValue(hintValue)}));
+                        }
+                    }
+                }
+            }
+            return applyToDatabaseQuery(valueToApply, query, loader, activeSession);
+        }
+
+        static String getQueryId(DatabaseQuery query) {
+            String queryId = query.getName();
+            if(queryId == null) {
+                queryId = query.getEJBQLString();
+            }
+            return getPrintValue(queryId);
+        }
+
+        static String getPrintValue(Object hintValue) {
+            return hintValue != null ? hintValue.toString() : "null";
+        }
+
+        static String getUpperCaseString(Object hintValue) {
+            return hintValue != null ? hintValue.toString().toUpperCase(Locale.ROOT) : null;
+        }
+
+        static Class<?> loadClass(String className, DatabaseQuery query, ClassLoader loader) throws QueryException {
+            try {
+                if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()) {
+                    try {
+                        return AccessController.doPrivileged(new PrivilegedClassForName<>(className, true, loader));
+                    } catch (PrivilegedActionException exception) {
+                        throw QueryException.classNotFoundWhileUsingQueryHint(query, className, exception.getException());
+                    }
+                } else {
+                    return PrivilegedAccessHelper.getClassForName(className, true, loader);
+                }
+            } catch (ClassNotFoundException exception){
+                throw QueryException.classNotFoundWhileUsingQueryHint(query, className, exception);
+            }
+        }
+
+        static <T> T newInstance(Class<T> theClass, DatabaseQuery query, String hint) {
+            try {
+                if (PrivilegedAccessHelper.shouldUsePrivilegedAccess()){
+                    return AccessController.doPrivileged(new PrivilegedNewInstanceFromClass<>(theClass));
+                } else {
+                    return PrivilegedAccessHelper.newInstanceFromClass(theClass);
+                }
+            } catch (Exception exception) {
+                throw QueryException.errorInstantiatedClassForQueryHint(exception, query, theClass, hint);
+            }
+        }
+
+        void initialize() {
+            if(valueArray != null) {
+                valueMap = new HashMap<>(valueArray.length);
+                if(valueArray instanceof Object[][] valueArray2) {
+                    for(int i=0; i<valueArray2.length; i++) {
+                        valueMap.put(getUpperCaseString(valueArray2[i][0]), valueArray2[i][1]);
+                        if(valueArray2[i][1] == null) {
+                            valueToApplyMayBeNull = true;
+                        }
+                    }
+                } else {
+                    for(int i=0; i<valueArray.length; i++) {
+                        valueMap.put(getUpperCaseString(valueArray[i]), valueArray[i]);
+                        if(valueArray[i] == null) {
+                            valueToApplyMayBeNull = true;
+                        }
+                    }
+                }
+                defaultValueToApply = valueMap.get(defaultValue.toUpperCase(Locale.ROOT));
+            }
+        }
+
+        static void addHint(Hint hint) {
+            hint.initialize();
+            mainMap.put(hint.name, hint);
+        }
+
+        static Set<String> getSupportedHints(){
+            return mainMap.keySet();
+        }
+    }
+
+    /**
+     * This hint can be used to indicate whether or not a ResultSetMapping query should
+     * return populated DatabaseRecords vs. raw data.  This hint is particularly useful
+     * when the structure of the returned data is not known.
+     */
+    protected static class ReturnNameValuePairsHint extends Hint {
+        ReturnNameValuePairsHint() {
+            super(QueryHints.RETURN_NAME_VALUE_PAIRS, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.TRUE, Boolean.TRUE},
+                {HintValues.FALSE, Boolean.FALSE}
+            };
+        }
+
+        /**
+         * Applies the given hint value to the query if it is non-null.  The given query
+         * is expected to be a ResultSetMappingQuery instance.
+         * @throws IllegalArgumentException if 'query' is not a ResultSetMappingQuery instance
+         */
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isResultSetMappingQuery()) {
+                if (valueToApply != null) {
+                    ((ResultSetMappingQuery) query).setShouldReturnNameValuePairs(((Boolean) valueToApply));
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class BindParametersHint extends Hint {
+        BindParametersHint() {
+            super(QueryHints.BIND_PARAMETERS, HintValues.PERSISTENCE_UNIT_DEFAULT);
+            valueArray = new Object[][] {
+                {HintValues.PERSISTENCE_UNIT_DEFAULT, null},
+                {HintValues.TRUE, Boolean.TRUE},
+                {HintValues.FALSE, Boolean.FALSE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (valueToApply == null) {
+                query.ignoreBindAllParameters();
+            } else {
+                query.setShouldBindAllParameters(((Boolean)valueToApply).booleanValue());
+            }
+            return query;
+        }
+    }
+
+    protected static class AllowNativeSQLQueryHint extends Hint {
+        AllowNativeSQLQueryHint() {
+            super(QueryHints.ALLOW_NATIVE_SQL_QUERY, HintValues.PERSISTENCE_UNIT_DEFAULT);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            query.setAllowNativeSQLQuery((Boolean) valueToApply);
+            return query;
+        }
+    }
+
+    /**
+     * INTERNAL:
+     * 325167: Make reserved # bind parameter char generic to enable native SQL pass through
+     */
+    protected static class ParameterDelimiterHint extends Hint {
+        ParameterDelimiterHint() {
+            super(QueryHints.PARAMETER_DELIMITER, ParameterDelimiterType.DEFAULT);
+            // No valueArray modification is required for unrestricted values
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            // Only change the default set by the DatabaseQuery constructor - if an override is requested via the Hint
+            if (valueToApply != null) {
+                query.setParameterDelimiter(((String)valueToApply));
+            }
+            return query;
+        }
+    }
+
+    protected static class CacheRetrieveModeHint extends Hint {
+        CacheRetrieveModeHint() {
+            this(QueryHints.CACHE_RETRIEVE_MODE, CacheRetrieveMode.USE.name());
+        }
+
+        CacheRetrieveModeHint(String name, String defaultValue) {
+            super(name, defaultValue);
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                if (valueToApply.equals(CacheRetrieveMode.BYPASS) || valueToApply.equals(CacheRetrieveMode.BYPASS.name())) {
+                    query.retrieveBypassCache();
+                } else if (valueToApply.equals(CacheRetrieveMode.USE) || valueToApply.equals(CacheRetrieveMode.USE.name())) {
+                    // Explicitly clear the bypass cache flag to allow Query-level USE to override EntityManager-level BYPASS
+                    query.setShouldRetrieveBypassCache(false);
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+
+            return query;
+        }
+    }
+
+    protected static class CacheRetrieveModeLegacyHint extends CacheRetrieveModeHint {
+        CacheRetrieveModeLegacyHint() {
+            super("jakarta.persistence.cacheRetrieveMode", CacheRetrieveMode.USE.name());
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (activeSession != null) {
+                String[] properties = new String[] { QueryHints.CACHE_RETRIEVE_MODE, "jakarta.persistence.cacheRetrieveMode" };
+                activeSession.log(SessionLog.INFO, SessionLog.TRANSACTION, "deprecated_property", properties);
+            }
+            return super.applyToDatabaseQuery(valueToApply, query, loader, activeSession);
+        }
+    }
+
+    protected static class CacheStoreModeHint extends Hint {
+        CacheStoreModeHint() {
+            this(QueryHints.CACHE_STORE_MODE, CacheStoreMode.USE.name());
+        }
+
+        CacheStoreModeHint(String name, String defaultValue) {
+            super(name, defaultValue);
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (valueToApply.equals(CacheStoreMode.BYPASS) || valueToApply.equals(CacheStoreMode.BYPASS.name())) {
+                query.storeBypassCache();
+            } else if (valueToApply.equals(CacheStoreMode.REFRESH) || valueToApply.equals(CacheStoreMode.REFRESH.name())) {
+                if (query.isObjectLevelReadQuery()) {
+                    ((ObjectLevelReadQuery) query).refreshIdentityMapResult();
+                    // Explicitly clear the bypass cache flag to allow Query-level REFRESH to override EntityManager-level BYPASS
+                    query.setShouldStoreBypassCache(false);
+                } else {
+                    throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+                }
+            } else if (valueToApply.equals(CacheStoreMode.USE) || valueToApply.equals(CacheStoreMode.USE.name())) {
+                // Explicitly clear the bypass cache flag to allow Query-level USE to override EntityManager-level BYPASS
+                query.setShouldStoreBypassCache(false);
+            }
+
+            return query;
+        }
+    }
+
+    protected static class CacheStoreModeLegacyHint extends CacheStoreModeHint {
+        CacheStoreModeLegacyHint() {
+            super("jakarta.persistence.cacheStoreMode", CacheStoreMode.USE.name());
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (activeSession != null) {
+                String[] properties = new String[] { QueryHints.CACHE_STORE_MODE, "jakarta.persistence.cacheStoreMode" };
+                activeSession.log(SessionLog.INFO, SessionLog.TRANSACTION, "deprecated_property", properties);
+            }
+            return super.applyToDatabaseQuery(valueToApply, query, loader, activeSession);
+        }
+    }
+
+    /**
+     * Configure the cache usage of the query.
+     * As many of the usages require a ReadObjectQuery, the hint may also require to change the query type.
+     */
+    protected static class CacheUsageHint extends Hint {
+        CacheUsageHint() {
+            super(QueryHints.CACHE_USAGE, CacheUsage.DEFAULT);
+            valueArray = new Object[][] {
+                {CacheUsage.UseEntityDefault, ObjectLevelReadQuery.UseDescriptorSetting},
+                {CacheUsage.DoNotCheckCache, ObjectLevelReadQuery.DoNotCheckCache},
+                {CacheUsage.CheckCacheByExactPrimaryKey, ObjectLevelReadQuery.CheckCacheByExactPrimaryKey},
+                {CacheUsage.CheckCacheByPrimaryKey, ObjectLevelReadQuery.CheckCacheByPrimaryKey},
+                {CacheUsage.CheckCacheThenDatabase, ObjectLevelReadQuery.CheckCacheThenDatabase},
+                {CacheUsage.CheckCacheOnly, ObjectLevelReadQuery.CheckCacheOnly},
+                {CacheUsage.ConformResultsInUnitOfWork, ObjectLevelReadQuery.ConformResultsInUnitOfWork},
+                {CacheUsage.NoCache, ModifyAllQuery.NO_CACHE},
+                {CacheUsage.Invalidate, ModifyAllQuery.INVALIDATE_CACHE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                int cacheUsage = (Integer) valueToApply;
+                ((ObjectLevelReadQuery)query).setCacheUsage(cacheUsage);
+                if (cacheUsage == ObjectLevelReadQuery.CheckCacheByExactPrimaryKey
+                        || cacheUsage == ObjectLevelReadQuery.CheckCacheByPrimaryKey
+                        || cacheUsage == ObjectLevelReadQuery.CheckCacheThenDatabase) {
+                    ReadObjectQuery newQuery = new ReadObjectQuery();
+                    newQuery.copyFromQuery(query);
+                    return newQuery;
+                }
+            } else if (query.isModifyAllQuery()) {
+                int cacheUsage = (Integer) valueToApply;
+                ((ModifyAllQuery)query).setCacheUsage(cacheUsage);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    /**
+     * Configure the cache usage of the query.
+     * As many of the usages require a ReadObjectQuery, the hint may also require to change the query type.
+     */
+    protected static class BatchWriteHint extends Hint {
+        BatchWriteHint() {
+            super(QueryHints.BATCH_WRITING, HintValues.FALSE);
+            valueArray = new Object[][] {
+                    {HintValues.FALSE, Boolean.FALSE},
+                    {HintValues.TRUE, Boolean.TRUE}
+                };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isDataReadQuery()) {
+                DataModifyQuery newQuery = new DataModifyQuery();
+                newQuery.copyFromQuery(query);
+                newQuery.setIsBatchExecutionSupported((Boolean) valueToApply);
+                return newQuery;
+            } else if (query.isModifyQuery()) {
+                ((ModifyQuery)query).setIsBatchExecutionSupported((Boolean) valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class CascadePolicyHint extends Hint {
+        CascadePolicyHint() {
+            super(QueryHints.REFRESH_CASCADE, CascadePolicy.DEFAULT);
+            valueArray = new Object[][] {
+                {CascadePolicy.NoCascading, DatabaseQuery.NoCascading},
+                {CascadePolicy.CascadePrivateParts, DatabaseQuery.CascadePrivateParts},
+                {CascadePolicy.CascadeAllParts, DatabaseQuery.CascadeAllParts},
+                {CascadePolicy.CascadeByMapping, DatabaseQuery.CascadeByMapping}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            query.setCascadePolicy((Integer)valueToApply);
+            return query;
+        }
+    }
+
+    /**
+     * Configure the type of the query.
+     */
+    protected static class QueryTypeHint extends Hint {
+        QueryTypeHint() {
+            super(QueryHints.QUERY_TYPE, QueryType.DEFAULT);
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (valueToApply.equals(QueryType.DEFAULT)) {
+                return query;
+            }
+            // Allows an query type, or a custom query class.
+            DatabaseQuery newQuery = query;
+            if (valueToApply.equals(QueryType.ReadAll)) {
+                newQuery = new ReadAllQuery();
+            } else if (valueToApply.equals(QueryType.ReadObject)) {
+                newQuery = new ReadObjectQuery();
+            } else if (valueToApply.equals(QueryType.Report)) {
+                newQuery = new ReportQuery();
+                if (query.isObjectLevelReadQuery()) {
+                    ((ReportQuery)newQuery).addAttribute("root", ((ReportQuery)newQuery).getExpressionBuilder());
+                }
+            } else if (valueToApply.equals(QueryType.ResultSetMapping)) {
+                newQuery = new ResultSetMappingQuery();
+            } else if (valueToApply.equals(QueryType.UpdateAll)) {
+                newQuery = new UpdateAllQuery();
+            } else if (valueToApply.equals(QueryType.DeleteAll)) {
+                newQuery = new DeleteAllQuery();
+            } else if (valueToApply.equals(QueryType.DataModify)) {
+                newQuery = new DataModifyQuery();
+            } else if (valueToApply.equals(QueryType.DataRead)) {
+                newQuery = new DataReadQuery();
+            } else if (valueToApply.equals(QueryType.DirectRead)) {
+                newQuery = new DirectReadQuery();
+            } else if (valueToApply.equals(QueryType.ValueRead)) {
+                newQuery = new ValueReadQuery();
+            } else {
+                Class<?> queryClass = loadClass((String)valueToApply, query, loader);
+                newQuery = (DatabaseQuery)newInstance(queryClass, query, QueryHints.QUERY_TYPE);
+            }
+            newQuery.copyFromQuery(query);
+            return newQuery;
+        }
+    }
+
+    protected static class PessimisticLockHint extends Hint {
+        PessimisticLockHint() {
+            super(QueryHints.PESSIMISTIC_LOCK, PessimisticLock.DEFAULT);
+            valueArray = new Object[][] {
+                {PessimisticLock.NoLock, ObjectLevelReadQuery.NO_LOCK},
+                {PessimisticLock.Lock, ObjectLevelReadQuery.LOCK},
+                {PessimisticLock.LockNoWait, ObjectLevelReadQuery.LOCK_NOWAIT}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectBuildingQuery()) {
+                ((ObjectBuildingQuery)query).setLockMode((Short) valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class PessimisticLockScope extends Hint {
+        PessimisticLockScope() {
+            super(QueryHints.PESSIMISTIC_LOCK_SCOPE, jakarta.persistence.PessimisticLockScope.NORMAL.name());
+            valueArray = new Object[] {
+                jakarta.persistence.PessimisticLockScope.NORMAL.name(),
+                jakarta.persistence.PessimisticLockScope.EXTENDED.name()
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                boolean shouldExtend = valueToApply.equals(jakarta.persistence.PessimisticLockScope.EXTENDED.name());
+                ObjectLevelReadQuery olrQuery = (ObjectLevelReadQuery)query;
+                olrQuery.setShouldExtendPessimisticLockScope(shouldExtend);
+                if(shouldExtend) {
+                    olrQuery.extendPessimisticLockScope();
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class PessimisticLockTimeoutHint extends Hint {
+        PessimisticLockTimeoutHint() {
+            super(QueryHints.PESSIMISTIC_LOCK_TIMEOUT, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                // According to QueryHints.PESSIMISTIC_LOCK_TIMEOUT javadoc valid values are Integer or Strings
+                // that can be parsed to int values.
+                // String class is final so no need to use instanceof
+                if (valueToApply.getClass() == String.class) {
+                    ((ObjectLevelReadQuery) query).setWaitTimeout(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.PESSIMISTIC_LOCK_TIMEOUT));
+                // Now the second case, which must be Number. Anything else will cause class cast exception.
+                } else {
+                    int value;
+                    try {
+                        value = ((Number) valueToApply).intValue();
+                    } catch (ClassCastException cce) {
+                        throw new IllegalArgumentException(
+                                ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",
+                                                                   new String[] {getQueryId(query), name, getPrintValue(valueToApply)}));
+                    }
+                    ((ObjectLevelReadQuery) query).setWaitTimeout(value);
+                }
+            } else {
+                throw new IllegalArgumentException(
+                        ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",
+                                                           new String[] {getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class PessimisticLockTimeoutUnitHint extends Hint {
+        PessimisticLockTimeoutUnitHint() {
+            super(QueryHints.PESSIMISTIC_LOCK_TIMEOUT_UNIT, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                // According to QueryHints.PESSIMISTIC_LOCK_TIMEOUT_UNIT javadoc valid value is TimeUnit
+                // But let's handle String values too to be foolproof
+                // String class is final so no need to use instanceof
+                if (valueToApply.getClass() == String.class) {
+                    ((ObjectLevelReadQuery) query).setWaitTimeoutUnit(TimeUnit.valueOf((String) valueToApply));
+                // Now the second case, which must be TimeUnit. Anything else will cause class cast exception.
+                } else {
+                    TimeUnit unit;
+                    try {
+                        unit = (TimeUnit) valueToApply;
+                    } catch (ClassCastException cce) {
+                        throw new IllegalArgumentException(
+                                ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",
+                                                                   new String[] {getQueryId(query), name, getPrintValue(valueToApply)}));
+                    }
+                    ((ObjectLevelReadQuery) query).setWaitTimeoutUnit(unit);
+                }
+            } else {
+                throw new IllegalArgumentException(
+                        ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",
+                                                           new String[] {getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+    
+    protected static class RefreshHint extends Hint {
+        RefreshHint() {
+            super(QueryHints.REFRESH, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectBuildingQuery()) {
+                ((ObjectBuildingQuery)query).setShouldRefreshIdentityMapResult((Boolean) valueToApply);
+                // Set default cascade to be by mapping.
+                if (!query.shouldCascadeParts()) {
+                    query.cascadeByMapping();
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class ResultTypeHint extends Hint {
+        ResultTypeHint() {
+            super(QueryHints.RESULT_TYPE, ResultType.DEFAULT);
+            valueArray = new Object[][] {
+                {ResultType.Map, ResultType.Map},
+                {ResultType.Array, ResultType.Array},
+                {ResultType.Value, ResultType.Value},
+                {ResultType.Attribute, ResultType.Attribute}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isDataReadQuery()) {
+                if (valueToApply == ResultType.Map) {
+                    ((DataReadQuery)query).setResultType(DataReadQuery.MAP);
+                } else if (valueToApply == ResultType.Array) {
+                    ((DataReadQuery)query).setResultType(DataReadQuery.ARRAY);
+                } else if (valueToApply == ResultType.Attribute) {
+                    ((DataReadQuery)query).setResultType(DataReadQuery.ATTRIBUTE);
+                } else if (valueToApply == ResultType.Value) {
+                    ((DataReadQuery)query).setResultType(DataReadQuery.VALUE);
+                }
+            } else if (query.isReportQuery()) {
+                if (valueToApply == ResultType.Map) {
+                    ((ReportQuery)query).setReturnType(ReportQuery.ShouldReturnReportResult);
+                } else if (valueToApply == ResultType.Array) {
+                    ((ReportQuery)query).setReturnType(ReportQuery.ShouldReturnArray);
+                } else if (valueToApply == ResultType.Attribute) {
+                    ((ReportQuery)query).setReturnType(ReportQuery.ShouldReturnSingleAttribute);
+                } else if (valueToApply == ResultType.Value) {
+                    ((ReportQuery)query).setReturnType(ReportQuery.ShouldReturnSingleValue);
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class IndirectionPolicyHint extends Hint {
+        IndirectionPolicyHint() {
+            super(QueryHints.INDIRECTION_POLICY, CacheUsageIndirectionPolicy.DEFAULT);
+            valueArray = new Object[][] {
+                {CacheUsageIndirectionPolicy.Conform, InMemoryQueryIndirectionPolicy.SHOULD_IGNORE_EXCEPTION_RETURN_CONFORMED},
+                {CacheUsageIndirectionPolicy.NotConform, InMemoryQueryIndirectionPolicy.SHOULD_IGNORE_EXCEPTION_RETURN_CONFORMED},
+                {CacheUsageIndirectionPolicy.Trigger, InMemoryQueryIndirectionPolicy.SHOULD_TRIGGER_INDIRECTION},
+                {CacheUsageIndirectionPolicy.Exception, InMemoryQueryIndirectionPolicy.SHOULD_THROW_INDIRECTION_EXCEPTION}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery) query).setInMemoryQueryIndirectionPolicyState((Integer)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class ResultSetTypeHint extends Hint {
+        ResultSetTypeHint() {
+            super(QueryHints.RESULT_SET_TYPE, ResultSetType.DEFAULT);
+            valueArray = new Object[][] {
+                {ResultSetType.Forward, ScrollableCursorPolicy.FETCH_FORWARD},
+                {ResultSetType.ForwardOnly, ScrollableCursorPolicy.TYPE_FORWARD_ONLY},
+                {ResultSetType.Reverse, ScrollableCursorPolicy.FETCH_REVERSE},
+                {ResultSetType.ScrollInsensitive, ScrollableCursorPolicy.TYPE_SCROLL_INSENSITIVE},
+                {ResultSetType.ScrollSensitive, ScrollableCursorPolicy.TYPE_SCROLL_SENSITIVE},
+                {ResultSetType.Unknown, ScrollableCursorPolicy.FETCH_UNKNOWN}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            int value = (Integer)valueToApply;
+            if (query.isReadAllQuery()) {
+                if (!((ReadAllQuery) query).getContainerPolicy().isScrollableCursorPolicy()) {
+                    ((ReadAllQuery) query).useScrollableCursor();
+                }
+                ((ScrollableCursorPolicy)((ReadAllQuery) query).getContainerPolicy()).setResultSetType(value);
+            } else if (query.isDataReadQuery()) {
+                if (!((DataReadQuery) query).getContainerPolicy().isScrollableCursorPolicy()) {
+                    ((DataReadQuery) query).useScrollableCursor();
+                }
+                ((ScrollableCursorPolicy)((DataReadQuery) query).getContainerPolicy()).setResultSetType(value);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class ResultSetConcurrencyHint extends Hint {
+        ResultSetConcurrencyHint() {
+            super(QueryHints.RESULT_SET_CONCURRENCY, ResultSetConcurrency.DEFAULT);
+            valueArray = new Object[][] {
+                {ResultSetConcurrency.ReadOnly, ScrollableCursorPolicy.CONCUR_READ_ONLY},
+                {ResultSetConcurrency.Updatable, ScrollableCursorPolicy.CONCUR_UPDATABLE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            int value = (Integer)valueToApply;
+            if (query.isReadAllQuery()) {
+                if (!((ReadAllQuery) query).getContainerPolicy().isScrollableCursorPolicy()) {
+                    ((ReadAllQuery) query).useScrollableCursor();
+                }
+                ((ScrollableCursorPolicy)((ReadAllQuery) query).getContainerPolicy()).setResultSetConcurrency(value);
+            } else if (query.isDataReadQuery()) {
+                if (!((DataReadQuery) query).getContainerPolicy().isScrollableCursorPolicy()) {
+                    ((DataReadQuery) query).useScrollableCursor();
+                }
+                ((ScrollableCursorPolicy)((DataReadQuery) query).getContainerPolicy()).setResultSetConcurrency(value);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class ExclusiveHint extends Hint {
+        ExclusiveHint() {
+            super(QueryHints.EXCLUSIVE_CONNECTION, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectBuildingQuery()) {
+                ((ObjectBuildingQuery)query).setShouldUseExclusiveConnection((Boolean) valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class InheritanceJoinHint extends Hint {
+        InheritanceJoinHint() {
+            super(QueryHints.INHERITANCE_OUTER_JOIN, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery)query).setShouldOuterJoinSubclasses((Boolean) valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class FetchGroupDefaultHint extends Hint {
+        FetchGroupDefaultHint() {
+            super(QueryHints.FETCH_GROUP_DEFAULT, HintValues.TRUE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery)query).setShouldUseDefaultFetchGroup((Boolean) valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class FetchGroupNameHint extends Hint {
+        FetchGroupNameHint() {
+            super(QueryHints.FETCH_GROUP_NAME, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery)query).setFetchGroupName((String)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class FetchGroupHint extends Hint {
+        FetchGroupHint() {
+            super(QueryHints.FETCH_GROUP, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                if(valueToApply != null) {
+                    ((ObjectLevelReadQuery)query).setFetchGroup(((AttributeGroup)valueToApply).toFetchGroup());
+                } else {
+                    ((ObjectLevelReadQuery)query).setFetchGroup(null);
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class FetchGraphHint extends Hint {
+        FetchGraphHint() {
+            super(QueryHints.JPA_FETCH_GRAPH, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                if(valueToApply != null) {
+                    if (valueToApply instanceof String){
+                        AttributeGroup eg = activeSession.getAttributeGroups().get(valueToApply);
+                        if (eg != null){
+                            FetchGroup fg = eg.toFetchGroup();
+                            fg.setShouldLoadAll(true);
+                            ((ObjectLevelReadQuery)query).setFetchGroup(fg);
+                        }else{
+                            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("no_entity_graph_of_name", new Object[]{valueToApply}));
+                        }
+                    }else if (valueToApply instanceof EntityGraphImpl){
+                        FetchGroup fg = ((EntityGraphImpl)valueToApply).getAttributeGroup().toFetchGroup();
+                        fg.setShouldLoadAll(true);
+                        ((ObjectLevelReadQuery)query).setFetchGroup(fg);
+                    }else{
+                        throw new IllegalArgumentException(ExceptionLocalization.buildMessage("not_usable_passed_to_entitygraph_hint", new Object[]{QueryHints.JPA_FETCH_GRAPH, valueToApply}));
+                    }
+                } else {
+                    ((ObjectLevelReadQuery)query).setFetchGroup(null);
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class FetchGroupAttributeHint extends Hint {
+        FetchGroupAttributeHint() {
+            super(QueryHints.FETCH_GROUP_ATTRIBUTE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                FetchGroup fetchGroup = ((ObjectLevelReadQuery)query).getFetchGroup();
+                if (fetchGroup == null) {
+                    fetchGroup = new FetchGroup();
+                    ((ObjectLevelReadQuery)query).setFetchGroup(fetchGroup);
+                }
+                fetchGroup.addAttribute((String)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class FetchGroupLoadHint extends Hint {
+        FetchGroupLoadHint() {
+            super(QueryHints.FETCH_GROUP_LOAD, HintValues.TRUE);
+            valueArray = new Object[][] {
+                    {HintValues.FALSE, Boolean.FALSE},
+                    {HintValues.TRUE, Boolean.TRUE}
+                };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                FetchGroup fetchGroup = ((ObjectLevelReadQuery)query).getFetchGroup();
+                if (fetchGroup == null) {
+                    fetchGroup = new FetchGroup();
+                    ((ObjectLevelReadQuery)query).setFetchGroup(fetchGroup);
+                }
+                fetchGroup.setShouldLoadAll((Boolean)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class LoadGroupHint extends Hint {
+        LoadGroupHint() {
+            super(QueryHints.LOAD_GROUP, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                if(valueToApply != null) {
+                    ((ObjectLevelReadQuery)query).setLoadGroup(((AttributeGroup)valueToApply).toLoadGroup());
+                } else {
+                    ((ObjectLevelReadQuery)query).setLoadGroup(null);
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class LoadGraphHint extends Hint {
+        LoadGraphHint() {
+            super(QueryHints.JPA_LOAD_GRAPH, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                if(valueToApply != null) {
+                    if (valueToApply instanceof String){
+                        AttributeGroup eg = activeSession.getAttributeGroups().get(valueToApply);
+                        if (eg != null){
+                            ((ObjectLevelReadQuery)query).setLoadGroup(eg.toLoadGroup());
+                        }else{
+                            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("no_entity_graph_of_name", new Object[]{valueToApply}));
+                        }
+                    }else if (valueToApply instanceof EntityGraphImpl){
+                        ((ObjectLevelReadQuery)query).setLoadGroup(((EntityGraphImpl)valueToApply).getAttributeGroup().toLoadGroup());
+                    }else{
+                        throw new IllegalArgumentException(ExceptionLocalization.buildMessage("not_usable_passed_to_entitygraph_hint", new Object[]{QueryHints.JPA_LOAD_GRAPH, valueToApply}));
+                    }
+                } else {
+                    ((ObjectLevelReadQuery)query).setFetchGroup(null);
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class LoadGroupAttributeHint extends Hint {
+        LoadGroupAttributeHint() {
+            super(QueryHints.LOAD_GROUP_ATTRIBUTE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                LoadGroup loadGroup = ((ObjectLevelReadQuery)query).getLoadGroup();
+                if (loadGroup == null) {
+                    loadGroup = new LoadGroup();
+                    ((ObjectLevelReadQuery)query).setLoadGroup(loadGroup);
+                }
+                loadGroup.addAttribute((String)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    /**
+     * Define the query cache hint.
+     * Only reset the query cache if unset (as other query cache properties may be set first).
+     */
+    protected static class QueryCacheHint extends Hint {
+        QueryCacheHint() {
+            super(QueryHints.QUERY_RESULTS_CACHE, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                if ((Boolean) valueToApply) {
+                    if (((ReadQuery)query).getQueryResultsCachePolicy() == null) {
+                        ((ReadQuery)query).cacheQueryResults();
+                    }
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    /**
+     * Define the query cache ignore null hint.
+     * Only reset the query cache if unset (as other query cache properties may be set first).
+     */
+    protected static class QueryCacheIgnoreNullHint extends Hint {
+        QueryCacheIgnoreNullHint() {
+            super(QueryHints.QUERY_RESULTS_CACHE_IGNORE_NULL, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                if (((ReadQuery)query).getQueryResultsCachePolicy() == null) {
+                    ((ReadQuery)query).cacheQueryResults();
+                }
+                ((ReadQuery)query).getQueryResultsCachePolicy().setIsNullIgnored((Boolean) valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    /**
+     * Define the query cache ignore null hint.
+     * Only reset the query cache if unset (as other query cache properties may be set first).
+     */
+    protected static class QueryCacheInvalidateOnChangeHint extends Hint {
+        QueryCacheInvalidateOnChangeHint() {
+            super(QueryHints.QUERY_RESULTS_CACHE_INVALIDATE, HintValues.TRUE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                if (((ReadQuery)query).getQueryResultsCachePolicy() == null) {
+                    ((ReadQuery)query).cacheQueryResults();
+                }
+                ((ReadQuery)query).getQueryResultsCachePolicy().setInvalidateOnChange((Boolean) valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    /**
+     * Define the query cache randomized expiry hint.
+     * Only reset the query cache if unset (as other query cache properties may be set first).
+     */
+    protected static class QueryCacheRandomizedExpiryHint extends Hint {
+        QueryCacheRandomizedExpiryHint() {
+            super(QueryHints.QUERY_RESULTS_CACHE_RANDOMIZE_EXPIRY, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                if (((ReadQuery)query).getQueryResultsCachePolicy() == null) {
+                    ((ReadQuery)query).cacheQueryResults();
+                }
+                if (((ReadQuery)query).getQueryResultsCachePolicy().getCacheInvalidationPolicy() == null) {
+                    ((ReadQuery)query).getQueryResultsCachePolicy().setCacheInvalidationPolicy(new TimeToLiveCacheInvalidationPolicy());
+                }
+                ((ReadQuery)query).getQueryResultsCachePolicy().getCacheInvalidationPolicy().setIsInvalidationRandomized((Boolean) valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    /**
+     * Define the query cache size hint.
+     * Only reset the query cache if unset (as other query cache properties may be set first).
+     */
+    protected static class QueryCacheSizeHint extends Hint {
+        QueryCacheSizeHint() {
+            super(QueryHints.QUERY_RESULTS_CACHE_SIZE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                ReadQuery readQuery = (ReadQuery)query;
+                if (readQuery.getQueryResultsCachePolicy() == null) {
+                    readQuery.cacheQueryResults();
+                }
+                try {
+                    readQuery.getQueryResultsCachePolicy().setMaximumCachedResults(Integer.parseInt((String)valueToApply));
+                } catch (NumberFormatException exception) {
+                    throw QueryException.queryHintContainedInvalidIntegerValue(QueryHints.QUERY_RESULTS_CACHE_SIZE, valueToApply, exception);
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    /**
+     * Define the query cache expiry hint.
+     * Only reset the query cache if unset (as other query cache properties may be set first).
+     */
+    protected static class QueryCacheExpiryHint extends Hint {
+        QueryCacheExpiryHint() {
+            super(QueryHints.QUERY_RESULTS_CACHE_EXPIRY, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                ReadQuery readQuery = (ReadQuery)query;
+                if (readQuery.getQueryResultsCachePolicy() == null) {
+                    readQuery.cacheQueryResults();
+                }
+                try {
+                    readQuery.getQueryResultsCachePolicy().setCacheInvalidationPolicy(
+                            new TimeToLiveCacheInvalidationPolicy(Integer.parseInt((String)valueToApply)));
+                } catch (NumberFormatException exception) {
+                    throw QueryException.queryHintContainedInvalidIntegerValue(QueryHints.QUERY_RESULTS_CACHE_EXPIRY, valueToApply, exception);
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    /**
+     * Define the query cache type hint.
+     * Only reset the query cache if unset (as other query cache properties may be set first).
+     */
+    protected static class QueryCacheTypeHint extends Hint {
+        QueryCacheTypeHint() {
+            super(QueryHints.QUERY_RESULTS_CACHE_TYPE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                ReadQuery readQuery = (ReadQuery)query;
+                if (readQuery.getQueryResultsCachePolicy() == null) {
+                    readQuery.cacheQueryResults();
+                }
+                if (valueToApply == null) {
+                    // Leave as default.
+                } else if (valueToApply.equals(CacheType.SOFT_WEAK.name())) {
+                    readQuery.getQueryResultsCachePolicy().setCacheType(ClassConstants.SoftCacheWeakIdentityMap_Class);
+                } else if (valueToApply.equals(CacheType.FULL.name())) {
+                    readQuery.getQueryResultsCachePolicy().setCacheType(ClassConstants.FullIdentityMap_Class);
+                } else if (valueToApply.equals(CacheType.WEAK.name())) {
+                    readQuery.getQueryResultsCachePolicy().setCacheType(ClassConstants.WeakIdentityMap_Class);
+                }  else if (valueToApply.equals(CacheType.SOFT.name())) {
+                    readQuery.getQueryResultsCachePolicy().setCacheType(ClassConstants.SoftIdentityMap_Class);
+                } else if (valueToApply.equals(CacheType.HARD_WEAK.name())) {
+                    readQuery.getQueryResultsCachePolicy().setCacheType(ClassConstants.HardCacheWeakIdentityMap_Class);
+                } else if (valueToApply.equals(CacheType.CACHE.name())) {
+                    readQuery.getQueryResultsCachePolicy().setCacheType(ClassConstants.CacheIdentityMap_Class);
+                } else if (valueToApply.equals(CacheType.NONE.name())) {
+                    readQuery.getQueryResultsCachePolicy().setCacheType(ClassConstants.NoIdentityMap_Class);
+                } else {
+                    throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-query-hint-value",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    /**
+     * Define the query cache expiry time of day hint.
+     * Only reset the query cache if unset (as other query cache properties may be set first).
+     */
+    protected static class QueryCacheExpiryTimeOfDayHint extends Hint {
+        QueryCacheExpiryTimeOfDayHint() {
+            super(QueryHints.QUERY_RESULTS_CACHE_EXPIRY_TIME_OF_DAY, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                ReadQuery readQuery = (ReadQuery)query;
+                if (readQuery.getQueryResultsCachePolicy() == null) {
+                    readQuery.cacheQueryResults();
+                }
+                try {
+                    Time time = Helper.timeFromString((String)valueToApply);
+                    Calendar calendar = Calendar.getInstance();
+                    calendar.setTime(time);
+                    readQuery.getQueryResultsCachePolicy().setCacheInvalidationPolicy(
+                            new DailyCacheInvalidationPolicy(calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), calendar.get(Calendar.SECOND), 0));
+                } catch (ConversionException exception) {
+                    throw QueryException.queryHintContainedInvalidIntegerValue(QueryHints.QUERY_RESULTS_CACHE_EXPIRY_TIME_OF_DAY, valueToApply, exception);
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class BatchHint extends Hint {
+        BatchHint() {
+            super(QueryHints.BATCH, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery() && !query.isReportQuery()) {
+                ObjectLevelReadQuery objectQuery = (ObjectLevelReadQuery)query;
+                StringTokenizer tokenizer = new StringTokenizer((String)valueToApply, ".");
+                if (tokenizer.countTokens() < 2){
+                    throw QueryException.queryHintDidNotContainEnoughTokens(query, QueryHints.BATCH, valueToApply);
+                }
+                // ignore the first token since we are assuming an alias to the primary class
+                // e.g. In e.phoneNumbers we will assume "e" refers to the base of the query
+                String previousToken = tokenizer.nextToken();
+                objectQuery.checkDescriptor(activeSession);
+                ClassDescriptor descriptor = objectQuery.getDescriptor();
+                Expression expression = objectQuery.getExpressionBuilder();
+                while (tokenizer.hasMoreTokens()) {
+                    String token = tokenizer.nextToken();
+                    DatabaseMapping mapping = descriptor.getObjectBuilder().getMappingForAttributeName(token);
+                    if (mapping == null) {
+                        // Allow batching of subclass mappings.
+                        if (!descriptor.hasInheritance()) {
+                            throw QueryException.queryHintNavigatedNonExistantRelationship(query, QueryHints.BATCH, valueToApply, previousToken + "." + token);
+                        }
+                    } else if (!mapping.isForeignReferenceMapping() && !mapping.isAggregateObjectMapping()) {
+                        throw QueryException.queryHintNavigatedIllegalRelationship(query, QueryHints.BATCH, valueToApply, previousToken + "." + token);
+                    }
+                    expression = expression.get(token, false);
+                    previousToken = token;
+                    if (mapping != null){
+                        descriptor = mapping.getReferenceDescriptor();
+                    }
+                }
+                objectQuery.addBatchReadAttribute(expression);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class BatchTypeHint extends Hint {
+        BatchTypeHint() {
+            super(QueryHints.BATCH_TYPE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                if (valueToApply instanceof BatchFetchType) {
+                    ((ObjectLevelReadQuery) query).setBatchFetchType((BatchFetchType)valueToApply);
+                } else {
+                    ((ObjectLevelReadQuery) query).setBatchFetchType(BatchFetchType.valueOf((String)valueToApply));
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+
+            return query;
+        }
+    }
+
+    protected static class BatchSizeHint extends Hint {
+        BatchSizeHint() {
+            super(QueryHints.BATCH_SIZE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery) query).setBatchFetchSize(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.BATCH_SIZE));
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+
+            return query;
+        }
+    }
+
+    protected static class FetchHint extends Hint {
+        FetchHint() {
+            super(QueryHints.FETCH, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery() && !query.isReportQuery()) {
+                ObjectLevelReadQuery olrq = (ObjectLevelReadQuery)query;
+                StringTokenizer tokenizer = new StringTokenizer((String)valueToApply, ".");
+                if (tokenizer.countTokens() < 2){
+                    throw QueryException.queryHintDidNotContainEnoughTokens(query, QueryHints.FETCH, valueToApply);
+                }
+                // ignore the first token since we are assuming read all query
+                // e.g. In e.phoneNumbers we will assume "e" refers to the base of the query
+                String previousToken = tokenizer.nextToken();
+                olrq.checkDescriptor(activeSession);
+                ClassDescriptor descriptor = olrq.getDescriptor();
+                Expression expression = olrq.getExpressionBuilder();
+                while (tokenizer.hasMoreTokens()){
+                    String token = tokenizer.nextToken();
+                    ForeignReferenceMapping frMapping = null;
+                    DatabaseMapping mapping = descriptor.getObjectBuilder().getMappingForAttributeName(token);
+                    if (mapping == null){
+                        throw QueryException.queryHintNavigatedNonExistantRelationship(query, QueryHints.FETCH, valueToApply, previousToken + "." + token);
+                    } else if (!mapping.isForeignReferenceMapping()){
+                        while (mapping.isAggregateObjectMapping() && tokenizer.hasMoreTokens()){
+                            expression = expression.get(token);
+                            token = tokenizer.nextToken();
+                            descriptor = mapping.getReferenceDescriptor();
+                            mapping = descriptor.getObjectBuilder().getMappingForAttributeName(token);
+                        }
+                        if (!mapping.isForeignReferenceMapping()){
+                            throw QueryException.queryHintNavigatedIllegalRelationship(query, QueryHints.FETCH, valueToApply, previousToken + "." + token);
+                        }
+                    }
+                    frMapping = (ForeignReferenceMapping)mapping;
+                    descriptor = frMapping.getReferenceDescriptor();
+                    if (frMapping.isCollectionMapping()){
+                        expression = expression.anyOf(token, false);
+                    } else {
+                        expression = expression.get(token);
+                    }
+                    previousToken = token;
+                }
+                olrq.addJoinedAttribute(expression);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class LeftFetchHint extends Hint {
+        LeftFetchHint() {
+            super(QueryHints.LEFT_FETCH, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery() && !query.isReportQuery()) {
+                ObjectLevelReadQuery olrq = (ObjectLevelReadQuery)query;
+                StringTokenizer tokenizer = new StringTokenizer((String)valueToApply, ".");
+                if (tokenizer.countTokens() < 2){
+                    throw QueryException.queryHintDidNotContainEnoughTokens(query, QueryHints.LEFT_FETCH, valueToApply);
+                }
+                // ignore the first token since we are assuming read all query
+                // e.g. In e.phoneNumbers we will assume "e" refers to the base of the query
+                String previousToken = tokenizer.nextToken();
+                olrq.checkDescriptor(activeSession);
+                ClassDescriptor descriptor = olrq.getDescriptor();
+                Expression expression = olrq.getExpressionBuilder();
+                while (tokenizer.hasMoreTokens()){
+                    String token = tokenizer.nextToken();
+                    ForeignReferenceMapping frMapping = null;
+                    DatabaseMapping mapping = descriptor.getObjectBuilder().getMappingForAttributeName(token);
+                    if (mapping == null){
+                        throw QueryException.queryHintNavigatedNonExistantRelationship(query, QueryHints.LEFT_FETCH, valueToApply, previousToken + "." + token);
+                    } else if (!mapping.isForeignReferenceMapping()){
+                        while (mapping.isAggregateObjectMapping() && tokenizer.hasMoreTokens()){
+                            expression = expression.get(token);
+                            token = tokenizer.nextToken();
+                            descriptor = mapping.getReferenceDescriptor();
+                            mapping = descriptor.getObjectBuilder().getMappingForAttributeName(token);
+                        }
+                        if (!mapping.isForeignReferenceMapping()){
+                            throw QueryException.queryHintNavigatedIllegalRelationship(query, QueryHints.LEFT_FETCH, valueToApply, previousToken + "." + token);
+                        }
+                    }
+                    frMapping = (ForeignReferenceMapping)mapping;
+                    descriptor = frMapping.getReferenceDescriptor();
+                    if (frMapping.isCollectionMapping()){
+                        expression = expression.anyOfAllowingNone(token, false);
+                    } else {
+                        expression = expression.getAllowingNull(token);
+                    }
+                    previousToken = token;
+                }
+                olrq.addJoinedAttribute(expression);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class ReadOnlyHint extends Hint {
+        ReadOnlyHint() {
+            super(QueryHints.READ_ONLY, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery)query).setIsReadOnly((Boolean) valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class NativeConnectionHint extends Hint {
+        NativeConnectionHint() {
+            super(QueryHints.NATIVE_CONNECTION, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            query.setIsNativeConnectionRequired((Boolean) valueToApply);
+            return query;
+        }
+    }
+
+    protected static class CursorHint extends Hint {
+        CursorHint() {
+            super(QueryHints.CURSOR, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (!(Boolean) valueToApply) {
+                if (query.isReadAllQuery()) {
+                    if (((ReadAllQuery) query).getContainerPolicy().isCursoredStreamPolicy()) {
+                        ((ReadAllQuery) query).setContainerPolicy(ContainerPolicy.buildDefaultPolicy());
+                    }
+                } else if (query.isDataReadQuery()) {
+                    if (((DataReadQuery) query).getContainerPolicy().isCursoredStreamPolicy()) {
+                        ((DataReadQuery) query).setContainerPolicy(ContainerPolicy.buildDefaultPolicy());
+                    }
+                }
+            } else {
+                if (query.isReadAllQuery()) {
+                    if (!((ReadAllQuery) query).getContainerPolicy().isCursoredStreamPolicy()) {
+                        ((ReadAllQuery) query).useCursoredStream();
+                    }
+                } else if (query.isDataReadQuery()) {
+                    if (!((DataReadQuery) query).getContainerPolicy().isCursoredStreamPolicy()) {
+                        ((DataReadQuery) query).useCursoredStream();
+                    }
+                } else {
+                    throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+                }
+            }
+
+            query.setIsPrepared(false);
+
+            return query;
+        }
+    }
+
+    protected static class CursorInitialSizeHint extends Hint {
+        CursorInitialSizeHint() {
+            super(QueryHints.CURSOR_INITIAL_SIZE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadAllQuery()) {
+                if (!((ReadAllQuery) query).getContainerPolicy().isCursoredStreamPolicy()) {
+                    ((ReadAllQuery) query).useCursoredStream();
+                }
+                ((CursoredStreamPolicy)((ReadAllQuery) query).getContainerPolicy()).setInitialReadSize(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.CURSOR_INITIAL_SIZE));
+            } else if (query.isDataReadQuery()) {
+                if (!((DataReadQuery) query).getContainerPolicy().isCursoredStreamPolicy()) {
+                    ((DataReadQuery) query).useCursoredStream();
+                }
+                ((CursoredStreamPolicy)((DataReadQuery) query).getContainerPolicy()).setInitialReadSize(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.CURSOR_INITIAL_SIZE));
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+
+            return query;
+        }
+    }
+
+    protected static class CursorPageSizeHint extends Hint {
+        CursorPageSizeHint() {
+            super(QueryHints.CURSOR_PAGE_SIZE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadAllQuery()) {
+                if (!((ReadAllQuery) query).getContainerPolicy().isCursorPolicy()) {
+                    ((ReadAllQuery) query).useCursoredStream();
+                }
+                ((CursorPolicy)((ReadAllQuery) query).getContainerPolicy()).setPageSize(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.CURSOR_PAGE_SIZE));
+            } else if (query.isDataReadQuery()) {
+                if (!((DataReadQuery) query).getContainerPolicy().isCursorPolicy()) {
+                    ((DataReadQuery) query).useCursoredStream();
+                }
+                ((CursorPolicy)((DataReadQuery) query).getContainerPolicy()).setPageSize(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.CURSOR_PAGE_SIZE));
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+
+            return query;
+        }
+    }
+
+    protected static class CursorSizeHint extends Hint {
+        CursorSizeHint() {
+            super(QueryHints.CURSOR_SIZE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadAllQuery()) {
+                if (!((ReadAllQuery) query).getContainerPolicy().isCursoredStreamPolicy()) {
+                    ((ReadAllQuery) query).useCursoredStream();
+                }
+                ((CursoredStreamPolicy)((ReadAllQuery) query).getContainerPolicy()).setSizeQuery(new ValueReadQuery((String)valueToApply));
+            } else if (query.isDataReadQuery()) {
+                if (!((DataReadQuery) query).getContainerPolicy().isCursoredStreamPolicy()) {
+                    ((DataReadQuery) query).useCursoredStream();
+                }
+                ((CursoredStreamPolicy)((ReadAllQuery) query).getContainerPolicy()).setSizeQuery(new ValueReadQuery((String)valueToApply));
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+
+            return query;
+        }
+    }
+
+    protected static class ScrollableCursorHint extends Hint {
+        ScrollableCursorHint() {
+            super(QueryHints.SCROLLABLE_CURSOR, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (!(Boolean) valueToApply) {
+                if (query.isReadAllQuery()) {
+                    if (((ReadAllQuery) query).getContainerPolicy().isScrollableCursorPolicy()) {
+                        ((ReadAllQuery) query).setContainerPolicy(ContainerPolicy.buildDefaultPolicy());
+                    }
+                } else if (query.isDataReadQuery()) {
+                    if (((DataReadQuery) query).getContainerPolicy().isScrollableCursorPolicy()) {
+                        ((DataReadQuery) query).setContainerPolicy(ContainerPolicy.buildDefaultPolicy());
+                    }
+                }
+            } else {
+                if (query.isReadAllQuery()) {
+                    if (!((ReadAllQuery) query).getContainerPolicy().isScrollableCursorPolicy()) {
+                        ((ReadAllQuery) query).useScrollableCursor();
+                    }
+                } else if (query.isDataReadQuery()) {
+                    if (!((DataReadQuery) query).getContainerPolicy().isScrollableCursorPolicy()) {
+                        ((DataReadQuery) query).useScrollableCursor();
+                    }
+                } else {
+                    throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+                }
+            }
+
+            return query;
+        }
+    }
+
+    protected static class MaintainCacheHint extends Hint {
+        MaintainCacheHint() {
+            super(QueryHints.MAINTAIN_CACHE, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            query.setShouldMaintainCache((Boolean) valueToApply);
+            return query;
+        }
+    }
+
+    protected static class PrepareHint extends Hint {
+        PrepareHint() {
+            super(QueryHints.PREPARE, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            query.setShouldPrepare((Boolean) valueToApply);
+            return query;
+        }
+    }
+
+    protected static class CacheStatementHint extends Hint {
+        CacheStatementHint() {
+            super(QueryHints.CACHE_STATMENT, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            query.setShouldCacheStatement((Boolean) valueToApply);
+            return query;
+        }
+    }
+
+    protected static class FlushHint extends Hint {
+        FlushHint() {
+            super(QueryHints.FLUSH, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.FALSE, Boolean.FALSE},
+                {HintValues.TRUE, Boolean.TRUE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            query.setFlushOnExecute((Boolean)valueToApply);
+            return query;
+        }
+    }
+
+    protected static class HintHint extends Hint {
+        HintHint() {
+            super(QueryHints.HINT, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            query.setHintString((String)valueToApply);
+            return query;
+        }
+    }
+
+    protected static class JDBCTimeoutHint extends Hint {
+        JDBCTimeoutHint() {
+            super(QueryHints.JDBC_TIMEOUT, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            // According to QueryHints.JDBC_TIMEOUT javadoc valid values are Integer or Strings
+            // that can be parsed to int values.
+            // String class is final so no need to use instanceof
+            if (valueToApply.getClass() == String.class) {
+                query.setQueryTimeout(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.JDBC_TIMEOUT));
+            // Now the second case, which must be Number. Anything else will cause class cast exception.
+            } else {
+                int value;
+                try {
+                    value = ((Number) valueToApply).intValue();
+                } catch (ClassCastException cce) {
+                    throw new IllegalArgumentException(
+                            ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",
+                                                               new String[] {getQueryId(query), name, getPrintValue(valueToApply)}));
+                }
+                query.setQueryTimeout(value);
+            }
+            query.setIsPrepared(false);
+            return query;
+        }
+    }
+
+    //Bug #456067: Added support for user defining the timeout units to use
+    protected static class QueryTimeoutUnitHint extends Hint {
+        QueryTimeoutUnitHint() {
+            super(QueryHints.QUERY_TIMEOUT_UNIT, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            // According to QueryHints.QUERY_TIMEOUT_UNIT javadoc, provided value shall be TimeUnit
+            // But let's handle String values too to be foolproof
+            // String class is final so no need to use instanceof
+            if (valueToApply.getClass() == String.class) {
+                query.setQueryTimeoutUnit(TimeUnit.valueOf((String) valueToApply));
+            // Now the second case, which must be TimeUnit. Anything else will cause class cast exception.
+            } else {
+                TimeUnit unit;
+                try {
+                    unit = (TimeUnit) valueToApply;
+                } catch (ClassCastException cce) {
+                    throw new IllegalArgumentException(
+                            ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",
+                                                               new String[] {getQueryId(query), name, getPrintValue(valueToApply)}));
+                }
+                query.setQueryTimeoutUnit(unit);
+            }
+            return query;
+        }
+    }
+
+    //Bug #456067: Added support for query hint "jakarta.persistence.query.timeout" defined in the spec
+    protected static class QueryTimeoutHint extends Hint {
+        QueryTimeoutHint() {
+            super(QueryHints.QUERY_TIMEOUT, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            // According to QueryHints.QUERY_TIMEOUT javadoc valid values are Strings that can be parsed to int values.
+            // Let's also accept Number values to be compatible with QueryHints.PESSIMISTIC_LOCK_TIMEOUT
+            // String class is final so no need to use instanceof
+            if (valueToApply.getClass() == String.class) {
+                query.setQueryTimeout(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.QUERY_TIMEOUT));
+            // Now the second case, which must be Number. Anything else will cause class cast exception.
+            } else {
+                int value;
+                try {
+                    value = ((Number) valueToApply).intValue();
+                } catch (ClassCastException cce) {
+                    throw new IllegalArgumentException(
+                            ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",
+                                                               new String[] {getQueryId(query), name, getPrintValue(valueToApply)}));
+                }
+                query.setQueryTimeout(value);
+            }
+            query.setIsPrepared(false);
+            return query;
+        }
+    }
+
+    protected static class JDBCFetchSizeHint extends Hint {
+        JDBCFetchSizeHint() {
+            super(QueryHints.JDBC_FETCH_SIZE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                ((ReadQuery) query).setFetchSize(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.JDBC_FETCH_SIZE));
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+
+            return query;
+        }
+    }
+
+    protected static class AsOfHint extends Hint {
+        AsOfHint() {
+            super(QueryHints.AS_OF, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery) query).setAsOfClause(new AsOfClause(Helper.timestampFromString((String)valueToApply)));
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+
+            return query;
+        }
+    }
+
+    protected static class AsOfSCNHint extends Hint {
+        AsOfSCNHint() {
+            super(QueryHints.AS_OF_SCN, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery) query).setAsOfClause(new AsOfSCNClause(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.AS_OF_SCN)));
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+
+            return query;
+        }
+    }
+
+    protected static class JDBCMaxRowsHint extends Hint {
+        JDBCMaxRowsHint() {
+            super(QueryHints.JDBC_MAX_ROWS, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                ((ReadQuery) query).setMaxRows(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.JDBC_MAX_ROWS));
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class JDBCFirstResultHint extends Hint {
+        JDBCFirstResultHint() {
+            super(QueryHints.JDBC_FIRST_RESULT, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadQuery()) {
+                ((ReadQuery) query).setFirstResult(QueryHintsHandler.parseIntegerHint(valueToApply, QueryHints.JDBC_FIRST_RESULT));
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class ResultCollectionTypeHint extends Hint {
+        ResultCollectionTypeHint() {
+            super(QueryHints.RESULT_COLLECTION_TYPE, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isReadAllQuery()) {
+                Class<?> collectionClass = null;
+                if (valueToApply instanceof String) {
+                    collectionClass = loadClass((String)valueToApply, query, loader);
+                } else {
+                    collectionClass = (Class)valueToApply;
+                }
+                ((ReadAllQuery)query).useCollectionClass(collectionClass);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class RedirectorHint extends Hint {
+        RedirectorHint() {
+            super(QueryHints.QUERY_REDIRECTOR, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            // Can be an instance, class, or class name.
+            try {
+                Object redirector = valueToApply;
+                if (valueToApply instanceof Class) {
+                    redirector = newInstance((Class)valueToApply, query, QueryHints.QUERY_REDIRECTOR);
+                } else if (valueToApply instanceof String) {
+                    Class<?> redirectorClass = loadClass((String)valueToApply, query, loader);
+                    redirector = newInstance(redirectorClass, query, QueryHints.QUERY_REDIRECTOR);
+                }
+                query.setRedirector((QueryRedirector)redirector);
+            } catch (ClassCastException exception){
+                throw QueryException.unableToSetRedirectorOnQueryFromHint(query,QueryHints.QUERY_REDIRECTOR, valueToApply.getClass().getName(), exception);
+            }
+            return query;
+        }
+    }
+
+    protected static class PartitioningHint extends Hint {
+        PartitioningHint() {
+            super(QueryHints.PARTITIONING, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            // Can be an instance, class, or name.
+            Object policy = valueToApply;
+            if (valueToApply instanceof Class) {
+                policy = newInstance((Class)valueToApply, query, QueryHints.PARTITIONING);
+            } else if (valueToApply instanceof String) {
+                policy = activeSession.getProject().getPartitioningPolicy((String)valueToApply);
+                if (policy == null) {
+                    throw DescriptorException.missingPartitioningPolicy((String)valueToApply, null, null);
+                }
+            }
+            query.setPartitioningPolicy((PartitioningPolicy)policy);
+            return query;
+        }
+    }
+
+    protected static class CompositeMemberHint extends Hint {
+        CompositeMemberHint() {
+            super(QueryHints.COMPOSITE_UNIT_MEMBER, "");
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            query.setSessionName((String)valueToApply);
+            return query;
+        }
+    }
+
+    protected static class ResultSetAccess extends Hint {
+        ResultSetAccess() {
+            super(QueryHints.RESULT_SET_ACCESS, HintValues.PERSISTENCE_UNIT_DEFAULT);
+            valueArray = new Object[][] {
+                {HintValues.PERSISTENCE_UNIT_DEFAULT, null},
+                {HintValues.TRUE, Boolean.TRUE},
+                {HintValues.FALSE, Boolean.FALSE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                if (valueToApply != null) {
+                    ((ObjectLevelReadQuery)query).setIsResultSetAccessOptimizedQuery((Boolean)valueToApply);
+                } else {
+                    ((ObjectLevelReadQuery)query).clearIsResultSetOptimizedQuery();
+                }
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class SerializedObject extends Hint {
+        SerializedObject() {
+            super(QueryHints.SERIALIZED_OBJECT, HintValues.FALSE);
+            valueArray = new Object[][] {
+                {HintValues.TRUE, Boolean.TRUE},
+                {HintValues.FALSE, Boolean.FALSE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery)query).setShouldUseSerializedObjectPolicy((Boolean)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class PrintInnerJoinInWhereClauseHint extends Hint {
+        PrintInnerJoinInWhereClauseHint() {
+            super(QueryHints.INNER_JOIN_IN_WHERE_CLAUSE, HintValues.TRUE);
+            valueArray = new Object[][] {
+                    {HintValues.TRUE, Boolean.TRUE},
+                    {HintValues.FALSE, Boolean.FALSE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query.isObjectLevelReadQuery()) {
+                ((ObjectLevelReadQuery)query).setPrintInnerJoinInWhereClause((Boolean)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+    protected static class QueryResultsCacheValidation extends Hint {
+        QueryResultsCacheValidation() {
+            super(QueryHints.QUERY_RESULTS_CACHE_VALIDATION, HintValues.FALSE);
+            valueArray = new Object[][] {
+                    {HintValues.TRUE, Boolean.TRUE},
+                    {HintValues.FALSE, Boolean.FALSE}
+            };
+        }
+
+        @Override
+        DatabaseQuery applyToDatabaseQuery(Object valueToApply, DatabaseQuery query, ClassLoader loader, AbstractSession activeSession) {
+            if (query instanceof ReadQuery) {
+                ((ReadQuery)query).setAllowQueryResultsCacheValidation((Boolean)valueToApply);
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-type-for-query-hint",new Object[]{getQueryId(query), name, getPrintValue(valueToApply)}));
+            }
+            return query;
+        }
+    }
+
+}

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/internal/jpa/QueryHintsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2025 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2025 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -882,6 +882,7 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
 
     @Override
     public StoredProcedureQueryImpl setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
+        FindOptionUtils.setCacheRetrieveMode(getDatabaseQuery().getProperties(), cacheRetrieveMode);
         setHint(QueryHints.CACHE_RETRIEVE_MODE, cacheRetrieveMode);
         return this;
     }
@@ -893,6 +894,7 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
 
     @Override
     public StoredProcedureQueryImpl setCacheStoreMode(CacheStoreMode cacheStoreMode) {
+        FindOptionUtils.setCacheStoreMode(getDatabaseQuery().getProperties(), cacheStoreMode);
         setHint(QueryHints.CACHE_STORE_MODE, cacheStoreMode);
         return this;
     }
@@ -904,6 +906,7 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
 
     @Override
     public StoredProcedureQueryImpl setTimeout(Integer timeout) {
+        FindOptionUtils.setTimeout(getDatabaseQuery().getProperties(), timeout);
         setHint(QueryHints.QUERY_TIMEOUT, timeout);
         return this;
     }
@@ -925,19 +928,19 @@ public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedu
         if (entityManager == null || entityManager.properties == null) {
             return;
         }
-        
+
         DatabaseQuery dbQuery = getDatabaseQuery();
         if (dbQuery == null) {
             return;
         }
-        
+
         Map<String, Object> emProperties = entityManager.properties;
-        
+
         // CACHE_RETRIEVE_MODE only applies to ObjectLevelReadQuery (SELECT queries)
         if (dbQuery.isObjectLevelReadQuery() && emProperties.containsKey(QueryHints.CACHE_RETRIEVE_MODE)) {
             setHint(QueryHints.CACHE_RETRIEVE_MODE, emProperties.get(QueryHints.CACHE_RETRIEVE_MODE));
         }
-        
+
         // CACHE_STORE_MODE applies to all query types:
         // - For ObjectLevelReadQuery: controls whether results are stored in cache after reading
         // - For ModifyQuery: controls whether cache is invalidated after UPDATE/DELETE

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/internal/jpa/StoredProcedureQueryImpl.java
@@ -1,0 +1,1190 @@
+/*
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+//     Zoltan NAGY & tware - updated support for MaxRows
+//     11/01/2010-2.2 Guy Pelletier
+//       - 322916: getParameter on Query throws NPE
+//     11/09/2010-2.1 Michael O'Brien
+//       - 329089: PERF: EJBQueryImpl.setParamenterInternal() move indexOf check inside non-native block
+//     02/08/2012-2.4 Guy Pelletier
+//       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
+//     06/20/2012-2.5 Guy Pelletier
+//       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
+//     07/13/2012-2.5 Guy Pelletier
+//       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
+//     08/24/2012-2.5 Guy Pelletier
+//       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
+//     09/13/2012-2.5 Guy Pelletier
+//       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
+//     09/27/2012-2.5 Guy Pelletier
+//       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
+//     11/05/2012-2.5 Guy Pelletier
+//       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
+//     08/23/2023: Tomas Kraus
+//       - New Jakarta Persistence 3.2 Features
+package org.eclipse.persistence.internal.jpa;
+
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.LockTimeoutException;
+import jakarta.persistence.Parameter;
+import jakarta.persistence.ParameterMode;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.QueryTimeoutException;
+import jakarta.persistence.StoredProcedureQuery;
+import jakarta.persistence.TemporalType;
+
+import org.eclipse.persistence.config.QueryHints;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.internal.databaseaccess.*;
+import org.eclipse.persistence.internal.databaseaccess.DatasourceCall.ParameterType;
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.internal.jpa.querydef.ParameterExpressionImpl;
+import org.eclipse.persistence.internal.localization.ExceptionLocalization;
+import org.eclipse.persistence.internal.sessions.AbstractRecord;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.logging.SessionLog;
+import org.eclipse.persistence.queries.DataReadQuery;
+import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.queries.ReadAllQuery;
+import org.eclipse.persistence.queries.ResultSetMappingQuery;
+import org.eclipse.persistence.queries.SQLResultSetMapping;
+import org.eclipse.persistence.queries.StoredProcedureCall;
+
+/**
+ * Concrete JPA query class. The JPA query wraps a StoredProcesureQuery which
+ * is executed.
+ */
+public class StoredProcedureQueryImpl extends QueryImpl implements StoredProcedureQuery {
+    protected boolean hasMoreResults;
+
+    // Call will be returned from an execute. From it you can get the result set.
+    protected DatabaseCall executeCall;
+    protected Statement executeStatement;
+    protected int executeResultSetIndex = -1;
+
+    // If the procedure returns output cursor(s), we'll use them to satisfy
+    // getResultList and getSingleResult calls so keep track of our index.
+    protected int outputCursorIndex = -1;
+    protected boolean isOutputCursorResultSet = false;
+
+    /**
+     * Base constructor for StoredProcedureQueryImpl. Initializes basic variables.
+     */
+    protected StoredProcedureQueryImpl(EntityManagerImpl entityManager) {
+        super(entityManager);
+    }
+
+    /**
+     * Create an StoredProcedureQueryImpl with a DatabaseQuery.
+     */
+    public StoredProcedureQueryImpl(DatabaseQuery query, EntityManagerImpl entityManager) {
+        super(query, entityManager);
+        // Inherit applicable hints from EntityManager
+        inheritEntityManagerHints();
+    }
+
+    /**
+     * Create an StoredProcedureQueryImpl with a query name.
+     */
+    public StoredProcedureQueryImpl(String name, EntityManagerImpl entityManager) {
+        super(entityManager);
+        this.queryName = name;
+        // Inherit applicable hints from EntityManager
+        inheritEntityManagerHints();
+    }
+
+    /**
+     * Build the given result set into a list objects. Assumes there is an
+     * execute call available and therefore should not be called unless an
+     * execute statement was issued by the user.
+     */
+    protected List<?> buildResultRecords(ResultSet resultSet) {
+        try {
+            AbstractSession session = (AbstractSession) getActiveSession();
+            DatabaseAccessor accessor = (DatabaseAccessor) executeCall.getQuery().getAccessor();
+
+            executeCall.setFields(null);
+            executeCall.matchFieldOrder(resultSet, accessor, session);
+            ResultSetMetaData metaData = resultSet.getMetaData();
+
+            List<AbstractRecord> result =  new Vector<>();
+            while (resultSet.next()) {
+                result.add(accessor.fetchRow(executeCall.getFields(), executeCall.getFieldsArray(), resultSet, metaData, session));
+            }
+
+            // The result set must be closed in case the statement is cached and not closed.
+            resultSet.close();
+
+            return result;
+        } catch (Exception e) {
+            setRollbackOnly();
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
+     * Build a ResultSetMappingQuery from a sql result set mapping name and a
+     * stored procedure call.
+     * <p>
+     * This is called from a named stored procedure that employs result set
+     * mapping name(s) which should be available from the session.
+     */
+    public static DatabaseQuery buildResultSetMappingNameQuery(List<String> resultSetMappingNames, StoredProcedureCall call) {
+        ResultSetMappingQuery query = new ResultSetMappingQuery();
+        call.setReturnMultipleResultSetCollections(call.hasMultipleResultSets() && ! call.isMultipleCursorOutputProcedure());
+        query.setCall(call);
+        query.setIsUserDefined(true);
+        query.setSQLResultSetMappingNames(resultSetMappingNames);
+        return query;
+    }
+
+    /**
+     * Build a ResultSetMappingQuery from a sql result set mapping name and a
+     * stored procedure call.
+     * <p>
+     * This is called from a named stored procedure that employs result set
+     * mapping name(s) which should be available from the session.
+     */
+    public static DatabaseQuery buildResultSetMappingNameQuery(List<String> resultSetMappingNames, StoredProcedureCall call, Map<String, Object> hints, ClassLoader classLoader, AbstractSession session) {
+        // apply any query hints
+        DatabaseQuery hintQuery = applyHints(hints, buildResultSetMappingNameQuery(resultSetMappingNames, call) , classLoader, session);
+
+        // apply any query arguments
+        applyArguments(call, hintQuery);
+
+        return hintQuery;
+    }
+
+    /**
+     * Build a ResultSetMappingQuery from the sql result set mappings given
+     *  a stored procedure call.
+     * <p>
+     * This is called from a named stored procedure query that employs result
+     * class name(s). The resultSetMappings are build from these class name(s)
+     * and are not available from the session.
+     */
+    public static DatabaseQuery buildResultSetMappingQuery(List<SQLResultSetMapping> resultSetMappings, StoredProcedureCall call) {
+        ResultSetMappingQuery query = new ResultSetMappingQuery();
+        call.setReturnMultipleResultSetCollections(call.hasMultipleResultSets() && ! call.isMultipleCursorOutputProcedure());
+        query.setCall(call);
+        query.setIsUserDefined(true);
+        query.setSQLResultSetMappings(resultSetMappings);
+        return query;
+    }
+
+    /**
+     * Build a ResultSetMappingQuery from the sql result set mappings given
+     *  a stored procedure call.
+     * <p>
+     * This is called from a named stored procedure query that employs result
+     * class name(s). The resultSetMappings are build from these class name(s)
+     * and are not available from the session.
+     */
+    public static DatabaseQuery buildResultSetMappingQuery(List<SQLResultSetMapping> resultSetMappings, StoredProcedureCall call, Map<String, Object> hints, ClassLoader classLoader, AbstractSession session) {
+        // apply any query hints
+        DatabaseQuery hintQuery = applyHints(hints, buildResultSetMappingQuery(resultSetMappings, call), classLoader, session);
+
+        // apply any query arguments
+        applyArguments(call, hintQuery);
+
+        return hintQuery;
+    }
+
+    /**
+     * Build a ReadAllQuery from a class and stored procedure call.
+     */
+    public static DatabaseQuery buildStoredProcedureQuery(Class<?> resultClass, StoredProcedureCall call, Map<String, Object> hints, ClassLoader classLoader, AbstractSession session) {
+        DatabaseQuery query = new ReadAllQuery(resultClass);
+        query.setCall(call);
+        query.setIsUserDefined(true);
+
+        // apply any query hints
+        query = applyHints(hints, query, classLoader, session);
+
+        // apply any query arguments
+        applyArguments(call, query);
+
+        return query;
+    }
+
+    /**
+     * Build a DataReadQuery with the stored procedure call given.
+     */
+    public static DatabaseQuery buildStoredProcedureQuery(StoredProcedureCall call, Map<String, Object> hints, ClassLoader classLoader, AbstractSession session) {
+        DataReadQuery query = new DataReadQuery();
+        query.setResultType(DataReadQuery.AUTO);
+
+        query.setCall(call);
+        query.setIsUserDefined(true);
+
+        // apply any query hints
+        DatabaseQuery hintQuery = applyHints(hints, query, classLoader, session);
+
+        // apply any query arguments
+        applyArguments(call, hintQuery);
+
+        return hintQuery;
+    }
+
+    /**
+     * Build a ResultSetMappingQuery from a sql result set mapping name and a
+     * stored procedure call.
+     */
+    public static DatabaseQuery buildStoredProcedureQuery(String sqlResultSetMappingName, StoredProcedureCall call, Map<String, Object> hints, ClassLoader classLoader, AbstractSession session) {
+        ResultSetMappingQuery query = new ResultSetMappingQuery();
+        query.setSQLResultSetMappingName(sqlResultSetMappingName);
+        query.setCall(call);
+        query.setIsUserDefined(true);
+
+        // apply any query hints
+        DatabaseQuery hintQuery = applyHints(hints, query, classLoader, session);
+
+        // apply any query arguments
+        applyArguments(call, hintQuery);
+
+        return hintQuery;
+    }
+
+    /**
+     * Call this method to close any open connections to the database.
+     */
+    @Override
+    public void close() {
+        if (executeCall != null) {
+            DatabaseQuery query = executeCall.getQuery();
+            AbstractSession session = query.getSession();
+
+            // Release the accessors acquired for the query.
+            for (Accessor accessor : query.getAccessors()) {
+                session.releaseReadConnection(accessor);
+            }
+
+            try {
+                if (executeStatement != null) {
+                    DatabaseAccessor accessor = (DatabaseAccessor) query.getAccessor();
+                    accessor.releaseStatement(executeStatement, query.getSQLString(), executeCall, session);
+                }
+            } catch (SQLException exception) {
+                // Catch the exception and log a message.
+                session.log(SessionLog.WARNING, SessionLog.CONNECTION, "exception_caught_closing_statement", exception);
+            }
+        }
+
+        executeCall = null;
+        executeStatement = null;
+    }
+
+    /**
+     * Returns true if the first result corresponds to a result set, and false
+     * if it is an update count or if there are no results other than through
+     * INOUT and OUT parameters, if any.
+     * @return true if first result corresponds to result set
+     * @throws QueryTimeoutException if the query execution exceeds the query
+     * timeout value set and only the statement is rolled back
+     * @throws PersistenceException if the query execution exceeds the query
+     * timeout value set and the transaction is rolled back
+     */
+    @Override
+    public boolean execute() {
+        try {
+            entityManager.verifyOpen();
+
+            if (! getDatabaseQueryInternal().isResultSetMappingQuery()) {
+                throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_execute"));
+            }
+
+            getResultSetMappingQuery().setIsExecuteCall(true);
+            executeCall = (DatabaseCall) executeReadQuery();
+            executeStatement = executeCall.getStatement();
+
+            // Add this query to the entity manager open queries list.
+            // The query will be closed in the following cases:
+            // Within a transaction:
+            //  - on commit
+            //  - on rollback
+            // Outside of a transaction:
+            //  - em close
+            // Other safeguards, we will close the query if/when
+            //  - we hit the end of the results.
+            //  - this query is garbage collected (finalize method)
+            //
+            // Deferring closing the call avoids having to go through all the
+            // results now (and building all the result objects) and things
+            // remain on a as needed basis from the statement.
+            entityManager.addOpenQuery(this);
+
+            hasMoreResults = executeCall.getExecuteReturnValue();
+
+            // If execute returned false but we have output cursors then return
+            // true and build the results from the output cursors.
+            if (!hasMoreResults && getCall().hasOutputCursors()) {
+                hasMoreResults = true;
+                outputCursorIndex = 0;
+                isOutputCursorResultSet = true;
+            }
+
+            return hasMoreResults;
+        } catch (LockTimeoutException exception) {
+            throw exception;
+        } catch (PersistenceException | IllegalStateException exception) {
+            setRollbackOnly();
+            throw exception;
+        } catch (RuntimeException exception) {
+            setRollbackOnly();
+            throw new PersistenceException(exception);
+        }
+    }
+
+    /**
+     * Execute an update or delete statement (from a stored procedure query).
+     * @return the number of entities updated or deleted
+     */
+    @Override
+    public int executeUpdate() {
+        try {
+            // Need to throw TransactionRequiredException if there is no active transaction
+            entityManager.checkForTransaction(true);
+
+            // Legacy: we could have a data read query or a read all query, so
+            // clearly we shouldn't be executing an update on it. As of JPA 2.1
+            // API we always create a result set mapping query to interact with
+            // a stored procedure.
+            // Also if the result set mapping query has result set mappings
+            // defined, then it's clearly expecting result sets and we can be
+            // preemptive in throwing an exception.
+            if (! getDatabaseQueryInternal().isResultSetMappingQuery() || getResultSetMappingQuery().hasResultSetMappings()) {
+                throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_execute_update"));
+            }
+
+            // If the return value is true indicating a result set then throw an exception.
+            if (execute()) {
+                throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_execute_update"));
+            } else {
+                return getUpdateCount();
+            }
+        } catch (LockTimeoutException exception) {
+            throw exception;
+        } catch (PersistenceException | IllegalStateException e) {
+            setRollbackOnly();
+            throw e;
+        } catch (RuntimeException exception) {
+            setRollbackOnly();
+            throw new PersistenceException(exception);
+        } finally {
+            close(); // Close the connection once we're done.
+        }
+    }
+
+    /**
+     * Finalize method in case the query is not closed.
+     */
+    @Override
+    @SuppressWarnings("removal")
+    public void finalize() {
+        close();
+    }
+
+    /**
+     * Return the stored procedure call associated with this query.
+     */
+    protected StoredProcedureCall getCall() {
+        return (StoredProcedureCall) getDatabaseQueryInternal().getCall();
+    }
+
+    /**
+     * Return the internal map of parameters.
+     */
+    @Override
+    protected Map<String, Parameter<?>> getInternalParameters() {
+        if (parameters == null) {
+            parameters = new HashMap<>();
+
+            int index = 0;
+
+            for (Object parameter : getCall().getParameters()) {
+                ParameterType parameterType = getCall().getParameterTypes().get(index);
+                String argumentName = getCall().getProcedureArgumentNames().get(index);
+
+                DatabaseField field = null;
+
+                if (parameterType == ParameterType.INOUT) {
+                    field = (DatabaseField) ((Object[]) parameter)[0];
+                } else if (parameterType == ParameterType.IN) {
+                    field = (DatabaseField) parameter;
+                } else if (parameterType == ParameterType.OUT || parameterType == ParameterType.OUT_CURSOR) {
+                    if (parameter instanceof OutputParameterForCallableStatement) {
+                        field = ((OutputParameterForCallableStatement) parameter).getOutputField();
+                    } else {
+                        field = (DatabaseField) parameter;
+                    }
+                }
+
+                // If field is not null (one we care about) then add it, otherwise continue.
+                if (field != null) {
+                    // If the argument name is null then it is a positional parameter.
+                    if (argumentName == null) {
+                        parameters.put(field.getName(), new ParameterExpressionImpl(null, field.getType(), Integer.parseInt(field.getName())));
+                    } else {
+                        parameters.put(field.getName(), new ParameterExpressionImpl(null, field.getType(), field.getName()));
+                    }
+                }
+
+                ++index;
+            }
+        }
+
+        return parameters;
+    }
+
+    /**
+     * Used to retrieve the values passed back from the procedure through INOUT
+     * and OUT parameters. For portability, all results corresponding to result
+     * sets and update counts must be retrieved before the values of output
+     * parameters.
+     * @param position parameter position
+     * @return the result that is passed back through the parameter
+     * @throws IllegalArgumentException if the position does not correspond to a
+     * parameter of the query or is not an INOUT or OUT parameter
+     */
+    @Override
+    public Object getOutputParameterValue(int position) {
+        entityManager.verifyOpen();
+
+        if (isValidCallableStatement()) {
+            try {
+                Object obj = executeCall.getOutputParameterValue((CallableStatement) executeStatement, position - 1, entityManager.getAbstractSession());
+
+                if (obj instanceof ResultSet) {
+                    // If a result set is returned we have to build the objects.
+                    return getResultSetMappingQuery().buildObjectsFromRecords(buildResultRecords((ResultSet) obj), ++executeResultSetIndex);
+                } else {
+                    return obj;
+                }
+            } catch (Exception exception) {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("jpa21_invalid_parameter_position", new Object[] { position, exception.getMessage() }), exception);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Used to retrieve the values passed back from the procedure through INOUT
+     * and OUT parameters. For portability, all results corresponding to result
+     * sets and update counts must be retrieved before the values of output
+     * parameters.
+     * @param parameterName name of the parameter as registered or specified in
+     *        metadata
+     * @return the result that is passed back through the parameter
+     * @throws IllegalArgumentException if the parameter name does not
+     * correspond to a parameter of the query or is not an INOUT or OUT parameter
+     */
+    @Override
+    public Object getOutputParameterValue(String parameterName) {
+        entityManager.verifyOpen();
+
+        if (isValidCallableStatement()) {
+            try {
+                Object obj = executeCall.getOutputParameterValue((CallableStatement) executeStatement, parameterName, entityManager.getAbstractSession());
+
+                if (obj instanceof ResultSet) {
+                    // If a result set is returned we have to build the objects.
+                    return getResultSetMappingQuery().buildObjectsFromRecords(buildResultRecords((ResultSet) obj), ++executeResultSetIndex);
+                }
+                return obj;
+            } catch (Exception exception) {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("jpa21_invalid_parameter_name", new Object[] { parameterName, exception.getMessage() }), exception);
+            }
+        }
+
+        return null;
+    }
+
+    private boolean hasPositionalParameters() {
+        for (Parameter parameter: this.getParameters()) {
+            if (parameter.getName() != null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Execute the query and return the query results as a List.
+     * @return a list of the results
+     */
+    @Override
+    public List getResultList() {
+        // bug51411440: need to throw IllegalStateException if query
+        // executed on closed em
+        this.entityManager.verifyOpenWithSetRollbackOnly();
+        try {
+            // If there is no execute statement, the user has not called
+            // execute and is simply calling getResultList directly on the query.
+            if (executeStatement == null) {
+                // If it's not a result set mapping query (as of JPA 2.1 we
+                // always create a result set mapping query to interact with a
+                // stored procedure) then throw an exception.
+                if (! getDatabaseQueryInternal().isResultSetMappingQuery()) {
+                    throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_get_result_list"));
+                }
+
+                // If the return value is false indicating no result set then throw an exception.
+                if (execute()) {
+                    return getResultList();
+                } else {
+                    throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_get_result_list"));
+                }
+            } else {
+                if (hasMoreResults()) {
+                    if (isOutputCursorResultSet) {
+                        // Return result set list for the current outputCursorIndex.
+                        List results = null;
+                        if (hasPositionalParameters()) {
+                            results = (List) getOutputParameterValue(getCall().getOutputCursors().get(outputCursorIndex++).getIndex() + 1);
+                        } else {
+                            results = (List) getOutputParameterValue(getCall().getOutputCursors().get(outputCursorIndex++).getName());
+                        }
+
+                        // Update the hasMoreResults flag.
+                        hasMoreResults = (outputCursorIndex < getCall().getOutputCursors().size());
+
+                        return results;
+                    } else {
+                        // Build the result records first.
+                        List result = buildResultRecords(executeStatement.getResultSet());
+
+                        // Move the result pointer.
+                        moveResultPointer();
+
+                        return getResultSetMappingQuery().buildObjectsFromRecords(result, ++executeResultSetIndex);
+                    }
+                } else {
+                    return null;
+                }
+            }
+        } catch (LockTimeoutException e) {
+            throw e;
+        } catch (PersistenceException | IllegalStateException e) {
+            setRollbackOnly();
+            throw e;
+        } catch (Exception e) {
+            setRollbackOnly();
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
+     * Return the ResultSetMappingQuery for this stored procedure query.
+     * NOTE: Methods assumes associated database query is a ResultSetMappingQuery.
+     */
+    protected ResultSetMappingQuery getResultSetMappingQuery() {
+        if (executeCall != null) {
+            return (ResultSetMappingQuery) executeCall.getQuery();
+        } else {
+            return (ResultSetMappingQuery) getDatabaseQuery();
+        }
+    }
+
+    @Override
+    public Object getSingleResultOrNull() {
+        return getSingleResult(false);
+    }
+
+    @Override
+    public Object getSingleResult() {
+        return getSingleResult(true);
+    }
+
+    private Object getSingleResult(boolean failOnEmpty) {
+        // bug51411440: need to throw IllegalStateException if query
+        // executed on closed em
+        this.entityManager.verifyOpenWithSetRollbackOnly();
+        try {
+            // If there is no execute statement, the user has not called
+            // execute and is simply calling getSingleResult directly on the query.
+            if (executeStatement == null) {
+                // If it's not a result set mapping query (as of JPA 2.1 we
+                // always create a result set mapping query to interact with a
+                // stored procedure) then throw an exception.
+                if (! getDatabaseQueryInternal().isResultSetMappingQuery()) {
+                    throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_get_single_result"));
+                }
+
+                // If the return value is true indicating a result set then
+                // build and return the single result.
+                if (execute()) {
+                    return getSingleResult(failOnEmpty);
+                } else {
+                    throw new IllegalStateException(ExceptionLocalization.buildMessage("incorrect_spq_query_for_get_result_list"));
+                }
+            } else {
+                if (hasMoreResults()) {
+                    // Build the result records first.
+                    List<?> results;
+
+                    if (isOutputCursorResultSet) {
+                        // Return result set list for the current outputCursorIndex.
+                        if (hasPositionalParameters()) {
+                            results = (List<?>) getOutputParameterValue(getCall().getOutputCursors().get(outputCursorIndex++).getIndex() + 1);
+                        } else {
+                            results = (List<?>) getOutputParameterValue(getCall().getOutputCursors().get(outputCursorIndex++).getName());
+                        }
+
+                        // Update the hasMoreResults flag.
+                        hasMoreResults = (outputCursorIndex < getCall().getOutputCursors().size());
+                    } else {
+                        // Build the result records first.
+                        List<?> result = buildResultRecords(executeStatement.getResultSet());
+
+                        // Move the result pointer.
+                        moveResultPointer();
+
+                        results = getResultSetMappingQuery().buildObjectsFromRecords(result, ++executeResultSetIndex);
+                    }
+
+                    if (results.size() > 1) {
+                        throwNonUniqueResultException(ExceptionLocalization.buildMessage("too_many_results_for_get_single_result", null));
+                    } else if (results.isEmpty()) {
+                        if (failOnEmpty) {
+                            throwNoResultException(ExceptionLocalization.buildMessage("no_entities_retrieved_for_get_single_result", null));
+                        } else {
+                            return null;
+                        }
+                    }
+                    // If hasMoreResults is true, we should throw an exception here.
+                    if (results.size() > 1 || hasMoreResults) {
+                        throwNonUniqueResultException(ExceptionLocalization.buildMessage("too_many_results_for_get_single_result", null));
+                    }
+
+                    return results.get(0);
+                } else {
+                    return null;
+                }
+            }
+        } catch (LockTimeoutException e) {
+            throw e;
+        } catch (PersistenceException | IllegalStateException e) {
+            setRollbackOnly();
+            throw e;
+        } catch (Exception e) {
+            setRollbackOnly();
+            throw new PersistenceException(e);
+        } finally {
+            close(); // Close the connection once we're done.
+        }
+    }
+
+    /**
+     * Returns the update count or -1 if there is no pending result
+     * or if the next result is not an update count.
+     * @return update count or -1 if there is no pending result or
+     * if the next result is not an update count
+     * @throws QueryTimeoutException if the query execution exceeds
+     * the query timeout value set and only the statement is
+     * rolled back
+     * @throws PersistenceException if the query execution exceeds
+     * the query timeout value set and the transaction
+     * is rolled back
+     */
+    @Override
+    public int getUpdateCount() {
+        entityManager.verifyOpenWithSetRollbackOnly();
+
+        if (executeStatement != null) {
+            try {
+                int updateCount = executeStatement.getUpdateCount();
+
+                // Moving the result pointer when -1 is reached doesn't seem
+                // to be an issue for the jbdc driver, however as a safeguard,
+                // once -1 is reached don't bother trying to move the pointer
+                // as there is no need to do so.
+                if (updateCount > -1) {
+                    moveResultPointer();
+                }
+                return updateCount;
+            } catch (SQLException e) {
+                throw getDetailedException(DatabaseException.sqlException(e, executeCall, executeCall.getQuery().getAccessor(), executeCall.getQuery().getSession(), false));
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Returns true if the next result corresponds to a result set, and false if
+     * it is an update count or if there are no results other than through INOUT
+     * and OUT parameters, if any.
+     *
+     * @return true if next result corresponds to result set
+     * @throws QueryTimeoutException if the query execution exceeds the query
+     * timeout value set and only the statement is rolled back
+     * @throws PersistenceException if the query execution exceeds the query
+     * timeout value set and the transaction is rolled back
+     */
+    @Override
+    public boolean hasMoreResults() {
+        entityManager.verifyOpen();
+
+        return hasMoreResults;
+    }
+
+    /**
+     * Returns true if the execute statement for this query is 1) not null (i.e.
+     * query has been executed and 2) is an instance of callable statement,
+     * meaning there are out parameters associated with it.
+     */
+    protected boolean isValidCallableStatement() {
+        if (executeStatement == null) {
+            throw new IllegalStateException(ExceptionLocalization.buildMessage("jpa21_invalid_call_on_un_executed_query"));
+        }
+
+        if (! (executeStatement instanceof CallableStatement)) {
+            throw new IllegalStateException(ExceptionLocalization.buildMessage("jpa21_invalid_call_with_no_output_parameters"));
+        }
+
+        return true;
+    }
+
+    /**
+     * INTERNAL:
+     * Move the pointer up and update our has more results flag.
+     * Once there are no result sets left, this will always return false.
+     */
+    private void moveResultPointer() {
+        try {
+            hasMoreResults = executeStatement.getMoreResults();
+        } catch (SQLException e) {
+            // swallow it.
+            hasMoreResults = false;
+        }
+    }
+
+    /**
+     * Register a positional parameter. All positional parameters must be
+     * registered.
+     *
+     * @param position parameter position
+     * @param type type of the parameter
+     * @param mode parameter mode
+     * @return the same query instance
+     */
+    @Override
+    @SuppressWarnings({"rawtypes"})
+    public StoredProcedureQuery registerStoredProcedureParameter(int position, Class type, ParameterMode mode) {
+        entityManager.verifyOpenWithSetRollbackOnly();
+        StoredProcedureCall call = (StoredProcedureCall) getDatabaseQuery().getCall();
+
+        if (mode.equals(ParameterMode.IN)) {
+            call.addUnamedArgument(String.valueOf(position), type);
+        } else if (mode.equals(ParameterMode.OUT)) {
+            call.addUnamedOutputArgument(String.valueOf(position), type);
+        } else if (mode.equals(ParameterMode.INOUT)) {
+            call.addUnamedInOutputArgument(String.valueOf(position), String.valueOf(position), type);
+        } else if (mode.equals(ParameterMode.REF_CURSOR)) {
+            call.useUnnamedCursorOutputAsResultSet(position);
+        }
+
+        // Force a re-calculate of the parameters.
+        this.parameters = null;
+
+        return this;
+    }
+
+    /**
+     * Register a named parameter. When using parameter names, all parameters
+     * must be registered in the order in which they occur in the parameter list
+     * of the stored procedure.
+     *
+     * @param parameterName name of the parameter as registered or
+     *        specified in metadata
+     * @param type type of the parameter
+     * @param mode parameter mode
+     * @return the same query instance
+     */
+    @Override
+    @SuppressWarnings({"rawtypes"})
+    public StoredProcedureQuery registerStoredProcedureParameter(String parameterName, Class type, ParameterMode mode) {
+        entityManager.verifyOpenWithSetRollbackOnly();
+        StoredProcedureCall call = (StoredProcedureCall) getDatabaseQuery().getCall();
+
+        if (mode.equals(ParameterMode.IN)) {
+            call.addNamedArgument(parameterName, parameterName, type);
+        } else if (mode.equals(ParameterMode.OUT)) {
+            call.addNamedOutputArgument(parameterName, parameterName, type);
+        } else if (mode.equals(ParameterMode.INOUT)) {
+            call.addNamedInOutputArgument(parameterName, parameterName, parameterName, type);
+        } else if (mode.equals(ParameterMode.REF_CURSOR)) {
+            call.useNamedCursorOutputAsResultSet(parameterName);
+        }
+
+        // Force a re-calculate of the parameters.
+        this.parameters = null;
+
+        return this;
+    }
+
+    /**
+     * Set the position of the first result to retrieve.
+     *
+     * @param startPosition
+     *            position of the first result, numbered from 0
+     * @return the same query instance
+     */
+    @Override
+    public StoredProcedureQueryImpl setFirstResult(int startPosition) {
+        throw new IllegalStateException(ExceptionLocalization.buildMessage("operation_not_supported", new Object[]{"setFirstResult", "StoredProcedureQuery"}));
+    }
+
+    /**
+     * Set the flush mode type to be used for the query execution.
+     * The flush mode type applies to the query regardless of the
+     * flush mode type in use for the entity manager.
+     * @param flushMode flush mode
+     * @return the same query instance
+     */
+    @Override
+    public StoredProcedureQueryImpl setFlushMode(FlushModeType flushMode) {
+        return (StoredProcedureQueryImpl) super.setFlushMode(flushMode);
+    }
+
+    @Override
+    public CacheRetrieveMode getCacheRetrieveMode() {
+        return FindOptionUtils.getCacheRetrieveMode(entityManager.getAbstractSession(), getDatabaseQuery().getProperties());
+    }
+
+    @Override
+    public StoredProcedureQueryImpl setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode) {
+        setHint(QueryHints.CACHE_RETRIEVE_MODE, cacheRetrieveMode);
+        return this;
+    }
+
+    @Override
+    public CacheStoreMode getCacheStoreMode() {
+        return FindOptionUtils.getCacheStoreMode(entityManager.getAbstractSession(), getDatabaseQuery().getProperties());
+    }
+
+    @Override
+    public StoredProcedureQueryImpl setCacheStoreMode(CacheStoreMode cacheStoreMode) {
+        setHint(QueryHints.CACHE_STORE_MODE, cacheStoreMode);
+        return this;
+    }
+
+    @Override
+    public Integer getTimeout() {
+        return FindOptionUtils.getTimeout(entityManager.getAbstractSession(), getDatabaseQuery().getProperties());
+    }
+
+    @Override
+    public StoredProcedureQueryImpl setTimeout(Integer timeout) {
+        setHint(QueryHints.QUERY_TIMEOUT, timeout);
+        return this;
+    }
+
+    /**
+     * Inherit applicable query hints from the EntityManager.
+     * This method is called during query construction to automatically propagate
+     * EntityManager-level settings to newly created queries.
+     *
+     * Currently propagates cache-related hints (CACHE_RETRIEVE_MODE and CACHE_STORE_MODE)
+     * from EntityManager to queries.
+     * - CACHE_RETRIEVE_MODE only applies to ObjectLevelReadQuery (SELECT queries)
+     * - CACHE_STORE_MODE applies to both ObjectLevelReadQuery (SELECT) and ModifyQuery (UPDATE/DELETE)
+     *
+     * This follows the same pattern as EntityManagerImpl.getQueryHints() (lines 2840-2899)
+     * but is specifically designed for createStoredProcedureQuery() operations.
+     */
+    protected void inheritEntityManagerHints() {
+        if (entityManager == null || entityManager.properties == null) {
+            return;
+        }
+        
+        DatabaseQuery dbQuery = getDatabaseQuery();
+        if (dbQuery == null) {
+            return;
+        }
+        
+        Map<String, Object> emProperties = entityManager.properties;
+        
+        // CACHE_RETRIEVE_MODE only applies to ObjectLevelReadQuery (SELECT queries)
+        if (dbQuery.isObjectLevelReadQuery() && emProperties.containsKey(QueryHints.CACHE_RETRIEVE_MODE)) {
+            setHint(QueryHints.CACHE_RETRIEVE_MODE, emProperties.get(QueryHints.CACHE_RETRIEVE_MODE));
+        }
+        
+        // CACHE_STORE_MODE applies to all query types:
+        // - For ObjectLevelReadQuery: controls whether results are stored in cache after reading
+        // - For ModifyQuery: controls whether cache is invalidated after UPDATE/DELETE
+        if (emProperties.containsKey(QueryHints.CACHE_STORE_MODE)) {
+            setHint(QueryHints.CACHE_STORE_MODE, emProperties.get(QueryHints.CACHE_STORE_MODE));
+        }
+    }
+
+    /**
+     * Set a query property or hint. The hints elements may be used to specify
+     * query properties and hints. Properties defined by this specification must
+     * be observed by the provider. Vendor-specific hints that are not
+     * recognized by a provider must be silently ignored. Portable applications
+     * should not rely on the standard timeout hint. Depending on the database
+     * in use, this hint may or may not be observed.
+     *
+     * @param hintName name of the property or hint
+     * @param value value for the property or hint
+     * @return the same query instance
+     * @throws IllegalArgumentException if the second argument is not valid for
+     * the implementation
+     */
+    @Override
+    public StoredProcedureQuery setHint(String hintName, Object value) {
+        try {
+            entityManager.verifyOpen();
+            setHintInternal(hintName, value);
+            return this;
+        } catch (RuntimeException e) {
+            setRollbackOnly();
+            throw e;
+        }
+    }
+
+    /**
+     * Set the lock mode type to be used for the query execution.
+     *
+     * @throws IllegalStateException
+     *             if not a Java Persistence query language SELECT query
+     */
+    @Override
+    public StoredProcedureQueryImpl setLockMode(LockModeType lockMode) {
+        return (StoredProcedureQueryImpl) super.setLockMode(lockMode);
+    }
+
+    /**
+     * Set the maximum number of results to retrieve.
+     *
+     * @return the same query instance
+     */
+    @Override
+    public StoredProcedureQueryImpl setMaxResults(int maxResult) {
+        throw new IllegalStateException(ExceptionLocalization.buildMessage("operation_not_supported", new Object[]{"setMaxResults", "StoredProcedureQuery"}));
+    }
+
+    /**
+     * Bind an instance of java.util.Calendar to a positional parameter.
+     *
+     * @return the same query instance
+     * @throws IllegalArgumentException if position does not correspond to a
+     * positional parameter of the query or if the value argument is of
+     * incorrect type
+     */
+    @Override
+    public StoredProcedureQuery setParameter(int position, Calendar value, TemporalType temporalType) {
+        entityManager.verifyOpenWithSetRollbackOnly();
+        return setParameter(position, convertTemporalType(value, temporalType));
+    }
+
+    /**
+     * Bind an instance of java.util.Date to a positional parameter.
+     *
+     * @return the same query instance
+     * @throws IllegalArgumentException if position does not correspond to a
+     * positional parameter of the query or if the value argument is of
+     * incorrect type
+     */
+    @Override
+    public StoredProcedureQuery setParameter(int position, Date value, TemporalType temporalType) {
+        entityManager.verifyOpenWithSetRollbackOnly();
+        return setParameter(position, convertTemporalType(value, temporalType));
+    }
+
+    /**
+     * Bind an argument to a positional parameter.
+     *
+     * @return the same query instance
+     * @throws IllegalArgumentException if position does not correspond to a
+     * positional parameter of the query or if the argument is of incorrect type
+     */
+    @Override
+    public StoredProcedureQuery setParameter(int position, Object value) {
+        try {
+            entityManager.verifyOpen();
+            setParameterInternal(position, value);
+            return this;
+        } catch (RuntimeException e) {
+            setRollbackOnly();
+            throw e;
+        }
+    }
+
+    /**
+     * Bind an instance of java.util.Calendar to a Parameter object.
+     *
+     * @return the same query instance
+     * @throws IllegalArgumentException if the parameter does not correspond to
+     * a parameter of the query
+     */
+    @Override
+    public StoredProcedureQuery setParameter(Parameter<Calendar> param, Calendar value, TemporalType temporalType) {
+        if (param == null) {
+            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("NULL_PARAMETER_PASSED_TO_SET_PARAMETER"));
+        }
+        //bug 402686: type validation
+        String position = getParameterId(param);
+        ParameterExpressionImpl parameter = (ParameterExpressionImpl) this.getInternalParameters().get(position);
+        if (parameter == null ) {
+            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("NO_PARAMETER_WITH_NAME", new Object[] { param.toString(), this.databaseQuery }));
+        }
+        if (!parameter.getParameterType().equals(param.getParameterType())) {
+            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("INCORRECT_PARAMETER_TYPE", new Object[] { position, param.getParameterType() }));
+        }
+        return this.setParameter(position, value, temporalType);
+    }
+
+    /**
+     * Bind an instance of java.util.Date to a Parameter object.
+     *
+     * @return the same query instance
+     * @throws IllegalArgumentException if the parameter does not correspond to
+     * a parameter of the query
+     */
+    @Override
+    public StoredProcedureQuery setParameter(Parameter<Date> param, Date value, TemporalType temporalType) {
+        if (param == null) {
+            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("NULL_PARAMETER_PASSED_TO_SET_PARAMETER"));
+        }
+        //bug 402686: type validation
+        String position = getParameterId(param);
+        ParameterExpressionImpl parameter = (ParameterExpressionImpl) this.getInternalParameters().get(position);
+        if (parameter == null ) {
+            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("NO_PARAMETER_WITH_NAME", new Object[] { param.toString(), this.databaseQuery }));
+        }
+        if (!parameter.getParameterType().equals(param.getParameterType())) {
+            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("INCORRECT_PARAMETER_TYPE", new Object[] { position, param.getParameterType() }));
+        }
+        return this.setParameter(position, value, temporalType);
+    }
+
+    /**
+     * Bind the value of a Parameter object.
+     *
+     * @return the same query instance
+     * @throws IllegalArgumentException if the parameter does not correspond to
+     * a parameter of the query
+     */
+    @Override
+    public <T> StoredProcedureQuery setParameter(Parameter<T> param, T value) {
+        if (param == null) {
+            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("NULL_PARAMETER_PASSED_TO_SET_PARAMETER"));
+        }
+        //bug 402686: type validation
+        String position = getParameterId(param);
+        ParameterExpressionImpl parameter = (ParameterExpressionImpl) this.getInternalParameters().get(position);
+        if (parameter == null ) {
+            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("NO_PARAMETER_WITH_NAME", new Object[] { param.toString(), this.databaseQuery }));
+        }
+        if (!parameter.getParameterType().equals(param.getParameterType())) {
+            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("INCORRECT_PARAMETER_TYPE", new Object[] { position, param.getParameterType() }));
+        }
+        return this.setParameter(position, value);
+    }
+
+    /**
+     * Bind an instance of java.util.Calendar to a named parameter.
+     *
+     * @return the same query instance
+     * @throws IllegalArgumentException if the parameter name does not
+     * correspond to a parameter of the query or if the value argument is of
+     * incorrect type
+     */
+    @Override
+    public StoredProcedureQuery setParameter(String name, Calendar value, TemporalType temporalType) {
+        entityManager.verifyOpenWithSetRollbackOnly();
+        return setParameter(name, convertTemporalType(value, temporalType));
+    }
+
+    /**
+     * Bind an instance of java.util.Date to a named parameter.
+     *
+     * @return the same query instance
+     * @throws IllegalArgumentException if the parameter name does not
+     * correspond to a parameter of the query or if the value argument is of
+     * incorrect type
+     */
+    @Override
+    public StoredProcedureQuery setParameter(String name, Date value, TemporalType temporalType) {
+        entityManager.verifyOpenWithSetRollbackOnly();
+        return setParameter(name, convertTemporalType(value, temporalType));
+    }
+
+    /**
+     * Bind an argument to a named parameter.
+     *
+     * @return the same query instance
+     * @throws IllegalArgumentException if the parameter name does not
+     * correspond to a parameter of the query or if the argument is of incorrect
+     * type
+     */
+    @Override
+    public StoredProcedureQuery setParameter(String name, Object value) {
+        try {
+            entityManager.verifyOpen();
+            setParameterInternal(name, value, false);
+            return this;
+        } catch (RuntimeException e) {
+            setRollbackOnly();
+            throw e;
+        }
+    }
+
+    /**
+     * Bind an argument to a named or indexed parameter.
+     *
+     * @param name
+     *            the parameter name
+     * @param value
+     *            to bind
+     * @param isIndex
+     *            defines if index or named
+     */
+    @Override
+    protected void setParameterInternal(String name, Object value, boolean isIndex) {
+        Parameter<?> parameter = this.getInternalParameters().get(name);
+        StoredProcedureCall call = (StoredProcedureCall) getDatabaseQuery().getCall();
+        if (parameter == null) {
+            if (isIndex) {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-argument-index", new Object[] { name, call.getProcedureName() }));
+            } else {
+                throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-wrong-argument-name", new Object[] { name, call.getProcedureName() }));
+            }
+        }
+        if (!isValidActualParameter(value, parameter.getParameterType())) {
+            throw new IllegalArgumentException(ExceptionLocalization.buildMessage("ejb30-incorrect-parameter-type", new Object[] { name, value.getClass(), parameter.getParameterType(), call.getProcedureName() }));
+        }
+        this.parameterValues.put(name, value);
+    }
+}
+

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/queries/DatabaseQuery.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/queries/DatabaseQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1998, 2025 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/queries/DatabaseQuery.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/queries/DatabaseQuery.java
@@ -1,0 +1,2835 @@
+/*
+ * Copyright (c) 1998, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025 IBM Corporation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation from Oracle TopLink
+//     07/16/2009-2.0 Guy Pelletier
+//       - 277039: JPA 2.0 Cache Usage Settings
+//     10/15/2010-2.2 Guy Pelletier
+//       - 322008: Improve usability of additional criteria applied to queries at the session/EM
+//     10/29/2010-2.2 Michael O'Brien
+//       - 325167: Make reserved # bind parameter char generic to enable native SQL pass through
+//     04/01/2011-2.3 Guy Pelletier
+//       - 337323: Multi-tenant with shared schema support (part 2)
+//     05/24/2011-2.3 Guy Pelletier
+//       - 345962: Join fetch query when using tenant discriminator column fails.
+//     06/30/2011-2.3.1 Guy Pelletier
+//       - 341940: Add disable/enable allowing native queries
+//     07/13/2012-2.5 Guy Pelletier
+//       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
+//     11/05/2012-2.5 Guy Pelletier
+//       - 350487: JPA 2.1 Specification defined support for Stored Procedure Calls
+//     08/11/2012-2.5 Guy Pelletier
+//       - 393867: Named queries do not work when using EM level Table Per Tenant Multitenancy.
+//     08/11/2014-2.5 Rick Curtis
+//       - 440594: Tolerate invalid NamedQuery at EntityManager creation.
+//     09/03/2015 - Will Dazey
+//       - 456067 : Added support for defining query timeout units
+package org.eclipse.persistence.queries;
+
+import org.eclipse.persistence.config.ParameterDelimiterType;
+import org.eclipse.persistence.descriptors.ClassDescriptor;
+import org.eclipse.persistence.descriptors.DescriptorQueryManager;
+import org.eclipse.persistence.descriptors.partitioning.PartitioningPolicy;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.exceptions.EclipseLinkException;
+import org.eclipse.persistence.exceptions.OptimisticLockException;
+import org.eclipse.persistence.exceptions.QueryException;
+import org.eclipse.persistence.expressions.Expression;
+import org.eclipse.persistence.internal.databaseaccess.Accessor;
+import org.eclipse.persistence.internal.databaseaccess.DatabaseCall;
+import org.eclipse.persistence.internal.databaseaccess.DatasourcePlatform;
+import org.eclipse.persistence.internal.expressions.SQLStatement;
+import org.eclipse.persistence.internal.helper.ConversionManager;
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.internal.helper.Helper;
+import org.eclipse.persistence.internal.helper.InvalidObject;
+import org.eclipse.persistence.internal.queries.CallQueryMechanism;
+import org.eclipse.persistence.internal.queries.DatabaseQueryMechanism;
+import org.eclipse.persistence.internal.queries.DatasourceCallQueryMechanism;
+import org.eclipse.persistence.internal.queries.ExpressionQueryMechanism;
+import org.eclipse.persistence.internal.queries.JPQLCallQueryMechanism;
+import org.eclipse.persistence.internal.queries.StatementQueryMechanism;
+import org.eclipse.persistence.internal.sessions.AbstractRecord;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.internal.sessions.UnitOfWorkImpl;
+import org.eclipse.persistence.internal.sessions.remote.RemoteSessionController;
+import org.eclipse.persistence.internal.sessions.remote.Transporter;
+import org.eclipse.persistence.mappings.DatabaseMapping;
+import org.eclipse.persistence.sessions.DataRecord;
+import org.eclipse.persistence.sessions.DatabaseRecord;
+import org.eclipse.persistence.sessions.SessionProfiler;
+import org.eclipse.persistence.sessions.remote.DistributedSession;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * <p>
+ * <b>Purpose</b>: Abstract class for all database query objects. DatabaseQuery
+ * is a visible class to the EclipseLink user. Users create an appropriate query
+ * by creating an instance of a concrete subclasses of DatabaseQuery.
+ *
+ * <p>
+ * <b>Responsibilities</b>:
+ * <ul>
+ * <li>Provide a common protocol for query objects.
+ * <li>Defines a generic execution interface.
+ * <li>Provides query property values
+ * <li>Holds arguments to the query
+ * </ul>
+ *
+ * @author Yvon Lavoie
+ * @since TOPLink/Java 1.0
+ */
+public abstract class DatabaseQuery implements Cloneable, Serializable {
+    /** INTERNAL: Property used for batch fetching in non object queries. */
+    public static final String BATCH_FETCH_PROPERTY = "BATCH_FETCH_PROPERTY";
+
+    /**
+     * Queries can be given a name and registered with a descriptor to allow
+     * common queries to be reused.
+     */
+    protected String name;
+
+    /**
+     * Arguments can be given and specified to predefined queries to allow
+     * reuse.
+     */
+    protected List<String> arguments;
+
+    /**
+     * PERF: Argument fields are cached in prepare to avoid rebuilding on each
+     * execution.
+     */
+    protected List<DatabaseField> argumentFields;
+
+    /**
+     * Arguments values can be given and specified to predefined queries to
+     * allow reuse.
+     */
+    protected List<Object> argumentValues;
+
+    /** Needed to differentiate queries with the same name. */
+    protected List<Class<?>> argumentTypes;
+
+    /** Used to build a list of argumentTypes by name pre-initialization */
+    protected List<String> argumentTypeNames;
+
+    /** Used for parameter retreival in JPQL **/
+    public enum ParameterType {POSITIONAL, NAMED}
+
+    protected List<ParameterType> argumentParameterTypes;
+
+    /** The descriptor cached on the prepare for object level queries. */
+    protected transient ClassDescriptor descriptor;
+
+    /** The list of descriptors this query deals with. Set via JPA processing for table per tenant queries */
+    protected List<ClassDescriptor> descriptors;
+
+    /**
+     * The query mechanism determines the mechanism on how the database will be
+     * accessed.
+     */
+    protected DatabaseQueryMechanism queryMechanism;
+
+    /**
+     * A redirector allows for a queries execution to be the execution of a
+     * piece of code.
+     */
+    protected QueryRedirector redirector;
+
+    /**
+     * Can be set to true in the case there is a redirector or a default
+     * redirector but the user does not want the query redirected.
+     */
+    protected boolean doNotRedirect = false;
+
+    /** Flag used for a query to bypass the identitymap and unit of work. */
+
+    // Bug#3476483 - Restore shouldMaintainCache to previous state after reverse
+    // of bug fix 3240668
+    protected boolean shouldMaintainCache;
+
+    /** JPA flags to control the shared cache */
+    protected boolean shouldRetrieveBypassCache = false;
+    protected boolean shouldStoreBypassCache = false;
+
+    /**
+     * Property used to override a persistence unit level that disallows native
+     * SQL queries.
+     * @see org.eclipse.persistence.sessions.Project#setAllowNativeSQLQueries(boolean) Project.setAllowNativeSQLQueries(boolean)
+     */
+    protected Boolean allowNativeSQLQuery;
+
+    /** Internally used by the mappings as a temporary store. */
+    protected Map<Object, Object> properties;
+
+    /**
+     * Only used after the query is cloned for execution to store the session
+     * under which the query was executed.
+     */
+    protected transient AbstractSession session;
+
+    /**
+     * Only used after the query is cloned for execution to store the execution
+     * session under which the query was executed.
+     */
+    protected transient AbstractSession executionSession;
+
+    /**
+     * Connection to use for database access, required for server session
+     * connection pooling.
+     * There can be multiple connections with partitioning and replication.
+     */
+    protected transient Collection<Accessor> accessors;
+
+    /**
+     * Mappings and the descriptor use parameterized mechanisms that will be
+     * translated with the data from the row.
+     */
+    protected AbstractRecord translationRow;
+
+    /**
+     * Internal flag used to bypass user define queries when executing one for
+     * custom sql/query support.
+     */
+    protected boolean isUserDefined;
+
+    /**
+     * Internal flag used to bypass user define queries when executing one for
+     * custom sql/query support.
+     */
+    protected boolean isUserDefinedSQLCall;
+
+    /** Policy that determines how the query will cascade to its object's parts. */
+    protected int cascadePolicy;
+
+    /** Used to override the default session in the session broker. */
+    protected String sessionName;
+
+    /** Queries prepare common stated in themselves. */
+    protected boolean isPrepared;
+
+    /** Used to indicate whether or not the call needs to be cloned. */
+    protected boolean shouldCloneCall;
+
+    /**
+     * Allow for the prepare of queries to be turned off, this allow for dynamic
+     * non-pre SQL generated queries.
+     */
+    protected boolean shouldPrepare;
+
+    /**
+     * List of arguments to check for null.
+     * If any are null, the query needs to be re-prepared.
+     */
+    protected List<DatabaseField> nullableArguments;
+
+    /** Bind all arguments to the SQL statement. */
+
+    // Has False, Undefined or True value. In case of Undefined -
+    // Session's shouldBindAllParameters() defines whether to bind or not.
+    protected Boolean shouldBindAllParameters;
+
+    /**
+     * Cache the prepared statement, this requires full parameter binding as
+     * well.
+     */
+
+    // Has False, Undefined or True value. In case of Undefined -
+    // Session's shouldCacheAllStatements() defines whether to cache or not.
+    protected Boolean shouldCacheStatement;
+
+    /** Use the WrapperPolicy for the objects returned by the query */
+    protected boolean shouldUseWrapperPolicy;
+
+    /**
+     * Table per class requires multiple query executions. Internally we prepare
+     * those queries and cache them against the source mapping's selection
+     * query. When queries are executed they are cloned so we need a mechanism
+     * to keep a reference back to the actual selection query so that we can
+     * successfully look up and chain query executions within a table per class
+     * inheritance hierarchy.
+     */
+    protected DatabaseMapping sourceMapping;
+
+    /**
+     * queryTimeout has three possible settings: DefaultTimeout, NoTimeout, and
+     * 1..N This applies to both DatabaseQuery.queryTimeout and
+     * DescriptorQueryManager.queryTimeout
+     * <p>
+     * DatabaseQuery.queryTimeout: - DefaultTimeout: get queryTimeout from
+     * DescriptorQueryManager - NoTimeout, 1..N: overrides queryTimeout in
+     * DescriptorQueryManager
+     * <p>
+     * DescriptorQueryManager.queryTimeout: - DefaultTimeout: get queryTimeout
+     * from parent DescriptorQueryManager. If there is no parent, default to
+     * NoTimeout - NoTimeout, 1..N: overrides parent queryTimeout
+     */
+    protected int queryTimeout;
+
+    protected TimeUnit queryTimeoutUnit;
+
+    protected boolean shouldReturnGeneratedKeys;
+
+    /* Used as default for read, means shallow write for modify. */
+    public static final int NoCascading = 1;
+
+    /*
+     * Used as default for write, used for refreshing to refresh the whole
+     * object.
+     */
+    public static final int CascadePrivateParts = 2;
+
+    /*
+     * Currently not supported, used for deep write/refreshes/reads in the
+     * future.
+     */
+    public static final int CascadeAllParts = 3;
+
+    /* Used by the unit of work. */
+    public static final int CascadeDependentParts = 4;
+
+    /*
+     * Used by aggregate Collections: As aggregates delete at update time,
+     * cascaded deletes must know to stop when entering postDelete for a
+     * particular mapping. Only used by the aggregate collection when update is
+     * occurring in a UnitOfWork CR 2811
+     */
+    public static final int CascadeAggregateDelete = 5;
+
+    /*
+     * Used when refreshing should check the mappings to determine if a
+     * particular mapping should be cascaded.
+     */
+    public static final int CascadeByMapping = 6;
+
+    /** Used for adding hints to the query string in oracle */
+    protected String hintString;
+
+    /*
+     * Stores the FlushMode of this Query. This is only applicable when executed
+     * in a flushable UnitOfWork and will be ignored otherwise.
+     */
+    protected Boolean flushOnExecute;
+
+    /**
+     * PERF: Determines if the query has already been cloned for execution, to
+     * avoid duplicate cloning.
+     */
+    protected boolean isExecutionClone;
+
+    /** PERF: Store if this query will use the descriptor custom query. */
+    protected volatile Boolean isCustomQueryUsed;
+
+    /** Allow connection unwrapping to be configured. */
+    protected boolean isNativeConnectionRequired;
+
+    /**
+     * Return the name to use for the query in performance monitoring.
+     */
+    protected transient String monitorName;
+
+    /** Allow additional validation to be performed before using the update call cache */
+    protected boolean shouldValidateUpdateCallCacheUse;
+
+    /** Allow queries to be targeted at specific connection pools. */
+    protected PartitioningPolicy partitioningPolicy;
+
+
+    /** Allow the reserved pound char used to delimit bind parameters to be overridden */
+    protected String parameterDelimiter;
+
+    /**
+     * PUBLIC: Initialize the state of the query
+     */
+    protected DatabaseQuery() {
+        this.shouldMaintainCache = true;
+        // bug 3524620: lazy-init query mechanism
+        // this.queryMechanism = new ExpressionQueryMechanism(this);
+        this.isUserDefined = false;
+        this.cascadePolicy = NoCascading;
+        this.isPrepared = false;
+        this.shouldUseWrapperPolicy = true;
+        this.queryTimeout = DescriptorQueryManager.DefaultTimeout;
+        this.queryTimeoutUnit = DescriptorQueryManager.DefaultTimeoutUnit;
+        this.shouldPrepare = true;
+        this.shouldCloneCall = false;
+        this.shouldBindAllParameters = null;
+        this.shouldCacheStatement = null;
+        this.isExecutionClone = false;
+        this.shouldValidateUpdateCallCacheUse = false;
+        this.parameterDelimiter = ParameterDelimiterType.DEFAULT;
+    }
+
+    /**
+     * PUBLIC:
+     * Return the query's partitioning policy.
+     */
+    public PartitioningPolicy getPartitioningPolicy() {
+        return partitioningPolicy;
+    }
+
+    /**
+     * PUBLIC:
+     * Set the query's partitioning policy.
+     * A PartitioningPolicy is used to partition, load-balance or replicate data across multiple difference databases
+     * or across a database cluster such as Oracle RAC.
+     * Partitioning can provide improved scalability by allowing multiple database machines to service requests.
+     * Setting a policy on a query will override the descriptor and session defaults.
+     */
+    public void setPartitioningPolicy(PartitioningPolicy partitioningPolicy) {
+        this.partitioningPolicy = partitioningPolicy;
+    }
+
+    /**
+     * INTERNAL:
+     * Return the name to use for the query in performance monitoring.
+     */
+    public String getMonitorName() {
+        if (monitorName == null) {
+            resetMonitorName();
+        }
+        return monitorName;
+    }
+
+    /**
+     * INTERNAL:
+     * Return the name to use for the query in performance monitoring.
+     */
+    public void resetMonitorName() {
+        if (getReferenceClassName() == null) {
+            this.monitorName = getClass().getSimpleName() + ":" + getName();
+        } else {
+            this.monitorName = getClass().getSimpleName() + ":" + getReferenceClassName() + ":" + getName();
+        }
+    }
+
+    /**
+     * PUBLIC: Add the argument named argumentName. This will cause the
+     * translation of references of argumentName in the receiver's expression,
+     * with the value of the argument as supplied to the query in order from
+     * executeQuery()
+     */
+    public void addArgument(String argumentName) {
+        addArgument(argumentName, Object.class);
+    }
+
+    /**
+     * PUBLIC: Add the argument named argumentName and its class type. This will
+     * cause the translation of references of argumentName in the receiver's
+     * expression, with the value of the argument as supplied to the query in
+     * order from executeQuery(). Specifying the class type is important if
+     * identically named queries are used but with different argument lists.
+     */
+    public void addArgument(String argumentName, Class<?> type) {
+        addArgument(argumentName, type, false);
+    }
+
+    /**
+     * INTERNAL: Add the argument named argumentName.  This method was added to maintain
+     * information about whether parameters are positional or named for JPQL query introspeciton
+     * API
+     */
+    public void addArgument(String argumentName, Class<?> type, ParameterType parameterType) {
+        addArgument(argumentName, type, parameterType, false);
+    }
+
+    /**
+     * PUBLIC: Add the argument named argumentName and its class type. This will
+     * cause the translation of references of argumentName in the receiver's
+     * expression, with the value of the argument as supplied to the query in
+     * order from executeQuery(). Specifying the class type is important if
+     * identically named queries are used but with different argument lists.
+     * If the argument can be null, and null must be treated differently in the
+     * generated SQL, then nullable should be set to true.
+     */
+    public void addArgument(String argumentName, Class<?> type, boolean nullable) {
+        getArguments().add(argumentName);
+        getArgumentTypes().add(type);
+        if(type != null) {
+            getArgumentTypeNames().add(type.getName());
+        }
+        if (nullable) {
+            getNullableArguments().add(new DatabaseField(argumentName));
+        }
+    }
+
+    /**
+     * INTERNAL: Add the argument named argumentName.  This method was added to maintain
+     * information about whether parameters are positional or named for JPQL query introspeciton
+     * API
+     */
+    public void addArgument(String argumentName, Class<?> type, ParameterType argumentParameterType, boolean nullable) {
+        addArgument(argumentName, type, nullable);
+        getArgumentParameterTypes().add(argumentParameterType);
+    }
+
+    /**
+     * PUBLIC: Add the argument named argumentName and its class type. This will
+     * cause the translation of references of argumentName in the receiver's
+     * expression, with the value of the argument as supplied to the query in
+     * order from executeQuery(). Specifying the class type is important if
+     * identically named queries are used but with different argument lists.
+     */
+    public void addArgument(String argumentName, String typeAsString) {
+        getArguments().add(argumentName);
+        // bug 3197587
+        getArgumentTypes().add(Helper.getObjectClass(ConversionManager.loadClass(typeAsString)));
+        getArgumentTypeNames().add(typeAsString);
+    }
+
+    /**
+     * INTERNAL: Add an argument to the query, but do not resolve the class yet.
+     * This is useful for building a query without putting the domain classes on
+     * the classpath for the Mapping Workbench.
+     */
+    public void addArgumentByTypeName(String argumentName, String typeAsString) {
+        getArguments().add(argumentName);
+        getArgumentTypeNames().add(typeAsString);
+    }
+
+    /**
+     * PUBLIC: Add the argumentValue. Argument values must be added in the same
+     * order the arguments are defined.
+     */
+    public void addArgumentValue(Object argumentValue) {
+        getArgumentValues().add(argumentValue);
+    }
+
+    /**
+     * PUBLIC: Add the argumentValues to the query. Argument values must be
+     * added in the same order the arguments are defined.
+     */
+    public void addArgumentValues(List theArgumentValues) {
+        getArgumentValues().addAll(theArgumentValues);
+    }
+
+    /**
+     * PUBLIC: Used to define a store procedure or SQL query. This may be used
+     * for multiple SQL executions to be mapped to a single query. This cannot
+     * be used for cursored selects, delete alls or does exists.
+     */
+    public void addCall(Call call) {
+        setQueryMechanism(call.buildQueryMechanism(this, getQueryMechanism()));
+        // Must un-prepare is prepare as the SQL may change.
+        setIsPrepared(false);
+    }
+
+    /**
+     * PUBLIC: Used to define a statement level query. This may be used for
+     * multiple SQL executions to be mapped to a single query. This cannot be
+     * used for cursored selects, delete all(s) or does exists.
+     */
+    public void addStatement(SQLStatement statement) {
+        // bug 3524620: lazy-init query mechanism
+        if (!hasQueryMechanism()) {
+            setQueryMechanism(new StatementQueryMechanism(this));
+        } else if (!getQueryMechanism().isStatementQueryMechanism()) {
+            setQueryMechanism(new StatementQueryMechanism(this));
+        }
+        ((StatementQueryMechanism) getQueryMechanism()).getSQLStatements().add(statement);
+        // Must un-prepare is prepare as the SQL may change.
+        setIsPrepared(false);
+    }
+
+    /**
+     * PUBLIC: Bind all arguments to any SQL statement.
+     */
+    public void bindAllParameters() {
+        setShouldBindAllParameters(true);
+    }
+
+    /**
+     * INTERNAL: In the case of EJBQL, an expression needs to be generated.
+     * Build the required expression.
+     */
+    protected void buildSelectionCriteria(AbstractSession session) {
+        this.getQueryMechanism().buildSelectionCriteria(session);
+    }
+
+    /**
+     * PUBLIC: Cache the prepared statements, this requires full parameter
+     * binding as well.
+     */
+    public void cacheStatement() {
+        setShouldCacheStatement(true);
+    }
+
+    /**
+     * PUBLIC: Cascade the query and its properties on the queries object(s) and
+     * all objects related to the queries object(s). This includes private and
+     * independent relationships, but not read-only relationships. This will
+     * still stop on uninstantiated indirection objects except for deletion.
+     * Great caution should be used in using the property as the query may
+     * effect a large number of objects. This policy is used by the unit of work
+     * to ensure persistence by reachability.
+     */
+    public void cascadeAllParts() {
+        setCascadePolicy(CascadeAllParts);
+    }
+
+    /**
+     * PUBLIC: Cascade the query and its properties on the queries object(s) and
+     * all related objects where the mapping has been set to cascade the merge.
+     */
+    public void cascadeByMapping() {
+        setCascadePolicy(CascadeByMapping);
+    }
+
+    /**
+     * INTERNAL: Used by unit of work, only cascades constraint dependencies.
+     */
+    public void cascadeOnlyDependentParts() {
+        setCascadePolicy(CascadeDependentParts);
+    }
+
+    /**
+     * PUBLIC: Cascade the query and its properties on the queries object(s) and
+     * all privately owned objects related to the queries object(s). This is the
+     * default for write and delete queries. This policy should normally be used
+     * for refreshing, otherwise you could refresh half of any object.
+     */
+    public void cascadePrivateParts() {
+        setCascadePolicy(CascadePrivateParts);
+    }
+
+    /**
+     * INTERNAL: Ensure that the descriptor has been set.
+     */
+    public void checkDescriptor(AbstractSession session) throws QueryException {
+    }
+
+    /**
+     * INTERNAL: Check to see if this query already knows the return value
+     * without performing any further work.
+     */
+    public Object checkEarlyReturn(AbstractSession session, AbstractRecord translationRow) {
+        return null;
+    }
+
+    /**
+     * INTERNAL: Check to see if a custom query should be used for this query.
+     * This is done before the query is copied and prepared/executed. null means
+     * there is none.
+     */
+    protected DatabaseQuery checkForCustomQuery(AbstractSession session, AbstractRecord translationRow) {
+        return null;
+    }
+
+    /**
+     * INTERNAL: Check to see if this query needs to be prepare and prepare it.
+     * The prepare is done on the original query to ensure that the work is not
+     * repeated.
+     */
+    public void checkPrepare(AbstractSession session, AbstractRecord translationRow) {
+        this.checkPrepare(session, translationRow, false);
+    }
+
+    /**
+     * INTERNAL: Call the prepare on the query.
+     */
+    public void prepareInternal(AbstractSession session) {
+        setSession(session);
+        try {
+            prepare();
+        } finally {
+            setSession(null);
+        }
+    }
+
+    /**
+     * INTERNAL: Check to see if this query needs to be prepare and prepare it.
+     * The prepare is done on the original query to ensure that the work is not
+     * repeated.
+     */
+    public void checkPrepare(AbstractSession session, AbstractRecord translationRow, boolean force) {
+        try {
+            // This query is first prepared for global common state, this must be synced.
+            if (!this.isPrepared) {// Avoid the monitor is already prepare, must
+                // If this query will use the custom query, do not prepare.
+                if ((!force) && (!this.shouldPrepare || !((DatasourcePlatform)session.getDatasourcePlatform()).shouldPrepare(this)
+                        || (checkForCustomQuery(session, translationRow) != null))) {
+                    return;
+                }
+                // check again for concurrency.
+                // Profile the query preparation time.
+                session.startOperationProfile(SessionProfiler.QueryPreparation, this, SessionProfiler.ALL);
+                // Prepared queries cannot be custom as then they would never have
+                // been prepared.
+                synchronized (this) {
+                    if (!isPrepared()) {
+                        // When custom SQL is used there is a possibility that the
+                        // SQL contains the # token (for stored procedures or temporary tables).
+                        // Avoid this by telling the call if this is custom SQL with parameters.
+                        // This must not be called for SDK calls.
+                        if ((isReadQuery() || isDataModifyQuery()) && isCallQuery() && (getQueryMechanism() instanceof CallQueryMechanism)
+                                && ((translationRow == null) || (translationRow.isEmpty() && !translationRow.hasSopObject()))) {
+                            // Must check for read object queries as the row will be
+                            // empty until the prepare.
+                            if (isReadObjectQuery() || isUserDefined()) {
+                                ((CallQueryMechanism) getQueryMechanism()).setCallHasCustomSQLArguments();
+                            }
+                        } else if (isCallQuery() && (getQueryMechanism() instanceof CallQueryMechanism)) {
+                            ((CallQueryMechanism) getQueryMechanism()).setCallHasCustomSQLArguments();
+                        }
+                        setSession(session);// Session is required for some init stuff.
+                        prepare();
+                        setSession(null);
+                        setIsPrepared(true);// MUST not set prepare until done as
+                        // other thread may hit before finishing the prepare.
+                    }
+                }
+                // Profile the query preparation time.
+                session.endOperationProfile(SessionProfiler.QueryPreparation, this, SessionProfiler.ALL);
+            }
+        } catch (QueryException knownFailure) {
+            // Set the query, as prepare can be called directly.
+            if (knownFailure.getQuery() == null) {
+                knownFailure.setQuery(this);
+                knownFailure.setSession(session);
+            }
+            throw knownFailure;
+        } catch (EclipseLinkException knownFailure) {
+            throw knownFailure;
+        } catch (RuntimeException unexpectedFailure) {
+            throw QueryException.prepareFailed(unexpectedFailure, this);
+        }
+    }
+
+    /**
+     * INTERNAL: Clone the query
+     */
+    @Override
+    public Object clone() {
+        try {
+            DatabaseQuery cloneQuery = (DatabaseQuery) super.clone();
+
+            // partial fix for 3054240
+            // need to pay attention to other components of the query, too MWN
+            if (cloneQuery.properties != null) {
+                if (cloneQuery.properties.isEmpty()) {
+                    cloneQuery.properties = null;
+                } else {
+                    cloneQuery.properties = new HashMap<>(this.properties);
+                }
+            }
+
+            // bug 3524620: now that the query mechanism is lazy-init'd,
+            // only clone the query mechanism if we have one.
+            if (this.queryMechanism != null) {
+                cloneQuery.queryMechanism = this.queryMechanism.clone(cloneQuery);
+            }
+            cloneQuery.isPrepared = this.isPrepared; // Setting some things may trigger unprepare.
+            // JPA 3.2 cache bypass flags must be preserved in clones
+            cloneQuery.shouldRetrieveBypassCache = this.shouldRetrieveBypassCache;
+            cloneQuery.shouldStoreBypassCache = this.shouldStoreBypassCache;
+            return cloneQuery;
+        } catch (CloneNotSupportedException e) {
+            return null;
+        }
+    }
+
+    /**
+     * INTERNAL Used to give the subclasses opportunity to copy aspects of the
+     * cloned query to the original query.
+     */
+    protected void clonedQueryExecutionComplete(DatabaseQuery query, AbstractSession session) {
+        // no-op for this class
+    }
+
+    /**
+     * INTERNAL: Convert all the class-name-based settings in this query to
+     * actual class-based settings This method is implemented by subclasses as
+     * necessary.
+     *
+     */
+    public void convertClassNamesToClasses(ClassLoader classLoader) {
+        // note: normally we would fix the argument types here, but they are
+        // already
+        // lazily instantiated
+    }
+
+    /**
+     * PUBLIC: Do not Bind all arguments to any SQL statement.
+     */
+    public void dontBindAllParameters() {
+        setShouldBindAllParameters(false);
+    }
+
+    /**
+     * PUBLIC: Don't cache the prepared statements, this requires full parameter
+     * binding as well.
+     */
+    public void dontCacheStatement() {
+        setShouldCacheStatement(false);
+    }
+
+    /**
+     * PUBLIC: Do not cascade the query and its properties on the queries
+     * object(s) relationships. This does not effect the queries private parts
+     * but only the object(s) direct row-level attributes. This is the default
+     * for read queries and can be used in writing if it is known that only
+     * row-level attributes changed, or to resolve circular foreign key
+     * dependencies.
+     */
+    public void dontCascadeParts() {
+        setCascadePolicy(NoCascading);
+    }
+
+    /**
+     * PUBLIC: Set for the identity map (cache) to be ignored completely. The
+     * cache check will be skipped and the result will not be put into the
+     * identity map. This can be used to retrieve the exact state of an object
+     * on the database. By default the identity map is always maintained.
+     */
+    public void dontMaintainCache() {
+        setShouldMaintainCache(false);
+    }
+
+    /**
+     * INTERNAL: Execute the query
+     *
+     * @exception DatabaseException
+     *                - an error has occurred on the database.
+     * @exception OptimisticLockException
+     *                - an error has occurred using the optimistic lock feature.
+     * @return - the result of executing the query.
+     */
+    public abstract Object executeDatabaseQuery() throws DatabaseException, OptimisticLockException;
+
+    /**
+     * INTERNAL: Override query execution where Session is a UnitOfWork.
+     * <p>
+     * If there are objects in the cache return the results of the cache lookup.
+     *
+     * @param unitOfWork
+     *            - the session in which the receiver will be executed.
+     * @param translationRow
+     *            - the arguments
+     * @exception DatabaseException
+     *                - an error has occurred on the database.
+     * @exception OptimisticLockException
+     *                - an error has occurred using the optimistic lock feature.
+     * @return An object, the result of executing the query.
+     */
+    public Object executeInUnitOfWork(UnitOfWorkImpl unitOfWork, AbstractRecord translationRow) throws DatabaseException, OptimisticLockException {
+        return execute(unitOfWork, translationRow);
+    }
+
+    /**
+     * INTERNAL: Execute the query. If there are objects in the cache return the
+     * results of the cache lookup.
+     *
+     * @param session
+     *            - the session in which the receiver will be executed.
+     * @exception DatabaseException
+     *                - an error has occurred on the database.
+     * @exception OptimisticLockException
+     *                - an error has occurred using the optimistic lock feature.
+     * @return An object, the result of executing the query.
+     */
+    public Object execute(AbstractSession session, AbstractRecord translationRow) throws DatabaseException, OptimisticLockException {
+        DatabaseQuery queryToExecute = this;
+        // JPQL call may not have defined the reference class yet, so need to use prepare.
+        if (isJPQLCallQuery() && isObjectLevelReadQuery()) {
+            ((ObjectLevelReadQuery)this).checkPrePrepare(session);
+        } else {
+            checkDescriptor(session);
+        }
+        QueryRedirector localRedirector = getRedirectorForQuery();
+        // refactored redirection for bug 3241138
+        if (localRedirector != null) {
+            return redirectQuery(localRedirector, queryToExecute, session, translationRow);
+        }
+
+        // Bug 5529564 - If this is a user defined selection query (custom SQL),
+        // prepare the query before hand so that we may look up the correct fk
+        // values from the query parameters when checking early return.
+        if (queryToExecute.isCustomSelectionQuery() && queryToExecute.shouldPrepare()) {
+            queryToExecute.checkPrepare(session, translationRow);
+        }
+
+        // This allows the query to check the cache or return early without
+        // doing any work.
+        Object earlyReturn = queryToExecute.checkEarlyReturn(session, translationRow);
+        // If know not to exist (checkCacheOnly, deleted, null primary key),
+        // return null.
+        if (earlyReturn == InvalidObject.instance) {
+            return null;
+        }
+        if (earlyReturn != null) {
+            return earlyReturn;
+        }
+
+        boolean hasCustomQuery = false;
+        if (!isPrepared() && shouldPrepare()) {
+            // Prepared queries cannot be custom as then they would never have
+            // been prepared.
+            DatabaseQuery customQuery = checkForCustomQuery(session, translationRow);
+            if (customQuery != null) {
+                hasCustomQuery = true;
+                // The custom query will be used not the original.
+                queryToExecute = customQuery;
+            }
+        }
+
+        // PERF: Queries need to be cloned for execution as they may be
+        // concurrently reused, and execution specific state is stored in the
+        // clone.
+        // In some case the query is known to be a one off, or cloned elsewhere
+        // so the query keeps track if it has been cloned already.
+        queryToExecute = session.prepareDatabaseQuery(queryToExecute);
+
+        boolean prepare = queryToExecute.shouldPrepare(translationRow, session);
+        if (prepare) {
+            queryToExecute.checkPrepare(session, translationRow);
+        }
+
+        // Then cloned for concurrency and repeatable execution.
+        if (!queryToExecute.isExecutionClone()) {
+            queryToExecute = (DatabaseQuery) queryToExecute.clone();
+        }
+        // Check for query argument values.
+        if ((this.argumentValues != null) && (!this.argumentValues.isEmpty()) && translationRow.isEmpty()) {
+            translationRow = rowFromArguments(this.argumentValues, session);
+        }
+        queryToExecute.setTranslationRow(translationRow);
+
+        // If the prepare has been disable the clone is prepare dynamically to
+        // not parameterize the SQL.
+        if (!prepare) {
+            queryToExecute.setIsPrepared(false);
+            queryToExecute.setTranslationRow(translationRow);
+            queryToExecute.checkPrepare(session, translationRow, true);
+        }
+        queryToExecute.setSession(session);
+        if (hasCustomQuery) {
+            prepareCustomQuery(queryToExecute);
+            localRedirector = queryToExecute.getRedirector();
+            // refactored redirection for bug 3241138
+            if (localRedirector != null) {
+                return redirectQuery(localRedirector, queryToExecute, session, queryToExecute.getTranslationRow());
+            }
+        }
+        queryToExecute.prepareForExecution();
+
+        // Then executed.
+        Object result = queryToExecute.executeDatabaseQuery();
+
+        // Give the subclasses the opportunity to retrieve aspects of the cloned
+        // query.
+        clonedQueryExecutionComplete(queryToExecute, session);
+        return result;
+    }
+
+    /**
+     * INTERNAL: Extract the correct query result from the transporter.
+     */
+    public Object extractRemoteResult(Transporter transporter) {
+        return transporter.getObject();
+    }
+
+    /**
+     * INTERNAL: Return the accessor.
+     */
+    public Accessor getAccessor() {
+        if ((this.accessors == null) || (this.accessors.isEmpty())) {
+            return null;
+        }
+        if (this.accessors instanceof List) {
+            return ((List<Accessor>)this.accessors).get(0);
+        }
+        return this.accessors.iterator().next();
+    }
+
+    /**
+     * INTERNAL: Return the accessors.
+     */
+    public Collection<Accessor> getAccessors() {
+        return this.accessors;
+    }
+
+    /**
+     * INTERNAL: Return the arguments for use with the pre-defined query option
+     */
+    public List<String> getArguments() {
+        if (this.arguments == null) {
+            this.arguments = new ArrayList<>();
+        }
+        return this.arguments;
+    }
+
+    /**
+     * INTERNAL:
+     * Used to calculate parameter types in JPQL
+     */
+    public List<ParameterType> getArgumentParameterTypes(){
+        if (argumentParameterTypes == null){
+            this.argumentParameterTypes = new ArrayList<>();
+        }
+        return this.argumentParameterTypes;
+    }
+
+    /**
+     * INTERNAL: Return the argumentTypes for use with the pre-defined query
+     * option
+     */
+    public List<Class<?>> getArgumentTypes() {
+        if ((this.argumentTypes == null) || (this.argumentTypes.isEmpty() && (this.argumentTypeNames != null) && !this.argumentTypeNames.isEmpty())) {
+            this.argumentTypes = new ArrayList<>();
+            // Bug 3256198 - lazily initialize the argument types from their
+            // class names
+            if (this.argumentTypeNames != null) {
+                Iterator<String> args = this.argumentTypeNames.iterator();
+                while (args.hasNext()) {
+                    String argumentTypeName = args.next();
+                    this.argumentTypes.add(Helper.getObjectClass(ConversionManager.loadClass(argumentTypeName)));
+                }
+            }
+        }
+        return this.argumentTypes;
+    }
+
+    /**
+     * INTERNAL: Return the argumentTypeNames for use with the pre-defined query
+     * option These are used pre-initialization to construct the argumentTypes
+     * list.
+     */
+    public List<String> getArgumentTypeNames() {
+        if (argumentTypeNames == null) {
+            argumentTypeNames = new ArrayList<>();
+        }
+        return argumentTypeNames;
+    }
+
+    /**
+     * INTERNAL: Set the argumentTypes for use with the pre-defined query option
+     */
+    public void setArgumentTypes(List<Class<?>> argumentTypes) {
+        this.argumentTypes = argumentTypes;
+        // bug 3256198 - ensure the list of type names matches the argument
+        // types.
+        getArgumentTypeNames().clear();
+        for (Class<?> type : argumentTypes) {
+            this.argumentTypeNames.add(type.getName());
+        }
+    }
+
+    /**
+     * INTERNAL: Set the argumentTypes for use with the pre-defined query option
+     */
+    public void setArgumentTypeNames(List<String> argumentTypeNames) {
+        this.argumentTypeNames = argumentTypeNames;
+    }
+
+    /**
+     * INTERNAL: Set the arguments for use with the pre-defined query option.
+     * Maintain the argumentTypes as well.
+     */
+    public void setArguments(List<String> arguments) {
+        List<Class<?>> types = new ArrayList<>(arguments.size());
+        List<String> typeNames = new ArrayList<>(arguments.size());
+        List<DatabaseField> typeFields = new ArrayList<>(arguments.size());
+        int size = arguments.size();
+        for (int index = 0; index < size; index++) {
+            types.add(Object.class);
+            typeNames.add("java.lang.Object");
+            DatabaseField field = new DatabaseField(arguments.get(index));
+            typeFields.add(field);
+        }
+        this.arguments = arguments;
+        this.argumentTypes = types;
+        this.argumentTypeNames = typeNames;
+        this.argumentFields = typeFields;
+    }
+
+    /**
+     * INTERNAL: Return the argumentValues for use with argumented queries.
+     */
+    public List<Object> getArgumentValues() {
+        if (this.argumentValues == null) {
+            this.argumentValues = new ArrayList<>();
+        }
+        return this.argumentValues;
+    }
+
+    /**
+     * INTERNAL: Set the argumentValues for use with argumented queries.
+     */
+    public void setArgumentValues(List<Object> theArgumentValues) {
+        this.argumentValues = theArgumentValues;
+    }
+
+    /**
+     * OBSOLETE: Return the call for this query. This call contains the SQL and
+     * argument list.
+     *
+     * @see #getDatasourceCall()
+     */
+    public DatabaseCall getCall() {
+        Call call = getDatasourceCall();
+        if (call instanceof DatabaseCall) {
+            return (DatabaseCall) call;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * ADVANCED: Return the call for this query. This call contains the SQL and
+     * argument list.
+     *
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord) prepareCall(Session, Record)
+     */
+    public Call getDatasourceCall() {
+        Call call = null;
+        if (this.queryMechanism instanceof DatasourceCallQueryMechanism mechanism) {
+            call = mechanism.getCall();
+            // If has multiple calls return the first one.
+            if ((call == null) && mechanism.hasMultipleCalls()) {
+                call = mechanism.getCalls().get(0);
+            }
+        }
+        if ((call == null) && (this.queryMechanism != null) && this.queryMechanism.isJPQLCallQueryMechanism()) {
+            call = ((JPQLCallQueryMechanism) this.queryMechanism).getJPQLCall();
+        }
+        return call;
+    }
+
+    /**
+     * ADVANCED: Return the calls for this query. This method can be called for
+     * queries with multiple calls This call contains the SQL and argument list.
+     *
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord) prepareCall(Session, Record)
+     */
+    public List getDatasourceCalls() {
+        List calls = new Vector();
+        if (getQueryMechanism() instanceof DatasourceCallQueryMechanism mechanism) {
+
+            // If has multiple calls return the first one.
+            if (mechanism.hasMultipleCalls()) {
+                calls = mechanism.getCalls();
+            } else {
+                calls.add(mechanism.getCall());
+            }
+        }
+        if ((calls.isEmpty()) && getQueryMechanism().isJPQLCallQueryMechanism()) {
+            calls.add(((JPQLCallQueryMechanism) getQueryMechanism()).getJPQLCall());
+        }
+        return calls;
+    }
+
+    /**
+     * INTERNAL: Return the cascade policy.
+     */
+    public int getCascadePolicy() {
+        return cascadePolicy;
+    }
+
+    /**
+     * INTERNAL: Return the descriptor assigned with the reference class
+     */
+    public ClassDescriptor getDescriptor() {
+        return descriptor;
+    }
+
+    /**
+     * INTERNAL:
+     * This is here only for JPA queries and currently only populated for JPA
+     * queries. JPAQuery is a jpa class and currently not part of the core.
+     */
+    public List<ClassDescriptor> getDescriptors() {
+        return null;
+    }
+
+    /**
+     * INTERNAL:
+     * TopLink_sessionName_domainClass.  Cached in properties
+     */
+     public String getDomainClassNounName(String sessionName) {
+        if (getProperty("DMSDomainClassNounName") == null) {
+            StringBuilder buffer = new StringBuilder("EclipseLink");
+            if (sessionName != null) {
+                buffer.append(sessionName);
+            }
+            if (getReferenceClassName() != null) {
+                buffer.append("_");
+                buffer.append(getReferenceClassName());
+            }
+            setProperty("DMSDomainClassNounName", buffer.toString());
+        }
+        return (String)getProperty("DMSDomainClassNounName");
+     }
+
+    /**
+     * PUBLIC: Return the name of the query
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * INTERNAL:
+     * Return the String used to delimit an SQL parameter.
+     */
+    public String getParameterDelimiter() {
+        if(null == parameterDelimiter || parameterDelimiter.isEmpty()) {
+            parameterDelimiter = ParameterDelimiterType.DEFAULT;
+        }
+        return parameterDelimiter;
+    }
+
+    /**
+     * INTERNAL:
+     * Return the char used to delimit an SQL parameter.
+     */
+    public char getParameterDelimiterChar() {
+        return getParameterDelimiter().charAt(0);
+    }
+
+    /**
+     * INTERNAL: Property support for use by mappings.
+     */
+    public Map<Object, Object> getProperties() {
+        if (this.properties == null) {
+            // Lazy initialize to conserve space and allocation time.
+            this.properties = new HashMap<>();
+        }
+        return this.properties;
+    }
+
+    /**
+     * INTERNAL: Property support used by mappings to store temporary stuff in
+     * the query.
+     */
+    public synchronized Object getProperty(Object property) {
+        if (this.properties == null) {
+            return null;
+        }
+        return this.properties.get(property);
+    }
+
+    /**
+     * INTERNAL:
+     * TopLink_sessionName_domainClass_queryClass_queryName (if exist).  Cached in properties
+     */
+    public String getQueryNounName(String sessionName) {
+        if (getProperty("DMSQueryNounName") == null) {
+            StringBuilder buffer = new StringBuilder(getDomainClassNounName(sessionName));
+            buffer.append("_");
+            buffer.append(getClass().getSimpleName());
+            if (getName() != null) {
+                buffer.append("_");
+                buffer.append(getName());
+            }
+            setProperty("DMSQueryNounName", buffer.toString());
+        }
+        return (String)getProperty("DMSQueryNounName");
+    }
+
+    /**
+     * INTERNAL: Return the mechanism assigned to the query
+     */
+    public DatabaseQueryMechanism getQueryMechanism() {
+        // Bug 3524620 - lazy init
+        if (this.queryMechanism == null) {
+            this.queryMechanism = new ExpressionQueryMechanism(this);
+        }
+        return this.queryMechanism;
+    }
+
+    /**
+     * INTERNAL: Check if the mechanism has been set yet, used for lazy init.
+     */
+    public boolean hasQueryMechanism() {
+        return (this.queryMechanism != null);
+    }
+
+    /**
+     * PUBLIC: Return the number of seconds the driver will wait for a Statement
+     * to execute to the given number of seconds.
+     *
+     * @see DescriptorQueryManager#getQueryTimeout()
+     */
+    public int getQueryTimeout() {
+        return queryTimeout;
+    }
+
+    /**
+     * PUBLIC: Return the unit of time the driver will wait for a Statement to
+     * execute.
+     * 
+     * @see DescriptorQueryManager#getQueryTimeoutUnit()
+     */
+    public TimeUnit getQueryTimeoutUnit() {
+        return queryTimeoutUnit;
+    }
+
+    /**
+     * INTERNAL: Returns the specific default redirector for this query type.
+     * There are numerous default query redirectors. See ClassDescriptor for
+     * their types.
+     */
+    protected QueryRedirector getDefaultRedirector() {
+        return this.descriptor.getDefaultQueryRedirector();
+    }
+
+    /**
+     * PUBLIC: Return the query redirector. A redirector can be used in a query
+     * to replace its execution with the execution of code. This can be used for
+     * named or parameterized queries to allow dynamic configuration of the
+     * query base on the query arguments.
+     *
+     * @see QueryRedirector
+     */
+    public QueryRedirector getRedirectorForQuery() {
+        if (doNotRedirect) {
+            return null;
+        }
+        if (redirector != null) {
+            return redirector;
+        }
+        if (descriptor != null) {
+            return getDefaultRedirector();
+        }
+        return null;
+    }
+
+    /**
+     * PUBLIC: Return the query redirector. A redirector can be used in a query
+     * to replace its execution with the execution of code. This can be used for
+     * named or parameterized queries to allow dynamic configuration of the
+     * query base on the query arguments.
+     *
+     * @see QueryRedirector
+     */
+    public QueryRedirector getRedirector() {
+        if (doNotRedirect) {
+            return null;
+        }
+        return redirector;
+    }
+
+    /**
+     * PUBLIC: Return the domain class associated with this query. By default
+     * this is null, but should be overridden in subclasses.
+     */
+    public Class<?> getReferenceClass() {
+        return null;
+    }
+
+    /**
+     * INTERNAL: return the name of the reference class. Added for Mapping
+     * Workbench removal of classpath dependency. Overridden by subclasses.
+     */
+    public String getReferenceClassName() {
+        return null;
+    }
+
+    /**
+     * PUBLIC: Return the selection criteria of the query. This should only be
+     * used with expression queries, null will be returned for others.
+     */
+    public Expression getSelectionCriteria() {
+        if (this.queryMechanism == null) {
+            return null;
+        }
+        return this.queryMechanism.getSelectionCriteria();
+    }
+
+    /**
+     * INTERNAL:
+     * TopLink_sessionName_domainClass_queryClass_queryName (if exist)_operationName (if exist).  Cached in properties
+     */
+    public String getSensorName(String operationName, String sessionName) {
+        if (operationName == null) {
+            return getQueryNounName(sessionName);
+        }
+        @SuppressWarnings({"unchecked"})
+        Hashtable<String, String> sensorNames = (Hashtable<String, String>) getProperty("DMSSensorNames");
+        if (sensorNames == null) {
+            sensorNames = new Hashtable<>();
+            setProperty("DMSSensorNames", sensorNames);
+        }
+        String sensorName = sensorNames.get(operationName);
+        if (sensorName == null) {
+            StringBuilder buffer = new StringBuilder(getQueryNounName(sessionName));
+            buffer.append("_");
+            buffer.append(operationName);
+            sensorName = buffer.toString();
+            sensorNames.put(operationName, sensorName);
+        }
+        return sensorName;
+    }
+
+    /**
+     * INTERNAL: Return the current session.
+     */
+    public AbstractSession getSession() {
+        return session;
+    }
+
+    /**
+     * INTERNAL: Return the execution session. This is the session used to build
+     * objects returned by the query.
+     */
+    public AbstractSession getExecutionSession() {
+        if (this.executionSession == null) {
+            if (getSession() != null) {
+                this.executionSession = getSession().getExecutionSession(this);
+            }
+        }
+        return this.executionSession;
+    }
+
+    /**
+     * INTERNAL: Set the execution session. This is the session used to build
+     * objects returned by the query.
+     */
+    protected void setExecutionSession(AbstractSession executionSession) {
+        this.executionSession = executionSession;
+    }
+
+    /**
+     * PUBLIC: Return the name of the session that the query should be executed
+     * under. This can be with the session broker to override the default
+     * session.
+     */
+    public String getSessionName() {
+        return sessionName;
+    }
+
+    /**
+     * PUBLIC: Return the SQL statement of the query. This can only be used with
+     * statement queries.
+     */
+    public SQLStatement getSQLStatement() {
+        return ((StatementQueryMechanism) getQueryMechanism()).getSQLStatement();
+    }
+
+    /**
+     * PUBLIC: Return the JPQL string of the query.
+     */
+    public String getJPQLString() {
+        return getEJBQLString();
+    }
+
+    /**
+     * PUBLIC: Return the EJBQL string of the query.
+     */
+    public String getEJBQLString() {
+        if (!(getQueryMechanism().isJPQLCallQueryMechanism())) {
+            return null;
+        }
+        JPQLCall call = ((JPQLCallQueryMechanism) getQueryMechanism()).getJPQLCall();
+        return call.getEjbqlString();
+    }
+
+    /**
+     * PUBLIC: Return the current database hint string of the query.
+     */
+    public String getHintString() {
+        return hintString;
+    }
+
+    /**
+     * ADVANCED: Return the SQL string of the query. This can be used for SQL
+     * queries. This can also be used for normal queries if they have been
+     * prepared, (i.e. query.prepareCall()).
+     *
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord) prepareCall(Session, Record)
+     */
+    public String getSQLString() {
+        Call call = getDatasourceCall();
+        if (call == null) {
+            return null;
+        }
+        if (!(call instanceof SQLCall)) {
+            return null;
+        }
+
+        return ((SQLCall) call).getSQLString();
+    }
+
+    /**
+     * ADVANCED: Return the SQL strings of the query. Used for queries with
+     * multiple calls This can be used for SQL queries. This can also be used
+     * for normal queries if they have been prepared, (i.e.
+     * query.prepareCall()).
+     *
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord) prepareCall(Session, Record)
+     */
+    public List getSQLStrings() {
+        List calls = getDatasourceCalls();
+        if ((calls == null) || calls.isEmpty()) {
+            return null;
+        }
+        Vector returnSQL = new Vector(calls.size());
+        Iterator iterator = calls.iterator();
+        while (iterator.hasNext()) {
+            Call call = (Call) iterator.next();
+            if (!(call instanceof SQLCall)) {
+                return null;
+            }
+            returnSQL.add(((SQLCall) call).getSQLString());
+        }
+        return returnSQL;
+    }
+
+    /**
+     * INTERNAL: Returns the internal tri-state value of shouldBindParameters
+     * used far cascading these settings
+     */
+    public Boolean getShouldBindAllParameters() {
+        return this.shouldBindAllParameters;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public DatabaseMapping getSourceMapping() {
+        return sourceMapping;
+    }
+
+    /**
+     * ADVANCED: This can be used to access a queries translated SQL if they
+     * have been prepared, (i.e. query.prepareCall()). The Record argument is
+     * one of (Record, XMLRecord) that contains the query arguments.
+     *
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord)
+     */
+    public String getTranslatedSQLString(org.eclipse.persistence.sessions.Session session, DataRecord translationRow) {
+        prepareCall(session, translationRow);
+        // CR#2859559 fix to use Session and Record interfaces not impl classes.
+        CallQueryMechanism queryMechanism = (CallQueryMechanism) getQueryMechanism();
+        if (queryMechanism.getCall() == null) {
+            return null;
+        }
+        SQLCall call = (SQLCall) queryMechanism.getCall().clone();
+        call.setUsesBinding(false);
+        call.translate((AbstractRecord) translationRow, queryMechanism.getModifyRow(), (AbstractSession) session);
+        return call.getSQLString();
+    }
+
+    /**
+     * ADVANCED: This can be used to access a queries translated SQL if they
+     * have been prepared, (i.e. query.prepareCall()). This method can be used
+     * for queries with multiple calls.
+     *
+     * @see #prepareCall(org.eclipse.persistence.sessions.Session, DataRecord) prepareCall(Session, Record)
+     */
+    public List getTranslatedSQLStrings(org.eclipse.persistence.sessions.Session session, DataRecord translationRow) {
+        prepareCall(session, translationRow);
+        CallQueryMechanism queryMechanism = (CallQueryMechanism) getQueryMechanism();
+        if ((queryMechanism.getCalls() == null) || queryMechanism.getCalls().isEmpty()) {
+            return null;
+        }
+        Vector calls = new Vector(queryMechanism.getCalls().size());
+        Iterator iterator = queryMechanism.getCalls().iterator();
+        while (iterator.hasNext()) {
+            SQLCall call = (SQLCall) iterator.next();
+            call = (SQLCall) call.clone();
+            call.setUsesBinding(false);
+            call.translate((AbstractRecord) translationRow, queryMechanism.getModifyRow(), (AbstractSession) session);
+            calls.add(call.getSQLString());
+        }
+        return calls;
+    }
+
+    /**
+     * INTERNAL: Return the row for translation
+     */
+    public AbstractRecord getTranslationRow() {
+        return translationRow;
+    }
+
+    /**
+     * INTERNAL: returns true if the accessor has already been set. The
+     * getAccessor() will attempt to lazily initialize it.
+     */
+    public boolean hasAccessor() {
+        return this.accessors != null;
+    }
+
+    /**
+     * INTERNAL: Return if any properties exist in the query.
+     */
+    public boolean hasProperties() {
+        return (properties != null) && (!properties.isEmpty());
+    }
+
+    /**
+     * INTERNAL: Return if any arguments exist in the query.
+     */
+    public boolean hasArguments() {
+        return (arguments != null) && (!arguments.isEmpty());
+    }
+
+    /**
+     * PUBLIC: Return if a name of the session that the query should be executed
+     * under has been specified. This can be with the session broker to override
+     * the default session.
+     */
+    public boolean hasSessionName() {
+        return sessionName != null;
+    }
+
+    /**
+     * PUBLIC: Session's shouldBindAllParameters() defines whether to bind or
+     * not (default setting)
+     */
+    public void ignoreBindAllParameters() {
+        this.shouldBindAllParameters = null;
+    }
+
+    /**
+     * PUBLIC: Session's shouldCacheAllStatements() defines whether to cache or
+     * not (default setting)
+     */
+    public void ignoreCacheStatement() {
+        this.shouldCacheStatement = null;
+    }
+
+    /**
+     * PUBLIC: Return true if this query uses SQL, a stored procedure, or SDK
+     * call.
+     */
+    public boolean isCallQuery() {
+        return (this.queryMechanism != null) && this.queryMechanism.isCallQueryMechanism();
+    }
+
+    /**
+     * INTERNAL: Returns true if this query has been created as the result of
+     * cascading a delete of an aggregate collection in a UnitOfWork CR 2811
+     */
+    public boolean isCascadeOfAggregateDelete() {
+        return this.cascadePolicy == CascadeAggregateDelete;
+    }
+
+    /**
+     * PUBLIC: Return if this is a data modify query.
+     */
+    public boolean isDataModifyQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return if this is a data read query.
+     */
+    public boolean isDataReadQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return if this is a value read query.
+     */
+    public boolean isValueReadQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return if this is a direct read query.
+     */
+    public boolean isDirectReadQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return if this is a delete all query.
+     */
+    public boolean isDeleteAllQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return if this is a delete object query.
+     */
+    public boolean isDeleteObjectQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this query uses an expression query mechanism
+     */
+    public boolean isExpressionQuery() {
+        return (this.queryMechanism == null) || this.queryMechanism.isExpressionQueryMechanism();
+    }
+
+    /**
+     * PUBLIC: Return true if this is a modify all query.
+     */
+    public boolean isModifyAllQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this is a modify query.
+     */
+    public boolean isModifyQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this is an update all query.
+     */
+    public boolean isUpdateAllQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this is an update object query.
+     */
+    public boolean isUpdateObjectQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: If executed against a RepeatableWriteUnitOfWork if this attribute
+     * is true EclipseLink will write changes to the database before executing
+     * the query.
+     */
+    public Boolean getFlushOnExecute() {
+        return this.flushOnExecute;
+    }
+
+    /**
+     * PUBLIC: Return true if this is an insert object query.
+     */
+    public boolean isInsertObjectQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this is an object level modify query.
+     */
+    public boolean isObjectLevelModifyQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this is an object level read query.
+     */
+    public boolean isObjectLevelReadQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return if this is an object building query.
+     */
+    public boolean isObjectBuildingQuery() {
+        return false;
+    }
+
+    /**
+     * INTERNAL: Queries are prepared when they are executed and then do not
+     * need to be prepared on subsequent executions. This method returns true if
+     * this query has been prepared. Updating the settings on a query will
+     * 'un-prepare' the query.
+     */
+    public boolean isPrepared() {
+        return isPrepared;
+    }
+
+    /**
+     * PUBLIC: Return true if this is a read all query.
+     */
+    public boolean isReadAllQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this is a read object query.
+     */
+    public boolean isReadObjectQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this is a read query.
+     */
+    public boolean isReadQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this is a report query.
+     */
+    public boolean isReportQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this is a result set mapping query.
+     */
+    public boolean isResultSetMappingQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Return true if this query uses an SQL query mechanism .
+     */
+    public boolean isSQLCallQuery() {
+        // BUG#2669342 CallQueryMechanism and isCallQueryMechanism have
+        // different meaning as SDK return true but isn't.
+        Call call = getDatasourceCall();
+        return (call != null) && (call instanceof SQLCall);
+    }
+
+    /**
+     * PUBLIC: Return true if this query uses an JPQL query mechanism .
+     */
+    public boolean isJPQLCallQuery() {
+        return ((this.queryMechanism != null)
+                && this.queryMechanism.isJPQLCallQueryMechanism()
+                && ((JPQLCallQueryMechanism)this.queryMechanism).getJPQLCall() != null);
+    }
+
+    /**
+     * INTERNAL: Return true if the query is a custom user defined query.
+     */
+    public boolean isUserDefined() {
+        return isUserDefined;
+    }
+
+    /**
+     * INTERNAL: Return true if the query is a custom user defined SQL call query.
+     */
+    public boolean isUserDefinedSQLCall() {
+        return this.isUserDefinedSQLCall;
+    }
+
+    /**
+     * INTERNAL: Return true if the query uses default properties. This is used
+     * to determine if this query is cacheable. i.e. does not use any properties
+     * that may conflict with another query with the same EJBQL or selection
+     * criteria.
+     */
+    public boolean isDefaultPropertiesQuery() {
+        return (!this.isUserDefined) && (this.shouldPrepare) && (this.queryTimeout == DescriptorQueryManager.DefaultTimeout)
+            && (this.hintString == null) && (this.shouldBindAllParameters == null) && (this.shouldCacheStatement == null) && (this.shouldUseWrapperPolicy);
+    }
+
+    /**
+     * PUBLIC: Return true if this is a write object query.
+     */
+    public boolean isWriteObjectQuery() {
+        return false;
+    }
+
+    /**
+     * PUBLIC: Set for the identity map (cache) to be maintained. This is the
+     * default.
+     */
+    public void maintainCache() {
+        setShouldMaintainCache(true);
+    }
+
+    /**
+     * INTERNAL: This is different from 'prepareForExecution' in that this is
+     * called on the original query, and the other is called on the copy of the
+     * query. This query is copied for concurrency so this prepare can only
+     * setup things that will apply to any future execution of this query.
+     * <p>
+     * Resolve the queryTimeout using the DescriptorQueryManager if required.
+     */
+    protected void prepare() throws QueryException {
+        // If the queryTimeout is DefaultTimeout, resolve using the
+        // DescriptorQueryManager.
+        if (this.queryTimeout == DescriptorQueryManager.DefaultTimeout) {
+            if (this.descriptor == null) {
+                setQueryTimeout(this.session.getQueryTimeoutDefault());
+                if(this.session.getQueryTimeoutUnitDefault() == null) {
+                    this.session.setQueryTimeoutUnitDefault(DescriptorQueryManager.DefaultTimeoutUnit);
+                }
+                setQueryTimeoutUnit(this.session.getQueryTimeoutUnitDefault());
+            } else {
+                int timeout = this.descriptor.getQueryManager().getQueryTimeout();
+                // No timeout means none set, so use the session default.
+                if ((timeout == DescriptorQueryManager.DefaultTimeout) || (timeout == DescriptorQueryManager.NoTimeout)) {
+                    timeout = this.session.getQueryTimeoutDefault();
+                }
+                setQueryTimeout(timeout);
+
+                //Bug #456067
+                TimeUnit timeoutUnit = this.descriptor.getQueryManager().getQueryTimeoutUnit();
+                if(timeoutUnit == DescriptorQueryManager.DefaultTimeoutUnit) {
+                    timeoutUnit = this.session.getQueryTimeoutUnitDefault();
+                }
+                setQueryTimeoutUnit(timeoutUnit);
+            }
+        }
+
+        this.argumentFields = buildArgumentFields();
+
+        getQueryMechanism().prepare();
+        resetMonitorName();
+    }
+
+    /**
+     * INTERNAL: Copy all setting from the query. This is used to morph queries
+     * from one type to the other. By default this calls prepareFromQuery, but
+     * additional properties may be required to be copied as prepareFromQuery
+     * only copies properties that affect the SQL.
+     */
+    public void copyFromQuery(DatabaseQuery query) {
+        prepareFromQuery(query);
+        this.cascadePolicy = query.cascadePolicy;
+        this.flushOnExecute = query.flushOnExecute;
+        this.arguments = query.arguments;
+        this.nullableArguments = query.nullableArguments;
+        this.argumentTypes = query.argumentTypes;
+        this.argumentTypeNames = query.argumentTypeNames;
+        this.argumentValues = query.argumentValues;
+        this.queryTimeout = query.queryTimeout;
+        this.queryTimeoutUnit = query.queryTimeoutUnit;
+        this.redirector = query.redirector;
+        this.sessionName = query.sessionName;
+        this.shouldBindAllParameters = query.shouldBindAllParameters;
+        this.shouldCacheStatement = query.shouldCacheStatement;
+        this.shouldMaintainCache = query.shouldMaintainCache;
+        this.shouldPrepare = query.shouldPrepare;
+        this.shouldUseWrapperPolicy = query.shouldUseWrapperPolicy;
+        this.properties = query.properties;
+        this.doNotRedirect = query.doNotRedirect;
+        this.shouldRetrieveBypassCache = query.shouldRetrieveBypassCache;
+        this.shouldStoreBypassCache = query.shouldStoreBypassCache;
+        this.parameterDelimiter = query.parameterDelimiter;
+        this.shouldCloneCall = query.shouldCloneCall;
+        this.partitioningPolicy = query.partitioningPolicy;
+    }
+
+    /**
+     * INTERNAL: Prepare the query from the prepared query. This allows a
+     * dynamic query to prepare itself directly from a prepared query instance.
+     * This is used in the JPQL parse cache to allow preparsed queries to be
+     * used to prepare dynamic queries. This only copies over properties that
+     * are configured through JPQL.
+     */
+    public void prepareFromQuery(DatabaseQuery query) {
+        setQueryMechanism((DatabaseQueryMechanism) query.getQueryMechanism().clone());
+        getQueryMechanism().setQuery(this);
+        this.descriptor = query.descriptor;
+        this.hintString = query.hintString;
+        this.isCustomQueryUsed = query.isCustomQueryUsed;
+        this.argumentFields = query.argumentFields;
+        // this.properties = query.properties; - Cannot set properties and CMP
+        // stores finders there.
+    }
+
+    /**
+     * ADVANCED: Pre-generate the call/SQL for the query. This method takes a
+     * Session and an implementor of Record (DatebaseRow or XMLRecord). This can
+     * be used to access the SQL for a query without executing it. To access the
+     * call use, query.getCall(), or query.getSQLString() for the SQL. Note the
+     * SQL will have argument markers in it (i.e. "?"). To translate these use
+     * query.getTranslatedSQLString(session, translationRow).
+     *
+     * @see #getCall()
+     * @see #getSQLString()
+     * @see #getTranslatedSQLString(org.eclipse.persistence.sessions.Session,
+     *      DataRecord)
+     */
+    public void prepareCall(org.eclipse.persistence.sessions.Session session, DataRecord translationRow) throws QueryException {
+        // CR#2859559 fix to use Session and Record interfaces not impl classes.
+        checkPrepare((AbstractSession) session, (AbstractRecord) translationRow, true);
+    }
+
+    /**
+     * INTERNAL: Set the properties needed to be cascaded into the custom query.
+     */
+    protected void prepareCustomQuery(DatabaseQuery customQuery) {
+        // Nothing by default.
+    }
+
+    /**
+     * INTERNAL: Prepare the receiver for execution in a session. In particular,
+     * set the descriptor of the receiver to the ClassDescriptor for the
+     * appropriate class for the receiver's object.
+     */
+    public void prepareForExecution() throws QueryException {
+    }
+
+    protected void prepareForRemoteExecution() {
+    }
+
+    /**
+     * INTERNAL: Use a EclipseLink redirector to redirect this query to a
+     * method. Added for bug 3241138
+     *
+     */
+    public Object redirectQuery(QueryRedirector redirector, DatabaseQuery queryToRedirect, AbstractSession session, AbstractRecord translationRow) {
+        if (redirector == null) {
+            return null;
+        }
+        DatabaseQuery queryToExecute = (DatabaseQuery) queryToRedirect.clone();
+        queryToExecute.setRedirector(null);
+
+        // since we deal with a clone when using a redirector, the descriptor
+        // will
+        // get set on the clone, but not on the original object. So before
+        // returning
+        // the results, set the descriptor from the clone onto this object
+        // (original
+        // query) - GJPP, BUG# 2692956
+        Object toReturn = redirector.invokeQuery(queryToExecute, translationRow, session);
+        setDescriptor(queryToExecute.getDescriptor());
+        return toReturn;
+    }
+
+    protected Object remoteExecute() {
+        this.session.startOperationProfile(SessionProfiler.Remote, this, SessionProfiler.ALL);
+        Transporter transporter = ((DistributedSession) this.session).getRemoteConnection().remoteExecute((DatabaseQuery) this.clone());
+        this.session.endOperationProfile(SessionProfiler.Remote, this, SessionProfiler.ALL);
+        return extractRemoteResult(transporter);
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public Object remoteExecute(AbstractSession session) {
+        setSession(session);
+        prepareForRemoteExecution();
+        return remoteExecute();
+    }
+
+    /**
+     * INTERNAL: Property support used by mappings.
+     */
+    public void removeProperty(Object property) {
+        getProperties().remove(property);
+    }
+
+    /**
+     * INTERNAL: replace the value holders in the specified result object(s)
+     */
+    public Map replaceValueHoldersIn(Object object, RemoteSessionController controller) {
+        // by default, do nothing
+        return null;
+    }
+
+    /**
+     * ADVANCED: JPA flag used to control the behavior of the shared cache. This
+     * flag specifies the behavior when data is retrieved by the find methods
+     * and by the execution of queries. Calling this method will set a retrieve
+     * bypass to true.
+     */
+    public void retrieveBypassCache() {
+        setShouldRetrieveBypassCache(true);
+    }
+
+    /**
+     * INTERNAL: Build the list of arguments fields from the argument names and
+     * types.
+     */
+    public List<DatabaseField> buildArgumentFields() {
+        List<String> arguments = getArguments();
+        List<Class<?>> argumentTypes = getArgumentTypes();
+        List<DatabaseField> argumentFields = new ArrayList<>(arguments.size());
+        int size = arguments.size();
+        for (int index = 0; index < size; index++) {
+            DatabaseField argumentField = new DatabaseField(arguments.get(index));
+            argumentField.setType(argumentTypes.get(index));
+            argumentFields.add(argumentField);
+        }
+
+        return argumentFields;
+    }
+
+    /**
+     * INTERNAL: Translate argumentValues into a database row.
+     */
+    public AbstractRecord rowFromArguments(List argumentValues, AbstractSession session) throws QueryException {
+        List<DatabaseField> argumentFields = this.argumentFields;
+
+        // PERF: argumentFields are set in prepare, but need to be built if
+        // query is not prepared.
+        if (!isPrepared() || (argumentFields == null)) {
+            argumentFields = buildArgumentFields();
+        }
+
+        if (argumentFields.size() != argumentValues.size()) {
+            throw QueryException.argumentSizeMismatchInQueryAndQueryDefinition(this);
+        }
+
+        int argumentsSize = argumentFields.size();
+        AbstractRecord row = new DatabaseRecord(argumentsSize);
+        for (int index = 0; index < argumentsSize; index++) {
+            row.put(argumentFields.get(index), argumentValues.get(index));
+        }
+
+        return row;
+    }
+
+    /**
+     * INTERNAL:
+     * Set the list of connection accessors to execute the query on.
+     */
+    public void setAccessors(Collection<Accessor> accessors) {
+        this.accessors = accessors;
+    }
+
+    /**
+     * INTERNAL: Set the accessor, the query must always use the same accessor
+     * for database access. This is required to support connection pooling.
+     */
+    public void setAccessor(Accessor accessor) {
+        if (accessor == null) {
+            this.accessors = null;
+            return;
+        }
+        List<Accessor> accessors = new ArrayList<>(1);
+        accessors.add(accessor);
+        this.accessors = accessors;
+    }
+
+    /**
+     * PUBLIC: Used to define a store procedure or SQL query.
+     */
+    public void setDatasourceCall(Call call) {
+        if (call == null) {
+            return;
+        }
+        setQueryMechanism(call.buildNewQueryMechanism(this));
+    }
+
+    /**
+     * PUBLIC: Used to define a store procedure or SQL query.
+     */
+    public void setCall(Call call) {
+        setDatasourceCall(call);
+        isUserDefinedSQLCall = true;
+    }
+
+    /**
+     * INTERNAL: Set the cascade policy.
+     */
+    public void setCascadePolicy(int policyConstant) {
+        cascadePolicy = policyConstant;
+    }
+
+    /**
+     * INTERNAL: Set the descriptor for the query.
+     */
+    public void setDescriptor(ClassDescriptor descriptor) {
+        // If the descriptor changed must unprepare as the SQL may change.
+        if (this.descriptor != descriptor) {
+            setIsPrepared(false);
+        }
+        this.descriptor = descriptor;
+    }
+
+    /**
+     * PUBLIC: Set the JPQL string of the query. If arguments are required in
+     * the string they will be preceded by ":" then the argument name. The JPQL
+     * arguments must also be added as argument to the query.
+     */
+    public void setJPQLString(String jpqlString) {
+        setEJBQLString(jpqlString);
+    }
+
+    /**
+     * PUBLIC: Set the EJBQL string of the query. If arguments are required in
+     * the string they will be preceded by "?" then the argument number.
+     */
+    public void setEJBQLString(String ejbqlString) {
+        // Added the check for when we are building the query from the
+        // deployment XML
+        if ((ejbqlString != null) && (!ejbqlString.isEmpty())) {
+            JPQLCallQueryMechanism mechanism = new JPQLCallQueryMechanism(this, new JPQLCall(ejbqlString));
+            setQueryMechanism(mechanism);
+        }
+    }
+
+    /**
+     * PUBLIC: If executed against a RepeatableWriteUnitOfWork if this attribute
+     * is true EclipseLink will write changes to the database before executing
+     * the query.
+     */
+    public void setFlushOnExecute(Boolean flushMode) {
+        this.flushOnExecute = flushMode;
+    }
+
+    /**
+     * Used to set a database hint string on the query. This should be the full
+     * hint string including the comment delimiters. The hint string will be
+     * generated into the SQL string after the SELECT/INSERT/UPDATE/DELETE
+     * instruction.
+     * <p>
+     * <b>Example:</b>
+     * <pre>
+     * readAllQuery.setHintString("/*+ index(scott.emp ix_emp) * /");
+     * </pre>
+     * would result in SQL like:
+     * <pre>select /*+ index(scott.emp ix_emp) * / from scott.emp emp_alias</pre>
+     * <p>
+     * This method will cause a query to re-prepare if it has already been
+     * executed.
+     *
+     * @param newHintString
+     *            the hint string to be added into the SQL call.
+     */
+    public void setHintString(String newHintString) {
+        hintString = newHintString;
+        setIsPrepared(false);
+    }
+
+    /**
+     * INTERNAL: If changes are made to the query that affect the derived SQL or
+     * Call parameters the query needs to be prepared again.
+     * <p>
+     * Automatically called internally.
+     */
+    public void setIsPrepared(boolean isPrepared) {
+        this.isPrepared = isPrepared;
+        if (!isPrepared) {
+            this.isCustomQueryUsed = null;
+            if (this.queryMechanism != null) {
+                this.queryMechanism.unprepare();
+            }
+        }
+    }
+
+    /**
+     * INTERNAL: PERF: Return if the query is an execution clone. This allow the
+     * clone during execution to be avoided in the cases when the query has
+     * already been clone elsewhere.
+     */
+    public boolean isExecutionClone() {
+        return isExecutionClone;
+    }
+
+    /**
+     * INTERNAL: PERF: Set if the query is an execution clone. This allow the
+     * clone during execution to be avoided in the cases when the query has
+     * already been clone elsewhere.
+     */
+    public void setIsExecutionClone(boolean isExecutionClone) {
+        this.isExecutionClone = isExecutionClone;
+    }
+
+    /**
+     * INTERNAL: PERF: Return if this query will use the descriptor custom query
+     * instead of executing itself.
+     */
+    public Boolean isCustomQueryUsed() {
+        return this.isCustomQueryUsed;
+    }
+
+    /**
+     * INTERNAL: If the query mechanism is a call query mechanism and there are
+     * no arguments on the query then it must be a foreign reference custom
+     * selection query.
+     */
+    protected boolean isCustomSelectionQuery() {
+        return getQueryMechanism().isCallQueryMechanism() && getArguments().isEmpty();
+    }
+
+    /**
+     * INTERNAL: PERF: Set if this query will use the descriptor custom query
+     * instead of executing itself.
+     * @param isCustomQueryUsed Custom query flag as {@code boolean}.
+     */
+    protected void setIsCustomQueryUsed(final boolean isCustomQueryUsed) {
+        this.isCustomQueryUsed = isCustomQueryUsed;
+    }
+
+    /**
+     * INTERNAL: Set if the query is a custom user defined query.
+     */
+    public void setIsUserDefined(boolean isUserDefined) {
+        this.isUserDefined = isUserDefined;
+    }
+
+    /**
+     * INTERNAL: Set if the query is a custom user defined sql call query.
+     */
+    public void setIsUserDefinedSQLCall(boolean isUserDefinedSQLCall) {
+        this.isUserDefinedSQLCall = isUserDefinedSQLCall;
+    }
+
+    /**
+     * PUBLIC: Set the query's name. Queries can be named and added to a
+     * descriptor or the session and then referenced by name.
+     */
+    public void setName(String queryName) {
+        name = queryName;
+    }
+
+    /**
+     * INTERNAL:
+     * Set the String char used to delimit an SQL parameter.
+     */
+    public void setParameterDelimiter(String aParameterDelimiter) {
+        // 325167: if the parameterDelimiter is invalid - use the default # symbol
+        if(null == aParameterDelimiter || aParameterDelimiter.isEmpty()) {
+            aParameterDelimiter = ParameterDelimiterType.DEFAULT;
+        }
+        parameterDelimiter = aParameterDelimiter;
+    }
+
+    /**
+     * INTERNAL: Property support used by mappings.
+     */
+    public void setProperties(Map<Object, Object> properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * INTERNAL: Property support used by mappings to store temporary stuff.
+     */
+    public synchronized void setProperty(Object property, Object value) {
+        getProperties().put(property, value);
+    }
+
+    /**
+     * Set the query mechanism for the query.
+     */
+    protected void setQueryMechanism(DatabaseQueryMechanism queryMechanism) {
+        this.queryMechanism = queryMechanism;
+        // Must un-prepare is prepare as the SQL may change.
+        setIsPrepared(false);
+    }
+
+    /**
+     * PUBLIC: Set the number of seconds the driver will wait for a Statement to
+     * execute to the given number of seconds. If the limit is exceeded, a
+     * DatabaseException is thrown.
+     * <p>
+     * queryTimeout - the new query timeout limit in seconds; DefaultTimeout is
+     * the default, which redirects to DescriptorQueryManager's queryTimeout.
+     *
+     * @see DescriptorQueryManager#setQueryTimeout(int)
+     *
+     */
+    public void setQueryTimeout(int queryTimeout) {
+        this.queryTimeout = queryTimeout;
+        this.shouldCloneCall = true;
+    }
+
+    public void setQueryTimeoutUnit(TimeUnit queryTimeoutUnit) {
+        this.queryTimeoutUnit = queryTimeoutUnit;
+        this.shouldCloneCall = true;
+    }
+
+    /**
+     * PUBLIC: Set the query redirector. A redirector can be used in a query to
+     * replace its execution with the execution of code. This can be used for
+     * named or parameterized queries to allow dynamic configuration of the
+     * query base on the query arguments.
+     *
+     * @see QueryRedirector
+     */
+    public void setRedirector(QueryRedirector redirector) {
+        this.redirector = redirector;
+        this.doNotRedirect = false;
+        this.setIsPrepared(false);
+    }
+
+    /**
+     * PUBLIC: To any user of this object. Set the selection criteria of the
+     * query. This method be used when dealing with expressions.
+     */
+    public void setSelectionCriteria(Expression expression) {
+        // Do not overwrite the call if the expression is null.
+        if ((expression == null) && (!getQueryMechanism().isExpressionQueryMechanism())) {
+            return;
+        }
+        if (!getQueryMechanism().isExpressionQueryMechanism()) {
+            setQueryMechanism(new ExpressionQueryMechanism(this, expression));
+        } else {
+            ((ExpressionQueryMechanism) getQueryMechanism()).setSelectionCriteria(expression);
+        }
+
+        // Must un-prepare is prepare as the SQL may change.
+        setIsPrepared(false);
+    }
+
+    /**
+     * INTERNAL: Set the session for the query
+     */
+    public void setSession(AbstractSession session) {
+        this.session = session;
+        this.executionSession = null;
+    }
+
+    /**
+     * PUBLIC: Set the name of the session that the query should be executed
+     * under. This can be with the session broker to override the default
+     * session.
+     */
+    public void setSessionName(String sessionName) {
+        this.sessionName = sessionName;
+    }
+
+    /**
+     * PUBLIC: Bind all arguments to any SQL statement.
+     */
+    public void setShouldBindAllParameters(boolean shouldBindAllParameters) {
+        this.shouldBindAllParameters = shouldBindAllParameters;
+        setIsPrepared(false);
+    }
+
+    /**
+     * INTERNAL: Sets the internal tri-state value of shouldBindAllParams Used
+     * to cascade this value to other queries
+     */
+    public void setShouldBindAllParameters(Boolean bindAllParams) {
+        this.shouldBindAllParameters = bindAllParams;
+    }
+
+    /**
+     * PUBLIC: Cache the prepared statements, this requires full parameter
+     * binding as well.
+     */
+    public void setShouldCacheStatement(boolean shouldCacheStatement) {
+        this.shouldCacheStatement = shouldCacheStatement;
+        setIsPrepared(false);
+    }
+
+    /**
+     * PUBLIC: Set if the identity map (cache) should be used or not. If not the
+     * cache check will be skipped and the result will not be put into the
+     * identity map. By default the identity map is always maintained.
+     */
+    public void setShouldMaintainCache(boolean shouldMaintainCache) {
+        this.shouldMaintainCache = shouldMaintainCache;
+    }
+
+    /**
+     * PUBLIC: Set if the query should be prepared. EclipseLink automatically
+     * prepares queries to generate their SQL only once, one each execution of
+     * the query the SQL does not need to be generated again only the arguments
+     * need to be translated. This option is provide to disable this
+     * optimization as in can cause problems with certain types of queries that
+     * require dynamic SQL based on their arguments.
+     * <p>
+     * These queries include:
+     * <ul>
+     * <li>Expressions that make use of 'equal' where the argument value has the
+     * potential to be null, this can cause problems on databases that require
+     * IS NULL, instead of = NULL.
+     * <li>Expressions that make use of 'in' and that use parameter binding,
+     * this will cause problems as the in values must be bound individually.
+     * </ul>
+     */
+    public void setShouldPrepare(boolean shouldPrepare) {
+        this.shouldPrepare = shouldPrepare;
+        setIsPrepared(false);
+    }
+
+    /**
+     * ADVANCED: JPA flag used to control the behavior of the shared cache. This
+     * flag specifies the behavior when data is retrieved by the find methods
+     * and by the execution of queries.
+     */
+    public void setShouldRetrieveBypassCache(boolean shouldRetrieveBypassCache) {
+        this.shouldRetrieveBypassCache = shouldRetrieveBypassCache;
+    }
+
+    /**
+     * ADVANCED: JPA flag used to control the behavior of IDENTITY generation. This
+     * flag specifies the behavior when data is retrieved by the find methods
+     * and by the execution of queries.
+     * <p>
+     * This flag is only applicable to Insert queries and will only apply if the database
+     * platform supports {@link java.sql.Statement#RETURN_GENERATED_KEYS}
+     */
+    public void setShouldReturnGeneratedKeys(boolean shouldReturnGeneratedKeys) {
+        this.shouldReturnGeneratedKeys = shouldReturnGeneratedKeys;
+    }
+
+    /**
+     * ADVANCED: JPA flag used to control the behavior of the shared cache. This
+     * flag specifies the behavior when data is read from the database and when
+     * data is committed into the database.
+     */
+    public void setShouldStoreBypassCache(boolean shouldStoreBypassCache) {
+        this.shouldStoreBypassCache = shouldStoreBypassCache;
+    }
+
+    /**
+     * INTERNAL:
+     * Set if additional validation should be performed before the query uses
+     * the update call cache.
+     */
+    public void setShouldValidateUpdateCallCacheUse(boolean shouldCheckUpdateCallCacheUse) {
+        this.shouldValidateUpdateCallCacheUse = shouldCheckUpdateCallCacheUse;
+    }
+
+    /**
+     * ADVANCED: The wrapper policy can be enable on a query.
+     */
+    public void setShouldUseWrapperPolicy(boolean shouldUseWrapperPolicy) {
+        this.shouldUseWrapperPolicy = shouldUseWrapperPolicy;
+    }
+
+    /**
+     * INTERNAL:
+     */
+    public void setSourceMapping(DatabaseMapping sourceMapping) {
+        this.sourceMapping = sourceMapping;
+    }
+
+    /**
+     * PUBLIC: To any user of this object. Set the SQL statement of the query.
+     * This method should only be used when dealing with statement objects.
+     */
+    public void setSQLStatement(SQLStatement sqlStatement) {
+        setQueryMechanism(new StatementQueryMechanism(this, sqlStatement));
+    }
+
+    /**
+     * PUBLIC: To any user of this object. Set the SQL string of the query. This
+     * method should only be used when dealing with user defined SQL strings. If
+     * arguments are required in the string they will be preceded by "#" then
+     * the argument name. Warning: Allowing an unverified SQL string to be
+     * passed into this method makes your application vulnerable to SQL
+     * injection attacks.
+     */
+    public void setSQLString(String sqlString) {
+        // Added the check for when we are building the query from the
+        // deployment XML
+        if ((sqlString != null) && (!sqlString.isEmpty())) {
+            setCall(new SQLCall(sqlString));
+        }
+    }
+
+    /**
+     * INTERNAL: Set the row for translation
+     */
+    public void setTranslationRow(AbstractRecord translationRow) {
+        this.translationRow = translationRow;
+    }
+
+    /**
+     * PUBLIC: Bind all arguments to any SQL statement.
+     */
+    public boolean shouldBindAllParameters() {
+        return Boolean.TRUE.equals(shouldBindAllParameters);
+    }
+
+    /**
+     * INTERNAL:
+     * Return true if this individual query should allow native a SQL call
+     * to be issued.
+     */
+    public boolean shouldAllowNativeSQLQuery(boolean projectAllowsNativeQueries) {
+        // If allow native SQL query is undefined, use the project setting
+        // otherwise use the allow native SQL setting.
+        return (allowNativeSQLQuery == null) ? projectAllowsNativeQueries : allowNativeSQLQuery;
+    }
+
+    /**
+     * PUBLIC: Cache the prepared statements, this requires full parameter
+     * binding as well.
+     */
+    public boolean shouldCacheStatement() {
+        return Boolean.TRUE.equals(shouldCacheStatement);
+    }
+
+    /**
+     * PUBLIC: Flag used to determine if all parts should be cascaded
+     */
+    public boolean shouldCascadeAllParts() {
+        return this.cascadePolicy == CascadeAllParts;
+    }
+
+    /**
+     * PUBLIC: Mappings should be checked to determined if the current operation
+     * should be cascaded to the objects referenced.
+     */
+    public boolean shouldCascadeByMapping() {
+        return this.cascadePolicy == CascadeByMapping;
+    }
+
+    /**
+     * INTERNAL: Flag used for unit of works cascade policy.
+     */
+    public boolean shouldCascadeOnlyDependentParts() {
+        return this.cascadePolicy == CascadeDependentParts;
+    }
+
+    /**
+     * PUBLIC: Flag used to determine if any parts should be cascaded
+     */
+    public boolean shouldCascadeParts() {
+        return this.cascadePolicy != NoCascading;
+    }
+
+    /**
+     * PUBLIC: Flag used to determine if any private parts should be cascaded
+     */
+    public boolean shouldCascadePrivateParts() {
+        return (this.cascadePolicy == CascadePrivateParts) || (this.cascadePolicy == CascadeAllParts);
+    }
+
+    /**
+     * INTERNAL: Flag used to determine if the call needs to be cloned.
+     */
+    public boolean shouldCloneCall() {
+        return shouldCloneCall;
+    }
+
+    /**
+     * PUBLIC: Local shouldBindAllParameters() should be ignored, Session's
+     * shouldBindAllParameters() should be used.
+     */
+    public boolean shouldIgnoreBindAllParameters() {
+        return shouldBindAllParameters == null;
+    }
+
+    /**
+     * PUBLIC: Local shouldCacheStatement() should be ignored, Session's
+     * shouldCacheAllStatements() should be used.
+     */
+    public boolean shouldIgnoreCacheStatement() {
+        return shouldCacheStatement == null;
+    }
+
+    /**
+     * PUBLIC: Return if the identity map (cache) should be used or not. If not
+     * the cache check will be skipped and the result will not be put into the
+     * identity map. By default the identity map is always maintained.
+     */
+    public boolean shouldMaintainCache() {
+        return shouldMaintainCache;
+    }
+
+    /**
+     * PUBLIC: Return if the query should be prepared. EclipseLink automatically
+     * prepares queries to generate their SQL only once, one each execution of
+     * the query the SQL does not need to be generated again only the arguments
+     * need to be translated. This option is provide to disable this
+     * optimization as in can cause problems with certain types of queries that
+     * require dynamic SQL based on their arguments.
+     * <p>
+     * These queries include:
+     * <ul>
+     * <li>Expressions that make use of 'equal' where the argument value has the
+     * potential to be null, this can cause problems on databases that require
+     * IS NULL, instead of = NULL.
+     * <li>Expressions that make use of 'in' and that use parameter binding,
+     * this will cause problems as the in values must be bound individually.
+     * </ul>
+     */
+    public boolean shouldPrepare() {
+        return shouldPrepare;
+    }
+
+    /**
+     * INTERNAL:
+     * Check if the query should be prepared, or dynamic, depending on the arguments.
+     * This allows null parameters to affect the SQL, such as stored procedure default values,
+     * or IS NULL, or insert defaults.
+     */
+    public boolean shouldPrepare(AbstractRecord translationRow, AbstractSession session) {
+        if (!this.shouldPrepare) {
+            return false;
+        }
+        if (!((DatasourcePlatform)session.getDatasourcePlatform()).shouldPrepare(this)) {
+            this.shouldPrepare = false;
+            return false;
+        }
+        if (this.nullableArguments != null) {
+            for (DatabaseField argument : this.nullableArguments) {
+                if (translationRow.get(argument) == null) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * ADVANCED: JPA flag used to control the behavior of the shared cache. This
+     * flag specifies the behavior when data is retrieved by the find methods
+     * and by the execution of queries.
+     */
+    public boolean shouldRetrieveBypassCache() {
+        return this.shouldRetrieveBypassCache;
+    }
+
+    /**
+     * ADVANCED: JPA flag used to control the behavior of IDENTITY generation. This
+     * flag specifies the behavior when data is retrieved by the find methods
+     * and by the execution of queries.
+     * <p>
+     * This flag is only applicable to Insert queries and will only apply if the database
+     * platform supports {@link java.sql.Statement#RETURN_GENERATED_KEYS}
+     */
+    public boolean shouldReturnGeneratedKeys() {
+        return this.shouldReturnGeneratedKeys;
+    }
+
+    /**
+     * ADVANCED: JPA flag used to control the behavior of the shared cache. This
+     * flag specifies the behavior when data is read from the database and when
+     * data is committed into the database.
+     */
+    public boolean shouldStoreBypassCache() {
+        return this.shouldStoreBypassCache;
+    }
+
+    /**
+     * ADVANCED: The wrapper policy can be enabled on a query.
+     */
+    public boolean shouldUseWrapperPolicy() {
+        return shouldUseWrapperPolicy;
+    }
+
+    /**
+     * ADVANCED:
+     * Return true if additional validation should be performed before the query uses
+     * the update call cache, false otherwise.
+     */
+    public boolean shouldValidateUpdateCallCacheUse() {
+        return shouldValidateUpdateCallCacheUse;
+    }
+
+    /**
+     * ADVANCED: JPA flag used to control the behavior of the shared cache. This
+     * flag specifies the behavior when data is read from the database and when
+     * data is committed into the database. Calling this method will set a store
+     * bypass to true.
+     * <p>
+     * Note: For a cache store mode of REFRESH, see refreshIdentityMapResult()
+     * from ObjectLevelReadQuery.
+     */
+    public void storeBypassCache() {
+        setShouldStoreBypassCache(true);
+    }
+
+    @Override
+    public String toString() {
+        String referenceClassString = "";
+        String nameString = "";
+        String queryString = "";
+        if (getReferenceClass() != null) {
+            referenceClassString = "referenceClass=" + getReferenceClass().getSimpleName() + " ";
+        }
+        if ((getName() != null) && (!getName().isEmpty())) {
+            nameString = "name=\"" + getName() + "\" ";
+        }
+        if (isSQLCallQuery()) {
+            queryString = "sql=\"" + getSQLString() + "\"";
+        } else if (isJPQLCallQuery()) {
+            queryString = "jpql=\"" + getJPQLString() + "\"";
+        }
+        return getClass().getSimpleName() + "(" + nameString + referenceClassString + queryString + ")";
+    }
+
+    /**
+     * ADVANCED: Set if the descriptor requires usage of a native (unwrapped)
+     * JDBC connection. This may be required for some Oracle JDBC support when a
+     * wrapping DataSource is used.
+     */
+    public void setIsNativeConnectionRequired(boolean isNativeConnectionRequired) {
+        this.isNativeConnectionRequired = isNativeConnectionRequired;
+    }
+
+    /**
+     * ADVANCED: Return if the descriptor requires usage of a native (unwrapped)
+     * JDBC connection. This may be required for some Oracle JDBC support when a
+     * wrapping DataSource is used.
+     */
+    public boolean isNativeConnectionRequired() {
+        return isNativeConnectionRequired;
+    }
+
+    /**
+     * This method is used in combination with redirected queries. If a
+     * redirector is set on the query or there is a default redirector on the
+     * Descriptor setting this value to true will force EclipseLink to ignore
+     * the redirector during execution. This setting will be used most often
+     * when reexecuting the query within a redirector.
+     */
+    public boolean getDoNotRedirect() {
+        return doNotRedirect;
+    }
+
+    /**
+     * This method is used in combination with redirected queries. If a
+     * redirector is set on the query or there is a default redirector on the
+     * Descriptor setting this value to true will force EclipseLink to ignore
+     * the redirector during execution. This setting will be used most often
+     * when reexecuting the query within a redirector.
+     */
+    public void setDoNotRedirect(boolean doNotRedirect) {
+        this.doNotRedirect = doNotRedirect;
+    }
+
+    /**
+     * INTERNAL:
+     * Return temporary map of batched objects.
+     */
+    @SuppressWarnings({"unchecked"})
+    public Map<Object, Object> getBatchObjects() {
+        return (Map<Object, Object>)getProperty(BATCH_FETCH_PROPERTY);
+    }
+
+    /**
+     * INTERNAL:
+     * Set temporary map of batched objects.
+     */
+    public void setBatchObjects(Map<Object, Object> batchObjects) {
+        setProperty(BATCH_FETCH_PROPERTY, batchObjects);
+    }
+
+    /**
+     * INTERNAL:
+     * Set to true if this individual query should be marked to bypass a
+     * persistence unit level disallow SQL queries flag.
+     */
+    public void setAllowNativeSQLQuery(Boolean allowNativeSQLQuery) {
+        this.allowNativeSQLQuery = allowNativeSQLQuery;
+    }
+
+    /**
+     * INTERNAL:
+     * Return if the query has any nullable arguments.
+     */
+    public boolean hasNullableArguments() {
+        return (this.nullableArguments != null) && !this.nullableArguments.isEmpty();
+    }
+
+    /**
+     * INTERNAL:
+     * Return the list of arguments to check for null.
+     * If any are null, the query needs to be re-prepared.
+     */
+    public List<DatabaseField> getNullableArguments() {
+        if (this.nullableArguments == null) {
+            this.nullableArguments = new ArrayList<>();
+        }
+        return nullableArguments;
+    }
+
+    /**
+     * INTERNAL:
+     * Set the list of arguments to check for null.
+     * If any are null, the query needs to be re-prepared.
+     */
+    public void setNullableArguments(List<DatabaseField> nullableArguments) {
+        this.nullableArguments = nullableArguments;
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Update EclipseLink to support setCacheRetrieveMode and setCacheStoreMode JPA 3.2 methods and adds overlay to bring changes to OpenLiberty. 
Also enables tests, which were disabled earlier due to missing of this implementation.

For #33189