### PR TITLE
Fix Open Liberty unit tests to work with Java 25

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1934,12 +1934,12 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
-      <version>1.16.1</version>
+      <version>1.17.8</version>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.16.1</version>
+      <version>1.17.8</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -382,8 +382,8 @@ javax:javaee-api:7.0
 joda-time:joda-time:1.6.2
 joda-time:joda-time:2.9.9
 jtidy:jtidy:4aug2000r7-dev
-net.bytebuddy:byte-buddy-agent:1.16.1
-net.bytebuddy:byte-buddy:1.16.1
+net.bytebuddy:byte-buddy-agent:1.17.8
+net.bytebuddy:byte-buddy:1.17.8
 net.java.dev.jna:jna:5.8.0
 net.minidev:json-smart:1.3.1
 net.sf.ehcache:ehcache-core:2.5.2
@@ -539,11 +539,11 @@ org.aspectj:aspectjrt:1.9.24
 org.asynchttpclient:async-http-client:2.12.3
 org.bitbucket.b_c:jose4j:0.9.5
 org.bouncycastle:bcpg-jdk18on:1.78.1
-org.bouncycastle:bcprov-jdk18on:1.78.1
-org.bouncycastle:bcutil-jdk18on:1.78.1
 org.bouncycastle:bcpg-jdk18on:1.82
 org.bouncycastle:bcpkix-jdk18on:1.82
+org.bouncycastle:bcprov-jdk18on:1.78.1
 org.bouncycastle:bcprov-jdk18on:1.82
+org.bouncycastle:bcutil-jdk18on:1.78.1
 org.bouncycastle:bcutil-jdk18on:1.82
 org.brotli:dec:0.1.2
 org.checkerframework:checker-compat-qual:2.5.2

--- a/dev/com.ibm.ws.crypto.passwordutil/bnd.bnd
+++ b/dev/com.ibm.ws.crypto.passwordutil/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -62,6 +62,6 @@ instrument.disabled: true
 	org.jmock:jmock;strategy=exact;version=2.5.1, \
 	org.mockito:mockito-core;version=4.11.0, \
     org.mockito:mockito-inline;version=4.11.0, \
-    net.bytebuddy:byte-buddy;version=1.16.1, \
-    net.bytebuddy:byte-buddy-agent;version=1.16.1, \
+    net.bytebuddy:byte-buddy;version=1.17.8, \
+    net.bytebuddy:byte-buddy-agent;version=1.17.8, \
 	com.ibm.ws.logging;version=latest

--- a/dev/com.ibm.ws.ejbcontainer.core/test/com/ibm/ws/ejbcontainer/jitdeploy/ClassDefinerTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/test/com/ibm/ws/ejbcontainer/jitdeploy/ClassDefinerTest.java
@@ -22,7 +22,10 @@ import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
 import java.util.concurrent.Callable;
 
+import com.ibm.ws.kernel.service.util.JavaInfo;
+
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class ClassDefinerTest
@@ -216,6 +219,8 @@ public class ClassDefinerTest
     @Test
     public void testSecurity() throws Exception
     {
+        // AccessController.checkPermission is not supported on Java 25
+        Assume.assumeTrue(JavaInfo.majorVersion() <= 21);
         byte[] classBytes = readClassBytes(TestSecurity.class);
         for (ClassDefiner definer : new ClassDefiner[] { new ClassDefiner() })
         {

--- a/dev/com.ibm.ws.kernel.boot_test/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.boot_test/bnd.bnd
@@ -29,4 +29,5 @@ test.project: true
 	com.ibm.websphere.org.osgi.core;version=latest, \
 	com.ibm.ws.logging.core;version=latest,\
 	com.ibm.ws.kernel.boot;version=latest,\
-	com.ibm.ws.kernel.boot.core;version=latest
+	com.ibm.ws.kernel.boot.core;version=latest,\
+	com.ibm.ws.kernel.service;version=latest

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/security/WLPDynamicPolicyTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/security/WLPDynamicPolicyTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,6 +24,8 @@ import java.security.Policy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import com.ibm.ws.kernel.service.util.JavaInfo;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -81,7 +83,9 @@ public class WLPDynamicPolicyTest {
 
     @After
     public void tearDown() throws Exception {
-        Policy.setPolicy(policy);
+        if (JavaInfo.majorVersion() <= 21) {
+            Policy.setPolicy(policy);
+        }
         mockery.assertIsSatisfied();
     }
 

--- a/dev/com.ibm.ws.kernel.service/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.service/bnd.bnd
@@ -90,5 +90,5 @@ instrument.classesExcludes: com/ibm/ws/kernel/service/utils/resources/*.class, \
   com.ibm.ws.logging;version=latest, \
   org.mockito:mockito-core;version=4.11.0, \
   org.mockito:mockito-inline;version=4.11.0, \
-  net.bytebuddy:byte-buddy;version=1.16.1, \
-  net.bytebuddy:byte-buddy-agent;version=1.16.1
+  net.bytebuddy:byte-buddy;version=1.17.8, \
+  net.bytebuddy:byte-buddy-agent;version=1.17.8

--- a/dev/com.ibm.ws.security.authorization.jacc.ejb/test/com/ibm/ws/security/authorization/jacc/ejb/impl/EJBJaccServiceImplTest.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.ejb/test/com/ibm/ws/security/authorization/jacc/ejb/impl/EJBJaccServiceImplTest.java
@@ -38,6 +38,7 @@ import org.junit.rules.TestRule;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 
+import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.ws.security.authorization.jacc.JaccService;
 import com.ibm.ws.security.authorization.jacc.MethodInfo;
 import com.ibm.ws.security.authorization.jacc.PolicyConfigurationManager;
@@ -121,7 +122,9 @@ public class EJBJaccServiceImplTest {
         } else {
             System.clearProperty(JACC_FACTORY_EE9);
         }
-        Policy.setPolicy(policy);
+        if (JavaInfo.majorVersion() <= 21) {
+            Policy.setPolicy(policy);
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.security.authorization.jacc.web/test/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImplTest.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.web/test/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImplTest.java
@@ -34,6 +34,7 @@ import org.junit.rules.TestRule;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 
+import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.ws.security.authorization.jacc.JaccService;
 import com.ibm.ws.security.authorization.jacc.PolicyConfigurationManager;
 import com.ibm.ws.security.authorization.jacc.common.PolicyConfigurationManagerImpl;
@@ -112,7 +113,9 @@ public class WebJaccServiceImplTest {
         } else {
             System.clearProperty(JACC_FACTORY_EE9);
         }
-        Policy.setPolicy(policy);
+        if (JavaInfo.majorVersion() <= 21) {
+            Policy.setPolicy(policy);
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.security.authorization.jacc/test/com/ibm/ws/security/authorization/jacc/internal/JaccServiceImplTest.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/test/com/ibm/ws/security/authorization/jacc/internal/JaccServiceImplTest.java
@@ -33,6 +33,7 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 
+import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.ws.security.authorization.jacc.PolicyConfigurationManager;
 import com.ibm.ws.security.authorization.jacc.common.PolicyConfigurationManagerImpl;
 import com.ibm.ws.security.authorization.jacc.common.PolicyProxy;
@@ -110,7 +111,9 @@ public class JaccServiceImplTest {
         } else {
             System.clearProperty(JACC_FACTORY_EE9);
         }
-        Policy.setPolicy(policy);
+        if (JavaInfo.majorVersion() <= 21) {
+            Policy.setPolicy(policy);
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
@@ -197,5 +197,5 @@ Include-Resource: \
 	com.ibm.ws.config;version=latest,\
 	org.mockito:mockito-core;version=4.11.0, \
   	org.mockito:mockito-inline;version=4.11.0, \
-  	net.bytebuddy:byte-buddy;version=1.16.1, \
-  	net.bytebuddy:byte-buddy-agent;version=1.16.1
+  	net.bytebuddy:byte-buddy;version=1.17.8, \
+  	net.bytebuddy:byte-buddy-agent;version=1.17.8

--- a/dev/com.ibm.ws.security.saml.websso.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.websso.2.0/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -181,8 +181,8 @@ instrument.classesExcludes: com/ibm/ws/security/saml/sso20/internal/resources/Sa
 	org.jmock:jmock;strategy=exact;version='2.5.1',\
 	org.mockito:mockito-core;version='4.11.0',\
 	org.mockito:mockito-inline;version='4.11.0',\
-  net.bytebuddy:byte-buddy;version=1.16.1,\
-  net.bytebuddy:byte-buddy-agent;version=1.16.1,\
+  net.bytebuddy:byte-buddy;version=1.17.8,\
+  net.bytebuddy:byte-buddy-agent;version=1.17.8,\
 	com.ibm.ws.org.objenesis:objenesis;version='1.0',\
 	fattest.simplicity;version=latest,\
 	com.ibm.ws.security.test.common;version=latest,\

--- a/dev/com.ibm.ws.security.utility/bnd.bnd
+++ b/dev/com.ibm.ws.security.utility/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -51,6 +51,6 @@ instrument.disabled: true
     com.ibm.ws.kernel.boot;version=latest, \
     org.mockito:mockito-core;version=4.11.0, \
     org.mockito:mockito-inline;version=4.11.0, \
-    net.bytebuddy:byte-buddy;version=1.16.1, \
-    net.bytebuddy:byte-buddy-agent;version=1.16.1, \
+    net.bytebuddy:byte-buddy;version=1.17.8, \
+    net.bytebuddy:byte-buddy-agent;version=1.17.8, \
 	com.ibm.ws.logging;version=latest

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -133,8 +133,8 @@ fat.test.container.images:\
     jakarta.tck.arquillian:tck-porting-lib;version=11.0.1
 
 -testpath:\
-    net.bytebuddy:byte-buddy-agent;version=1.16.1,\
-    net.bytebuddy:byte-buddy;version=1.16.1,\
+    net.bytebuddy:byte-buddy-agent;version=1.17.8,\
+    net.bytebuddy:byte-buddy;version=1.17.8,\
     org.mockito:mockito-core;version=4.11.0,\
     org.mockito:mockito-inline;version=4.11.0,\
     org.objenesis:objenesis;version=3.4

--- a/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
+++ b/dev/io.openliberty.security.oidcclientcore.internal/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
@@ -86,6 +86,6 @@ Export-Package: \
 	com.ibm.ws.logging;version=latest, \
   	org.mockito:mockito-core;version=4.11.0, \
   	org.mockito:mockito-inline;version=4.11.0, \
-  	net.bytebuddy:byte-buddy;version=1.16.1, \
-  	net.bytebuddy:byte-buddy-agent;version=1.16.1
+  	net.bytebuddy:byte-buddy;version=1.17.8, \
+  	net.bytebuddy:byte-buddy-agent;version=1.17.8
 	


### PR DESCRIPTION
- Updates for Policy.setPolicy() not being allowed any longer with Java 25
- Do not run test that uses AccessController.checkPermission
- Upgrade to newer version of bytebuddy that supports Java 25

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
