### PR TITLE
Remove sha1 exceptions not needed in fips custom profile - wssec fat

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/semeruFips140_3CustomProfile.properties
@@ -5,19 +5,14 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.ehcache.impl.persistence.FileUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.UsernameTokenUtil}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecDKSign}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
     {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.util.EncryptionUtils}, \
     {Mac, HmacSHA1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/semeruFips140_3CustomProfile.properties
@@ -6,20 +6,15 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.CryptoBase}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.ehcache.impl.persistence.FileUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.UsernameTokenUtil}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecDKSign}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
     {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.util.EncryptionUtils}, \
     {Cipher, DESede, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/semeruFips140_3CustomProfile.properties
@@ -6,16 +6,12 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.CryptoBase}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.ehcache.impl.persistence.FileUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.UsernameTokenUtil}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecDKSign}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}, \
     {MessageDigest, MD5, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, MD5, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}]
@@ -24,7 +20,6 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {AlgorithmParameters, PBEWithMD5AndDES, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {KeyStore, JCEKS, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}, \
     {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.util.EncryptionUtils}, \
     {Cipher, DESede, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/semeruFips140_3CustomProfile.properties
@@ -6,20 +6,15 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.CryptoBase}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.ehcache.impl.persistence.FileUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.UsernameTokenUtil}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecDKSign}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
     {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.util.EncryptionUtils}, \
     {Cipher, DESede, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/semeruFips140_3CustomProfile.properties
@@ -8,11 +8,9 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.ehcache.impl.persistence.FileUtils}]
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
     {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/semeruFips140_3CustomProfile.properties
@@ -8,14 +8,11 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.ehcache.impl.persistence.FileUtils}]
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
     {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.7 = org.apache.jcp.xml.dsig.internal.dom.XMLDSigRI 
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.8 = org.apache.wss4j.dom.transform.STRTransformProvider

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/semeruFips140_3CustomProfile.properties
@@ -8,11 +8,9 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.ehcache.impl.persistence.FileUtils}]
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
     {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/semeruFips140_3CustomProfile.properties
@@ -8,11 +8,9 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.ehcache.impl.persistence.FileUtils}]
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
     {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/semeruFips140_3CustomProfile.properties
@@ -8,11 +8,9 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.ehcache.impl.persistence.FileUtils}]
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
     {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]


### PR DESCRIPTION
Runtime code has been updated with fips toggle (fips or no fips with corresponding algorithm), the FAT's fips custom profile properties do not need some of SHA1 message exceptions now.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
