### PR TITLE
add missing idp metadata for shib idp 3.3.1 for jdk 8 test runs

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/conf/metadata-providers.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/conf/metadata-providers.xml
@@ -67,7 +67,7 @@
 	<!--
     <MetadataProvider id="LocalMetadata"  xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spMetadata.xml"/>
 	-->
-<!--   -->     
+<!--   -->
 <MetadataProvider id="chain" xsi:type="ChainingMetadataProvider">
     <MetadataProvider id="spMetadata1" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp1Metadata.xml"/>
     <MetadataProvider id="spMetadata1s2" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp1s2Metadata.xml"/>
@@ -80,6 +80,10 @@
     <MetadataProvider id="spMetadataDefaultSP" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/defaultSPMetadata.xml"/>
     <MetadataProvider id="spMetadata_enc_sha1" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp_enc_sha1Metadata.xml"/>
     <MetadataProvider id="spMetadata_enc_aes128" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp_enc_aes128Metadata.xml"/>
+    <MetadataProvider id="spMetadata_enc_aes128_ec" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp_enc_aes128_ecMetadata.xml"/>
+    <MetadataProvider id="spMetadata_enc_ecdsaSP_rsaIDP" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp_enc_ecdsaSP_rsaIDP_Metadata.xml"/>
+    <MetadataProvider id="spMetadata_enc_rsaSP_ecdsaIDP" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp_enc_rsaSP_ecdsaIDP_Metadata.xml"/>
+    <MetadataProvider id="spMetadata_enc_aes128_no_sign" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp_enc_aes128_nosignatureMetadata.xml"/>
     <MetadataProvider id="spMetadata_enc_aes256" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp_enc_aes256Metadata.xml"/>
     <MetadataProvider id="spMetadata_enc_aes192" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp_enc_aes192Metadata.xml"/>
     <MetadataProvider id="spMetadata_enc_aes256_mismatch" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/sp_enc_aes256MisMatchMetadata.xml"/>
@@ -87,23 +91,23 @@
     <MetadataProvider id="spMetadata_dash" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spDashMetadata.xml"/>
     <MetadataProvider id="spMetadata_OP" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spOPMetadata.xml"/>
     <MetadataProvider id="spMetadata_underscore" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spUnderscoreMetadata.xml"/>
-	<MetadataProvider id="spMetadataNameIdCustomize" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDCustomizeMetaData.xml"/>
-	<MetadataProvider id="spMetadataNameIdEncrypted" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDEncryptedMetaData.xml"/>
-	<MetadataProvider id="spMetadataNameIdEntity" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDEntityMetaData.xml"/>
-	<MetadataProvider id="spMetadataNameIdKerberos" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDKerberosMetaData.xml"/>
-	<MetadataProvider id="spMetadataNameIdPersistent" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDPersistentMetaData.xml"/>
-	<MetadataProvider id="spMetadataNameIdTransient" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDTransientMetaData.xml"/>
-	<MetadataProvider id="spMetadataNameIdWindowsDomain" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDWindowsDomainMetaData.xml"/>
-	<MetadataProvider id="spMetadataNameIdX590SubjectName" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDX509SubjectNameMetaData.xml"/>
+    <MetadataProvider id="spMetadataNameIdCustomize" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDCustomizeMetaData.xml"/>
+    <MetadataProvider id="spMetadataNameIdEncrypted" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDEncryptedMetaData.xml"/>
+    <MetadataProvider id="spMetadataNameIdEntity" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDEntityMetaData.xml"/>
+    <MetadataProvider id="spMetadataNameIdKerberos" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDKerberosMetaData.xml"/>
+    <MetadataProvider id="spMetadataNameIdPersistent" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDPersistentMetaData.xml"/>
+    <MetadataProvider id="spMetadataNameIdTransient" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDTransientMetaData.xml"/>
+    <MetadataProvider id="spMetadataNameIdWindowsDomain" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDWindowsDomainMetaData.xml"/>
+    <MetadataProvider id="spMetadataNameIdX590SubjectName" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spNameIDX509SubjectNameMetaData.xml"/>
     <MetadataProvider id="spMetadataabsExternalURL" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/customLogout_absExternalURLMetadata.xml"/>
     <MetadataProvider id="spMetadataabsLocalURL" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/customLogout_absLocalURLMetadata.xml"/>
     <MetadataProvider id="spMetadataemptyString" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/customLogout_emptyStringMetadata.xml"/>
     <MetadataProvider id="spMetadatainvalidRelativePath" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/customLogout_invalidRelativePathMetadata.xml"/>
     <MetadataProvider id="spMetadatainvalidURL" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/customLogout_invalidURLMetadata.xml"/>
-	<MetadataProvider id="spMetadatarelativePath" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/customLogout_relativePathMetadata.xml"/>
-	<MetadataProvider id="spMetadata1server2" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/server2sp1Metadata.xml"/>
-	<MetadataProvider id="spMetadata2server2" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/server2sp2Metadata.xml"/>
-	<MetadataProvider id="spShortLifetime" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spShortLifetimeMetadata.xml"/>
-</MetadataProvider>  
-<!--   --> 
+    <MetadataProvider id="spMetadatarelativePath" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/customLogout_relativePathMetadata.xml"/>
+    <MetadataProvider id="spMetadata1server2" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/server2sp1Metadata.xml"/>
+    <MetadataProvider id="spMetadata2server2" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/server2sp2Metadata.xml"/>
+    <MetadataProvider id="spShortLifetime" xsi:type="FilesystemMetadataProvider" metadataFile="%{idp.home}/metadata/spShortLifetimeMetadata.xml"/>
+</MetadataProvider>
+<!--   -->
 </MetadataProvider>

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/metadata/sp_enc_aes128_ecMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/metadata/sp_enc_aes128_ecMetadata.xml.orig
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor
+	xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+	entityID="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_aes128_ec"
+>
+	<md:SPSSODescriptor
+		AuthnRequestsSigned="false"
+		WantAssertionsSigned="true"
+		protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"
+	>
+
+		<md:KeyDescriptor use="signing">
+			<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+				<ds:X509Data>
+					<ds:X509Certificate>MIIB3TCCAYOgAwIBAgIIGU+b9RssTr8wCgYIKoZIzj0EAwIwYzELMAkGA1UEBhMC
+dXMxDjAMBgNVBAgTBXRleGFzMQ8wDQYDVQQHEwZhdXN0aW4xDDAKBgNVBAoTA2li
+bTERMA8GA1UECxMIcnVudGltZXMxEjAQBgNVBAMTCWxvY2FsdXNlcjAeFw0yNTA4
+MzEyMjA2MTRaFw0zNTA4MjkyMjA2MTRaMGMxCzAJBgNVBAYTAnVzMQ4wDAYDVQQI
+EwV0ZXhhczEPMA0GA1UEBxMGYXVzdGluMQwwCgYDVQQKEwNpYm0xETAPBgNVBAsT
+CHJ1bnRpbWVzMRIwEAYDVQQDEwlsb2NhbHVzZXIwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAAR+jgDNLh1vVCABhMMMrtlcyGv2d0UmymnbxcR7wAfv0MadsBJAk6Dr
+7JNDInnYYrpOKL14sbUnefG5N4hBE7CCoyEwHzAdBgNVHQ4EFgQU8qJz/5pgTAr3
+5Spkt3EKWiVIYm4wCgYIKoZIzj0EAwIDSAAwRQIgGz08ZBkU30de6sOZHTDBJZt2
+tbUw5iLzXep02KBHrLoCIQC8jkUyBRLdd4z1mBKDSl07Q6Ex7n9APYHfqYwQ8/Hf
+8g==
+					</ds:X509Certificate>
+				</ds:X509Data>
+			</ds:KeyInfo>
+		</md:KeyDescriptor>
+
+		<md:KeyDescriptor use="encryption">
+			<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+				<ds:X509Data>
+					<ds:X509Certificate>MIIB3TCCAYOgAwIBAgIIGU+b9RssTr8wCgYIKoZIzj0EAwIwYzELMAkGA1UEBhMC
+dXMxDjAMBgNVBAgTBXRleGFzMQ8wDQYDVQQHEwZhdXN0aW4xDDAKBgNVBAoTA2li
+bTERMA8GA1UECxMIcnVudGltZXMxEjAQBgNVBAMTCWxvY2FsdXNlcjAeFw0yNTA4
+MzEyMjA2MTRaFw0zNTA4MjkyMjA2MTRaMGMxCzAJBgNVBAYTAnVzMQ4wDAYDVQQI
+EwV0ZXhhczEPMA0GA1UEBxMGYXVzdGluMQwwCgYDVQQKEwNpYm0xETAPBgNVBAsT
+CHJ1bnRpbWVzMRIwEAYDVQQDEwlsb2NhbHVzZXIwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAAR+jgDNLh1vVCABhMMMrtlcyGv2d0UmymnbxcR7wAfv0MadsBJAk6Dr
+7JNDInnYYrpOKL14sbUnefG5N4hBE7CCoyEwHzAdBgNVHQ4EFgQU8qJz/5pgTAr3
+5Spkt3EKWiVIYm4wCgYIKoZIzj0EAwIDSAAwRQIgGz08ZBkU30de6sOZHTDBJZt2
+tbUw5iLzXep02KBHrLoCIQC8jkUyBRLdd4z1mBKDSl07Q6Ex7n9APYHfqYwQ8/Hf
+8g==
+					</ds:X509Certificate>
+				</ds:X509Data>
+			</ds:KeyInfo>
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-gcm">
+			</md:EncryptionMethod>
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128">
+			</md:EncryptionMethod>
+		</md:KeyDescriptor>
+
+		<md:SingleLogoutService
+			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_aes128_ec/slo"
+			Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" />		
+		<md:AssertionConsumerService
+			Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_aes128_ec/acs"
+			index="0"
+			isDefault="true" />
+	</md:SPSSODescriptor>
+</md:EntityDescriptor>

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/metadata/sp_enc_aes128_nosignatureMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/metadata/sp_enc_aes128_nosignatureMetadata.xml.orig
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor
+	xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+	entityID="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_aes128_no_sign"
+>
+	<md:SPSSODescriptor
+		AuthnRequestsSigned="false"
+		WantAssertionsSigned="false"
+		protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"
+	>
+
+		<md:KeyDescriptor use="encryption">
+			<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+				<ds:X509Data>
+					<ds:X509Certificate>MIIB3TCCAYOgAwIBAgIIGU+b9RssTr8wCgYIKoZIzj0EAwIwYzELMAkGA1UEBhMC
+dXMxDjAMBgNVBAgTBXRleGFzMQ8wDQYDVQQHEwZhdXN0aW4xDDAKBgNVBAoTA2li
+bTERMA8GA1UECxMIcnVudGltZXMxEjAQBgNVBAMTCWxvY2FsdXNlcjAeFw0yNTA4
+MzEyMjA2MTRaFw0zNTA4MjkyMjA2MTRaMGMxCzAJBgNVBAYTAnVzMQ4wDAYDVQQI
+EwV0ZXhhczEPMA0GA1UEBxMGYXVzdGluMQwwCgYDVQQKEwNpYm0xETAPBgNVBAsT
+CHJ1bnRpbWVzMRIwEAYDVQQDEwlsb2NhbHVzZXIwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAAR+jgDNLh1vVCABhMMMrtlcyGv2d0UmymnbxcR7wAfv0MadsBJAk6Dr
+7JNDInnYYrpOKL14sbUnefG5N4hBE7CCoyEwHzAdBgNVHQ4EFgQU8qJz/5pgTAr3
+5Spkt3EKWiVIYm4wCgYIKoZIzj0EAwIDSAAwRQIgGz08ZBkU30de6sOZHTDBJZt2
+tbUw5iLzXep02KBHrLoCIQC8jkUyBRLdd4z1mBKDSl07Q6Ex7n9APYHfqYwQ8/Hf
+8g==
+					</ds:X509Certificate>
+				</ds:X509Data>
+			</ds:KeyInfo>
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-gcm">
+			</md:EncryptionMethod>
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128">
+			</md:EncryptionMethod>
+
+		</md:KeyDescriptor>
+		<md:SingleLogoutService
+			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_aes128_no_sign/slo"
+			Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" />		
+		<md:AssertionConsumerService
+			Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_aes128_no_sign/acs"
+			index="0"
+			isDefault="true" />
+	</md:SPSSODescriptor>
+</md:EntityDescriptor>

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/metadata/sp_enc_ecdsaSP_rsaIDP_Metadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/metadata/sp_enc_ecdsaSP_rsaIDP_Metadata.xml.orig
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor
+	xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+	entityID="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_ecdsaSP_rsaIDP"
+>
+	<md:SPSSODescriptor
+		AuthnRequestsSigned="false"
+		WantAssertionsSigned="true"
+		protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"
+	>
+
+		<md:KeyDescriptor use="signing">
+			<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+				<ds:X509Data>
+					<ds:X509Certificate>MIIB3TCCAYOgAwIBAgIIGU+b9RssTr8wCgYIKoZIzj0EAwIwYzELMAkGA1UEBhMC
+dXMxDjAMBgNVBAgTBXRleGFzMQ8wDQYDVQQHEwZhdXN0aW4xDDAKBgNVBAoTA2li
+bTERMA8GA1UECxMIcnVudGltZXMxEjAQBgNVBAMTCWxvY2FsdXNlcjAeFw0yNTA4
+MzEyMjA2MTRaFw0zNTA4MjkyMjA2MTRaMGMxCzAJBgNVBAYTAnVzMQ4wDAYDVQQI
+EwV0ZXhhczEPMA0GA1UEBxMGYXVzdGluMQwwCgYDVQQKEwNpYm0xETAPBgNVBAsT
+CHJ1bnRpbWVzMRIwEAYDVQQDEwlsb2NhbHVzZXIwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAAR+jgDNLh1vVCABhMMMrtlcyGv2d0UmymnbxcR7wAfv0MadsBJAk6Dr
+7JNDInnYYrpOKL14sbUnefG5N4hBE7CCoyEwHzAdBgNVHQ4EFgQU8qJz/5pgTAr3
+5Spkt3EKWiVIYm4wCgYIKoZIzj0EAwIDSAAwRQIgGz08ZBkU30de6sOZHTDBJZt2
+tbUw5iLzXep02KBHrLoCIQC8jkUyBRLdd4z1mBKDSl07Q6Ex7n9APYHfqYwQ8/Hf
+8g==
+					</ds:X509Certificate>
+				</ds:X509Data>
+			</ds:KeyInfo>
+		</md:KeyDescriptor>
+
+		<md:KeyDescriptor use="encryption">
+			<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+				<ds:X509Data>
+					<ds:X509Certificate>MIIB3TCCAYOgAwIBAgIIGU+b9RssTr8wCgYIKoZIzj0EAwIwYzELMAkGA1UEBhMC
+dXMxDjAMBgNVBAgTBXRleGFzMQ8wDQYDVQQHEwZhdXN0aW4xDDAKBgNVBAoTA2li
+bTERMA8GA1UECxMIcnVudGltZXMxEjAQBgNVBAMTCWxvY2FsdXNlcjAeFw0yNTA4
+MzEyMjA2MTRaFw0zNTA4MjkyMjA2MTRaMGMxCzAJBgNVBAYTAnVzMQ4wDAYDVQQI
+EwV0ZXhhczEPMA0GA1UEBxMGYXVzdGluMQwwCgYDVQQKEwNpYm0xETAPBgNVBAsT
+CHJ1bnRpbWVzMRIwEAYDVQQDEwlsb2NhbHVzZXIwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAAR+jgDNLh1vVCABhMMMrtlcyGv2d0UmymnbxcR7wAfv0MadsBJAk6Dr
+7JNDInnYYrpOKL14sbUnefG5N4hBE7CCoyEwHzAdBgNVHQ4EFgQU8qJz/5pgTAr3
+5Spkt3EKWiVIYm4wCgYIKoZIzj0EAwIDSAAwRQIgGz08ZBkU30de6sOZHTDBJZt2
+tbUw5iLzXep02KBHrLoCIQC8jkUyBRLdd4z1mBKDSl07Q6Ex7n9APYHfqYwQ8/Hf
+8g==
+					</ds:X509Certificate>
+				</ds:X509Data>
+			</ds:KeyInfo>
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-gcm">
+			</md:EncryptionMethod>
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128">
+			</md:EncryptionMethod>
+		</md:KeyDescriptor>
+
+		<md:SingleLogoutService
+			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_ecdsaSP_rsaIDP/slo"
+			Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" />		
+		<md:AssertionConsumerService
+			Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_ecdsaSP_rsaIDP/acs"
+			index="0"
+			isDefault="true" />
+	</md:SPSSODescriptor>
+</md:EntityDescriptor>

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/metadata/sp_enc_rsaSP_ecdsaIDP_Metadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/3.3.1/metadata/sp_enc_rsaSP_ecdsaIDP_Metadata.xml.orig
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor
+	xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+	entityID="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_rsaSP_ecdsaIDP"
+>
+	<md:SPSSODescriptor
+		AuthnRequestsSigned="false"
+		WantAssertionsSigned="true"
+		protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"
+	>
+		<md:KeyDescriptor use="signing">
+			<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+				<ds:X509Data>
+					<ds:X509Certificate>MIIDBjCCAe6gAwIBAgIEVydUZTANBgkqhkiG9w0BAQsFADAvMQswCQYDVQQGEwJVUzEMMAoGA1UE
+						ChMDSUJNMRIwEAYDVQQDDAluZXdfdXNlcjIwHhcNMTYwNTAyMTMyMTQxWhcNMzUwNzAxMTMyMTQx
+						WjAvMQswCQYDVQQGEwJVUzEMMAoGA1UEChMDSUJNMRIwEAYDVQQDDAluZXdfdXNlcjIwggEiMA0G
+						CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCXrqxihzkdcYeeu0YIxnobzMsecCX7GE/ts5AyarAS
+						q3Aj7Ikkbdqy8uElCKLM/RwwDfXt6QkTpUAnYMFPyDaemolJcr8i5VCiQzgI2nQghsPrqqBUsngN
+						LWPN/oYVyIkCIY4fO2XwgJ3v+rQS+5hzB3+xSNOvBGmQtwQfZn8UTayHhrzZTDLFmRfeCFtn/cwW
+						2wyPPDRxKoo9SuAYKvhlwBZl6jJ7zVwvJtjlVv/n95l+R4EgPBJKyyolGaw0EWzbdz5EDKa0po/v
+						CxDDkBMR4jul7SSJYumofjC2wNXI3UL+n69klKJrQ5An/Pz1vk6SakULqoYEbELt46TvXAInAgMB
+						AAGjKjAoMBMGA1UdIwQMMAqACIwWUD/0aQzNMBEGA1UdDgQKBAiMFlA/9GkMzTANBgkqhkiG9w0B
+						AQsFAAOCAQEAP6loJKkjdMul7lPmn3N+nWf0+kyXsDp8DeFCGrh2lGozBLnUobd3c/+edL+zZnhl
+						moE+7ByktdWcfgOS6aB8BGHfUlyPnEm4hd9AOA5dHh7up0gowCU1HeY5j2MY6ztQtK5aE6EZ5vOC
+						rvqAS1sBBsRqQ+QJUxVMOnJpsbqjTuvOSxgiDY/XS7/8WYnehfz7cAlBQFdGSOIA9YJ2zjoK54J/
+						yV6Fk9vtFdim6l3odryRuwIJ5f77ib8LmkB88VGC8zLizeVucj6W/QrDm6VktuCXTjAwJveo60mV
+						MYfdAMTuT+9/WfJbr6xCgrGB8IYGi8JKlWgp+sgJYLY7hsU4Kw==
+					</ds:X509Certificate>
+				</ds:X509Data>
+			</ds:KeyInfo>
+		</md:KeyDescriptor>
+
+		<!-- encryption key is intentionally commented out, i.e. encryption is disabled to test for idp ECDSA signing when Liberty uses RSA keystore -->
+		<!-- <md:KeyDescriptor use="encryption">
+			<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+				<ds:X509Data>
+					<ds:X509Certificate>MIIDBjCCAe6gAwIBAgIEVydUZTANBgkqhkiG9w0BAQsFADAvMQswCQYDVQQGEwJVUzEMMAoGA1UE
+						ChMDSUJNMRIwEAYDVQQDDAluZXdfdXNlcjIwHhcNMTYwNTAyMTMyMTQxWhcNMzUwNzAxMTMyMTQx
+						WjAvMQswCQYDVQQGEwJVUzEMMAoGA1UEChMDSUJNMRIwEAYDVQQDDAluZXdfdXNlcjIwggEiMA0G
+						CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCXrqxihzkdcYeeu0YIxnobzMsecCX7GE/ts5AyarAS
+						q3Aj7Ikkbdqy8uElCKLM/RwwDfXt6QkTpUAnYMFPyDaemolJcr8i5VCiQzgI2nQghsPrqqBUsngN
+						LWPN/oYVyIkCIY4fO2XwgJ3v+rQS+5hzB3+xSNOvBGmQtwQfZn8UTayHhrzZTDLFmRfeCFtn/cwW
+						2wyPPDRxKoo9SuAYKvhlwBZl6jJ7zVwvJtjlVv/n95l+R4EgPBJKyyolGaw0EWzbdz5EDKa0po/v
+						CxDDkBMR4jul7SSJYumofjC2wNXI3UL+n69klKJrQ5An/Pz1vk6SakULqoYEbELt46TvXAInAgMB
+						AAGjKjAoMBMGA1UdIwQMMAqACIwWUD/0aQzNMBEGA1UdDgQKBAiMFlA/9GkMzTANBgkqhkiG9w0B
+						AQsFAAOCAQEAP6loJKkjdMul7lPmn3N+nWf0+kyXsDp8DeFCGrh2lGozBLnUobd3c/+edL+zZnhl
+						moE+7ByktdWcfgOS6aB8BGHfUlyPnEm4hd9AOA5dHh7up0gowCU1HeY5j2MY6ztQtK5aE6EZ5vOC
+						rvqAS1sBBsRqQ+QJUxVMOnJpsbqjTuvOSxgiDY/XS7/8WYnehfz7cAlBQFdGSOIA9YJ2zjoK54J/
+						yV6Fk9vtFdim6l3odryRuwIJ5f77ib8LmkB88VGC8zLizeVucj6W/QrDm6VktuCXTjAwJveo60mV
+						MYfdAMTuT+9/WfJbr6xCgrGB8IYGi8JKlWgp+sgJYLY7hsU4Kw==
+					</ds:X509Certificate>
+				</ds:X509Data>
+			</ds:KeyInfo>
+		</md:KeyDescriptor> -->
+		<md:SingleLogoutService
+			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_rsaSP_ecdsaIDP/slo"
+			Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" />		
+		<md:AssertionConsumerService
+			Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_rsaSP_ecdsaIDP/acs"
+			index="0"
+			isDefault="true" />
+	</md:SPSSODescriptor>
+</md:EntityDescriptor>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


fix build defect: [link](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=307031)
failures occur on jdk8. shibboleth idp metadata configuration file is missing the reference for shib idp version 3.3.1 which is for the jdk8 test runs.

SOE run using jdk8: https://libh-proxy1.fyre.ibm.com/cognitive/pipelineAnalysis.html?pipelineId=53527377-3ed4-44aa-80b6-309f9ef4db97

AIX ibm8 FIPS140-3: https://libh-proxy1.fyre.ibm.com/cognitive/pipelineAnalysis.html?pipelineId=56ade818-0c0f-45c2-8a35-c5e0687d51ac