### PR TITLE
Avoid tracing MCP Session ID

### DIFF
--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpCdiExtensionMetadata.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpCdiExtensionMetadata.java
@@ -15,6 +15,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
+import io.openliberty.mcp.internal.sessions.McpSessionStore;
 import jakarta.enterprise.inject.spi.Extension;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE)

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpRequestTracker.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpRequestTracker.java
@@ -23,6 +23,7 @@ import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCErrorCode;
 import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCException;
 import io.openliberty.mcp.internal.requests.CancellationImpl;
 import io.openliberty.mcp.internal.requests.ExecutionRequestId;
+import io.openliberty.mcp.internal.sessions.McpSessionId;
 import io.openliberty.mcp.messaging.Cancellation;
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -70,13 +71,13 @@ public class McpRequestTracker {
      * Will skip cancellation if the server is in stateless mode.
      * request is cancelled with a fixed reason: {@code "Session cancelled"}
      */
-    public void cancelSessionRequests(String sessionId) {
+    public void cancelSessionRequests(McpSessionId sessionId) {
         Boolean stateless = mcpConfigService.run(McpConfiguration::isStateless).orElse(false);
         if (Boolean.TRUE.equals(stateless)) {
             return;
         }
 
-        Set<ExecutionRequestId> requests = sessionToRequestIds.remove(sessionId);
+        Set<ExecutionRequestId> requests = sessionToRequestIds.remove(sessionId.value());
         if (requests == null) {
             return;
         }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
@@ -39,6 +39,9 @@ import io.openliberty.mcp.internal.requests.McpRequestId;
 import io.openliberty.mcp.internal.requests.McpToolCallParams;
 import io.openliberty.mcp.internal.responses.McpInitializeResult;
 import io.openliberty.mcp.internal.responses.McpInitializeResult.ServerInfo;
+import io.openliberty.mcp.internal.sessions.McpSession;
+import io.openliberty.mcp.internal.sessions.McpSessionId;
+import io.openliberty.mcp.internal.sessions.McpSessionStore;
 import io.openliberty.mcp.messaging.Cancellation;
 import io.openliberty.mcp.tools.ToolCallException;
 import io.openliberty.mcp.tools.ToolResponse;
@@ -446,7 +449,7 @@ public class McpServlet extends HttpServlet {
     private void cancelRequest(McpTransport transport) {
         McpNotificationParams notificationParams = transport.getMcpRequest().getParams(McpNotificationParams.class, jsonb);
         McpRequestId mcpReqId = notificationParams.getRequestId();
-        String sessionId = transport.getSessionId();
+        McpSessionId sessionId = transport.getSessionId();
         if (sessionId == null) {
             transport.sendEmptyResponse();
             return;
@@ -470,7 +473,7 @@ public class McpServlet extends HttpServlet {
     }
 
     private ExecutionRequestId createOngoingRequestId(McpTransport transport) {
-        String sessionId = transport.getSessionId();
+        McpSessionId sessionId = transport.getSessionId();
         if (sessionId != null) {
             return new ExecutionRequestId(transport.getMcpRequest().id(),
                                           sessionId);

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpTransport.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpTransport.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.mcp.internal.exceptions.jsonrpc.HttpResponseException;
@@ -32,6 +33,9 @@ import io.openliberty.mcp.internal.requests.McpRequestId;
 import io.openliberty.mcp.internal.responses.McpErrorResponse;
 import io.openliberty.mcp.internal.responses.McpResponse;
 import io.openliberty.mcp.internal.responses.McpResultResponse;
+import io.openliberty.mcp.internal.sessions.McpSession;
+import io.openliberty.mcp.internal.sessions.McpSessionId;
+import io.openliberty.mcp.internal.sessions.McpSessionStore;
 import io.openliberty.mcp.tools.ToolResponse;
 import jakarta.json.JsonException;
 import jakarta.json.bind.Jsonb;
@@ -166,7 +170,7 @@ public class McpTransport {
      * <p>
      * Intended only for sending the Session ID header with initialize response
      */
-    void setResponseHeader(String name, String value) {
+    void setResponseHeader(String name, @Sensitive String value) {
         res.setHeader(name, value);
     }
 
@@ -186,7 +190,7 @@ public class McpTransport {
      *
      * @return the session ID string, or {@code null} if none is available
      */
-    public String getSessionId() {
+    public McpSessionId getSessionId() {
         return sessionInfo == null ? null : sessionInfo.getSessionId();
     }
 

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/sessions/McpSession.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/sessions/McpSession.java
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package io.openliberty.mcp.internal;
+package io.openliberty.mcp.internal.sessions;
 
 import java.time.Instant;
 
@@ -17,12 +17,12 @@ import java.time.Instant;
 
 public class McpSession {
 
-    private final String sessionId;
+    private final McpSessionId sessionId;
     private final Instant created;
     private Instant lastAccessed;
 
     public McpSession(String sessionId) {
-        this.sessionId = sessionId;
+        this.sessionId = new McpSessionId(sessionId);
         this.created = Instant.now();
         this.lastAccessed = this.created;
     }
@@ -35,7 +35,7 @@ public class McpSession {
         this.lastAccessed = Instant.now();
     }
 
-    public String getSessionId() {
+    public McpSessionId getSessionId() {
         return sessionId;
     }
 

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/sessions/McpSessionId.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/sessions/McpSessionId.java
@@ -7,8 +7,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package io.openliberty.mcp.internal.requests;
+package io.openliberty.mcp.internal.sessions;
 
-import io.openliberty.mcp.internal.sessions.McpSessionId;
+public record McpSessionId(String value) {
 
-public record ExecutionRequestId(McpRequestId id, McpSessionId sessionId) {}
+    @Override
+    public String toString() {
+        if (value.length() <= 3)
+            return value;
+        return value.substring(0, 3) + "*".repeat(value.length() - 3);
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/sessions/McpSessionId.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/sessions/McpSessionId.java
@@ -9,13 +9,16 @@
  *******************************************************************************/
 package io.openliberty.mcp.internal.sessions;
 
-public record McpSessionId(String value) {
+import com.ibm.websphere.ras.annotation.Sensitive;
+
+public record McpSessionId(@Sensitive String value) {
 
     @Override
     public String toString() {
-        if (value.length() <= 3)
+        int visibleSessionIdLength = 6;
+        if (value.length() <= visibleSessionIdLength)
             return value;
-        return value.substring(0, 3) + "*".repeat(value.length() - 3);
+        return value.substring(0, visibleSessionIdLength) + "*".repeat(value.length() - visibleSessionIdLength);
     }
 
 }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/sessions/McpSessionStore.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/sessions/McpSessionStore.java
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package io.openliberty.mcp.internal;
+package io.openliberty.mcp.internal.sessions;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import com.ibm.ws.kernel.service.util.ServiceCaller;
 
+import io.openliberty.mcp.internal.McpRequestTracker;
 import io.openliberty.mcp.internal.config.McpConfiguration;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/SessionIdTest.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/SessionIdTest.java
@@ -19,8 +19,12 @@ public class SessionIdTest {
 
     @Test
     public void testSessionIdToString() {
-        McpSessionId id = new McpSessionId("123456789");
-        assertEquals("123******", id.toString());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 36; i++)
+            sb.append(1);
+
+        McpSessionId testMcpSessionId = new McpSessionId(sb.toString());
+        assertEquals("111111" + "*".repeat(30), testMcpSessionId.toString());
     }
 
 }

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/SessionIdTest.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/SessionIdTest.java
@@ -7,8 +7,20 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package io.openliberty.mcp.internal.requests;
+package io.openliberty.mcp.internal.test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 import io.openliberty.mcp.internal.sessions.McpSessionId;
 
-public record ExecutionRequestId(McpRequestId id, McpSessionId sessionId) {}
+public class SessionIdTest {
+
+    @Test
+    public void testSessionIdToString() {
+        McpSessionId id = new McpSessionId("123456789");
+        assertEquals("123******", id.toString());
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
@@ -10,6 +10,7 @@
 package io.openliberty.mcp.internal.fat.tool;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
 import static io.openliberty.mcp.internal.fat.utils.TestConstants.ACCEPT;
 import static io.openliberty.mcp.internal.fat.utils.TestConstants.MCP_PROTOCOL_VERSION;
 import static io.openliberty.mcp.internal.fat.utils.TestConstants.MCP_SESSION_ID;
@@ -18,6 +19,8 @@ import static io.openliberty.mcp.internal.fat.utils.TestConstants.VALUE_MCP_PROT
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Pattern;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -34,6 +37,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpRequest;
@@ -3028,8 +3032,12 @@ public class ToolTest extends FATServletClient {
     }
 
     @Test
+    @Mode(FULL)
     public void testSessionIdNotTraced() throws Exception {
         String sessionId = client.getSessionId();
+        int visibleSessionIdLength = 6;
+        String redactedSessionId = sessionId.substring(0, visibleSessionIdLength) + "*".repeat(sessionId.length() - visibleSessionIdLength);
+
         assertNotNull("Expected session ID from MCP initialization", sessionId);
         String request = """
                         {
@@ -3045,7 +3053,9 @@ public class ToolTest extends FATServletClient {
                         }
                         """;
         client.callMCP(request);
-        assertNull(server.waitForStringInTrace(sessionId, 12000));
+
+        assertNotNull(server.waitForStringInTrace(Pattern.quote(redactedSessionId)));
+        assertNull(server.waitForStringInTrace(sessionId, 3000)); // wait 3 seconds to confirm full session Id not found in trace
     }
 
     @Test

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
@@ -16,6 +16,7 @@ import static io.openliberty.mcp.internal.fat.utils.TestConstants.MCP_SESSION_ID
 import static io.openliberty.mcp.internal.fat.utils.TestConstants.VALUE_ACCEPT_DEFAULT;
 import static io.openliberty.mcp.internal.fat.utils.TestConstants.VALUE_MCP_PROTOCOL_VERSION;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -3024,6 +3025,27 @@ public class ToolTest extends FATServletClient {
         String duplicateResponse = client.callMCP(requestTemplate);
 
         JSONAssert.assertEquals(expectedResponseString, duplicateResponse, true);
+    }
+
+    @Test
+    public void testSessionIdNotTraced() throws Exception {
+        String sessionId = client.getSessionId();
+        assertNotNull("Expected session ID from MCP initialization", sessionId);
+        String request = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "textContentTool",
+                            "arguments": {
+                              "input": "hello"
+                            }
+                          }
+                        }
+                        """;
+        client.callMCP(request);
+        assertNull(server.waitForStringInTrace(sessionId, 12000));
     }
 
     @Test


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Resolves #33369 
Avoids including the Session ID in the trace by:
- Storing the `sessionID` in its own `McpSessionID` class
- Replacing the `sessionID` string to use the new `McpSessionID` class
- Using `@Sesnsitive` when the `sessionID` value needs to be used
