### PR TITLE
dividedBy replaces divide on NumericExpression

### DIFF
--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/NumericExpression.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/NumericExpression.java
@@ -46,22 +46,6 @@ public interface NumericExpression<T, N extends Number & Comparable<N>> //
         return NumericCast.of(this, Long.class);
     }
 
-    default NumericExpression<T, N> divide(N divisor) {
-        return NumericOperatorExpression.of(Operator.DIVIDE,
-                                            this,
-                                            divisor);
-    }
-
-    default NumericExpression<T, N> //
-                    divide(NumericExpression<? super T, N> divisorExpression) {
-        return NumericOperatorExpression.of(Operator.DIVIDE,
-                                            this,
-                                            divisorExpression);
-    }
-
-    // TODO either remove divide (above) or dividedBy (below), depending on
-    // what ends up in the API.
-
     default NumericExpression<T, N> dividedBy(N divisor) {
         return NumericOperatorExpression.of(Operator.DIVIDE,
                                             this,


### PR DESCRIPTION
Corresponds to recent spec update to choose dividedBy over divide.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
