### PR TITLE
Improve com.ibm.ws.jsf.2.2_fat Selenium Testing Reliabiility 

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
@@ -104,7 +104,7 @@ public class FATSuite extends TestContainerSuite {
                     .andWith(FeatureReplacementAction.EE11_FEATURES());
 
     
-    public static DockerImageName getChromeImage() {
+    private static DockerImageName getChromeImage() {
         if (FATRunner.ARM_ARCHITECTURE) {
             return DockerImageName.parse("seleniarm/standalone-chromium:4.8.3").asCompatibleSubstituteFor("selenium/standalone-chrome");
         } else {

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
@@ -9,7 +9,6 @@
  *******************************************************************************/
 package com.ibm.ws.jsf22.fat;
 
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -21,6 +20,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.fat.util.FatLogHandler;
 import com.ibm.ws.jsf22.fat.tests.JSF22AppConfigPopTests;
 import com.ibm.ws.jsf22.fat.tests.JSF22ClientWindowTests;
@@ -47,11 +47,6 @@ import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
 import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
-
-import com.ibm.websphere.simplicity.log.Log;
-
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.testcontainers.containers.BrowserWebDriverContainer;
 /**
  * JSF 2.2 Tests
  *

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,11 +9,16 @@
  *******************************************************************************/
 package com.ibm.ws.jsf22.fat;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import com.ibm.ws.fat.util.FatLogHandler;
@@ -40,7 +45,13 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
+import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
+import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
 
+import com.ibm.websphere.simplicity.log.Log;
+
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.testcontainers.containers.BrowserWebDriverContainer;
 /**
  * JSF 2.2 Tests
  *
@@ -81,6 +92,12 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite extends TestContainerSuite {
 
+    private static final Class<?> c = FATSuite.class;
+
+    private static BrowserWebDriverContainer<?> CHROME_CONTAINER = null;
+
+    private static ExtendedWebDriver DRIVER;
+
     // EE10 requires Java 11.
     // EE11 requires Java 17
     // If we only specify EE10/EE11 for lite mode it will cause no tests to run with lower Java versions which causes an error.
@@ -91,6 +108,7 @@ public class FATSuite extends TestContainerSuite {
                     .andWith(FeatureReplacementAction.EE10_FEATURES().conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17))
                     .andWith(FeatureReplacementAction.EE11_FEATURES());
 
+    
     public static DockerImageName getChromeImage() {
         if (FATRunner.ARM_ARCHITECTURE) {
             return DockerImageName.parse("seleniarm/standalone-chromium:4.8.3").asCompatibleSubstituteFor("selenium/standalone-chrome");
@@ -99,12 +117,60 @@ public class FATSuite extends TestContainerSuite {
         }
     }
 
+    public static ExtendedWebDriver getWebDriver() throws Exception {
+        int retryCount = 3;
+        while(DRIVER == null && retryCount > 0) {
+            Log.info(c, "getWebDriver", "Attempting to initialize WebDriver, attempts remaining: " + retryCount);
+            try {
+                CHROME_CONTAINER = new BrowserWebDriverContainer<>(getChromeImage()).withCapabilities(new ChromeOptions())
+                            .withAccessToHost(true)
+                            .withSharedMemorySize(2147483648L); // avoids "message":"Duplicate mount point: /dev/shm"
+                CHROME_CONTAINER.start();
+                DRIVER = new CustomDriver(new RemoteWebDriver(CHROME_CONTAINER.getSeleniumAddress(), new ChromeOptions().setAcceptInsecureCerts(true)));
+            } catch (Exception ex1) {
+                Log.info(c, "getWebDriver", "Failed to initialize WebDriver on attempt. Exception: " + ex1.getMessage(), ex1);
+                retryCount--;
+                try {
+                    Thread.sleep(10000); // wait for 10 seconds before retrying
+                } catch (InterruptedException ie) {}
+            }
+        }
+        if(DRIVER == null) {
+            throw new Exception("Failed to initialize WebDriver after multiple attempts! See log for details.");
+        }
+        return DRIVER;
+    }
+
     /**
      * @see {@link FatLogHandler#generateHelpFile()}
      */
     @BeforeClass
     public static void generateHelpFile() {
         FatLogHandler.generateHelpFile();
+    }
+
+    /*
+     * Tear down the WebDriver and Chrome container after all tests have run.
+     */
+    @AfterClass
+    public static void tearDownWebDriver() {
+        Log.info(c, "tearDownWebDriver", "Tearing down WebDriver and Chrome container.");
+        if (DRIVER != null) {
+            try {
+                DRIVER.quit(); // closes all sessions and terminutes the webdriver
+            } catch (Exception e) {
+                Log.info(c, "tearDownWebDriver", "Exception occurred while quitting WebDriver: " + e.getMessage(), e);
+            }
+            DRIVER = null;
+        }
+        if (CHROME_CONTAINER != null) {
+            try {
+                CHROME_CONTAINER.stop();
+            } catch (Exception e) {
+                Log.info(c, "tearDownWebDriver", "Exception occurred while stopping Chrome container: " + e.getMessage(), e);
+            }
+            CHROME_CONTAINER = null;
+        }
     }
 
 }

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ClientWindowTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ClientWindowTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,16 +22,11 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.Testcontainers;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jsf22.fat.FATSuite;
 import com.ibm.ws.jsf22.fat.JSFUtils;
-import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
-import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
-import io.openliberty.faces.fat.selenium.util.internal.WebPage;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -39,6 +34,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEEAction;
 import componenttest.topology.impl.LibertyServer;
+import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
+import io.openliberty.faces.fat.selenium.util.internal.WebPage;
 
 /**
  * Tests to execute on the jsfTestServer2 that use HtmlUnit.

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ClientWindowTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ClientWindowTests.java
@@ -16,9 +16,7 @@ import java.util.ArrayList;
 
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -27,7 +25,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.Testcontainers;
-import org.testcontainers.containers.BrowserWebDriverContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jsf22.fat.FATSuite;
@@ -60,13 +57,7 @@ public class JSF22ClientWindowTests {
 
     @Server("jsfTestServer2")
     public static LibertyServer jsfTestServer2;
-
-    @ClassRule
-    public static BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>(FATSuite.getChromeImage()).withCapabilities(new ChromeOptions())
-                    .withAccessToHost(true)
-                    .withSharedMemorySize(2147483648L); // avoids "message":"Duplicate mount point: /dev/shm"
-
-
+    
     private static ExtendedWebDriver driver;
 
     @BeforeClass
@@ -85,7 +76,7 @@ public class JSF22ClientWindowTests {
 
         Testcontainers.exposeHostPorts(jsfTestServer2.getHttpDefaultPort(), jsfTestServer2.getHttpDefaultSecurePort());
 
-        driver = new CustomDriver(new RemoteWebDriver(chrome.getSeleniumAddress(), new ChromeOptions().setAcceptInsecureCerts(true)));
+        driver = FATSuite.getWebDriver();
     }
 
     @AfterClass
@@ -94,7 +85,6 @@ public class JSF22ClientWindowTests {
         if (jsfTestServer2 != null && jsfTestServer2.isStarted()) {
             jsfTestServer2.stopServer();
         }
-        driver.quit(); // closes all sessions and terminutes the webdriver
     }
 
     /*

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ComponentTesterTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ComponentTesterTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,16 +16,12 @@ import java.net.URL;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.Testcontainers;
-import org.testcontainers.containers.BrowserWebDriverContainer;
 
 import com.gargoylesoftware.htmlunit.BrowserVersion;
 import com.gargoylesoftware.htmlunit.NicelyResynchronizingAjaxController;
@@ -35,9 +31,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jsf22.fat.FATSuite;
 import com.ibm.ws.jsf22.fat.JSFUtils;
-import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
-import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
-import io.openliberty.faces.fat.selenium.util.internal.WebPage;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -45,6 +38,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEEAction;
 import componenttest.topology.impl.LibertyServer;
+import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
+import io.openliberty.faces.fat.selenium.util.internal.WebPage;
 import junit.framework.Assert;
 
 /**

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ComponentTesterTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ComponentTesterTests.java
@@ -65,11 +65,7 @@ public class JSF22ComponentTesterTests {
     @Server("jsfTestServer2")
     public static LibertyServer jsfTestServer2;
 
-    @ClassRule
-    public static BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>(FATSuite.getChromeImage()).withCapabilities(new ChromeOptions())
-                    .withAccessToHost(true)
-                    .withSharedMemorySize(2147483648L); // avoids "message":"Duplicate mount point: /dev/shm"
-
+    private static ExtendedWebDriver driver;
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -82,6 +78,8 @@ public class JSF22ComponentTesterTests {
         jsfTestServer2.startServer(c.getSimpleName() + ".log");
 
         Testcontainers.exposeHostPorts(jsfTestServer2.getHttpDefaultPort(), jsfTestServer2.getHttpDefaultSecurePort());
+
+        driver = FATSuite.getWebDriver();
     }
 
     @AfterClass
@@ -243,9 +241,6 @@ public class JSF22ComponentTesterTests {
      */
     @Test
     public void JSF22ComponentTester_TestCommandLinkOrder() throws Exception {
-
-        ExtendedWebDriver driver = new CustomDriver(new RemoteWebDriver(chrome.getSeleniumAddress(), new ChromeOptions().setAcceptInsecureCerts(true)));
-
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "testActionListenerOrder.xhtml");
         WebPage page = new WebPage(driver);
         page.get(url);

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22InputFileTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22InputFileTests.java
@@ -55,9 +55,7 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.Testcontainers;
-import org.testcontainers.containers.BrowserWebDriverContainer;
 
-import com.ibm.ws.jsf22.fat.JSFUtils;
 import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
 import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
 import io.openliberty.faces.fat.selenium.util.internal.WebPage;
@@ -77,15 +75,10 @@ public class JSF22InputFileTests {
 
     protected static final Class<?> c = JSF22InputFileTests.class;
 
-    private static ExtendedWebDriver driver;
-
-    @ClassRule
-    public static BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>(FATSuite.getChromeImage()).withCapabilities(new ChromeOptions())
-                    .withAccessToHost(true)
-                    .withSharedMemorySize(2147483648L); // avoids "message":"Duplicate mount point: /dev/shm"
-
     @Server("jsfTestServer2")
     public static LibertyServer jsfTestServer2;
+
+    private static ExtendedWebDriver driver;
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -98,9 +91,9 @@ public class JSF22InputFileTests {
 
         Testcontainers.exposeHostPorts(jsfTestServer2.getHttpDefaultPort(), jsfTestServer2.getHttpDefaultSecurePort());
 
-        driver = new CustomDriver(new RemoteWebDriver(chrome.getSeleniumAddress(), new ChromeOptions().setAcceptInsecureCerts(true)));
+        driver = FATSuite.getWebDriver();
 
-        driver.getRemoteWebDriver().setFileDetector(new LocalFileDetector());
+        driver.getRemoteWebDriver().setFileDetector(new LocalFileDetector()); // could be reset during the tear down, but not necessary
     }
 
     @AfterClass
@@ -109,8 +102,6 @@ public class JSF22InputFileTests {
         if (jsfTestServer2 != null && jsfTestServer2.isStarted()) {
             jsfTestServer2.stopServer();
         }
-
-        driver.quit(); // closes all sessions and terminutes the webdriver
     }
 
     @After

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22InputFileTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22InputFileTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,8 @@
  *******************************************************************************/
 package com.ibm.ws.jsf22.fat.tests;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,25 +18,23 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Iterator;
-import java.util.List;
-
 
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.testcontainers.Testcontainers;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlFileInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
-
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jsf22.fat.FATSuite;
@@ -48,15 +46,6 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEEAction;
 import componenttest.topology.impl.LibertyServer;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.LocalFileDetector;
-import org.openqa.selenium.remote.RemoteWebDriver;
-import org.testcontainers.Testcontainers;
-
-import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
 import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
 import io.openliberty.faces.fat.selenium.util.internal.WebPage;
 

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFCompELTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFCompELTests.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -25,7 +24,6 @@ import org.junit.runner.RunWith;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.Testcontainers;
-import org.testcontainers.containers.BrowserWebDriverContainer;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
@@ -62,11 +60,6 @@ public class JSFCompELTests {
 
     @Server("jsfTestServer2")
     public static LibertyServer jsfTestServer2;
-
-    @ClassRule
-    public static BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>(FATSuite.getChromeImage()).withCapabilities(new ChromeOptions())
-                    .withAccessToHost(true)
-                    .withSharedMemorySize(2147483648L); // avoids "message":"Duplicate mount point: /dev/shm"
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -263,16 +256,12 @@ public class JSFCompELTests {
     @Test
     public void testAjaxEvent() throws Exception {
         // Fix the response once RTC is fixed
-
-        ExtendedWebDriver driver = new CustomDriver(new RemoteWebDriver(chrome.getSeleniumAddress(), new ChromeOptions().setAcceptInsecureCerts(true)));
-
+        ExtendedWebDriver driver = FATSuite.getWebDriver();
         String url = JSFUtils.createSeleniumURLString(jsfTestServer2, contextRoot, "AjaxEvent.xhtml");
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();
-
         assertTrue("true not found in page", page.isInPage("true"));
-
     }
 
 }

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFCompELTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFCompELTests.java
@@ -21,8 +21,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.Testcontainers;
 
 import com.gargoylesoftware.htmlunit.WebClient;
@@ -40,7 +38,6 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.JakartaEEAction;
 import componenttest.topology.impl.LibertyServer;
-import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
 import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
 import io.openliberty.faces.fat.selenium.util.internal.WebPage;
 import junit.framework.Assert;


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

For #33382

Rather than initialize the drivers per test class, it will be done per FAT bucket (i.e within FATSuite). Additionally, I've included retry behavior for scenarios where exceptions do occur. 

If the driver is null, then I throw an exception and hopefully one common defect will be used (rather than one for each test method or test class). 