### PR TITLE
Test Failure: io.openliberty.microprofile.health.file.healthcheck.internal_fat timed out (full mode)

### DIFF
--- a/dev/io.openliberty.microprofile.health.file.healthcheck.internal_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/SimpleFileBasedHealthCheckTest.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.internal_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/SimpleFileBasedHealthCheckTest.java
@@ -53,8 +53,6 @@ public class SimpleFileBasedHealthCheckTest {
 
     final static String SERVER_NAME = "HealthServer";
 
-    final static String SERVER_LONG_STARTUP_CHECK_INTERVAL = "HealthServerLongStartupCheckInterval";
-    final static String SERVER_LONG_CHECK_INTERVAL = "HealthServerLongCheckInterval";
     final static String FAIL_START_APP = "FailStartApp";
     final static String FAIL_START_APP_WAR = FAIL_START_APP + ".war";
 
@@ -89,12 +87,6 @@ public class SimpleFileBasedHealthCheckTest {
     @Server(SERVER_NAME)
     public static LibertyServer server;
 
-    @Server(SERVER_LONG_STARTUP_CHECK_INTERVAL)
-    public static LibertyServer serverLongStart;
-
-    @Server(SERVER_LONG_CHECK_INTERVAL)
-    public static LibertyServer serverLongCheck;
-
     @BeforeClass
     public static void beforeClass() {
 
@@ -110,14 +102,6 @@ public class SimpleFileBasedHealthCheckTest {
     public void after() throws Exception {
         if (server != null && server.isStarted()) {
             server.stopServer(IGNORED_FAILURES);
-        }
-
-        if (serverLongCheck != null && serverLongCheck.isStarted()) {
-            serverLongCheck.stopServer(IGNORED_FAILURES);
-        }
-
-        if (serverLongStart != null && serverLongStart.isStarted()) {
-            serverLongStart.stopServer(IGNORED_FAILURES);
         }
     }
 
@@ -215,152 +199,6 @@ public class SimpleFileBasedHealthCheckTest {
 
     }
 
-    @Test
-    /*
-     * Startup check is long at 30 seconds.
-     * The `StartupCheckUpAfterSecondQuery` servlet only returns UP after second query.
-     * This ensures that first query (i.e. first check of the startup check process will fail).
-     *
-     */
-    public void StartedHealthCheckTestLongStartupInterval() throws Exception {
-        final String METHOD_NAME = "StartedHealthCheckTestLongStartupInterval";
-
-        WebArchive testWAR = ShrinkWrap
-                        .create(WebArchive.class, FAIL_START_APP_WAR)
-                        .addAsWebInfResource(new File("test-applications/FileHealthCheckApp/resources/WEB-INF/web.xml"))
-                        .addPackage("io.openliberty.microprofile.health.file.healthcheck.app")
-                        .addPackage("io.openliberty.microprofile.health.file.healthcheck.app.start.after");
-
-        ShrinkHelper.exportDropinAppToServer(serverLongStart, testWAR, DeployOptions.SERVER_ONLY);
-
-        serverLongStart.startServer();
-
-        // Read to run a smarter planet
-        serverLongStart.waitForStringInLogUsingMark("CWWKF0011I");
-        assertTrue("Server is not started", serverLongStart.isStarted());
-
-        String serverRoot = serverLongStart.getServerRoot();
-        File serverRootDirFile = new File(serverRoot);
-
-        Log.info(getClass(), METHOD_NAME, "Server root directory is: " + serverRootDirFile.getAbsolutePath());
-
-        /*
-         * Expect:
-         * [X] /health dir
-         * [ ] Started
-         * [ ] Ready
-         * [ ] Live
-         *
-         * Not Expected:
-         * [X] Started
-         * [X] Ready
-         * [X] Live
-         */
-        Assert.assertTrue(Constants.HEALTH_DIR_SHOULD_HAVE_CREATED, HealthFileUtils.getHealthDirFile(serverRootDirFile).exists());
-        Assert.assertFalse(Constants.STARTED_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getStartFile(serverRootDirFile).exists());
-        Assert.assertFalse(Constants.READY_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getReadyFile(serverRootDirFile).exists());
-        Assert.assertFalse(Constants.LIVE_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getLiveFile(serverRootDirFile).exists());
-
-        //Started file should still not be created; consequently no other files are created
-        TimeUnit.SECONDS.sleep(10);
-        Assert.assertFalse(Constants.STARTED_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getStartFile(serverRootDirFile).exists());
-        Assert.assertFalse(Constants.READY_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getReadyFile(serverRootDirFile).exists());
-        Assert.assertFalse(Constants.LIVE_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getLiveFile(serverRootDirFile).exists());
-
-        /*
-         * Started file should still not be created; consequently no other files are created.
-         * Startup interval is set to 30 seconds, but due to potential machine slowness, we'll just wait 5 seconds here.
-         * Our next wait we'll wait 25 seconds and expect files to be created.
-         */
-        TimeUnit.SECONDS.sleep(5);
-        Assert.assertFalse(Constants.STARTED_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getStartFile(serverRootDirFile).exists());
-        Assert.assertFalse(Constants.READY_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getReadyFile(serverRootDirFile).exists());
-        Assert.assertFalse(Constants.LIVE_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getLiveFile(serverRootDirFile).exists());
-
-        TimeUnit.SECONDS.sleep(20);
-        Assert.assertTrue(Constants.STARTED_SHOULD_HAVE_CREATED, HealthFileUtils.getStartFile(serverRootDirFile).exists());
-        Assert.assertTrue(Constants.READY_SHOULD_HAVE_CREATED, HealthFileUtils.getReadyFile(serverRootDirFile).exists());
-        Assert.assertTrue(Constants.LIVE_SHOULD_HAVE_CREATED, HealthFileUtils.getLiveFile(serverRootDirFile).exists());
-
-    }
-
-    @Test
-    /*
-     * check interval is long at 30 seconds.
-     */
-    public void HealthCheckTestLongCheckInterval() throws Exception {
-        final String METHOD_NAME = "HealthCheckTestLongCheckInterval";
-
-        WebArchive testWAR = ShrinkWrap
-                        .create(WebArchive.class, FAIL_START_APP_WAR)
-                        .addAsWebInfResource(new File("test-applications/FileHealthCheckApp/resources/WEB-INF/web.xml"))
-                        .addPackage("io.openliberty.microprofile.health.file.healthcheck.app");
-
-        ShrinkHelper.exportDropinAppToServer(serverLongCheck, testWAR, DeployOptions.SERVER_ONLY);
-
-        serverLongCheck.startServer();
-
-        // Read to run a smarter planet
-        serverLongCheck.waitForStringInLogUsingMark("CWWKF0011I");
-        assertTrue("Server is not started", serverLongCheck.isStarted());
-
-        String serverRoot = serverLongCheck.getServerRoot();
-        File serverRootDirFile = new File(serverRoot);
-
-        Log.info(getClass(), METHOD_NAME, "Server root directory is: " + serverRootDirFile.getAbsolutePath());
-
-        /*
-         * Expect:
-         * [X] /health dir
-         * [x] Started
-         * [x] Ready
-         * [x] Live
-         *
-         * Not Expected:
-         * [] Started
-         * [] Ready
-         * [] Live
-         */
-        /*
-         * Checks that require to check that all files are created may encounter a scenario where FAT test is way ahead of the server.
-         * This results in the files not existing yet. isFilesCreated() will retry up to 2 seconds (w/ 250ms cycles).
-         */
-        Assert.assertTrue("Expected all files to be created: Review isAllHealthCheckFilesCreated logs for state of files.", FATSuite.isFilesCreated(serverRootDirFile));
-
-        /*
-         * The checkInterval is at 30 seconds.
-         * Due to slowness of server startup, or app startups or test execution startup we'll wait 12 and then 5 seconds.
-         * We will check the last 10 seconds and 5 seconds respectively for each cycle.
-         * We wait 12 and check the last 10 due the fact that the update phase maybe have issue the first health check queries during the wait.
-         * If that is the case, waiting 12 seconds and checking the last 12 seconds would fail due to the file being modified during that duration.
-         * and expect the live and ready files not to be updated.
-         *
-         * Then we'll wait 20 seconsd and we should expect it to have been updated during that time frame.
-         *
-         */
-        TimeUnit.SECONDS.sleep(12);
-        Assert.assertFalse(Constants.READY_SHOULD_NOT_HAVE_UPDATED,
-                           HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getReadyFile(serverRootDirFile), Duration.ofSeconds(10)));
-        Assert.assertFalse(Constants.LIVE_SHOULD_NOT_HAVE_UPDATED,
-                           HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getLiveFile(serverRootDirFile), Duration.ofSeconds(10)));
-
-        TimeUnit.SECONDS.sleep(5);
-        Assert.assertFalse(Constants.READY_SHOULD_NOT_HAVE_UPDATED,
-                           HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getReadyFile(serverRootDirFile), Duration.ofSeconds(5)));
-        Assert.assertFalse(Constants.LIVE_SHOULD_NOT_HAVE_UPDATED,
-                           HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getLiveFile(serverRootDirFile), Duration.ofSeconds(5)));
-
-        /*
-         * We are elapsed 38 seconds after we detected files are created (on the test infra).
-         * Checking within last 12 seconds. (i.e. elapsed after file create ~26-38).
-         * Big time window to account for slowness or "quickness" of the server.
-         */
-        TimeUnit.SECONDS.sleep(20);
-        Assert.assertTrue(Constants.READY_SHOULD_HAVE_UPDATED,
-                          HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getReadyFile(serverRootDirFile), Duration.ofSeconds(12)));
-        Assert.assertTrue(Constants.LIVE_SHOULD_HAVE_UPDATED,
-                          HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getLiveFile(serverRootDirFile), Duration.ofSeconds(12)));
-    }
 
     @Test
     /*

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/.classpath
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/.classpath
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/FileHealthCheckApp/src"/>
+	<classpathentry kind="src" path="test-applications/DelayedHealthCheckApp/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/.project
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.microprofile.health.file.healthcheck.longinterval_fat</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/bnd.bnd
@@ -1,0 +1,44 @@
+#*******************************************************************************
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+src: \
+	fat/src, \
+	test-applications/FileHealthCheckApp/src
+
+fat.project: true
+
+tested.features: \
+  servlet-4.0,\
+  servlet-6.0,\
+  servlet-6.1,\
+  servlet-3.1,\
+  mpConfig-3.0,\
+  mpConfig-3.1,\
+  mpConfig-1.3,\
+  mpConfig-2.0,\
+  mpHealth-4.0,\
+  jsonp-2.1,\
+  jsonp-1.0,\
+  jsonp-1.1,\
+  cdi-4.0,\
+  cdi-4.1,\
+  cdi-1.2,\
+  cdi-2.0
+
+-buildpath: \
+	com.ibm.websphere.javaee.jsonp.1.1;version=latest, \
+	com.ibm.websphere.javaee.cdi.2.0;version=latest, \
+	io.openliberty.org.eclipse.microprofile.health.3.1;version=latest, \
+    com.ibm.websphere.javaee.servlet.4.0;version=latest,\
+    com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
+	org.testng:testng;version=7.5.1,\
+	io.openliberty.microprofile.health.internal_fat.common

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/build.gradle
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/build.gradle
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+dependencies {
+  requiredLibs 'org.testng:testng:7.5.1'
+  requiredLibs project(':io.openliberty.microprofile.health.internal_fat.common')
+}
+
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/FATSuite.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.fat;
+
+import java.io.File;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.AlwaysPassesTest;
+import io.openliberty.microprofile.health.file.healthcheck.fat.utils.HealthFileUtils;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+    AlwaysPassesTest.class,
+    LongIntervalHealthCheckTest.class
+})
+public class FATSuite {
+
+    /**
+     * Checks if all health check files (started, ready, live) have been created.
+     * Retries up to 2 seconds with 250ms cycles to account for timing differences
+     * between FAT test execution and server file creation.
+     *
+     * @param serverRootDirFile The server root directory
+     * @return true if all files exist, false otherwise
+     */
+    public static boolean isFilesCreated(File serverRootDirFile) {
+        final String METHOD_NAME = "isFilesCreated";
+        final int MAX_RETRIES = 8; // 8 * 250ms = 2 seconds
+        final int SLEEP_MS = 250;
+
+        for (int i = 0; i < MAX_RETRIES; i++) {
+            File healthDir = HealthFileUtils.getHealthDirFile(serverRootDirFile);
+            File startFile = HealthFileUtils.getStartFile(serverRootDirFile);
+            File readyFile = HealthFileUtils.getReadyFile(serverRootDirFile);
+            File liveFile = HealthFileUtils.getLiveFile(serverRootDirFile);
+
+            boolean allExist = healthDir.exists() && startFile.exists() && readyFile.exists() && liveFile.exists();
+
+            if (allExist) {
+                Log.info(FATSuite.class, METHOD_NAME, "All health check files created successfully");
+                return true;
+            }
+
+            Log.info(FATSuite.class, METHOD_NAME,
+                     String.format("Retry %d/%d: healthDir=%b, started=%b, ready=%b, live=%b",
+                                   i + 1, MAX_RETRIES, healthDir.exists(), startFile.exists(),
+                                   readyFile.exists(), liveFile.exists()));
+
+            try {
+                Thread.sleep(SLEEP_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+
+        Log.info(FATSuite.class, METHOD_NAME, "Timeout waiting for health check files to be created");
+        return false;
+    }
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/LongIntervalHealthCheckTest.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/LongIntervalHealthCheckTest.java
@@ -1,0 +1,234 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.fat;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.microprofile.health.file.healthcheck.fat.utils.Constants;
+import io.openliberty.microprofile.health.file.healthcheck.fat.utils.HealthFileUtils;
+import io.openliberty.microprofile.health.internal_fat.shared.HealthActions;
+
+@RunWith(FATRunner.class)
+public class LongIntervalHealthCheckTest {
+
+    final static String SERVER_LONG_STARTUP_CHECK_INTERVAL = "HealthServerLongStartupCheckInterval";
+    final static String SERVER_LONG_CHECK_INTERVAL = "HealthServerLongCheckInterval";
+    final static String FAIL_START_APP = "FailStartApp";
+    final static String FAIL_START_APP_WAR = FAIL_START_APP + ".war";
+
+    private static final String[] IGNORED_FAILURES = { "CWMMH0052W", "CWMMH0054W", "CWMMH0053W", "CWMMH0050E" };
+
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(FeatureReplacementAction.ALL_SERVERS,
+                                                             MicroProfileActions.MP61, // mpHealth-4.0 w/ EE9
+                                                             MicroProfileActions.MP70_EE10, // mpHealth-4.0 FULL EE10
+                                                             MicroProfileActions.MP70_EE11, // mpHealth-4.0 FULL EE11
+                                                             HealthActions.MP14_MPHEALTH40, // mpHealth-4.0 FULL EE7
+                                                             HealthActions.MP41_MPHEALTH40); //mpHealth-4.0 FULL EE8
+
+    @Server(SERVER_LONG_STARTUP_CHECK_INTERVAL)
+    public static LibertyServer serverLongStart;
+
+    @Server(SERVER_LONG_CHECK_INTERVAL)
+    public static LibertyServer serverLongCheck;
+
+    @Before
+    public void before() throws Exception {
+        if (serverLongCheck != null) {
+            serverLongCheck.removeAllInstalledAppsForValidation();
+            serverLongCheck.deleteAllDropinApplications();
+        }
+        if (serverLongStart != null) {
+            serverLongStart.removeAllInstalledAppsForValidation();
+            serverLongStart.deleteAllDropinApplications();
+        }
+    }
+
+    @After
+    public void after() throws Exception {
+        if (serverLongCheck != null && serverLongCheck.isStarted()) {
+            serverLongCheck.stopServer(IGNORED_FAILURES);
+        }
+
+        if (serverLongStart != null && serverLongStart.isStarted()) {
+            serverLongStart.stopServer(IGNORED_FAILURES);
+        }
+    }
+
+    @Test
+    /*
+     * Startup check is long at 30 seconds.
+     * The `StartupCheckUpAfterSecondQuery` servlet only returns UP after second query.
+     * This ensures that first query (i.e. first check of the startup check process will fail).
+     *
+     */
+    public void StartedHealthCheckTestLongStartupInterval() throws Exception {
+        final String METHOD_NAME = "StartedHealthCheckTestLongStartupInterval";
+
+        WebArchive testWAR = ShrinkWrap
+                        .create(WebArchive.class, FAIL_START_APP_WAR)
+                        .addAsWebInfResource(new File("test-applications/FileHealthCheckApp/resources/WEB-INF/web.xml"))
+                        .addPackage("io.openliberty.microprofile.health.file.healthcheck.app")
+                        .addPackage("io.openliberty.microprofile.health.file.healthcheck.app.start.after");
+
+        ShrinkHelper.exportDropinAppToServer(serverLongStart, testWAR, DeployOptions.SERVER_ONLY);
+
+        serverLongStart.startServer();
+
+        // Read to run a smarter planet
+        serverLongStart.waitForStringInLogUsingMark("CWWKF0011I");
+        assertTrue("Server is not started", serverLongStart.isStarted());
+
+        String serverRoot = serverLongStart.getServerRoot();
+        File serverRootDirFile = new File(serverRoot);
+
+        Log.info(getClass(), METHOD_NAME, "Server root directory is: " + serverRootDirFile.getAbsolutePath());
+
+        /*
+         * Expect:
+         * [X] /health dir
+         * [ ] Started
+         * [ ] Ready
+         * [ ] Live
+         *
+         * Not Expected:
+         * [X] Started
+         * [X] Ready
+         * [X] Live
+         */
+        Assert.assertTrue(Constants.HEALTH_DIR_SHOULD_HAVE_CREATED, HealthFileUtils.getHealthDirFile(serverRootDirFile).exists());
+        Assert.assertFalse(Constants.STARTED_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getStartFile(serverRootDirFile).exists());
+        Assert.assertFalse(Constants.READY_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getReadyFile(serverRootDirFile).exists());
+        Assert.assertFalse(Constants.LIVE_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getLiveFile(serverRootDirFile).exists());
+
+        //Started file should still not be created; consequently no other files are created
+        TimeUnit.SECONDS.sleep(10);
+        Assert.assertFalse(Constants.STARTED_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getStartFile(serverRootDirFile).exists());
+        Assert.assertFalse(Constants.READY_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getReadyFile(serverRootDirFile).exists());
+        Assert.assertFalse(Constants.LIVE_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getLiveFile(serverRootDirFile).exists());
+
+        /*
+         * Started file should still not be created; consequently no other files are created.
+         * Startup interval is set to 30 seconds, but due to potential machine slowness, we'll just wait 5 seconds here.
+         * Our next wait we'll wait 25 seconds and expect files to be created.
+         */
+        TimeUnit.SECONDS.sleep(5);
+        Assert.assertFalse(Constants.STARTED_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getStartFile(serverRootDirFile).exists());
+        Assert.assertFalse(Constants.READY_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getReadyFile(serverRootDirFile).exists());
+        Assert.assertFalse(Constants.LIVE_SHOULD_NOT_HAVE_CREATED, HealthFileUtils.getLiveFile(serverRootDirFile).exists());
+
+        TimeUnit.SECONDS.sleep(20);
+        Assert.assertTrue(Constants.STARTED_SHOULD_HAVE_CREATED, HealthFileUtils.getStartFile(serverRootDirFile).exists());
+        Assert.assertTrue(Constants.READY_SHOULD_HAVE_CREATED, HealthFileUtils.getReadyFile(serverRootDirFile).exists());
+        Assert.assertTrue(Constants.LIVE_SHOULD_HAVE_CREATED, HealthFileUtils.getLiveFile(serverRootDirFile).exists());
+
+    }
+
+    @Test
+    /*
+     * check interval is long at 30 seconds.
+     */
+    public void HealthCheckTestLongCheckInterval() throws Exception {
+        final String METHOD_NAME = "HealthCheckTestLongCheckInterval";
+
+        WebArchive testWAR = ShrinkWrap
+                        .create(WebArchive.class, FAIL_START_APP_WAR)
+                        .addAsWebInfResource(new File("test-applications/FileHealthCheckApp/resources/WEB-INF/web.xml"))
+                        .addPackage("io.openliberty.microprofile.health.file.healthcheck.app");
+
+        ShrinkHelper.exportDropinAppToServer(serverLongCheck, testWAR, DeployOptions.SERVER_ONLY);
+
+        serverLongCheck.startServer();
+
+        // Read to run a smarter planet
+        serverLongCheck.waitForStringInLogUsingMark("CWWKF0011I");
+        assertTrue("Server is not started", serverLongCheck.isStarted());
+
+        String serverRoot = serverLongCheck.getServerRoot();
+        File serverRootDirFile = new File(serverRoot);
+
+        Log.info(getClass(), METHOD_NAME, "Server root directory is: " + serverRootDirFile.getAbsolutePath());
+
+        /*
+         * Expect:
+         * [X] /health dir
+         * [x] Started
+         * [x] Ready
+         * [x] Live
+         *
+         * Not Expected:
+         * [] Started
+         * [] Ready
+         * [] Live
+         */
+        /*
+         * Checks that require to check that all files are created may encounter a scenario where FAT test is way ahead of the server.
+         * This results in the files not existing yet. isFilesCreated() will retry up to 2 seconds (w/ 250ms cycles).
+         */
+        Assert.assertTrue("Expected all files to be created: Review isAllHealthCheckFilesCreated logs for state of files.", FATSuite.isFilesCreated(serverRootDirFile));
+
+        /*
+         * The checkInterval is at 30 seconds.
+         * Due to slowness of server startup, or app startups or test execution startup we'll wait 12 and then 5 seconds.
+         * We will check the last 10 seconds and 5 seconds respectively for each cycle.
+         * We wait 12 and check the last 10 due the fact that the update phase maybe have issue the first health check queries during the wait.
+         * If that is the case, waiting 12 seconds and checking the last 12 seconds would fail due to the file being modified during that duration.
+         * and expect the live and ready files not to be updated.
+         *
+         * Then we'll wait 20 seconsd and we should expect it to have been updated during that time frame.
+         *
+         */
+        TimeUnit.SECONDS.sleep(12);
+        Assert.assertFalse(Constants.READY_SHOULD_NOT_HAVE_UPDATED,
+                           HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getReadyFile(serverRootDirFile), Duration.ofSeconds(10)));
+        Assert.assertFalse(Constants.LIVE_SHOULD_NOT_HAVE_UPDATED,
+                           HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getLiveFile(serverRootDirFile), Duration.ofSeconds(10)));
+
+        TimeUnit.SECONDS.sleep(5);
+        Assert.assertFalse(Constants.READY_SHOULD_NOT_HAVE_UPDATED,
+                           HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getReadyFile(serverRootDirFile), Duration.ofSeconds(5)));
+        Assert.assertFalse(Constants.LIVE_SHOULD_NOT_HAVE_UPDATED,
+                           HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getLiveFile(serverRootDirFile), Duration.ofSeconds(5)));
+
+        /*
+         * We are elapsed 38 seconds after we detected files are created (on the test infra).
+         * Checking within last 12 seconds. (i.e. elapsed after file create ~26-38).
+         * Big time window to account for slowness or "quickness" of the server.
+         */
+        TimeUnit.SECONDS.sleep(20);
+        Assert.assertTrue(Constants.READY_SHOULD_HAVE_UPDATED,
+                          HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getReadyFile(serverRootDirFile), Duration.ofSeconds(12)));
+        Assert.assertTrue(Constants.LIVE_SHOULD_HAVE_UPDATED,
+                          HealthFileUtils.isLastModifiedTimeWithinLast(HealthFileUtils.getLiveFile(serverRootDirFile), Duration.ofSeconds(12)));
+    }
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/utils/Constants.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/utils/Constants.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.fat.utils;
+
+/**
+ *
+ */
+public class Constants {
+
+    public static final String SHOULD_HAVE_CREATED = " should have been created.";
+    public static final String SHOULD_NOT_HAVE_CREATED = " should not have been created.";
+
+    public static final String SHOULD_HAVE_UPDATED = " should have been updated.";
+    public static final String SHOULD_NOT_HAVE_UPDATED = " should not have been updated.";
+
+    public static final String HEALTH_DIR_SHOULD_HAVE_CREATED = "/health" + SHOULD_HAVE_CREATED;
+    public static final String HEALTH_DIR_SHOULD_NOT_HAVE_CREATED = "/health" + SHOULD_NOT_HAVE_CREATED;
+
+    public static final String LIVE_SHOULD_HAVE_CREATED = "/health/live" + SHOULD_HAVE_CREATED;
+    public static final String LIVE_SHOULD_NOT_HAVE_CREATED = "/health/live" + SHOULD_NOT_HAVE_CREATED;
+
+    public static final String STARTED_SHOULD_HAVE_CREATED = "/health/started" + SHOULD_HAVE_CREATED;
+    public static final String STARTED_SHOULD_NOT_HAVE_CREATED = "/health/started" + SHOULD_NOT_HAVE_CREATED;
+
+    public static final String READY_SHOULD_HAVE_CREATED = "/health/ready" + SHOULD_HAVE_CREATED;
+    public static final String READY_SHOULD_NOT_HAVE_CREATED = "/health/ready" + SHOULD_NOT_HAVE_CREATED;
+
+    public static final String LIVE_SHOULD_HAVE_UPDATED = "/health/live" + SHOULD_HAVE_UPDATED;
+    public static final String LIVE_SHOULD_NOT_HAVE_UPDATED = "/health/live" + SHOULD_NOT_HAVE_UPDATED;
+
+    public static final String STARTED_SHOULD_HAVE_UPDATED = "/health/started" + SHOULD_HAVE_UPDATED;
+    public static final String STARTED_SHOULD_NOT_HAVE_UPDATED = "/health/started" + SHOULD_NOT_HAVE_UPDATED;
+
+    public static final String READY_SHOULD_HAVE_UPDATED = "/health/ready" + SHOULD_HAVE_UPDATED;
+    public static final String READY_SHOULD_NOT_HAVE_UPDATED = "/health/ready" + SHOULD_NOT_HAVE_UPDATED;
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/utils/HealthFileUtils.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/utils/HealthFileUtils.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.fat.utils;
+
+import java.io.File;
+import java.time.Duration;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+/**
+ *
+ */
+public class HealthFileUtils {
+    private static void log(String method, String msg) {
+        Log.info(HealthFileUtils.class, method, msg);
+    }
+
+    public static long getLastModifiedTime(File file) {
+        final String METHOD_NAME = "getLastModifiedTime";
+
+        if (!file.exists()) {
+            log(METHOD_NAME, String.format("File %s does not exist", file.getAbsolutePath()));
+            return -1;
+        }
+
+        return file.lastModified();
+
+    }
+
+    public static boolean isLastModifiedTimeWithinLast(File file, Duration duration) {
+        final String METHOD_NAME = "isLastModifiedTimeWithinLast";
+
+        if (!file.exists()) {
+            log(METHOD_NAME, String.format("File %s does not exist", file.getAbsolutePath()));
+            return false;
+        }
+
+        long currTimeMilli = System.currentTimeMillis();
+        long lastMod = getLastModifiedTime(file);
+        long diff = (currTimeMilli - lastMod);
+
+        log(METHOD_NAME, String.format("The current time is [%d]. The last modified time was [%d]. The differene is [%d]", currTimeMilli, lastMod, diff));
+
+        return diff <= duration.toMillis();
+
+    }
+
+    public static File getHealthDirFile(File serverRootDirFile) {
+
+        File healthDirFile = new File(serverRootDirFile, "health");
+
+        return healthDirFile;
+    }
+
+    public static File getStartFile(File serverRootDirFile) {
+
+        File startedFile = new File(getHealthDirFile(serverRootDirFile), HealthCheckFileName.STARTED_FILE.getFileName());
+
+        return startedFile;
+    }
+
+    public static File getReadyFile(File serverRootDirFile) {
+
+        File readyFile = new File(getHealthDirFile(serverRootDirFile), HealthCheckFileName.READY_FILE.getFileName());
+
+        return readyFile;
+    }
+
+    public static File getLiveFile(File serverRootDirFile) {
+
+        File liveFile = new File(getHealthDirFile(serverRootDirFile), HealthCheckFileName.LIVE_FILE.getFileName());
+
+        return liveFile;
+    }
+
+    enum HealthCheckFileName {
+        STARTED_FILE("started"),
+        READY_FILE("ready"),
+        LIVE_FILE("live");
+
+        private final String fileName;
+
+        HealthCheckFileName(String fileName) {
+            this.fileName = fileName;
+        }
+
+        String getFileName() {
+            return fileName;
+        }
+    }
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongCheckInterval/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongCheckInterval/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+osgi.console=7771
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongCheckInterval/server.xml
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongCheckInterval/server.xml
@@ -1,0 +1,22 @@
+<server description="Server for testing Config Admin with dropin applications">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>localConnector-1.0</feature>
+        <feature>mpHealth-4.0</feature>
+        <feature>mpConfig-3.0</feature>
+        <feature>servlet-4.0</feature>
+    </featureManager>
+    
+    <mpHealth startupCheckInterval="1s" checkInterval="30s" />
+    	
+	<logging traceSpecification="*=info:HEALTH=all"/>
+	
+    <webContainer deferServletLoad="false"/>
+
+	<httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+		<tcpOptions portOpenRetries="60" />                   
+	</httpEndpoint>
+	
+</server>

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongStartupCheckInterval/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongStartupCheckInterval/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+osgi.console=7771
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongStartupCheckInterval/server.xml
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongStartupCheckInterval/server.xml
@@ -1,0 +1,22 @@
+<server description="Server for testing Config Admin with dropin applications">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>localConnector-1.0</feature>
+        <feature>mpHealth-4.0</feature>
+        <feature>mpConfig-3.0</feature>
+        <feature>servlet-4.0</feature>
+    </featureManager>
+    
+    <mpHealth startupCheckInterval="30s" checkInterval="5s" />
+    	
+	<logging traceSpecification="*=info:HEALTH=all"/>
+	
+    <webContainer deferServletLoad="false"/>
+
+	<httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+		<tcpOptions portOpenRetries="60" />                   
+	</httpEndpoint>
+	
+</server>

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/resources/META-INF/MANIFEST.MF
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Class-Path: 

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/resources/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+<web-app id="WebApp_ID" version="3.0" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+  <display-name>Delayed Servlet</display-name>
+  <description>Delayed Servlet for delayed application start up</description>
+
+  <servlet>
+    <display-name>DelayedServlet</display-name>
+    <servlet-name>DelayedServlet</servlet-name>
+    <servlet-class>io.openliberty.microprofile.health.delayed.health.check.app.DelayedServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  
+  <servlet-mapping>
+    <servlet-name>DelayedServlet</servlet-name>
+    <url-pattern>/DelayedServlet</url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health/delayed/health/check/app/DelayedLivenessCheck.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health/delayed/health/check/app/DelayedLivenessCheck.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.delayed.health.check.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+/**
+ *
+ */
+@Liveness
+@ApplicationScoped
+public class DelayedLivenessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("delayed-successful-liveness-check").up().build();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health/delayed/health/check/app/DelayedReadinessCheck.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health/delayed/health/check/app/DelayedReadinessCheck.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.delayed.health.check.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+/**
+ *
+ */
+@Readiness
+@ApplicationScoped
+public class DelayedReadinessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("delayed-successful-readiness-check").up().build();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health/delayed/health/check/app/DelayedServlet.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health/delayed/health/check/app/DelayedServlet.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.delayed.health.check.app;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ *
+ */
+public class DelayedServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @see HttpServlet#HttpServlet()
+     */
+    public DelayedServlet() {
+        super();
+        // TODO Auto-generated constructor stub
+    }
+
+    @Override
+    public void init() {
+        System.out.println("Entering DelayedServlet init function - Starting Thread.sleep for 40 seconds.");
+
+        try {
+            TimeUnit.SECONDS.sleep(40);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        System.out.println("Exiting DelayedServlet init function - Thread.sleep completed.");
+    }
+
+    /**
+     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // TODO Auto-generated method stub
+        response.setContentType("text/plain");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().append("Served at: ").append(request.getContextPath()).append("\n");
+        response.getWriter().println("Testing Delayed Servlet initialization.");
+    }
+
+    /**
+     * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // TODO Auto-generated method stub
+        doGet(request, response);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health/delayed/health/check/app/DelayedStartupCheck.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/DelayedHealthCheckApp/src/io/openliberty/microprofile/health/delayed/health/check/app/DelayedStartupCheck.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.delayed.health.check.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Startup;
+
+/**
+ *
+ */
+@Startup
+@ApplicationScoped
+public class DelayedStartupCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("delayed-success-startup-check").up().build();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/resources/META-INF/MANIFEST.MF
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Class-Path: 

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/resources/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+<web-app id="WebApp_ID" version="3.0" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+  <display-name>Delayed Servlet</display-name>
+  <description>Delayed Servlet for delayed application start up</description>
+
+  <servlet>
+    <display-name>HealthAppServlet</display-name>
+    <servlet-name>HealthAppServlet</servlet-name>
+    <servlet-class>io.openliberty.microprofile.health.file.healthcheck.app.HealthAppServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  
+  <servlet-mapping>
+    <servlet-name>HealthAppServlet</servlet-name>
+    <url-pattern>/HealthAppServlet</url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/HealthAppServlet.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/HealthAppServlet.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.app;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ *
+ */
+public class HealthAppServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    static Logger logger = Logger.getLogger("HealthAppServlet");
+
+    static boolean isLive = true;
+    static boolean isReady = true;
+
+    static long startTime;
+
+    /**
+     * @see HttpServlet#HttpServlet()
+     */
+    public HealthAppServlet() {
+        super();
+    }
+
+    @Override
+    public void init() {
+        startTime = System.currentTimeMillis();
+    }
+
+    /**
+     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        String liveInput;
+        if ((liveInput = request.getParameter("live")) != null) {
+            liveInput = liveInput.trim();
+            if (liveInput.equalsIgnoreCase("true")) {
+                isLive = true;
+            } else if (liveInput.equalsIgnoreCase("false")) {
+                isLive = false;
+            }
+        }
+
+        String readyInput;
+        if ((readyInput = request.getParameter("ready")) != null) {
+            readyInput = readyInput.trim();
+            if (readyInput.equalsIgnoreCase("true")) {
+                isReady = true;
+            } else if (readyInput.equalsIgnoreCase("false")) {
+                isReady = false;
+            }
+        }
+
+        response.setContentType("text/plain");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().append("Served at: ").append(request.getContextPath()).append("\n");
+        response.getWriter().println(String.format("Current status of flags: liveFlag[%b] readyFlag[%b]", isLive, isReady));
+        logger.info(String.format("Current status of flags: liveFlag[%b] readyFlag[%b]", isLive, isReady));
+        System.out.println((String.format("Current status of flags: liveFlag[%b] readyFlag[%b]", isLive, isReady)));
+    }
+
+    /**
+     * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // TODO Auto-generated method stub
+        doGet(request, response);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/LivenessCheck.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/LivenessCheck.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+/**
+ *
+ */
+@Liveness
+@ApplicationScoped
+public class LivenessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+
+        if (HealthAppServlet.isLive) {
+            return HealthCheckResponse.named("toggled-liveness-check").up().build();
+        } else {
+            return HealthCheckResponse.named("toggled-liveness-check").down().build();
+        }
+
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/ReadinessCheck.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/ReadinessCheck.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+/**
+ *
+ */
+@Readiness
+@ApplicationScoped
+public class ReadinessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+
+        if (HealthAppServlet.isReady) {
+            return HealthCheckResponse.named("toggled-readiness-check").up().build();
+        } else {
+            return HealthCheckResponse.named("toggled-readiness-check").down().build();
+        }
+
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/StartupCheck.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/StartupCheck.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Startup;
+
+/**
+ *
+ */
+@Startup
+@ApplicationScoped
+public class StartupCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("startup-check").up().build();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/live/fail/FailedLivenessCheck.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/live/fail/FailedLivenessCheck.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.app.live.fail;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+/**
+ *
+ */
+@Liveness
+@ApplicationScoped
+public class FailedLivenessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("failed-liveness-check").down().build();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/ready/fail/FailedReadinessCheck.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/ready/fail/FailedReadinessCheck.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.app.ready.fail;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+/**
+ *
+ */
+@Readiness
+@ApplicationScoped
+public class FailedReadinessCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("failed-readiness-check").down().build();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/start/after/StartupCheckUpAfterSecondQuery.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/start/after/StartupCheckUpAfterSecondQuery.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.app.start.after;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Startup;
+
+/**
+ *
+ */
+@Startup
+@ApplicationScoped
+public class StartupCheckUpAfterSecondQuery implements HealthCheck {
+
+    private int counter = 0;
+
+    @Override
+    public HealthCheckResponse call() {
+
+        /*
+         * Return up after first check.
+         */
+        if (counter != 0) {
+            return HealthCheckResponse.named("secondUP-startup-check").up().build();
+        } else {
+            counter++;
+            return HealthCheckResponse.named("secondUP-startup-check").down().build();
+        }
+
+    }
+
+}

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/start/fail/FailedStartupCheck.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/test-applications/FileHealthCheckApp/src/io/openliberty/microprofile/health/file/healthcheck/app/start/fail/FailedStartupCheck.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health.file.healthcheck.app.start.fail;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Startup;
+
+/**
+ *
+ */
+@Startup
+@ApplicationScoped
+public class FailedStartupCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("failed-startup-check").down().build();
+    }
+
+}


### PR DESCRIPTION
fixes #32637 

Supersedes: PR #32802 (which became too messy with refactored code)

Problem = The FAT bucket io.openliberty.microprofile.health.file.healthcheck.internal_fat was timing out because it took longer than 3 hours to execute in full mode. The timeout was caused by two test methods that use 30-second health check intervals (StartedHealthCheckTestLongStartupInterval and HealthCheckTestLongCheckInterval), making them significantly slower than other tests in the bucket.

Solution = Created a new FAT module io.openliberty.microprofile.health.file.healthcheck.longinterval_fat containing only the two long-running test methods. 

This allows:

- The original FAT bucket to complete within the timeout
- The long-running tests to run in their own bucket (approximately 4 minutes)
- Better test organization by separating tests based on execution time

Changes

- Created new FAT module with minimal test suite containing 2 test methods copied directly from integration branch
- Copied original test code - No refactoring, using original TimeUnit.SECONDS.sleep() logic from SimpleFileBasedHealthCheckTest.java
- Copied all required files from integration branch:

Test applications: FileHealthCheckApp (including start.after package), DelayedHealthCheckApp
Server configurations: HealthServerLongStartupCheckInterval, HealthServerLongCheckInterval
Utility classes: Constants.java, HealthFileUtils.java

- Configured build.gradle with proper dependencies (testng, common FAT module)
- Configured bnd.bnd with:

fat.project: true for automatic fat.gradle application
All tested features for FAT repeater support: servlet 3.1/4.0/6.0/6.1, mpConfig 1.3/2.0/3.0/3.1, mpHealth-4.0, cdi 1.2/2.0/4.0/4.1, jsonp 1.0/1.1/2.1

- Added Eclipse project configuration (.project and .classpath files)
- Updated settings.gradle - Removed unnecessary includes (bnd auto-discovers projects)
