### PR TITLE
Change MCP tool definitions to use a handler

### DIFF
--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpCdiExtension.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpCdiExtension.java
@@ -22,7 +22,10 @@ import io.openliberty.mcp.annotations.Tool;
 import io.openliberty.mcp.internal.ToolMetadata.ArgumentMetadata;
 import io.openliberty.mcp.internal.ToolMetadata.SpecialArgumentMetadata;
 import io.openliberty.mcp.internal.exceptions.GenericArgumentException;
+import io.openliberty.mcp.internal.requests.McpRequestIdDeserializer;
+import io.openliberty.mcp.internal.requests.McpRequestIdSerializer;
 import io.openliberty.mcp.internal.schemas.SchemaRegistry;
+import io.openliberty.mcp.internal.tools.BeanMethodHandler.MethodMetadata;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
@@ -31,6 +34,9 @@ import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.ProcessManagedBean;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
 
 /**
  * Finds tools
@@ -44,14 +50,21 @@ public class McpCdiExtension implements Extension {
     private ConcurrentHashMap<String, LinkedList<String>> duplicateToolsMap = new ConcurrentHashMap<>();
 
     private SchemaRegistry schemas = new SchemaRegistry();
+    private Jsonb jsonb = createJsonb();
 
-    void registerTools(@Observes ProcessManagedBean<?> pmb) {
+    private static Jsonb createJsonb() {
+        JsonbConfig jsonbConfig = new JsonbConfig().withSerializers(new McpRequestIdSerializer())
+                                                   .withDeserializers(new McpRequestIdDeserializer());
+    
+        return JsonbBuilder.create(jsonbConfig);
+    }
+
+    void registerTools(@Observes ProcessManagedBean<?> pmb, BeanManager beanManager) {
         AnnotatedType<?> type = pmb.getAnnotatedBeanClass();
-        Class<?> javaClass = type.getJavaClass();
         for (AnnotatedMethod<?> m : type.getMethods()) {
             Tool toolAnnotation = m.getAnnotation(Tool.class);
             if (toolAnnotation != null) {
-                registerTool(toolAnnotation, pmb.getBean(), m);
+                registerTool(toolAnnotation, pmb.getBean(), m, beanManager);
             }
         }
     }
@@ -107,8 +120,12 @@ public class McpCdiExtension implements Extension {
     private boolean reportOnDuplicateSpecialArguments(AfterDeploymentValidation afterDeploymentValidation) {
         AtomicBoolean error = new AtomicBoolean(false);
         for (ToolMetadata tool : tools.getAllTools()) {
+            if (tool.methodMetadata().isEmpty()) {
+                continue;
+            }
+            MethodMetadata methodMetadata = tool.methodMetadata().get();
             Map<SpecialArgumentType.Resolution, Integer> resultCountMap = new HashMap<>();
-            for (SpecialArgumentMetadata specialArgument : tool.specialArguments()) {
+            for (SpecialArgumentMetadata specialArgument : methodMetadata.specialArguments()) {
                 SpecialArgumentType.Resolution specialArgumentTypeResolution = specialArgument.typeResolution();
                 if (specialArgumentTypeResolution.specialArgsType() == SpecialArgumentType.UNSUPPORTED) {
                     continue;
@@ -133,7 +150,10 @@ public class McpCdiExtension implements Extension {
     private boolean reportOnInvalidSpecialArguments(AfterDeploymentValidation afterDeploymentValidation) {
         boolean error = false;
         for (ToolMetadata tool : tools.getAllTools()) {
-            for (SpecialArgumentMetadata specialArgument : tool.specialArguments()) {
+            if (tool.methodMetadata().isEmpty()) {
+                continue;
+            }
+            for (SpecialArgumentMetadata specialArgument : tool.methodMetadata().get().specialArguments()) {
                 if (specialArgument.typeResolution().specialArgsType() == SpecialArgumentType.UNSUPPORTED) {
                     error = true;
                     Tr.error(tc, "CWMCM0007E.invalid.arguments", tool.getToolQualifiedName(),
@@ -144,9 +164,9 @@ public class McpCdiExtension implements Extension {
         return error;
     }
 
-    private void registerTool(Tool tool, Bean<?> bean, AnnotatedMethod<?> method) {
+    private void registerTool(Tool tool, Bean<?> bean, AnnotatedMethod<?> method, BeanManager beanManager) {
         try {
-            ToolMetadata toolmd = ToolMetadata.createFrom(tool, bean, method);
+            ToolMetadata toolmd = ToolMetadata.createFrom(tool, bean, method, beanManager, jsonb);
             duplicateToolsMap.computeIfAbsent(toolmd.name(), key -> new LinkedList<>()).add(toolmd.getToolQualifiedName());
             tools.addTool(toolmd);
             if (TraceComponent.isAnyTracingEnabled()) {
@@ -169,6 +189,10 @@ public class McpCdiExtension implements Extension {
 
     public SchemaRegistry getSchemaRegistry() {
         return schemas;
+    }
+
+    public Jsonb getJsonb() {
+        return jsonb;
     }
 
 }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
@@ -11,11 +11,10 @@ package io.openliberty.mcp.internal;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
@@ -24,10 +23,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.ServiceCaller;
 
-import io.openliberty.mcp.content.Content;
-import io.openliberty.mcp.content.TextContent;
 import io.openliberty.mcp.internal.Capabilities.ServerCapabilities;
-import io.openliberty.mcp.internal.ToolMetadata.SpecialArgumentMetadata;
 import io.openliberty.mcp.internal.config.McpConfiguration;
 import io.openliberty.mcp.internal.exceptions.jsonrpc.HttpResponseException;
 import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCErrorCode;
@@ -36,24 +32,19 @@ import io.openliberty.mcp.internal.requests.CancellationImpl;
 import io.openliberty.mcp.internal.requests.ExecutionRequestId;
 import io.openliberty.mcp.internal.requests.McpInitializeParams;
 import io.openliberty.mcp.internal.requests.McpNotificationParams;
-import io.openliberty.mcp.internal.requests.McpRequestIdDeserializer;
-import io.openliberty.mcp.internal.requests.McpRequestIdSerializer;
 import io.openliberty.mcp.internal.requests.McpToolCallParams;
 import io.openliberty.mcp.internal.responses.McpInitializeResult;
 import io.openliberty.mcp.internal.responses.McpInitializeResult.ServerInfo;
 import io.openliberty.mcp.internal.sessions.McpSession;
 import io.openliberty.mcp.internal.sessions.McpSessionId;
 import io.openliberty.mcp.internal.sessions.McpSessionStore;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArguments;
 import io.openliberty.mcp.messaging.Cancellation;
 import io.openliberty.mcp.request.RequestId;
-import io.openliberty.mcp.tools.ToolCallException;
 import io.openliberty.mcp.tools.ToolResponse;
-import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
 import jakarta.json.bind.Jsonb;
-import jakarta.json.bind.JsonbBuilder;
-import jakarta.json.bind.JsonbConfig;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -69,8 +60,6 @@ public class McpServlet extends HttpServlet {
     private static final TraceComponent tc = Tr.register(McpServlet.class);
     private static final ServiceCaller<McpConfiguration> mcpConfigService = new ServiceCaller<>(McpServlet.class, McpConfiguration.class);
 
-    private Jsonb jsonb;
-
     @Inject
     BeanManager bm;
 
@@ -80,13 +69,15 @@ public class McpServlet extends HttpServlet {
     @Inject
     McpRequestTracker requestTracker;
 
+    @Inject
+    McpCdiExtension cdiExtension;
+
+    private Jsonb jsonb;
+
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
-        JsonbConfig jsonbConfig = new JsonbConfig().withSerializers(new McpRequestIdSerializer())
-                                                   .withDeserializers(new McpRequestIdDeserializer());
-
-        jsonb = JsonbBuilder.create(jsonbConfig);
+        jsonb = cdiExtension.getJsonb();
     }
 
     @Override
@@ -194,9 +185,9 @@ public class McpServlet extends HttpServlet {
             }
 
             if (params.getMetadata().returnsCompletionStage()) {
-                callToolMethodAndSendResponseAsync(transport, requestId, params, params.getMethod());
+                callToolMethodAndSendResponseAsync(transport, requestId, params);
             } else {
-                callToolSynchronously(transport, requestId, params, params.getMethod());
+                callToolSynchronously(transport, requestId, params);
             }
         } catch (IllegalAccessException e) {
             throw new JSONRPCException(JSONRPCErrorCode.INTERNAL_ERROR, List.of("Could not call " + params.getName()));
@@ -205,184 +196,55 @@ public class McpServlet extends HttpServlet {
         }
     }
 
-    @FFDCIgnore({ JSONRPCException.class, InvocationTargetException.class })
     private void callToolSynchronously(McpTransport transport,
                                        ExecutionRequestId requestId,
-                                       McpToolCallParams params,
-                                       Method method)
+                                       McpToolCallParams params)
                     throws IllegalAccessException, IllegalArgumentException {
-        CreationalContext<Object> cc = bm.createCreationalContext(null);
 
+        ToolArguments toolArgs = createToolArguments(params.getArguments(jsonb));
         if (requestId != null) {
-            CancellationImpl cancellation = new CancellationImpl();
-            cancellation.setRequestId(requestId);
-            requestTracker.registerOngoingRequest(requestId, cancellation);
+            requestTracker.registerOngoingRequest(requestId, (CancellationImpl) toolArgs.cancellation());
         }
 
         try {
-            Object bean = bm.getReference(params.getBean(), params.getBean().getBeanClass(), cc);
+            var handler = params.getMetadata().handler();
 
-            Object[] arguments = params.getArguments(jsonb);
-            addSpecialArguments(arguments, requestId, params.getMetadata());
-
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(this, tc, "Calling tool " + params.getMetadata().name(), arguments);
-            }
-
-            // Call the tool method synchronously
-            Object result = method.invoke(bean, arguments);
-
-            transport.sendResponse(evaluateToolResponse(result, params));
-
-        } catch (JSONRPCException e) {
-            throw e;
-        } catch (InvocationTargetException e) {
-            Throwable t = e.getCause();
-            if (isBusinessException(t, params)) {
-                transport.sendResponse(toErrorResponse(e.getCause()));
-            } else {
-                Tr.error(tc, "CWMCM0010E.internal.server.error.detailed",
-                         params.getMetadata().name(),
-                         e.getCause());
-                transport.sendResponse(ToolResponse.error(Tr.formatMessage(tc, "CWMCM0011E.internal.server.error")));
-            }
+            ToolResponse response = handler.apply(toolArgs);
+            transport.sendResponse(response);
         } finally {
-            cleanup(requestId, cc, params);
+            cleanup(requestId);
         }
     }
 
-    @FFDCIgnore({ InvocationTargetException.class })
     private void callToolMethodAndSendResponseAsync(McpTransport transport,
                                                     ExecutionRequestId requestId,
-                                                    McpToolCallParams params,
-                                                    Method method)
+                                                    McpToolCallParams params)
                     throws IllegalAccessException, IllegalArgumentException {
-        CreationalContext<Object> cc = bm.createCreationalContext(null);
+        ToolArguments toolArgs = createToolArguments(params.getArguments(jsonb));
 
         if (requestId != null) {
-            CancellationImpl cancellation = new CancellationImpl();
-            cancellation.setRequestId(requestId);
-            requestTracker.registerOngoingRequest(requestId, cancellation);
+            requestTracker.registerOngoingRequest(requestId, (CancellationImpl) toolArgs.cancellation());
         }
 
-        try {
-            Object bean = bm.getReference(params.getBean(), params.getBean().getBeanClass(), cc);
+        var handler = params.getMetadata().asyncHandler();
 
-            Object[] arguments = params.getArguments(jsonb);
-            addSpecialArguments(arguments, requestId, params.getMetadata());
-
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(this, tc, "Calling tool " + params.getMetadata().name(), arguments);
-            }
-            CompletionStage<?> stage = ((CompletionStage<?>) method.invoke(bean, arguments));
-            stage = stage.thenApply(result -> evaluateToolResponse(result, params))
-                         .exceptionally(throwable -> {
-                             Tr.error(tc,
-                                      "CWMCM0010E.internal.server.error.detailed",
-                                      params.getMetadata().name(),
-                                      throwable.getCause());
-                             return ToolResponse.error(Tr.formatMessage(tc, "CWMCM0011E.internal.server.error"));
-                         });
-            transport.sendResultAsync(stage)
-                     .whenComplete((result, throwable) -> cleanup(requestId, cc, params));
-        } catch (InvocationTargetException e) {
-            Throwable t = e.getCause();
-            if (isBusinessException(t, params)) {
-                transport.sendResponse(toErrorResponse(e.getCause()));
-            } else {
-                Tr.error(tc, "CWMCM0010E.internal.server.error.detailed",
-                         params.getMetadata().name(),
-                         e.getCause());
-                transport.sendResponse(ToolResponse.error(Tr.formatMessage(tc, "CWMCM0011E.internal.server.error")));
-            }
-            cleanup(requestId, cc, params);
-        }
-    }
-
-    private void cleanup(ExecutionRequestId requestId, CreationalContext<Object> cc, McpToolCallParams params) {
-        if (requestId != null && requestTracker.isOngoingRequest(requestId)) {
-            requestTracker.deregisterOngoingRequest(requestId);
-        }
-        try {
-            cc.release();
-        } catch (Exception ex) {
-            Tr.warning(tc, "CWMCM0012E.bean.release.fail", ex, params.getName());
-        }
-    }
-
-    private Object evaluateToolResponse(Object result, McpToolCallParams params) {
-        boolean includeStructuredContent = params.getMetadata().annotation().structuredContent();
-
-        // Map method response to a ToolResponse
-        if (result instanceof ToolResponse response) {
-            return response;
-        } else if (result instanceof List<?> list && !list.isEmpty() && list.stream().allMatch(item -> item instanceof Content)) {
-            @SuppressWarnings("unchecked")
-            List<Content> contents = (List<Content>) list;
-            return ToolResponse.success(contents);
-        } else if (result instanceof Content content) {
-            return ToolResponse.success(content);
-        } else if (result instanceof String s) {
-            return ToolResponse.success(s);
-        } else if (includeStructuredContent) {
-            return new ToolResponse(false, List.of(new TextContent(jsonb.toJson(result))), result, null);
-        } else {
-            return ToolResponse.success(Objects.toString(result));
-        }
+        CompletionStage<ToolResponse> response = handler.apply(toolArgs);
+        transport.sendResultAsync(response)
+                 .whenComplete((result, throwable) -> cleanup(requestId));
     }
 
     /**
-     * @param t
      * @return
      */
-    private boolean isBusinessException(Throwable t, McpToolCallParams params) {
-        if (t instanceof ToolCallException) {
-            return true;
-        }
-
-        if (params != null && params.getMetadata() != null) {
-            for (Class<? extends Throwable> clazz : params.getMetadata().businessExceptions()) {
-                if (clazz.isAssignableFrom(t.getClass())) {
-                    return true;
-                }
-            }
-        }
-        return false;
+    private ToolArguments createToolArguments(Map<String, Object> args) {
+        return new ToolArgumentsImpl(args, new CancellationImpl());
     }
 
-    // Helper method for ToolResponse Error
-    private ToolResponse toErrorResponse(Throwable t) {
-        String msg = t.getMessage() != null ? t.getMessage() : t.getClass().getSimpleName();
-        return ToolResponse.error(msg);
-    }
+    record ToolArgumentsImpl(Map<String, Object> args, Cancellation cancellation) implements ToolArguments {}
 
-    /**
-     * Adds the values for any special arguments to {@code argumentsArray}
-     *
-     * @param argumentsArray the array of arguments for the tool method
-     * @param requestId the ongoing request Id
-     * @param toolMetadata the tool metadata
-     */
-    private void addSpecialArguments(Object[] argumentsArray,
-                                     ExecutionRequestId requestId,
-                                     ToolMetadata toolMetadata) {
-        for (SpecialArgumentMetadata argMetadata : toolMetadata.specialArguments()) {
-            switch (argMetadata.typeResolution().specialArgsType()) {
-                case CANCELLATION -> {
-                    CancellationImpl cancellation;
-                    if (requestId != null) {
-                        cancellation = (CancellationImpl) requestTracker.getOngoingRequestCancellation(requestId);
-                    } else {
-                        cancellation = new CancellationImpl();
-                    }
-
-                    // Always inject it into args
-                    argumentsArray[argMetadata.index()] = cancellation;
-                }
-                default -> {
-
-                }
-            }
+    private void cleanup(ExecutionRequestId requestId) {
+        if (requestId != null && requestTracker.isOngoingRequest(requestId)) {
+            requestTracker.deregisterOngoingRequest(requestId);
         }
     }
 

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolDescription.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolDescription.java
@@ -9,7 +9,7 @@
  *******************************************************************************/
 package io.openliberty.mcp.internal;
 
-import io.openliberty.mcp.annotations.Tool;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolAnnotations;
 import jakarta.json.JsonObject;
 
 public class ToolDescription {
@@ -50,7 +50,7 @@ public class ToolDescription {
         this.title = toolMetadata.title();
         this.description = toolMetadata.description();
 
-        Tool.Annotations ann = toolMetadata.annotation().annotations();
+        ToolAnnotations ann = toolMetadata.annotations();
         if (isDefaultAnnotation(ann)) {
             this.annotations = null;
         } else {
@@ -69,7 +69,7 @@ public class ToolDescription {
      * Helper Method for default Annotation
      */
 
-    private boolean isDefaultAnnotation(Tool.Annotations ann) {
+    private boolean isDefaultAnnotation(ToolAnnotations ann) {
         return ann.readOnlyHint() == false
                && ann.destructiveHint() == true
                && ann.idempotentHint() == false

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolMetadata.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolMetadata.java
@@ -16,7 +16,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import io.openliberty.mcp.annotations.Schema;
 import io.openliberty.mcp.annotations.Tool;
@@ -26,20 +28,45 @@ import io.openliberty.mcp.content.Content;
 import io.openliberty.mcp.internal.exceptions.GenericArgumentException;
 import io.openliberty.mcp.internal.schemas.SchemaRegistry;
 import io.openliberty.mcp.internal.schemas.TypeUtility;
+import io.openliberty.mcp.internal.tools.AsyncBeanMethodHandler;
+import io.openliberty.mcp.internal.tools.BeanMethodHandler.MethodMetadata;
+import io.openliberty.mcp.internal.tools.SyncBeanMethodHandler;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolAnnotations;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArguments;
 import io.openliberty.mcp.tools.ToolResponse;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
 import jakarta.enterprise.inject.spi.AnnotatedParameter;
 import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.json.JsonObject;
+import jakarta.json.bind.Jsonb;
 
-public record ToolMetadata(Tool annotation, Bean<?> bean, AnnotatedMethod<?> method,
+/**
+ * Metadata about a tool
+ *
+ * @param name the tool name
+ * @param title the tool title, may be {@code null}
+ * @param description the tool description, may be {@code null}
+ * @param arguments a map of argument name to argument metadata
+ * @param annotations the MCP annotations applied to the tool
+ * @param returnsCompletionStage whether the tool is asynchronous
+ * @param inputSchema the input schema for the tool, usually an object containing all of the named parameters
+ * @param outputSchema the output schema, {@code null} if the tool does not return structured content
+ * @param handler the handler, {@code null} if this is an async tool
+ * @param asyncHandler the async handler, {@code null} if this is not an async tool
+ * @param methodMetadata data about the method if this tool was discovered by annotating a method with {@link Tool}. Should not be used in most circumstances.
+ */
+public record ToolMetadata(String name,
+                           String title,
+                           String description,
                            Map<String, ArgumentMetadata> arguments,
-                           List<SpecialArgumentMetadata> specialArguments,
-                           String name, String title, String description,
-                           List<Class<? extends Throwable>> businessExceptions,
+                           ToolAnnotations annotations,
                            boolean returnsCompletionStage,
                            JsonObject inputSchema,
-                           JsonObject outputSchema) {
+                           JsonObject outputSchema,
+                           Function<ToolArguments, ToolResponse> handler,
+                           Function<ToolArguments, CompletionStage<ToolResponse>> asyncHandler,
+                           Optional<MethodMetadata> methodMetadata) {
 
     public static final String MISSING_TOOL_ARG_NAME = "<<<MISSING TOOL_ARG NAME>>>";
 
@@ -49,10 +76,25 @@ public record ToolMetadata(Tool annotation, Bean<?> bean, AnnotatedMethod<?> met
 
     public ToolMetadata {
         arguments = ((arguments == null) ? Collections.emptyMap() : arguments);
-        specialArguments = ((specialArguments == null) ? Collections.emptyList() : specialArguments);
+
+        if (handler == null && asyncHandler == null) {
+            throw new IllegalArgumentException("Either handler or asyncHandler must be set");
+        } else if (handler != null && asyncHandler != null) {
+            throw new IllegalArgumentException("Only one of handler and async handler may be set");
+        }
     }
 
-    public static ToolMetadata createFrom(Tool annotation, Bean<?> bean, AnnotatedMethod<?> method) {
+    /**
+     * Create the tool metadata for a method annotated with {@link Tool}
+     *
+     * @param annotation the {@code Tool} annotation
+     * @param bean the bean containing the method
+     * @param method the annotated method
+     * @param bm the bean manager to use to obtain an instance of the bean
+     * @param jsonb the jsonb to use to serialize structured content
+     * @return the created tool metadata
+     */
+    public static ToolMetadata createFrom(Tool annotation, Bean<?> bean, AnnotatedMethod<?> method, BeanManager bm, Jsonb jsonb) {
         String name = annotation.name().equals(Tool.ELEMENT_NAME) ? method.getJavaMember().getName() : annotation.name();
         String title = annotation.title().isEmpty() ? null : annotation.title();
         String description = annotation.description().isEmpty() ? null : annotation.description();
@@ -83,19 +125,46 @@ public record ToolMetadata(Tool annotation, Bean<?> bean, AnnotatedMethod<?> met
 
         outputSchema = (outputSchema == null || outputSchema.isEmpty()) ? null : outputSchema;
 
-        return new ToolMetadata(annotation,
-                                bean,
-                                method,
-                                getArgumentMap(method),
-                                getSpecialArgumentList(method),
-                                name,
+        ToolAnnotations annotations = readAnnotations(annotation.annotations());
+
+        Map<String, ArgumentMetadata> argumentMap = getArgumentMap(method);
+
+        MethodMetadata methodMetadata = new MethodMetadata(name,
+                                                           bean,
+                                                           method.getJavaMember(),
+                                                           hasOutputSchema,
+                                                           businessExceptions,
+                                                           getSpecialArgumentList(method),
+                                                           getArgNameArray(method, argumentMap));
+
+        SyncBeanMethodHandler handler = null;
+        AsyncBeanMethodHandler asyncHandler = null;
+        if (returnsCompletionStage) {
+            asyncHandler = new AsyncBeanMethodHandler(jsonb, bm, methodMetadata);
+        } else {
+            handler = new SyncBeanMethodHandler(jsonb, bm, methodMetadata);
+        }
+
+        return new ToolMetadata(name,
                                 title,
                                 description,
-                                businessExceptions,
+                                getArgumentMap(method),
+                                annotations,
                                 returnsCompletionStage,
                                 inputSchema,
-                                outputSchema);
+                                outputSchema,
+                                handler,
+                                asyncHandler,
+                                Optional.of(methodMetadata));
 
+    }
+
+    private static String[] getArgNameArray(AnnotatedMethod<?> method, Map<String, ArgumentMetadata> argumentMap) {
+        String[] nameArray = new String[method.getJavaMember().getParameterCount()];
+        for (var entry : argumentMap.entrySet()) {
+            nameArray[entry.getValue().index] = entry.getKey();
+        }
+        return nameArray;
     }
 
     public static Map<String, ArgumentMetadata> getArgumentMap(AnnotatedMethod<?> method) {
@@ -155,11 +224,20 @@ public record ToolMetadata(Tool annotation, Bean<?> bean, AnnotatedMethod<?> met
         return Collections.unmodifiableList(result);
     }
 
+    public static ToolAnnotations readAnnotations(Tool.Annotations annotations) {
+        return new ToolAnnotations(annotations.title(),
+                                   annotations.readOnlyHint(),
+                                   annotations.destructiveHint(),
+                                   annotations.idempotentHint(),
+                                   annotations.openWorldHint());
+    }
+
     /**
      * Used for error reporting cases, such as locating Duplicate Tools and ToolArgs
      */
     public String getToolQualifiedName() {
-        return bean.getBeanClass() + "." + method.getJavaMember().getName();
+        return methodMetadata.map(m -> m.bean().getBeanClass().toString() + "." + m.method().getName())
+                             .orElse("User-defined tool: " + name);
     }
 
     /**

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/features/FeatureManager.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/features/FeatureManager.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) contributors to https://github.com/quarkiverse/quarkus-mcp-server
+ * Copyright (c) 2025 IBM Corporation and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Based on https://github.com/quarkiverse/quarkus-mcp-server/blob/main/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
+ * Modifications have been made.
+ *******************************************************************************/
+package io.openliberty.mcp.internal.features;
+
+import java.time.Instant;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import io.openliberty.mcp.internal.features.FeatureManager.FeatureInfo;
+import io.openliberty.mcp.messaging.Cancellation;
+import jakarta.json.JsonObject;
+
+/**
+ *
+ * @param <INFO>
+ */
+public interface FeatureManager<INFO extends FeatureInfo> extends Iterable<INFO> {
+
+    /**
+     *
+     */
+    interface FeatureInfo extends Comparable<FeatureInfo> {
+
+        /**
+         * It is guaranteed that the name is unique for a specific feature.
+         *
+         * @return the name
+         */
+        String name();
+
+        String description();
+
+// Not yet implemented:
+//        /**
+//         * @return the name of the respective server configuration
+//         * @see McpServer
+//         */
+//        String serverName();
+
+        /**
+         * @return {@code true} if backed by a business method of a CDI bean, {@code false} otherwise
+         */
+        boolean isMethod();
+
+        /**
+         * @return the timestamp this feature was registered
+         */
+        Instant createdAt();
+
+        @Override
+        default int compareTo(FeatureInfo o) {
+            // Sort by timestamp and name asc
+            int result = createdAt().compareTo(o.createdAt());
+            return result == 0 ? name().compareTo(o.name()) : result;
+        }
+
+        JsonObject asJson();
+
+    }
+
+    interface FeatureDefinition<INFO extends FeatureInfo, ARGUMENTS extends FeatureArguments, RESPONSE, THIS extends FeatureDefinition<INFO, ARGUMENTS, RESPONSE, THIS>> {
+
+        /**
+         *
+         * @param description
+         * @return self
+         */
+        THIS setDescription(String description);
+
+// Not yet implemented
+//        /**
+//         *
+//         * @param serverName
+//         * @return self
+//         * @see McpServer
+//         */
+//        THIS setServerName(String serverName);
+
+        /**
+         *
+         * @param fun
+         * @return self
+         */
+        THIS setHandler(Function<ARGUMENTS, RESPONSE> fun);
+
+        /**
+         *
+         * @param fun
+         * @return self
+         */
+        THIS setAsyncHandler(Function<ARGUMENTS, CompletionStage<RESPONSE>> fun);
+
+        /**
+         * Registers the resulting info and sends notifications to all connected clients.
+         *
+         * @return the info
+         */
+        INFO register();
+    }
+
+    interface RequestFeatureArguments extends FeatureArguments {
+
+// Not yet implemented:
+//        RequestId requestId();
+//
+//        Progress progress();
+
+        Cancellation cancellation();
+
+    }
+
+    interface FeatureArguments {
+
+// Not yet implemented:
+//        McpConnection connection();
+//
+//        McpLog log();
+//
+//        Roots roots();
+//
+//        Sampling sampling();
+//
+//        Elicitation elicitation();
+//
+//        RawMessage rawMessage();
+//
+//        Meta meta();
+
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/features/package-info.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/features/package-info.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ *
+ */
+@com.ibm.websphere.ras.annotation.TraceOptions(messageBundle = "io.openliberty.mcp.internal.resources.CWMCM", traceGroup = "MCP")
+package io.openliberty.mcp.internal.features;

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/CancellationImpl.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/CancellationImpl.java
@@ -19,7 +19,6 @@ import io.openliberty.mcp.messaging.Cancellation;
  */
 public class CancellationImpl implements Cancellation {
 
-    private ExecutionRequestId requestId;
     private volatile Optional<String> reason = null;
 
     /**
@@ -27,17 +26,10 @@ public class CancellationImpl implements Cancellation {
      */
     @Override
     public Result check() {
-        if (requestId == null) {
-            return new Result(false, Optional.empty());
-        }
         if (reason == null) {
             return new Result(false, Optional.empty());
         }
         return new Result(true, reason);
-    }
-
-    public void setRequestId(ExecutionRequestId requestId) {
-        this.requestId = requestId;
     }
 
     /**

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/McpToolCallParams.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/McpToolCallParams.java
@@ -9,8 +9,8 @@
  *******************************************************************************/
 package io.openliberty.mcp.internal.requests;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -21,11 +21,9 @@ import com.ibm.websphere.ras.TraceComponent;
 
 import io.openliberty.mcp.internal.ToolMetadata;
 import io.openliberty.mcp.internal.ToolMetadata.ArgumentMetadata;
-import io.openliberty.mcp.internal.ToolMetadata.SpecialArgumentMetadata;
 import io.openliberty.mcp.internal.ToolRegistry;
 import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCErrorCode;
 import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCException;
-import jakarta.enterprise.inject.spi.Bean;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import jakarta.json.bind.Jsonb;
@@ -47,7 +45,7 @@ public class McpToolCallParams {
     }
 
     private JsonObject arguments;
-    private Object[] parsedArguments;
+    private Map<String, Object> parsedArguments;
 
     public String getName() {
         return name;
@@ -63,11 +61,7 @@ public class McpToolCallParams {
         this.arguments = arguments;
     }
 
-    public Method getMethod() {
-        return metadata.method().getJavaMember();
-    }
-
-    public Object[] getArguments(Jsonb jsonb) {
+    public Map<String, Object> getArguments(Jsonb jsonb) {
         if (this.arguments == null) {
             throw new JSONRPCException(JSONRPCErrorCode.INVALID_PARAMS, List.of(Tr.formatMessage(tc, "jsonrpc.missing.params")));
         }
@@ -77,27 +71,25 @@ public class McpToolCallParams {
         return parsedArguments;
     }
 
-    private Object[] parseArguments(JsonObject arguments2, Jsonb jsonb) {
-        JsonObject argsObject = arguments2.asJsonObject();
-        Map<String, ArgumentMetadata> arguments = metadata.arguments();
-        List<SpecialArgumentMetadata> specialArguments = metadata.specialArguments();
-        Object[] results = new Object[arguments.size() + specialArguments.size()];
+    private Map<String, Object> parseArguments(JsonObject arguments, Jsonb jsonb) {
+        Map<String, ArgumentMetadata> metadatas = metadata.arguments();
+        Map<String, Object> result = new HashMap<>();
 
         HashSet<String> argsProcessed = new HashSet<>();
-        for (var entry : argsObject.entrySet()) {
+        for (var entry : arguments.entrySet()) {
             String argName = entry.getKey();
             JsonValue argValue = entry.getValue();
-            ArgumentMetadata argMetadata = metadata.arguments().get(argName);
+            ArgumentMetadata argMetadata = metadatas.get(argName);
             if (argMetadata != null) {
                 String json = jsonb.toJson(argValue);
-                results[argMetadata.index()] = jsonb.fromJson(json, argMetadata.type());
+                result.put(argName, jsonb.fromJson(json, argMetadata.type()));
             }
             argsProcessed.add(argName);
         }
 
-        validateProcessedArgs(argsProcessed, arguments.keySet());
+        validateProcessedArgs(argsProcessed, metadatas.keySet());
 
-        return results;
+        return result;
     }
 
     private void validateProcessedArgs(Set<String> processedArgs, Set<String> expectedArgs) {
@@ -122,7 +114,4 @@ public class McpToolCallParams {
         return !data.isEmpty() ? data : null;
     }
 
-    public Bean<?> getBean() {
-        return metadata.bean();
-    }
 }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/AsyncBeanMethodHandler.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/AsyncBeanMethodHandler.java
@@ -12,6 +12,7 @@ package io.openliberty.mcp.internal.tools;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
@@ -65,13 +66,11 @@ public class AsyncBeanMethodHandler extends BeanMethodHandler<CompletionStage<To
 
             return methodStage.thenApply(result -> createSuccessfulResponse(result))
                               .exceptionally(throwable -> {
-                                  if (throwable instanceof InvocationTargetException) {
+                                  if (throwable instanceof CompletionException) {
                                       throwable = throwable.getCause();
-                                      if (isBusinessException(throwable)) {
-                                          return createBusinessErrorResponse(throwable);
-                                      } else {
-                                          return createNonBusinessErrorResponse(throwable);
-                                      }
+                                  }
+                                  if (isBusinessException(throwable)) {
+                                      return createBusinessErrorResponse(throwable);
                                   } else {
                                       return createNonBusinessErrorResponse(throwable);
                                   }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/AsyncBeanMethodHandler.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/AsyncBeanMethodHandler.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.tools;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCErrorCode;
+import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCException;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArguments;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolDefinition;
+import io.openliberty.mcp.tools.ToolResponse;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.json.bind.Jsonb;
+
+/**
+ * A handler to call a bean method asynchronously, suitable for use with {@link ToolDefinition#setAsyncHandler(java.util.function.Function)}
+ */
+public class AsyncBeanMethodHandler extends BeanMethodHandler<CompletionStage<ToolResponse>> {
+
+    /**
+     * @param jsonb the Jsonb to use to encode a structured response
+     * @param bm the bean manager to use to look up the bean
+     * @param method metadata about the method to call
+     */
+    public AsyncBeanMethodHandler(Jsonb jsonb, BeanManager bm, MethodMetadata method) {
+        super(jsonb, bm, method);
+    }
+
+    @Override
+    @FFDCIgnore({ JSONRPCException.class, InvocationTargetException.class, IllegalAccessException.class, IllegalArgumentException.class, Throwable.class })
+    public CompletionStage<ToolResponse> apply(ToolArguments toolArgs) {
+        Object[] argsArray = constructArgsArray(toolArgs);
+        CreationalContext<Object> cc = bm.createCreationalContext(null);
+
+        try {
+            Object beanInstance = bm.getReference(method.bean(), method.bean().getBeanClass(), cc);
+
+            CompletionStage<?> methodStage;
+            try {
+                try {
+                    // Call the tool method
+                    methodStage = ((CompletionStage<?>) method.method().invoke(beanInstance, argsArray));
+                } catch (Throwable t) {
+                    releaseCc(cc);
+                    throw t;
+                }
+            } catch (IllegalAccessException e) {
+                throw new JSONRPCException(JSONRPCErrorCode.INTERNAL_ERROR, List.of("Could not call " + method.name()));
+            } catch (IllegalArgumentException e) {
+                throw new JSONRPCException(JSONRPCErrorCode.INVALID_PARAMS, List.of("Incorrect arguments in params"));
+            }
+
+            return methodStage.thenApply(result -> createSuccessfulResponse(result))
+                              .exceptionally(throwable -> {
+                                  if (throwable instanceof InvocationTargetException) {
+                                      throwable = throwable.getCause();
+                                      if (isBusinessException(throwable)) {
+                                          return createBusinessErrorResponse(throwable);
+                                      } else {
+                                          return createNonBusinessErrorResponse(throwable);
+                                      }
+                                  } else {
+                                      return createNonBusinessErrorResponse(throwable);
+                                  }
+                              })
+                              .whenComplete((result, throwable) -> releaseCc(cc));
+        } catch (JSONRPCException e) {
+            throw e;
+        } catch (InvocationTargetException e) {
+            Throwable t = e.getCause();
+            if (isBusinessException(t)) {
+                return CompletableFuture.completedStage(createBusinessErrorResponse(t));
+            } else {
+                return CompletableFuture.completedStage(createNonBusinessErrorResponse(t));
+            }
+        }
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/BeanMethodHandler.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/BeanMethodHandler.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.tools;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+import io.openliberty.mcp.content.Content;
+import io.openliberty.mcp.content.TextContent;
+import io.openliberty.mcp.internal.ToolMetadata.SpecialArgumentMetadata;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArguments;
+import io.openliberty.mcp.tools.ToolCallException;
+import io.openliberty.mcp.tools.ToolResponse;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.json.bind.Jsonb;
+
+/**
+ * Methods and data common to both {@link SyncBeanMethodHandler} and {@link AsyncBeanMethodHandler}
+ *
+ * @param <RESPONSE> the handler response type
+ */
+public abstract class BeanMethodHandler<RESPONSE> implements Function<ToolArguments, RESPONSE> {
+
+    private static final TraceComponent tc = Tr.register(BeanMethodHandler.class);
+
+    private Jsonb jsonb;
+    protected final BeanManager bm;
+    protected final MethodMetadata method;
+
+    /**
+     * The metadata needed to invoke a tool declared as a bean method
+     *
+     * @param name the tool name
+     * @param bean the bean where the tool is defined
+     * @param method the method which implements the tool
+     * @param isStructuredContent whether the tool returns structured content
+     * @param businessExceptions list of business exception types
+     * @param specialArguments special arguments required by the methods
+     * @param argNames an array corresponding to the method arguments. Each element contains either a name, in which case the argument with that name should be passed to the
+     *     parameter with the same index, or {@code null} in which case the parameter at that index expects a special argument.
+     *
+     */
+    public static record MethodMetadata(String name,
+                                        Bean<?> bean,
+                                        Method method,
+                                        boolean isStructuredContent,
+                                        List<Class<? extends Throwable>> businessExceptions,
+                                        List<SpecialArgumentMetadata> specialArguments,
+                                        String[] argNames) {}
+
+    /**
+     * @param jsonb the Jsonb to use to encode a structured response
+     * @param bm the bean manager to use to look up the bean
+     * @param method metadata about the method to call
+     */
+    public BeanMethodHandler(Jsonb jsonb, BeanManager bm, MethodMetadata method) {
+        super();
+        this.jsonb = jsonb;
+        this.bm = bm;
+        this.method = method;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public abstract RESPONSE apply(ToolArguments t);
+
+    protected Object[] constructArgsArray(ToolArguments t) {
+        Object[] argsArray = new Object[method.argNames().length];
+        int i = 0;
+        for (String name : method.argNames()) {
+            if (name != null) {
+                argsArray[i] = t.args().get(name);
+            }
+            i++;
+        }
+
+        for (SpecialArgumentMetadata specArg : method.specialArguments()) {
+            argsArray[specArg.index()] = switch (specArg.typeResolution().specialArgsType()) {
+                case CANCELLATION -> t.cancellation();
+                default -> throw new RuntimeException("Unknown arg"); //TODO FIX - possibly we can guarantee this is validated earlier
+            };
+        }
+        return argsArray;
+    }
+
+    protected ToolResponse createSuccessfulResponse(Object result) {
+        // Map method response to a ToolResponse
+        if (result instanceof ToolResponse response) {
+            return response;
+        } else if (result instanceof List<?> list && !list.isEmpty() && list.stream().allMatch(item -> item instanceof Content)) {
+            @SuppressWarnings("unchecked")
+            List<Content> contents = (List<Content>) list;
+            return ToolResponse.success(contents);
+        } else if (result instanceof Content content) {
+            return ToolResponse.success(content);
+        } else if (result instanceof String s) {
+            return ToolResponse.success(s);
+        } else if (method.isStructuredContent()) {
+            return new ToolResponse(false, List.of(new TextContent(jsonb.toJson(result))), result, null);
+        } else {
+            return ToolResponse.success(Objects.toString(result));
+        }
+    }
+
+    protected ToolResponse createBusinessErrorResponse(Throwable t) {
+        String msg = t.getMessage() != null ? t.getMessage() : t.getClass().getSimpleName();
+        return ToolResponse.error(msg);
+    }
+
+    protected ToolResponse createNonBusinessErrorResponse(Throwable t) {
+        Tr.error(tc,
+                 "CWMCM0010E.internal.server.error.detailed",
+                 method.name(),
+                 t);
+        return ToolResponse.error(Tr.formatMessage(tc, "CWMCM0011E.internal.server.error"));
+    }
+
+    protected boolean isBusinessException(Throwable t) {
+        if (t instanceof ToolCallException) {
+            return true;
+        }
+
+        for (Class<? extends Throwable> clazz : method.businessExceptions()) {
+            if (clazz.isAssignableFrom(t.getClass())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Release a creational context and log any errors
+     *
+     * @param cc the creational context
+     */
+    protected void releaseCc(CreationalContext<Object> cc) {
+        try {
+            cc.release();
+        } catch (Exception ex) {
+            Tr.warning(tc, "CWMCM0012E.bean.release.fail", ex, method.name());
+        }
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/SyncBeanMethodHandler.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/SyncBeanMethodHandler.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.tools;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCErrorCode;
+import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCException;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArguments;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolDefinition;
+import io.openliberty.mcp.tools.ToolResponse;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.json.bind.Jsonb;
+
+/**
+ * A handler to call a bean method synchronously, suitable for use with {@link ToolDefinition#setHandler(java.util.function.Function)}
+ */
+public class SyncBeanMethodHandler extends BeanMethodHandler<ToolResponse> {
+
+    /**
+     * @param jsonb the Jsonb to use to encode a structured response
+     * @param bm the bean manager to use to look up the bean
+     * @param method metadata about the method to call
+     */
+    public SyncBeanMethodHandler(Jsonb jsonb, BeanManager bm, MethodMetadata method) {
+        super(jsonb, bm, method);
+    }
+
+    @Override
+    @FFDCIgnore({ JSONRPCException.class, InvocationTargetException.class, IllegalAccessException.class, IllegalArgumentException.class })
+    public ToolResponse apply(ToolArguments toolArgs) {
+        Object[] argsArray = constructArgsArray(toolArgs);
+        CreationalContext<Object> cc = bm.createCreationalContext(null);
+
+        try {
+            Object beanInstance = bm.getReference(method.bean(), method.bean().getBeanClass(), cc);
+
+            Object result;
+            try {
+                // Call the tool method
+                result = method.method().invoke(beanInstance, argsArray);
+            } catch (IllegalAccessException e) {
+                throw new JSONRPCException(JSONRPCErrorCode.INTERNAL_ERROR, List.of("Could not call " + method.name()));
+            } catch (IllegalArgumentException e) {
+                throw new JSONRPCException(JSONRPCErrorCode.INVALID_PARAMS, List.of("Incorrect arguments in params"));
+            } finally {
+                releaseCc(cc);
+            }
+
+            return createSuccessfulResponse(result);
+
+        } catch (JSONRPCException e) {
+            throw e;
+        } catch (InvocationTargetException e) {
+            Throwable t = e.getCause();
+            if (isBusinessException(t)) {
+                return createBusinessErrorResponse(e.getCause());
+            } else {
+                return createNonBusinessErrorResponse(t);
+            }
+        }
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/ToolManager.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/ToolManager.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) contributors to https://github.com/quarkiverse/quarkus-mcp-server
+ * Copyright (c) 2025 IBM Corporation and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Based on https://github.com/quarkiverse/quarkus-mcp-server/blob/main/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
+ * Modifications have been made.
+ *******************************************************************************/
+package io.openliberty.mcp.internal.tools;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.openliberty.mcp.annotations.Tool;
+import io.openliberty.mcp.internal.features.FeatureManager;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolInfo;
+import io.openliberty.mcp.tools.ToolResponse;
+
+/**
+ * This manager can be used to obtain metadata and register a new tool programmatically.
+ */
+public interface ToolManager extends FeatureManager<ToolInfo> {
+
+    /**
+     *
+     * @param name
+     * @return the tool with the given name, or {@code null}
+     */
+    ToolInfo getTool(String name);
+
+    /**
+     *
+     * @param name The name must be unique
+     * @return a new definition builder
+     * @throws IllegalArgumentException if a tool with the given name already exits
+     * @see ToolDefinition#register()
+     */
+    ToolDefinition newTool(String name);
+
+    /**
+     * Removes a tool previously added with {@link #newTool(String)}.
+     *
+     * @return the removed tool or {@code null} if no such tool existed
+     */
+    ToolInfo removeTool(String name);
+
+    /**
+     * Tool info.
+     */
+    interface ToolInfo extends FeatureManager.FeatureInfo {
+
+        String title();
+
+        List<ToolArgument> arguments();
+
+        Optional<ToolAnnotations> annotations();
+
+    }
+
+    /**
+     * {@link ToolInfo} definition.
+     * <p>
+     * This construct is not thread-safe and should not be reused.
+     */
+    interface ToolDefinition extends FeatureDefinition<ToolInfo, ToolArguments, ToolResponse, ToolDefinition> {
+
+        /**
+         *
+         * @param name
+         * @param description
+         * @param required
+         * @param type
+         * @return self
+         */
+        default ToolDefinition addArgument(String name, String description, boolean required, java.lang.reflect.Type type) {
+            return addArgument(name, description, required, type, null);
+        }
+
+        /**
+         *
+         * @param name
+         * @param description
+         * @param required
+         * @param type
+         * @param defaultValue
+         * @return self
+         */
+        ToolDefinition addArgument(String name, String description, boolean required, java.lang.reflect.Type type,
+                                   String defaultValue);
+
+        /**
+         *
+         * @param annotations
+         * @return self
+         */
+        ToolDefinition setAnnotations(ToolAnnotations annotations);
+
+        /**
+         *
+         * @param title
+         * @return self
+         */
+        ToolDefinition setTitle(String title);
+
+        /**
+         * Generate the output schema for structured content from the given class.
+         *
+         * @param outputSchema
+         * @return self
+         */
+        ToolDefinition generateOutputSchema(Class<?> from);
+
+        /**
+         * @param schema
+         * @return self
+         */
+        ToolDefinition setOutputSchema(Object schema);
+
+        /**
+         * If not set the input schema is generated automatically.
+         *
+         * @param schema
+         * @return self
+         */
+        ToolDefinition setInputSchema(Object schema);
+
+        /**
+         * @return the tool info
+         * @throws IllegalArgumentException if a tool with the given name already exits
+         */
+        @Override
+        ToolInfo register();
+
+    }
+
+    public interface ToolArguments extends RequestFeatureArguments {
+
+        Map<String, Object> args();
+
+    }
+
+    record ToolArgument(String name, String description, boolean required, java.lang.reflect.Type type, String defaultValue) {}
+
+    /**
+     * @see Tool#annotations()
+     */
+    record ToolAnnotations(String title, boolean readOnlyHint, boolean destructiveHint, boolean idempotentHint,
+                           boolean openWorldHint) {}
+}

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/package-info.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/package-info.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ *
+ */
+@com.ibm.websphere.ras.annotation.TraceOptions(messageBundle = "io.openliberty.mcp.internal.resources.CWMCM", traceGroup = "MCP")
+package io.openliberty.mcp.internal.tools;

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/MessageParsingTest.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/MessageParsingTest.java
@@ -10,8 +10,8 @@
 package io.openliberty.mcp.internal.test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
 import java.math.BigDecimal;
@@ -91,7 +91,7 @@ public class MessageParsingTest {
         assertThat(request.id().value(), equalTo(new BigDecimal(2)));
         assertThat(request.getRequestMethod(), equalTo(RequestMethod.TOOLS_CALL));
         McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
-        assertThat(toolCallRequest.getArguments(jsonb), arrayContaining("Hello"));
+        assertEquals(Map.of("input", "Hello"), toolCallRequest.getArguments(jsonb));
     }
 
     @Test
@@ -338,7 +338,8 @@ public class MessageParsingTest {
                         """);
         McpRequest request = jsonb.fromJson(reader, McpRequest.class);
         McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
-        assertThat(toolCallRequest.getArguments(jsonb), arrayContaining(111, 222));
+
+        assertEquals(Map.of("num1", 111, "num2", 222), toolCallRequest.getArguments(jsonb));
     }
 
     @Test
@@ -358,7 +359,7 @@ public class MessageParsingTest {
                         """);
         McpRequest request = jsonb.fromJson(reader, McpRequest.class);
         McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
-        assertThat(toolCallRequest.getArguments(jsonb), arrayContaining(true));
+        assertEquals(Map.of("input", true), toolCallRequest.getArguments(jsonb));
     }
 
 }

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolMetadataTestUtility.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolMetadataTestUtility.java
@@ -11,6 +11,7 @@ package io.openliberty.mcp.internal.test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.openliberty.mcp.annotations.Tool;
 import io.openliberty.mcp.internal.ToolMetadata;
@@ -23,6 +24,16 @@ public class ToolMetadataTestUtility {
     public static ToolMetadata createFrom(Tool annotation, Map<String, ToolMetadata.ArgumentMetadata> arguments, List<ToolMetadata.SpecialArgumentMetadata> specialArguments) {
         // used for unit Tests that pre-populate argumentData and create Tools within the tests
         String title = annotation.title().isEmpty() ? null : annotation.title();
-        return new ToolMetadata(annotation, null, null, arguments, specialArguments, annotation.name(), title, annotation.description(), null, false, null, null);
+        return new ToolMetadata(annotation.name(),
+                                title,
+                                annotation.description(),
+                                arguments,
+                                ToolMetadata.readAnnotations(annotation.annotations()),
+                                false,
+                                null,
+                                null,
+                                t -> null,
+                                null,
+                                Optional.empty());
     }
 }

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/testutils/TestUtils.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/testutils/TestUtils.java
@@ -70,7 +70,7 @@ public class TestUtils {
     public static ToolMetadata findTool(Class<?> cls, String name) {
         List<ToolMetadata> tools = Arrays.stream(cls.getDeclaredMethods())
                                          .filter(m -> m.isAnnotationPresent(Tool.class))
-                                         .map(m -> ToolMetadata.createFrom(m.getAnnotation(Tool.class), null, new MockAnnotatedMethod<>(m)))
+                                         .map(m -> ToolMetadata.createFrom(m.getAnnotation(Tool.class), null, new MockAnnotatedMethod<>(m), null, null))
                                          .filter(m -> m.name().equals(name))
                                          .collect(Collectors.toList());
         if (tools.size() != 1) {

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/FATSuite.java
@@ -27,6 +27,7 @@ import io.openliberty.mcp.internal.fat.protocol.ProtocolVersionTest;
 import io.openliberty.mcp.internal.fat.statelessMode.StatefulModeTest;
 import io.openliberty.mcp.internal.fat.statelessMode.StatelessModeTest;
 import io.openliberty.mcp.internal.fat.tool.AsyncToolCancellationTest;
+import io.openliberty.mcp.internal.fat.tool.AsyncToolsErrorHandlingTest;
 import io.openliberty.mcp.internal.fat.tool.AsyncToolsTest;
 import io.openliberty.mcp.internal.fat.tool.CancellationTest;
 import io.openliberty.mcp.internal.fat.tool.DeploymentProblemTest;
@@ -43,6 +44,7 @@ import io.openliberty.mcp.internal.fat.tool.ToolTest;
 @SuiteClasses({
                 AsyncToolsTest.class,
                 AsyncToolCancellationTest.class,
+                AsyncToolsErrorHandlingTest.class,
                 AsyncToolLifecycleTest.class,
                 BeanLifecycleTest.class,
                 DeploymentProblemTest.class,

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AsyncToolsErrorHandlingTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AsyncToolsErrorHandlingTest.java
@@ -1,0 +1,247 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.tool;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.mcp.internal.fat.tool.asyncToolErrorHandlingApp.AsyncErrorHandlingTools;
+import io.openliberty.mcp.internal.fat.tool.asyncToolErrorHandlingApp.NonBusinessException;
+import io.openliberty.mcp.internal.fat.utils.McpClient;
+
+/**
+ *
+ */
+@RunWith(FATRunner.class)
+public class AsyncToolsErrorHandlingTest extends FATServletClient {
+
+    @Server("mcp-server-async")
+    public static LibertyServer server;
+
+    @Rule
+    public McpClient client = new McpClient(server, "/asyncToolErrorHandling");
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "asyncToolErrorHandling.war")
+                                   .addPackage(AsyncErrorHandlingTools.class.getPackage());
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer("CWMCM0010E"); // Tool threw non-business exception
+    }
+
+    @Before
+    public void markBeforeEachTest() throws Exception {
+        server.setMarkToEndOfLog();
+    }
+
+    @Test
+    public void testAsyncToolThrowsExceptionWrapped() throws Exception {
+        String response = callTool("BusinessException", "THROWN");
+        assertUserError(response, "BusinessException");
+    }
+
+    @Test
+    public void testAsyncToolThrowsExceptionWrappedBySuperclass() throws Exception {
+        String response = callTool("SpecificBusinessException", "THROWN");
+        assertUserError(response, "SpecificBusinessException");
+    }
+
+    @Test
+    public void testAsyncToolThrowsExceptionNotWrapped() throws Exception {
+        String response = callTool("NonBusinessException", "THROWN");
+        assertInternalError(response);
+        assertErrorLogged(NonBusinessException.class, "NonBusinessException");
+    }
+
+    @Test
+    public void testAsyncToolThrowsToolCallException() throws Exception {
+        String response = callTool("ToolCallException", "THROWN");
+        assertUserError(response, "ToolCallException");
+    }
+
+    @Test
+    public void testAsyncToolFailsWithExceptionWrapped() throws Exception {
+        String response = callTool("BusinessException", "FAILED");
+        assertUserError(response, "BusinessException");
+    }
+
+    @Test
+    public void testAsyncToolFailsWithExceptionWrappedBySuperclass() throws Exception {
+        String response = callTool("SpecificBusinessException", "FAILED");
+        assertUserError(response, "SpecificBusinessException");
+    }
+
+    @Test
+    public void testAsyncToolFailsWithExceptionNotWrapped() throws Exception {
+        String response = callTool("NonBusinessException", "FAILED");
+        assertInternalError(response);
+        assertErrorLogged(NonBusinessException.class, "NonBusinessException");
+    }
+
+    @Test
+    public void testAsyncToolFailsWithToolCallException() throws Exception {
+        String response = callTool("ToolCallException", "FAILED");
+        assertUserError(response, "ToolCallException");
+    }
+
+    @Test
+    public void testAsyncToolFailsWithDelayedExceptionWrapped() throws Exception {
+        String response = callTool("BusinessException", "FAILED_DELAY");
+        assertUserError(response, "BusinessException");
+    }
+
+    @Test
+    public void testAsyncToolFailsWithDelayedExceptionWrappedBySuperclass() throws Exception {
+        String response = callTool("SpecificBusinessException", "FAILED_DELAY");
+        assertUserError(response, "SpecificBusinessException");
+    }
+
+    @Test
+    public void testAsyncToolFailsWithDelayedExceptionNotWrapped() throws Exception {
+        String response = callTool("NonBusinessException", "FAILED_DELAY");
+        assertInternalError(response);
+        assertErrorLogged(NonBusinessException.class, "NonBusinessException");
+    }
+
+    @Test
+    public void testAsyncToolFailsWithDelayedToolCallException() throws Exception {
+        String response = callTool("NonBusinessException", "FAILED_DELAY");
+        assertInternalError(response);
+        assertErrorLogged(NonBusinessException.class, "NonBusinessException");
+    }
+
+    @Test
+    public void testAsyncToolMultistageFailsWithExceptionWrapped() throws Exception {
+        String response = callTool("BusinessException", "FAILED_MULTISTAGE");
+        assertUserError(response, "BusinessException");
+    }
+
+    @Test
+    public void testAsyncToolMultistageFailsWithExceptionWrappedBySuperclass() throws Exception {
+        String response = callTool("SpecificBusinessException", "FAILED_MULTISTAGE");
+        assertUserError(response, "SpecificBusinessException");
+    }
+
+    @Test
+    public void testAsyncToolMultistageFailsWithExceptionNotWrapped() throws Exception {
+        String response = callTool("NonBusinessException", "FAILED_MULTISTAGE");
+        assertInternalError(response);
+        assertErrorLogged(NonBusinessException.class, "NonBusinessException");
+    }
+
+    @Test
+    public void testAsyncToolMultistageFailsWithToolCallException() throws Exception {
+        String response = callTool("ToolCallException", "FAILED_MULTISTAGE");
+        assertUserError(response, "ToolCallException");
+    }
+
+    private static enum FailureMechanism {
+        /** Method throws exception */
+        THROW,
+        /** Method returns failed CompletionStage */
+        FAIL,
+        /** Method returns CompletionStage which later fails */
+        FAIL_DELAYED
+    };
+
+    private void doTest(Class<?> exceptionToThrow, FailureMechanism failureMechanism) {}
+
+    private void assertUserError(String response, String errorMessage) {
+        String expected = String.format("""
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 3,
+                          "result": {
+                            "content": [
+                              {
+                                "type": "text",
+                                "text": "%s"
+                              }
+                            ],
+                            "isError": true
+                          }
+                        }""",
+                                        errorMessage);
+        JSONAssert.assertEquals(expected, response, JSONCompareMode.STRICT);
+    }
+
+    private void assertInternalError(String response) {
+        String expected = """
+                          {
+                          "jsonrpc": "2.0",
+                          "id": 3,
+                          "result": {
+                            "content": [
+                              {
+                                "type": "text",
+                                "text": "CWMCM0011E: An internal server error occurred while running the tool."
+                              }
+                            ],
+                            "isError": true
+                          }
+                        }""";
+        JSONAssert.assertEquals(expected, response, JSONCompareMode.STRICT);
+    }
+
+    private void assertErrorLogged(Class<?> exceptionClass, String error) {
+        String logLine = server.waitForStringInLogUsingMark("CWMCM0010E");
+        assertThat(logLine,
+                   containsString("CWMCM0010E: The asyncErrorTool tool method threw an unexpected exception. The exception is " + exceptionClass.getName() + ": " + error));
+    }
+
+    private String callTool(String exceptionToThrow, String failureMechanism) throws Exception {
+        String request = String.format("""
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 3,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "asyncErrorTool",
+                            "arguments": {
+                              "exception": "%s",
+                              "failureMechanism": "%s"
+                            }
+                          }
+                        }
+                        """,
+                                       exceptionToThrow,
+                                       failureMechanism);
+
+        String response = client.callMCP(request);
+        Log.info(AsyncToolsErrorHandlingTest.class, "callTool", response);
+        return response;
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/asyncToolErrorHandlingApp/AsyncErrorHandlingTools.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/asyncToolErrorHandlingApp/AsyncErrorHandlingTools.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.tool.asyncToolErrorHandlingApp;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.openliberty.mcp.annotations.Tool;
+import io.openliberty.mcp.annotations.ToolArg;
+import io.openliberty.mcp.annotations.WrapBusinessError;
+import io.openliberty.mcp.tools.ToolCallException;
+import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class AsyncErrorHandlingTools {
+
+    @Resource
+    private ManagedScheduledExecutorService executor;
+
+    @Tool
+    @WrapBusinessError(BusinessException.class)
+    public CompletionStage<String> asyncErrorTool(@ToolArg String exception, @ToolArg String failureMechanism) throws Exception {
+        Supplier<? extends Exception> exceptionSupplier = switch (exception) {
+            case "BusinessException" -> () -> new BusinessException("BusinessException");
+            case "NonBusinessException" -> () -> new NonBusinessException("NonBusinessException");
+            case "SpecificBusinessException" -> () -> new SpecificBusinessException("SpecificBusinessException");
+            case "ToolCallException" -> () -> new ToolCallException("ToolCallException");
+            default -> throw new ToolCallException("Invalid exception type: " + exception);
+        };
+
+        CompletionStage<String> result = switch (failureMechanism) {
+            case "THROWN" -> throw exceptionSupplier.get();
+            case "FAILED" -> CompletableFuture.failedStage(exceptionSupplier.get());
+            case "FAILED_DELAY" -> delayedCS().thenCompose(ex -> CompletableFuture.failedStage(exceptionSupplier.get()));
+            case "FAILED_MULTISTAGE" -> CompletableFuture.<String> failedStage(exceptionSupplier.get())
+                                                         .thenApply(Function.identity())
+                                                         .thenApply(Function.identity())
+                                                         .thenApply(Function.identity());
+            default -> throw new ToolCallException("Invalid failure mechanism: " + failureMechanism);
+        };
+        return result;
+    }
+
+    /**
+     * Create a CompletionStage which completes after a delay.
+     * <p>
+     * Uses {@link ManagedScheduledExecutorService} to delay completion.
+     *
+     * @return CompletionStage which will complete in the future
+     */
+    private CompletionStage<String> delayedCS() {
+        CompletableFuture<String> cf = new CompletableFuture<>();
+        executor.schedule(() -> cf.complete("Delayed result"), 500, TimeUnit.MILLISECONDS);
+        return cf;
+    }
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/asyncToolErrorHandlingApp/BusinessException.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/asyncToolErrorHandlingApp/BusinessException.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.tool.asyncToolErrorHandlingApp;
+
+public class BusinessException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public BusinessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BusinessException(String message) {
+        super(message);
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/asyncToolErrorHandlingApp/NonBusinessException.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/asyncToolErrorHandlingApp/NonBusinessException.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.tool.asyncToolErrorHandlingApp;
+
+public class NonBusinessException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public NonBusinessException(String message) {
+        super(message);
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/asyncToolErrorHandlingApp/SpecificBusinessException.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/asyncToolErrorHandlingApp/SpecificBusinessException.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.tool.asyncToolErrorHandlingApp;
+
+public class SpecificBusinessException extends BusinessException {
+
+    private static final long serialVersionUID = 1L;
+
+    public SpecificBusinessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SpecificBusinessException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
This is preparatory work for supporting tools registered programatically without an annotated method.

- Add classes from quarkus-mcp: FeatureManager, ToolManager
- Split out the fields from ToolMetadata which are needed to call the method into MethodMetadata
- Create handlers for calling a bean method: SyncBeanMethodHandler, AsyncBeanMethodHandler. Much of the code here is moved from McpServlet.
- Move the Jsonb instance into McpCdiExtension since it's now needed to create the method handler at startup
- Update McpServlet.callTool to call the tool handlers
- Remove requestId from CancellationImpl as it was unused
- Make McpToolCallParams return a map of arguments rather than an array
- Fix areas of the code which were using the Tool annotation directly
- Update test utilities which create ToolMetadata

Also noticed an issue that we're not correctly handling Async tool business exceptions, so I've added tests and fixed that.

Part of #33351 
Fixes #33513

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
