### PR TITLE
Change the consumer service to delay starting

### DIFF
--- a/dev/com.ibm.ws.persistence_fat/bnd.bnd
+++ b/dev/com.ibm.ws.persistence_fat/bnd.bnd
@@ -39,4 +39,6 @@ tested.features: xmlBinding-3.0, servlet-5.0, jpacontainer-3.0, persistence-3.0,
 	com.ibm.ws.resource;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.org.apache.commons.io;version=latest,\
+	com.ibm.ws.kernel.feature;version=latest,\
+	com.ibm.ws.logging;version=latest,\
 	org.apache.derby:derby;version=10.11.1.1

--- a/dev/com.ibm.ws.persistence_fat/bnd.bnd
+++ b/dev/com.ibm.ws.persistence_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.persistence_fat/test-bundles/com.ibm.ws.persistence.consumer/src/persistence_fat/consumer/ConsumerService.java
+++ b/dev/com.ibm.ws.persistence_fat/test-bundles/com.ibm.ws.persistence.consumer/src/persistence_fat/consumer/ConsumerService.java
@@ -32,6 +32,9 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.feature.ServerStarted;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.persistence.DDLGenerationParticipant;
 import com.ibm.wsspi.persistence.InMemoryMappingFile;
@@ -52,6 +55,7 @@ import persistence_fat.consumer.internal.model.Person;
            immediate = true)
 public class ConsumerService implements ResourceFactory, DDLGenerationParticipant {
     private static final String PERSISTENCE_SERVICE = "persistenceService";
+    private static final TraceComponent tc = Tr.register(ConsumerService.class);
 
     private final AtomicServiceReference<PersistenceService> ps = new AtomicServiceReference<PersistenceService>(PERSISTENCE_SERVICE);
 
@@ -189,6 +193,15 @@ public class ConsumerService implements ResourceFactory, DDLGenerationParticipan
     protected void unsetPersistenceService(ServiceReference<PersistenceService> reference) {
         ps.unsetReference(reference);
     }
+
+    @Reference
+    protected synchronized void setServerStarted(ServerStarted serverStarted) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "ServerStarted bound. kernel indicates server is ready");
+        }
+    }
+
+    protected synchronized void unsetServerStarted(ServerStarted serverStarted) { }
 
     @Override
     public String getDDLFileName() {

--- a/dev/com.ibm.ws.persistence_fat/test-bundles/com.ibm.ws.persistence.consumer/src/persistence_fat/consumer/ConsumerService.java
+++ b/dev/com.ibm.ws.persistence_fat/test-bundles/com.ibm.ws.persistence.consumer/src/persistence_fat/consumer/ConsumerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Adds set and unset methods for ServerStarted to delay the starting of consumer service and makes sure it starts only after the server is ready.
Fix for RTC defect 307121