### PR TITLE
Work around most occurrences of 33182 by using lower case this

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -640,9 +640,6 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testConvertLongValue() throws Exception {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         assertEquals(47L,
                      primes.numberAsBigDecimal(47).longValue());
@@ -665,11 +662,15 @@ public class DataTestServlet extends FATServlet {
                                      .floatValue(),
                      0.01f);
 
-        assertEquals(31,
-                     primes.numberAsInt(31));
+        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
+            //TODO remove skip when fixed in Hibernate
+        } else {
+            assertEquals(31,
+                         primes.numberAsInt(31));
 
-        assertEquals(29,
-                     primes.numberAsInteger(29L).orElseThrow().intValue());
+            assertEquals(29,
+                         primes.numberAsInteger(29L).orElseThrow().intValue());
+        }
 
         assertEquals(23L,
                      primes.numberAsLong(23));
@@ -677,15 +678,18 @@ public class DataTestServlet extends FATServlet {
         assertEquals(19L,
                      primes.numberAsLongWrapper(19).orElseThrow().longValue());
 
-        assertEquals((short) 4013,
-                     primes.numberAsShort(4013));
+        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
+            //TODO remove skip when fixed in Hibernate
+        } else {
+            assertEquals((short) 4013,
+                         primes.numberAsShort(4013));
+        }
 
         assertEquals((short) 4007,
                      primes.numberAsShortWrapper(4007).orElseThrow().shortValue());
 
         assertEquals(false,
                      primes.numberAsShortWrapper(27).isPresent());
-
     }
 
     /**
@@ -2225,9 +2229,6 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testFromClauseIdentifiesEntity() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         products.clear();
 
@@ -2249,7 +2250,11 @@ public class DataTestServlet extends FATServlet {
         prod3.price = 16.99f;
         prod3 = multi.create(prod3);
 
-        assertEquals(3L, multi.countEverything());
+        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
+            //TODO remove skip when fixed in Hibernate or Liberty
+        } else {
+            assertEquals(3L, multi.countEverything());
+        }
 
         assertEquals(1L, multi.discount("TestFromClauseIdentifiesEntity-Product-3", 0.30f));
         assertEquals(3L, multi.discount("TestFromClauseIdentifiesEntity-Product-_", 0.20f));
@@ -2260,7 +2265,11 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(3L, multi.destroy("TestFromClauseIdentifiesEntity-%"));
 
-        assertEquals(0L, multi.countEverything());
+        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
+            //TODO remove skip when fixed in Hibernate or Liberty
+        } else {
+            assertEquals(0L, multi.countEverything());
+        }
     }
 
     /**
@@ -2269,9 +2278,6 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testFunctionWithIdThisArg() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         vehicles.delete();
 
@@ -3848,9 +3854,6 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testNamedParametersFromMethodParameterNames() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         assertArrayEquals(new long[] { 19, 29, 43, 47 },
                           primes.matchAny(19, "XLVII", "2B", "twenty-nine"));
@@ -3939,9 +3942,6 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testOrderByIdFunction() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         assertIterableEquals(List.of(19L, 17L, 13L, 11L, 7L, 5L, 3L, 2L),
                              primes.below(20L));
@@ -4997,9 +4997,6 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testSingularResultPageOfBoolean() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         PageRequest pageReq = PageRequest.ofSize(6);
         Page<Boolean> page = primes.pageOfExists(pageReq);
@@ -5017,9 +5014,6 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testSingularResultPageNumeric() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         Page<Long> page = primes.pageOfCountUpTo(20L, PageRequest.ofSize(4));
 
@@ -5634,10 +5628,6 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testTransactional() throws ExecutionException, IllegalStateException, InterruptedException, //
                     NotSupportedException, SecurityException, SystemException, TimeoutException {
-
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         personnel.removeAll().get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
 

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/PersonRepo.java
@@ -49,7 +49,7 @@ public interface PersonRepo {
     @Transactional(TxType.SUPPORTS)
     Person getPersonInCurrentOrNoTransaction(Long ssn_id);
 
-    @Query("UPDATE Person SET firstName=?2 WHERE ID(THIS)=?1")
+    @Query("UPDATE Person SET firstName=?2 WHERE ID(this)=?1")
     @Transactional(TxType.REQUIRED)
     boolean setFirstNameInCurrentOrNewTransaction(Long ssn_id,
                                                   String firstName);
@@ -59,7 +59,7 @@ public interface PersonRepo {
     boolean setFirstNameInCurrentTransaction(Long ssn,
                                              String newFirstName);
 
-    @Query("UPDATE Person SET firstName=:firstName WHERE id(THIS)=:id")
+    @Query("UPDATE Person SET firstName=:firstName WHERE id(this)=:id")
     @Transactional(TxType.REQUIRES_NEW)
     boolean setFirstNameInNewTransaction(@Param("id") Long ssn,
                                          @Param("firstName") String newFirstName);
@@ -69,7 +69,7 @@ public interface PersonRepo {
     boolean setFirstNameWhenNoTransactionIsPresent(Long id,
                                                    String newFirstName);
 
-    @Query("UPDATE Person SET firstName=?2 WHERE Id(This)=?1")
+    @Query("UPDATE Person SET firstName=?2 WHERE Id(this)=?1")
     @Transactional(TxType.NOT_SUPPORTED)
     boolean setFirstNameWithCurrentTransactionSuspended(Long id,
                                                         String newFirstName);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -65,7 +65,7 @@ public interface Primes {
     @Query("SELECT (num.name) FROM Prime As num")
     Page<String> all(Sort<Prime> sort, PageRequest pagination);
 
-    @Query("SELECT ID(THIS) WHERE ID(THIS) < ?1 ORDER BY ID(THIS) DESC")
+    @Query("SELECT ID(this) WHERE ID(this) < ?1 ORDER BY ID(this) DESC")
     List<Long> below(long exclusiveMax);
 
     @Query("SELECT binaryDigits WHERE numberId <= :max")
@@ -278,12 +278,12 @@ public interface Primes {
     Page<String> lengthBasedQuery(PageRequest pageRequest);
 
     @OrderBy(ID)
-    @Query("SELECT ID(THIS)" +
+    @Query("SELECT ID(this)" +
            "  FROM Prime" +
            " WHERE (name = :numberName" +
            "     OR :numeral=romanNumeral" +
            "     OR hex =:hex" +
-           "     OR ID(THIS)=:num)")
+           "     OR ID(this)=:num)")
     long[] matchAny(long num, String numeral, String hex, String numberName);
 
     @OrderBy(ID)
@@ -403,10 +403,10 @@ public interface Primes {
     double numberAsDouble(long num);
 
     @Asynchronous
-    @Query("SELECT numberId WHERE id(THIS)=?1")
+    @Query("SELECT numberId WHERE id(this)=?1")
     CompletableFuture<Optional<Float>> numberAsFloatWrapper(long num);
 
-    @Query("SELECT numberId WHERE Id(This)=?1")
+    @Query("SELECT numberId WHERE id(THIS)=?1")
     int numberAsInt(long num);
 
     @Query("SELECT numberId WHERE Id(This)=:num")
@@ -421,7 +421,7 @@ public interface Primes {
     @Query("SELECT numberId WHERE ID(THIS)=?1")
     short numberAsShort(long num);
 
-    @Query("SELECT numberId WHERE ID(THIS)=:num")
+    @Query("SELECT numberId WHERE ID(this)=:num")
     Optional<Short> numberAsShortWrapper(long num);
 
     @Query("""
@@ -437,11 +437,11 @@ public interface Primes {
     );
 
     // discouraged usage, but testing what happens
-    @Query("SELECT COUNT(THIS) WHERE ID(THIS) < :max")
+    @Query("SELECT COUNT(this) WHERE ID(this) < :max")
     Page<Long> pageOfCountUpTo(long max, PageRequest pageReq);
 
     // discouraged usage, but testing what happens
-    @Query("SELECT CASE WHEN COUNT(THIS) > 0 THEN TRUE ELSE FALSE END")
+    @Query("SELECT CASE WHEN COUNT(this) > 0 THEN TRUE ELSE FALSE END")
     Page<Boolean> pageOfExists(PageRequest pageReq);
 
     @Insert

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Vehicles.java
@@ -67,6 +67,6 @@ public interface Vehicles {
     @Query("UPDATE Vehicle SET price=price+?2 WHERE (vinId=?1)")
     boolean updateByVinIdAddPrice(String vin, float priceIncrease);
 
-    @Query("WHERE LOWER(ID(THIS)) = ?1")
+    @Query("WHERE LOWER(ID(this)) = ?1")
     Optional<Vehicle> withVINLowerCase(String lowerCaseVIN);
 }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
@@ -96,7 +96,7 @@ public interface Businesses extends BasicRepository<Business, Integer> {
     Stream<Business> in(@By("location_address.city") String city,
                         @By("location.address_state") String state);
 
-    @Query("SELECT CASE WHEN COUNT(THIS) > 0 THEN TRUE ELSE FALSE END" +
+    @Query("SELECT CASE WHEN COUNT(this) > 0 THEN TRUE ELSE FALSE END" +
            " WHERE location.address.houseNum = :houseNum" +
            "   AND location.address.street.name = :streetName" +
            "   AND location.address.street.direction = :streetDir" +

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -50,7 +50,7 @@ public interface Cities {
     Stream<City> byNameButNotId(String cityName,
                                 CityId exceptFor);
 
-    @Query("SELECT VERSION(THIS) WHERE ID(THIS) = ?1")
+    @Query("SELECT VERSION(this) WHERE ID(this) = ?1")
     long currentVersion(CityId id);
 
     @Query("SELECT VERSION(THIS) WHERE name = ?1 AND stateName = ?2")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -2259,9 +2259,6 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testExistsViaQueryLanguage() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         assertEquals(true, businesses.isLocatedAt(2800, "37th St", "NW", "IBM"));
         assertEquals(false, businesses.isLocatedAt(200, "1st St", "SW", "IBM"));
@@ -4772,27 +4769,32 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testUpdateEntityWithIdClassAndVersion() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         CityId mnId = CityId.of("Rochester", "Minnesota");
         CityId nyId = CityId.of("Rochester", "New York");
 
-        long mnVer = cities.currentVersion(mnId.name, mnId.getStateName());
-        long nyVer = cities.currentVersion(nyId.name, nyId.getStateName());
+        long mnVer;
+        long nyVer;
+        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
+            // TODO once fixed in Hibernate, update the JPQL query to use VERSION(THIS)
+            // instead of lower case VERSION(this)
+            mnVer = cities.currentVersion(mnId);
+            nyVer = cities.currentVersion(nyId);
+        } else {
+            mnVer = cities.currentVersion(mnId.name, mnId.getStateName());
+            nyVer = cities.currentVersion(nyId.name, nyId.getStateName());
 
-        // TODO enable once EclipseLink #29073 is fixed, and maybe remove the above
-        //long mnVer = cities.currentVersion(mnId);
-        //long nyVer = cities.currentVersion(nyId);
+            // TODO enable once EclipseLink #29073 is fixed, and maybe remove the above
+            //mnVer = cities.currentVersion(mnId);
+            //nyVer = cities.currentVersion(nyId);
 
-        // TODO allow this test to run once 28589 is fixed
-        // and verify that EclipseLink does not corrupt the area code value
-        // for the following subsequent tests:
-        // testCollectionAttribute, testIdClassOrderBySorts, testIdClassOrderByAnnotationWithCursorPagination,
-        // testIdClassOrderByNamePatternWithCursorPagination, testIdClassOrderByAnnotationReverseDirection
-        if (!isHibernate())
+            // TODO allow this test to run once 28589 is fixed
+            // and verify that EclipseLink does not corrupt the area code value
+            // for the following subsequent tests:
+            // testCollectionAttribute, testIdClassOrderBySorts, testIdClassOrderByAnnotationWithCursorPagination,
+            // testIdClassOrderByNamePatternWithCursorPagination, testIdClassOrderByAnnotationReverseDirection
             return;
+        }
 
         City[] updated = cities.modifyData(City.of(mnId, 122413, Set.of(507, 924), mnVer),
                                            City.of(nyId, 208546, Set.of(585), nyVer));


### PR DESCRIPTION
The real issue behind #33182 is that Hibernate doesn't recognize`THIS` as the implicit entity identification variable unless it is all in lower case.  I left a few occurrences in place to reproduce that and switched other usage with our tests to lower case so that most of the tests that were blocked by this can run.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
