### PR TITLE
Add `-Dcom.ibm.fips.mode` for tools

### DIFF
--- a/dev/cnf/resources/bin/tool.bat
+++ b/dev/cnf/resources/bin/tool.bat
@@ -79,7 +79,7 @@ if defined ENABLE_FIPS140_3 (
       if defined IBM_SDK_8 (
           set JVM_ARGS=-Xenablefips140-3 -Dcom.ibm.jsse2.usefipsprovider=true -Dcom.ibm.jsse2.usefipsProviderName=IBMJCEPlusFIPS !JVM_ARGS!
       ) else if defined SEMERU_FIPS (
-          set JVM_ARGS=-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Liberty -Djava.security.properties="!WLP_INSTALL_DIR!\lib\security\fips140_3\FIPS140-3-Liberty.properties" !JVM_ARGS!
+          set JVM_ARGS=-Dsemeru.fips=true -Dcom.ibm.fips.mode=140-3 -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Liberty -Djava.security.properties="!WLP_INSTALL_DIR!\lib\security\fips140_3\FIPS140-3-Liberty.properties" !JVM_ARGS!
       )
     )
 )


### PR DESCRIPTION
On Java25 the com.ibm.fips.mode property is not being properly popoulated when we run a tool. including as part of the arguments prevents this from being missed


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
