### PR TITLE
Move regression issues notifications to CI Orchestrator

### DIFF
--- a/.ci-orchestrator/regressionLabelIssue.yml
+++ b/.ci-orchestrator/regressionLabelIssue.yml
@@ -1,0 +1,39 @@
+type: pipeline_definition
+product: Liberty
+name: Open Liberty Regression Issues Notification
+description: Creates notification of an issue marked as a regression
+triggers:
+- type: event
+  triggerName: regression-label-trigger
+  groups: ["LibertyDev"]
+  eventType: GitHubIssueData
+  eventFilters:
+  - property: action
+    include: labeled
+  - property: repo
+    include: open-liberty
+  - property: labels
+    include: "regression"
+  - property: labels
+    exclude: "test"
+  propertyDefinitions:
+    - name: user
+      isRequired: true
+      description: "User who created issue"
+    - name: number
+      isRequired: true
+      description: "Issue number"
+    - name: githubUrl
+      isRequired: true
+      description: "Issue HTML URL"
+
+steps:
+- stepName: Regression Issue Notice
+  workType: Jenkins
+  projectName: regressionIssueNotify
+  timeoutInMinutes: 120
+  properties:
+    githubIssueApi: "https://api.github.com/repos/OpenLiberty/open-liberty/issues/${number}"
+    githubIssueCreator: ${user}
+    githubIssueNumber: ${number}
+    githubIssueHtml: ${githubUrl}


### PR DESCRIPTION
This introduces a new CI Orchestrator pipeline that is very similar to the "Open Liberty External Contributor New Issues" pipeline. It will trigger upon the action of labeling an Open Liberty issue with `regression`.

I've run standalone Jenkins jobs like https://libs-proxy1.fyre.ibm.com/jenkins/libh-jenkinsdev2913-1.fyre.ibm.com/job/regressionIssueNotify/8, which has resulted in Slack message https://ibm-cloud.slack.com/archives/C42GNNU5D/p1762897816209679:

