### PR TITLE
Netty: Remove SO_RESUEADDR false since it is the default

### DIFF
--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPConfigurationImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/udp/UDPConfigurationImpl.java
@@ -79,7 +79,6 @@ public class UDPConfigurationImpl implements BootstrapConfiguration {
      */
     @Override
     public void applyConfiguration(Bootstrap bootstrap) {
-        bootstrap.option(ChannelOption.SO_REUSEADDR, false);
         int receiveBufferSize = getReceiveBufferSize();
         if ((receiveBufferSize >= UDPConfigConstants.RECEIVE_BUFFER_SIZE_MIN)
             && (receiveBufferSize <= UDPConfigConstants.RECEIVE_BUFFER_SIZE_MAX)) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #32168