### PR TITLE
Handle MCP calls when CDI is inactive

### DIFF
--- a/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
+++ b/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
@@ -127,10 +127,9 @@ CWMCM0016E.error.sending.response.exception.explanation=An error occurred while 
 CWMCM0016E.error.sending.response.exception.useraction=No action is required.
 
 # Used for server logging
-CWMCM0017W.cdi.inactive.warning=CWMCM0017W: CDI is not active, skipping MCP servlet registration.
-CWMCM0017W.cdi.inactive.warning.explanation=If there are no CDI beans, then CDI is not active. Without CDI, the MCP server feature is unable to work.
-CWMCM0017W.cdi.inactive.warning.useraction=To use MCP, create a CDI managed bean that has an appropriate scope annotation (e.g., @ApplicationScoped or @RequestScoped).
-
+CWMCM0017W.cdi.inactive.warning=CWMCM0017W: CDI is not active, the MCP Server cannot start. Check that any MCP annotations are placed on methods of CDI beans which have an appropriate scope annotation (e.g. @ApplicationScoped)
+CWMCM0017W.cdi.inactive.warning.explanation=CDI is not active which may occur if there are no CDI beans in the application.
+CWMCM0017W.cdi.inactive.warning.useraction=Check that any MCP annotations are placed on methods of CDI beans which have an appropriate scope annotation (e.g., @ApplicationScoped or @RequestScoped). If your application archive contains a CDI extension, ensure it also includes a beans.xml. If your application has a beans.xml, check that "bean-discovery-mode" is not "none".
 # Used as part of a response to a client
 # do not translate jsonrpc
 # {0} = jsonrpc value

--- a/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
+++ b/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
@@ -126,6 +126,11 @@ CWMCM0016E.error.sending.response.exception=CWMCM0016E: Unexpected Server Error.
 CWMCM0016E.error.sending.response.exception.explanation=An error occurred while trying to send the response.
 CWMCM0016E.error.sending.response.exception.useraction=No action is required.
 
+# Used for server logging
+CWMCM0017W.cdi.inactive.warning=CWMCM0017W: CDI is not active, skipping MCP servlet registration.
+CWMCM0017W.cdi.inactive.warning.explanation=If there are no CDI beans, then CDI is not active. Without CDI, the MCP server feature is unable to work.
+CWMCM0017W.cdi.inactive.warning.useraction=To use MCP, create a CDI managed bean that has an appropriate scope annotation (e.g., @ApplicationScoped or @RequestScoped).
+
 # Used as part of a response to a client
 # do not translate jsonrpc
 # {0} = jsonrpc value

--- a/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
+++ b/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
@@ -129,7 +129,7 @@ CWMCM0016E.error.sending.response.exception.useraction=No action is required.
 # Used for server logging
 CWMCM0017W.cdi.inactive.warning=CWMCM0017W: CDI is not active, the MCP Server cannot start. Check that any MCP annotations are placed on methods of CDI beans which have an appropriate scope annotation (e.g. @ApplicationScoped)
 CWMCM0017W.cdi.inactive.warning.explanation=CDI is not active which may occur if there are no CDI beans in the application.
-CWMCM0017W.cdi.inactive.warning.useraction=Check that any MCP annotations are placed on methods of CDI beans which have an appropriate scope annotation (e.g., @ApplicationScoped or @RequestScoped). If your application archive contains a CDI extension, ensure it also includes a beans.xml. If your application has a beans.xml, check that "bean-discovery-mode" is not "none".
+CWMCM0017W.cdi.inactive.warning.useraction=Check that any MCP annotations are placed on methods of CDI beans that have an appropriate scope annotation (for example, @ApplicationScoped or @RequestScoped). If your application archive contains a CDI extension, ensure that it also includes a beans.xml. If your application has a beans.xml, check that "bean-discovery-mode" is not "none".
 # Used as part of a response to a client
 # do not translate jsonrpc
 # {0} = jsonrpc value

--- a/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
+++ b/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
@@ -127,7 +127,7 @@ CWMCM0016E.error.sending.response.exception.explanation=An error occurred while 
 CWMCM0016E.error.sending.response.exception.useraction=No action is required.
 
 # Used for server logging
-CWMCM0017W.cdi.inactive.warning=CWMCM0017W: CDI is not active, the MCP Server cannot start. Check that any MCP annotations are placed on methods of CDI beans which have an appropriate scope annotation (e.g. @ApplicationScoped)
+CWMCM0017W.cdi.inactive.warning=CWMCM0017W: CDI is not active. The MCP server cannot start. Verify that any MCP annotations are placed on methods of CDI beans that have an appropriate scope annotation (for example, @ApplicationScoped).
 CWMCM0017W.cdi.inactive.warning.explanation=CDI is not active which may occur if there are no CDI beans in the application.
 CWMCM0017W.cdi.inactive.warning.useraction=Check that any MCP annotations are placed on methods of CDI beans that have an appropriate scope annotation (for example, @ApplicationScoped or @RequestScoped). If your application archive contains a CDI extension, ensure that it also includes a beans.xml. If your application has a beans.xml, check that "bean-discovery-mode" is not "none".
 # Used as part of a response to a client

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServletInitializer.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServletInitializer.java
@@ -18,6 +18,7 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.wsspi.http.VirtualHost;
 
 import jakarta.servlet.FilterRegistration;
@@ -39,18 +40,23 @@ public class McpServletInitializer implements ServletContainerInitializer {
     private String mcpEndpoint = "/mcp"; // TODO: make configurable
 
     @Override
-    public void onStartup(Set<Class<?>> c, ServletContext context) throws ServletException {
-        if (ToolRegistry.get().hasTools()) {
-            Dynamic reg = context.addServlet("io.openliberty.mcp.servlet", McpServlet.class);
-            reg.addMapping(mcpEndpoint);
-            reg.setAsyncSupported(true);
+    @FFDCIgnore(IllegalStateException.class)
+    public void onStartup(Set<Class<?>> c, ServletContext context) throws ServletException, IllegalStateException {
+        try {
+            if (ToolRegistry.get().hasTools()) {
+                Dynamic reg = context.addServlet("io.openliberty.mcp.servlet", McpServlet.class);
+                reg.addMapping(mcpEndpoint);
+                reg.setAsyncSupported(true);
 
-            FilterRegistration.Dynamic filterReg = context.addFilter("io.openliberty.mcp.servlet.filter", McpForwardFilter.class);
-            filterReg.addMappingForUrlPatterns(null, false, "/mcp/");
-            filterReg.setAsyncSupported(true);
+                FilterRegistration.Dynamic filterReg = context.addFilter("io.openliberty.mcp.servlet.filter", McpForwardFilter.class);
+                filterReg.addMappingForUrlPatterns(null, false, "/mcp/");
+                filterReg.setAsyncSupported(true);
 
-            String fullMcpUrl = virtualHost.getUrlString(context.getContextPath() + mcpEndpoint, false);
-            Tr.info(tc, "MCP server endpoint: " + fullMcpUrl);
+                String fullMcpUrl = virtualHost.getUrlString(context.getContextPath() + mcpEndpoint, false);
+                Tr.info(tc, "MCP server endpoint: " + fullMcpUrl);
+            }
+        } catch (IllegalStateException e) {
+            Tr.warning(tc, "CDI is not active, skipping MCP servlet registration"); // called if ToolRegistry.get() has an issue with CDI
         }
     }
 

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServletInitializer.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServletInitializer.java
@@ -56,7 +56,7 @@ public class McpServletInitializer implements ServletContainerInitializer {
                 Tr.info(tc, "MCP server endpoint: " + fullMcpUrl);
             }
         } catch (IllegalStateException e) {
-            Tr.warning(tc, "CDI is not active, skipping MCP servlet registration"); // called if ToolRegistry.get() has an issue with CDI
+            Tr.warning(tc, "CWMCM0017W.cdi.inactive.warning"); // called if ToolRegistry.get() has an issue with CDI
         }
     }
 

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/FATSuite.java
@@ -30,6 +30,7 @@ import io.openliberty.mcp.internal.fat.tool.AsyncToolCancellationTest;
 import io.openliberty.mcp.internal.fat.tool.AsyncToolsTest;
 import io.openliberty.mcp.internal.fat.tool.CancellationTest;
 import io.openliberty.mcp.internal.fat.tool.DeploymentProblemTest;
+import io.openliberty.mcp.internal.fat.tool.InactiveCdiTest;
 import io.openliberty.mcp.internal.fat.tool.McpUrlPathTest;
 import io.openliberty.mcp.internal.fat.tool.NoParamNameTest;
 import io.openliberty.mcp.internal.fat.tool.ToolErrorHandlingTest;
@@ -47,6 +48,7 @@ import io.openliberty.mcp.internal.fat.tool.ToolTest;
                 DeploymentProblemTest.class,
                 CancellationTest.class,
                 HttpTest.class,
+                InactiveCdiTest.class,
                 LifecycleTest.class,
                 McpUrlPathTest.class,
                 NoParamNameTest.class,

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/InactiveCdiTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/InactiveCdiTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.tool;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static io.openliberty.mcp.internal.fat.utils.TestConstants.ACCEPT;
+import static io.openliberty.mcp.internal.fat.utils.TestConstants.MCP_PROTOCOL_VERSION;
+import static io.openliberty.mcp.internal.fat.utils.TestConstants.VALUE_ACCEPT_DEFAULT;
+import static io.openliberty.mcp.internal.fat.utils.TestConstants.VALUE_MCP_PROTOCOL_VERSION;
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import componenttest.topology.utils.HttpRequest;
+import io.openliberty.mcp.internal.fat.tool.inactiveCdiApp.InactiveCdiTool;
+
+@RunWith(FATRunner.class)
+public class InactiveCdiTest extends FATServletClient {
+    @Server("mcp-server")
+    public static LibertyServer server;
+
+    private static final String EXPECTED_ERROR_MESSAGE = "SRVE0190E: File not found: /mcp";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "inactiveCdiTest.war").addPackage(InactiveCdiTool.class.getPackage());
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer(EXPECTED_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void testMcpCallWithoutCDIReturnsNotFoundError() throws Exception {
+        String initializeRequest = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": "1",
+                          "method": "initialize",
+                          "params": {
+                            "protocolVersion": "2025-06-18",
+                            "capabilities": {
+                              "roots": {
+                                "listChanged": true
+                              },
+                              "sampling": {},
+                              "elicitation": {}
+                            },
+                            "clientInfo": {
+                              "name": "FAT Test Client",
+                              "title": "FAT Test Client",
+                              "version": "1.0.0"
+                            }
+                          }
+                        }
+                        """;
+
+        new HttpRequest(server, "/inactiveCdiTest/mcp")
+                                                       .requestProp(ACCEPT, VALUE_ACCEPT_DEFAULT)
+                                                       .requestProp(MCP_PROTOCOL_VERSION, VALUE_MCP_PROTOCOL_VERSION)
+                                                       .jsonBody(initializeRequest)
+                                                       .method("POST")
+                                                       .expectCode(404)
+                                                       .run(String.class);
+        assertNotNull(server.waitForStringInLogUsingMark(EXPECTED_ERROR_MESSAGE, server.getDefaultLogFile())); // expect a file not found error in the logs
+    }
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/InactiveCdiTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/InactiveCdiTest.java
@@ -37,7 +37,8 @@ public class InactiveCdiTest extends FATServletClient {
     @Server("mcp-server")
     public static LibertyServer server;
 
-    private static final String EXPECTED_ERROR_MESSAGE = "SRVE0190E: File not found: /mcp";
+    private static final String CDI_INACTIVE_WARNING_MESSAGE = "CWMCM0017W: CDI is not active, skipping MCP servlet registration";
+    private static final String FILE_NOT_FOUND_ERROR_MESSAGE = "SRVE0190E: File not found: /mcp";
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -48,11 +49,12 @@ public class InactiveCdiTest extends FATServletClient {
 
     @AfterClass
     public static void teardown() throws Exception {
-        server.stopServer(EXPECTED_ERROR_MESSAGE);
+        server.stopServer(CDI_INACTIVE_WARNING_MESSAGE, FILE_NOT_FOUND_ERROR_MESSAGE);
     }
 
     @Test
     public void testMcpCallWithoutCDIReturnsNotFoundError() throws Exception {
+        assertNotNull(server.waitForStringInLogUsingMark(CDI_INACTIVE_WARNING_MESSAGE, server.getDefaultLogFile()));
         String initializeRequest = """
                         {
                           "jsonrpc": "2.0",
@@ -83,6 +85,6 @@ public class InactiveCdiTest extends FATServletClient {
                                                        .method("POST")
                                                        .expectCode(404)
                                                        .run(String.class);
-        assertNotNull(server.waitForStringInLogUsingMark(EXPECTED_ERROR_MESSAGE, server.getDefaultLogFile())); // expect a file not found error in the logs
+        assertNotNull(server.waitForStringInLogUsingMark(FILE_NOT_FOUND_ERROR_MESSAGE, server.getDefaultLogFile())); // expect a file not found error in the logs
     }
 }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/inactiveCdiApp/InactiveCdiTool.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/inactiveCdiApp/InactiveCdiTool.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.tool.inactiveCdiApp;
+
+import io.openliberty.mcp.annotations.Tool;
+import io.openliberty.mcp.content.TextContent;
+
+/**
+ *
+ */
+public class InactiveCdiTool {
+    @Tool(name = "toolWithoutCDI", title = "Tool Without CDI", description = "Should not be called as the class is not a CDI bean")
+    public TextContent toolWithoutCDI() {
+        return new TextContent("Hello world!");
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


Resolves #33241

If `@ApplicationScoped` isn't used in any class, then CDI is not active and an error is thrown in `ToolRegistry.get()` when trying to access CDI when its inactive. 