### PR TITLE
SAML: Add doPriv to Open Saml Core for Java 2 Sec

### DIFF
--- a/dev/com.ibm.ws.org.opensaml.opensaml.core.3.4.5/src/org/opensaml/core/config/provider/SystemPropertyConfigurationPropertiesSource.java
+++ b/dev/com.ibm.ws.org.opensaml.opensaml.core.3.4.5/src/org/opensaml/core/config/provider/SystemPropertyConfigurationPropertiesSource.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the University Corporation for Advanced Internet Development,
+ * Inc. (UCAID) under one or more contributor license agreements.  See the
+ * NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The UCAID licenses this file to You under the Apache
+ * License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opensaml.core.config.provider;
+
+import java.util.Properties;
+
+import org.opensaml.core.config.ConfigurationPropertiesSource;
+
+/**
+ * A configuration properties source implementation which simply returns the system properties set.
+ */
+public class SystemPropertyConfigurationPropertiesSource implements ConfigurationPropertiesSource {
+
+    /** {@inheritDoc} */
+    public Properties getProperties() {
+        return System.getProperties();
+    }
+
+}

--- a/dev/io.openliberty.org.opensaml.opensaml.core/.classpath
+++ b/dev/io.openliberty.org.opensaml.opensaml.core/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.org.opensaml.opensaml.core/bnd.overrides
+++ b/dev/io.openliberty.org.opensaml.opensaml.core/bnd.overrides
@@ -196,5 +196,5 @@ Include-Resource: \
   @\${repo;io.openliberty.org.opensaml:opensaml-xacml-saml-impl;4.3.2.1}!/!META-INF/MANIFEST.MF|META-INF/maven/*|META-INF/services/*, \
   @\${repo;io.dropwizard.metrics:metrics-core;4.2.25}!/!META-INF/MANIFEST.MF|META-INF/maven/*|META-INF/services/*, \
   META-INF=resources/META-INF, \
-  ${if;${driver;gradle};org/opensaml=${bin}/org/opensaml;}
+  org/opensaml=${bin}/org/opensaml
 

--- a/dev/io.openliberty.org.opensaml.opensaml.core/src/org/opensaml/core/config/provider/SystemPropertyConfigurationPropertiesSource.java
+++ b/dev/io.openliberty.org.opensaml.opensaml.core/src/org/opensaml/core/config/provider/SystemPropertyConfigurationPropertiesSource.java
@@ -17,6 +17,8 @@
 
 package org.opensaml.core.config.provider;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Properties;
 
 import org.opensaml.core.config.ConfigurationPropertiesSource;
@@ -26,9 +28,16 @@ import org.opensaml.core.config.ConfigurationPropertiesSource;
  */
 public class SystemPropertyConfigurationPropertiesSource implements ConfigurationPropertiesSource {
 
-    /** {@inheritDoc} */
+    // Liberty Change Start: Add doPriv
+    @Override
     public Properties getProperties() {
-        return System.getProperties();
+        return AccessController.doPrivileged(new PrivilegedAction<Properties>() {
+            @Override
+            public Properties run() {
+                return System.getProperties();
+            }
+        });
     }
+    // Liberty Change End
 
 }


### PR DESCRIPTION
This PR adds a doPriv to the `SystemPropertyConfigurationPropertiesSource` class in Open Saml to resolve various Java 2 Security Erros.

- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
