### PR TITLE
Netty: Support Epoll & KQueue (v4.2.7)

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -628,6 +628,46 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-epoll</artifactId>
+      <version>4.2.7.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-kqueue</artifactId>
+      <version>4.2.7.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>4.2.7.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>jar</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>jar</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <version>4.2.7.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <version>jar</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <version>jar</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
       <version>4.2.7.Final</version>
     </dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -121,6 +121,14 @@ io.netty:netty-common:4.2.7.Final
 io.netty:netty-handler-proxy:4.2.7.Final
 io.netty:netty-handler:4.2.7.Final
 io.netty:netty-resolver:4.2.7.Final
+io.netty:netty-transport-classes-epoll:4.2.7.Final
+io.netty:netty-transport-classes-kqueue:4.2.7.Final
+io.netty:netty-transport-native-epoll:4.2.7.Final
+io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.2.7.Final
+io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.2.7.Final
+io.netty:netty-transport-native-kqueue:4.2.7.Final
+io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.2.7.Final
+io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.2.7.Final
 io.netty:netty-transport-native-unix-common:4.2.7.Final
 io.netty:netty-transport:4.2.7.Final
 io.openliberty.arquillian:arquillian-liberty-support-jakarta:2.1.1

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/LoggingRecvByteBufAllocator.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/LoggingRecvByteBufAllocator.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.RecvByteBufAllocator;
 
+import io.netty.util.UncheckedBooleanSupplier;
 /**
  * This class is a custom {@link RecvByteBufAllocator} that wraps an existing allocator to intercept buffer
  * allocations in order to log when a read operation is requested.
@@ -49,8 +50,9 @@ import io.netty.channel.RecvByteBufAllocator;
      */
     @Override
     @SuppressWarnings("deprecation")
-    public Handle newHandle() {
-        return new LoggingHandle(delegate.newHandle());
+    public ExtendedHandle newHandle() {
+        Handle handle = delegate.newHandle();
+        return new LoggingHandle((ExtendedHandle) handle);
     }
 
     /**
@@ -61,12 +63,12 @@ import io.netty.channel.RecvByteBufAllocator;
      * meantime, the deprecation warnings are supressed.
      */
     @SuppressWarnings("deprecation")
-    public class LoggingHandle implements Handle{
-        private final Handle delegateHandle;
+    public class LoggingHandle implements ExtendedHandle {
+        private final ExtendedHandle delegateHandle;
         private ChannelHandlerContext context;
 
         @SuppressWarnings("deprecation")
-        LoggingHandle(Handle handle){
+        LoggingHandle(ExtendedHandle handle){
             this.delegateHandle = handle;
         }
 
@@ -153,5 +155,12 @@ import io.netty.channel.RecvByteBufAllocator;
         public int attemptedBytesRead(){
             return delegateHandle.attemptedBytesRead();
         }
+
+        @Override
+        @SuppressWarnings("deprecation") // is SuppressWarnings needed?
+        public boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
+            return delegateHandle.continueReading(maybeMoreDataSupplier);
+        }
+
     } 
 }

--- a/dev/io.openliberty.io.netty/bnd.bnd
+++ b/dev/io.openliberty.io.netty/bnd.bnd
@@ -64,5 +64,12 @@ instrument.disabled: true
   io.netty:netty-handler-proxy;version=${nettyVersion},\
   io.netty:netty-resolver;version=${nettyVersion},\
   io.netty:netty-transport;version=${nettyVersion},\
-  io.netty:netty-transport-native-unix-common;version=${nettyVersion}
+  io.netty:netty-transport-native-unix-common;version=${nettyVersion},\
+  io.netty:netty-transport-classes-epoll;version=${nettyVersion},\
+  io.netty:netty-transport-native-epoll;version=${nettyVersion},\
+  io.netty:netty-transport-classes-kqueue;version=${nettyVersion},
+  netty-transport-native-epoll-4.1.126.Final-linux-x86_64;version=${nettyVersion},\
+  netty-transport-native-epoll-4.1.126.Final-linux-aarch_64;version=${nettyVersion},\
+  netty-transport-native-kqueue-4.1.126.Final-osx-x86_64;version=${nettyVersion},\
+  netty-transport-native-kqueue-4.1.126.Final-osx-aarch_64;version=${nettyVersion}
   

--- a/dev/io.openliberty.io.netty/bnd.bnd
+++ b/dev/io.openliberty.io.netty/bnd.bnd
@@ -48,7 +48,13 @@ Import-Package: \
   @\${repo;io.netty:netty-transport-native-kqueue:jar:osx-x86_64;${nettyVersion};EXACT}!/(META-INF/native/*),\
   @\${repo;io.netty:netty-transport-native-kqueue:jar:osx-aarch_64;${nettyVersion};EXACT}!/(META-INF/native/*)
 
-  
+Bundle-NativeCode: \
+  META-INF/native/libnetty_transport_native_epoll_aarch_64.so; osname=Linux; processor=aarch64,\
+  META-INF/native/libnetty_transport_native_epoll_x86_64.so; osname=Linux; processor=x86_64,\
+  META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib; osname=MacOSX; processor=aarch_64,\
+  META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib; osname=MacOSX; processor=x86_64,\
+  *
+
 Export-Package: \
   !io.netty.handler.ssl.*,\
   io.netty.*;version=${nettyVersion}; -split-package:=merge-first

--- a/dev/io.openliberty.io.netty/bnd.bnd
+++ b/dev/io.openliberty.io.netty/bnd.bnd
@@ -42,7 +42,13 @@ Import-Package: \
   !sun.*,\
   *
 
+-includeresource: \
+  @\${repo;io.netty:netty-transport-native-epoll:jar:linux-x86_64;${nettyVersion};EXACT}!/(META-INF/native/*),\
+  @\${repo;io.netty:netty-transport-native-epoll:jar:linux-aarch_64;${nettyVersion};EXACT}!/(META-INF/native/*),\
+  @\${repo;io.netty:netty-transport-native-kqueue:jar:osx-x86_64;${nettyVersion};EXACT}!/(META-INF/native/*),\
+  @\${repo;io.netty:netty-transport-native-kqueue:jar:osx-aarch_64;${nettyVersion};EXACT}!/(META-INF/native/*)
 
+  
 Export-Package: \
   !io.netty.handler.ssl.*,\
   io.netty.*;version=${nettyVersion}; -split-package:=merge-first
@@ -67,9 +73,6 @@ instrument.disabled: true
   io.netty:netty-transport-native-unix-common;version=${nettyVersion},\
   io.netty:netty-transport-classes-epoll;version=${nettyVersion},\
   io.netty:netty-transport-native-epoll;version=${nettyVersion},\
-  io.netty:netty-transport-classes-kqueue;version=${nettyVersion},
-  netty-transport-native-epoll-4.1.126.Final-linux-x86_64;version=${nettyVersion},\
-  netty-transport-native-epoll-4.1.126.Final-linux-aarch_64;version=${nettyVersion},\
-  netty-transport-native-kqueue-4.1.126.Final-osx-x86_64;version=${nettyVersion},\
-  netty-transport-native-kqueue-4.1.126.Final-osx-aarch_64;version=${nettyVersion}
+  io.netty:netty-transport-classes-kqueue;version=${nettyVersion},\
+  io.netty:netty-transport-native-kqueue;version=${nettyVersion}
   

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
@@ -50,6 +50,14 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.epoll.EpollIoHandler;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.epoll.EpollDatagramChannel;
+import io.netty.channel.kqueue.KQueueIoHandler;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannel;
+import io.netty.channel.kqueue.KQueueDatagramChannel;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -124,9 +132,22 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
                 }
             });
         }
+        IoHandler handler;
+        if (Epoll.isAvailable()) {
+            handler = new EpollIoHandler();
+        } else if (KQueue.isAvailable()) {
+            handler = new KQueueIoHandler();
+        } else {
+            handler = new NioIoHandler();
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Created IoHandler -> " + handler);
+        }
+
         // Compared to channelfw, quiesce is hit every time because
         // connections are lazy cleaned on deactivate
-        parentGroup = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        parentGroup = new MultiThreadIoEventLoopGroup(1, handler.newFactory());
         // Attempt to get the properties from the passed configuration but give priority to
         // the system properties if set
         int maxThreads;
@@ -150,8 +171,9 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
             });
         }
         AutoScalingEventExecutorChooserFactory scaler = createThreadScaler();
-        childGroup = new MultiThreadIoEventLoopGroup(maxThreads, null, scaler, NioIoHandler.newFactory());
         outboundConnections = new DefaultChannelGroup(childGroup.next());
+        childGroup = new MultiThreadIoEventLoopGroup(maxThreads, null, scaler, handler.newFactory());
+        
         if (metricsWindow > 0) {
             scheduledExecutorService.scheduleAtFixedRate(() -> {
                 StringBuilder sb = new StringBuilder("Getting metrics from MultiThreadIoEventLoopGroup with active threads " + ((MultiThreadIoEventLoopGroup)childGroup).activeExecutorCount() + " : ");
@@ -291,6 +313,53 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
             // are addressed
             System.setProperty("io.netty.allocator.type", "pooled");
         }
+    }
+
+    /*
+     * Used for server sockets - based on platform.
+     */
+    public Class getServerSocketChannelClass() {
+        if(Epoll.isAvailable()){
+            return EpollServerSocketChannel.class;
+        } else if (KQueue.isAvailable()) {
+            return KQueueServerSocketChannel.class;
+        } else {
+            return NioServerSocketChannel.class;
+        }
+    }
+
+    /*
+     * Used for client sockets - based on platform.
+     */
+    public Class getSocketChannelClass() {
+        if(Epoll.isAvailable()){
+            return EpollSocketChannel.class;
+        } else if (KQueue.isAvailable()) {
+            return KQueueSocketChannel.class;
+        } else {
+            return NioSocketChannel.class;
+        }
+    }
+
+    /*
+     * Used in UDP channels - based on platform.
+     */
+    public Class getDatagramClass() {
+        if (Epoll.isAvailable()) {
+            return EpollDatagramChannel.class;
+        } else if (KQueue.isAvailable()) {
+            return KQueueDatagramChannel.class;
+        } else {
+            return NioDatagramChannel.class;
+        }
+    }
+
+    @Modified
+    protected void modified(ComponentContext context, Map<String, Object> config) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+            Tr.event(this, tc, "Config updates are not currently implemented! Config will be ignored: ", config);
+        }
+        // update any framework-specific config
     }
 
     @Deactivate

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
@@ -30,6 +30,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
@@ -45,22 +46,24 @@ import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
 
 import io.netty.channel.Channel;
+import io.netty.channel.IoHandlerFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollIoHandler;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.epoll.EpollSocketChannel;
-import io.netty.channel.epoll.EpollDatagramChannel;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueDatagramChannel;
 import io.netty.channel.kqueue.KQueueIoHandler;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannel;
-import io.netty.channel.kqueue.KQueueDatagramChannel;
-import io.netty.channel.group.ChannelGroup;
-import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -132,22 +135,26 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
                 }
             });
         }
-        IoHandler handler;
+        IoHandlerFactory parentFactory;
+        IoHandlerFactory childFactory;
         if (Epoll.isAvailable()) {
-            handler = new EpollIoHandler();
+            parentFactory = EpollIoHandler.newFactory();
+            childFactory = EpollIoHandler.newFactory();
         } else if (KQueue.isAvailable()) {
-            handler = new KQueueIoHandler();
+            parentFactory = KQueueIoHandler.newFactory();
+            childFactory = KQueueIoHandler.newFactory();
         } else {
-            handler = new NioIoHandler();
+            parentFactory = NioIoHandler.newFactory();
+            childFactory = NioIoHandler.newFactory();
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "Created IoHandler -> " + handler);
+            Tr.debug(tc, "Created IoHandlerFactories -> parent: " + parentFactory + ", child: " + childFactory);
         }
 
         // Compared to channelfw, quiesce is hit every time because
         // connections are lazy cleaned on deactivate
-        parentGroup = new MultiThreadIoEventLoopGroup(1, handler.newFactory());
+        parentGroup = new MultiThreadIoEventLoopGroup(1, parentFactory);
         // Attempt to get the properties from the passed configuration but give priority to
         // the system properties if set
         int maxThreads;
@@ -171,8 +178,8 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
             });
         }
         AutoScalingEventExecutorChooserFactory scaler = createThreadScaler();
+        childGroup = new MultiThreadIoEventLoopGroup(maxThreads, null, scaler, childFactory);
         outboundConnections = new DefaultChannelGroup(childGroup.next());
-        childGroup = new MultiThreadIoEventLoopGroup(maxThreads, null, scaler, handler.newFactory());
         
         if (metricsWindow > 0) {
             scheduledExecutorService.scheduleAtFixedRate(() -> {
@@ -352,14 +359,6 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
         } else {
             return NioDatagramChannel.class;
         }
-    }
-
-    @Modified
-    protected void modified(ComponentContext context, Map<String, Object> config) {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(this, tc, "Config updates are not currently implemented! Config will be ignored: ", config);
-        }
-        // update any framework-specific config
     }
 
     @Deactivate

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/tcp/TCPUtils.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/tcp/TCPUtils.java
@@ -56,7 +56,7 @@ public class TCPUtils {
         BootstrapConfiguration config = new TCPConfigurationImpl(tcpOptions, true);
         ServerBootstrapExtended bs = new ServerBootstrapExtended();
         bs.group(framework.getParentGroup(), framework.getChildGroup());
-        bs.channel(NioServerSocketChannel.class);
+        bs.channel(framework.getServerSocketChannelClass());
         // apply the existing user config to the Netty TCP channel
         bs.applyConfiguration(config);
         ChannelInitializerWrapper tcpInitializer = new TCPChannelInitializerImpl(config, framework);
@@ -77,7 +77,7 @@ public class TCPUtils {
         BootstrapConfiguration config = new TCPConfigurationImpl(tcpOptions, false);
         BootstrapExtended bs = new BootstrapExtended();
         bs.group(framework.getChildGroup());
-        bs.channel(NioSocketChannel.class);
+        bs.channel(framework.getSocketChannelClass());
         // apply the existing user config to the Netty TCP channel
         bs.applyConfiguration(config);
         ChannelInitializerWrapper tcpInitializer = new TCPChannelInitializerImpl(config, framework);

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPUtils.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPUtils.java
@@ -64,7 +64,7 @@ public class UDPUtils {
         BootstrapExtended bs = new BootstrapExtended();
         bs.applyConfiguration(config);
         bs.group(framework.getChildGroup());
-        bs.channel(NioDatagramChannel.class);
+        bs.channel(framework.getDatagramClass());
         return bs;
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Performance Improvement Change for Netty: #32725

- Use epoll / kqueue based on platform  (via simple `isAvailable()` checks)
- Updated code to be flexible with the class types
- The logging handle change was necessary for this compilation error:
```
Execution failed for task ‘:com.ibm.ws.transport.http:compileJava’.
> Compilation failed; see the compiler output below.
  com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/LoggingRecvByteBufAllocator.java:53: error: incompatible types: Handle cannot be converted to ExtendedHandle
          return new LoggingHandle(delegate.newHandle());
```
