### PR TITLE
use 3.2 spec-defined setCacheRetrieveMode instead of query hint

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -37,7 +37,6 @@ import jakarta.data.exceptions.DataException;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Cursor;
-import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
@@ -128,11 +127,6 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
         if (queryInfo.entityInfo.loadGraph != null)
             query.setHint(Util.LOADGRAPH, queryInfo.entityInfo.loadGraph);
 
-        // TODO #33189 why are EntityManager.setCacheRetrieveMode and
-        // Query.setCacheRetrieveMode unable to set this instead?
-        query.setHint("jakarta.persistence.cache.retrieveMode",
-                      CacheRetrieveMode.BYPASS);
-
         query.setFirstResult(firstResult);
         query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1)); // extra position is for knowing whether to expect another page
 
@@ -181,11 +175,6 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
                 Tr.debug(this, tc, "query for count: " + queryInfo.jpqlCount);
             TypedQuery<Long> query = em.createQuery(queryInfo.jpqlCount, Long.class);
             queryInfo.setParameters(query, args);
-
-            // TODO #33189 why are EntityManager.setCacheRetrieveMode and
-            // Query.setCacheRetrieveMode unable to set this instead?
-            query.setHint("jakarta.persistence.cache.retrieveMode",
-                          CacheRetrieveMode.BYPASS);
 
             return query.getSingleResult();
         } catch (Exception x) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -30,7 +30,6 @@ import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Mode;
-import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
@@ -107,11 +106,6 @@ public class PageImpl<T> implements Page<T> {
         if (queryInfo.entityInfo.loadGraph != null)
             query.setHint(Util.LOADGRAPH, queryInfo.entityInfo.loadGraph);
 
-        // TODO #33189 why are EntityManager.setCacheRetrieveMode and
-        // Query.setCacheRetrieveMode unable to set this instead?
-        query.setHint("jakarta.persistence.cache.retrieveMode",
-                      CacheRetrieveMode.BYPASS);
-
         int maxPageSize = pageRequest.size();
         query.setFirstResult(queryInfo.computeOffset(pageRequest));
         query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1));
@@ -157,11 +151,6 @@ public class PageImpl<T> implements Page<T> {
                 Tr.debug(this, tc, "query for count: " + queryInfo.jpqlCount);
             TypedQuery<Long> query = em.createQuery(queryInfo.jpqlCount, Long.class);
             queryInfo.setParameters(query, args);
-
-            // TODO #33189 why are EntityManager.setCacheRetrieveMode and
-            // Query.setCacheRetrieveMode unable to set this instead?
-            query.setHint("jakarta.persistence.cache.retrieveMode",
-                          CacheRetrieveMode.BYPASS);
 
             return query.getSingleResult();
         } catch (Exception x) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -95,7 +95,6 @@ import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
-import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.TypedQuery;
@@ -912,11 +911,6 @@ public class QueryInfo {
         TypedQuery<Long> query = em.createQuery(jpql, Long.class);
         setParameters(query, args);
 
-        // TODO #33189 why are EntityManager.setCacheRetrieveMode and
-        // Query.setCacheRetrieveMode unable to set this instead?
-        query.setHint("jakarta.persistence.cache.retrieveMode",
-                      CacheRetrieveMode.BYPASS);
-
         Long count = query.getSingleResult();
 
         Object returnValue;
@@ -1700,11 +1694,6 @@ public class QueryInfo {
         query.setMaxResults(1);
         setParameters(query, args);
 
-        // TODO #33189 why are EntityManager.setCacheRetrieveMode and
-        // Query.setCacheRetrieveMode unable to set this instead?
-        query.setHint("jakarta.persistence.cache.retrieveMode",
-                      CacheRetrieveMode.BYPASS);
-
         List<?> results = query.getResultList();
         boolean found = !results.isEmpty();
 
@@ -1919,11 +1908,6 @@ public class QueryInfo {
 
             if (entityInfo.loadGraph != null)
                 query.setHint(Util.LOADGRAPH, entityInfo.loadGraph);
-
-            // TODO #33189 why are EntityManager.setCacheRetrieveMode and
-            // Query.setCacheRetrieveMode unable to set this instead?
-            query.setHint("jakarta.persistence.cache.retrieveMode",
-                          CacheRetrieveMode.BYPASS);
 
             if (type == FIND_AND_DELETE)
                 query.setLockMode(LockModeType.PESSIMISTIC_WRITE);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/provider/PUnitEMBuilder.java
@@ -27,6 +27,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.EntityManagerBuilder;
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceException;
@@ -70,6 +71,7 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
     @Trivial
     public EntityManager createEntityManager() {
         EntityManager em = emf.createEntityManager();
+        em.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "createEntityManager: " + em);

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -83,6 +83,7 @@ import io.openliberty.data.internal.persistence.EntityManagerBuilder;
 import io.openliberty.data.internal.persistence.Util;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.MappingException;
+import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
@@ -580,6 +581,7 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
     @Trivial
     public EntityManager createEntityManager() {
         EntityManager em = persistenceServiceUnit.createEntityManager();
+        em.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "createEntityManager: " + em);

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreTestServlet.java
@@ -265,8 +265,7 @@ public class DataStoreTestServlet extends FATServlet {
 
         tx.begin();
         try (EntityManager em = persistenceUnitRepo.entityManager()) {
-            // TODO #33189 the following is not honored:
-            //em.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
+            em.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
 
             Query update = em.createQuery("""
                             UPDATE PersistenceUnitEntity
@@ -281,13 +280,6 @@ public class DataStoreTestServlet extends FATServlet {
                              WHERE id = ?1
                             """);
             query.setParameter(1, id);
-
-            // TODO #33189 the following is not honored:
-            // query.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
-            // TODO #33189 should be able to replace the following setHint with either
-            // of the preceding TODOs that use em/query.setCacheRetrieveMode.
-            query.setHint("jakarta.persistence.cache.retrieveMode",
-                          CacheRetrieveMode.BYPASS);
 
             List<?> results = query.getResultList();
             assertEquals(1,


### PR DESCRIPTION
Now that the bug with EntityManager/Query.setCacheRetriveMode has been fixed (by an Open Liberty overlay of EclipseLink that the JPA team is working on merging into EclipseLink), switch to using setCacheRetrieveMode rather than the workaround that sets the value as a query hint.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
