### PR TITLE
tests must update version when using query language

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4239,9 +4239,6 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testQueryByMethodNameWithoutBy() {
-        if (skipForHibernateByDatabase("derby", "https://github.com/OpenLiberty/open-liberty/issues/33287")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         vehicles.delete();
 
@@ -4318,20 +4315,26 @@ public class DataTestServlet extends FATServlet {
                                      .map(v -> v.model)
                                      .collect(Collectors.toList()));
 
-        assertEquals(List.of("Impreza", "HR-V"),
-                     vehicles.deleteFoundOrderByPriceAscVinIdAsc(Limit.of(2))
-                                     .stream()
-                                     .map(v -> v.model)
-                                     .collect(Collectors.toList()));
+        if (skipForHibernateByDatabase("derby", "https://github.com/OpenLiberty/open-liberty/issues/33287")) {
+            //TODO remove skip when fixed in Hibernate or Liberty
+            assertEquals(5L, vehicles.delete());
+            assertEquals(0L, vehicles.countEverything());
+        } else {
+            assertEquals(List.of("Impreza", "HR-V"),
+                         vehicles.deleteFoundOrderByPriceAscVinIdAsc(Limit.of(2))
+                                         .stream()
+                                         .map(v -> v.model)
+                                         .collect(Collectors.toList()));
 
-        assertEquals(3L, vehicles.countEverything());
+            assertEquals(3L, vehicles.countEverything());
 
-        assertEquals(List.of("CR-V", "Explorer", "Outback"),
-                     vehicles.deleteAll()
-                                     .stream()
-                                     .map(v -> v.model)
-                                     .sorted()
-                                     .collect(Collectors.toList()));
+            assertEquals(List.of("CR-V", "Explorer", "Outback"),
+                         vehicles.deleteAll()
+                                         .stream()
+                                         .map(v -> v.model)
+                                         .sorted()
+                                         .collect(Collectors.toList()));
+        }
 
         assertEquals(false, vehicles.existsAny());
         assertEquals(0L, vehicles.findAll().count());

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -5876,9 +5876,6 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testUpdateMultiple() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33277")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         products.clear();
 
@@ -6054,9 +6051,6 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testVersionedUpdateViaQuery() {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33277")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         Product prod1 = new Product();
         prod1.pk = UUID.nameUUIDFromBytes("Q6008-U8-21001".getBytes());

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
@@ -59,7 +59,12 @@ public interface Products {
     @Query("DELETE FROM Product p WHERE p.name LIKE ?1")
     int purge(String namePattern);
 
-    @Query("UPDATE Product SET price = price - (?2 * price) WHERE name LIKE CONCAT('%', ?1, '%')")
+    @Query("""
+                    UPDATE Product
+                       SET price = price - (?2 * price),
+                           version = version + 1
+                     WHERE name LIKE CONCAT('%', ?1, '%')
+                    """)
     long putOnSale(String nameContains, float discount);
 
     @Query("SELECT name")
@@ -80,7 +85,7 @@ public interface Products {
     @Save
     Product[] saveMultiple(Product... p);
 
-    @Query("UPDATE Product SET price=?3 WHERE pk=?1 AND version=?2")
+    @Query("UPDATE Product SET price=?3, version=?2+1 WHERE pk=?1 AND version=?2")
     boolean setPrice(UUID pk,
                      long version,
                      float newPrice);


### PR DESCRIPTION
A few tests are relying on EclipseLink-specific behavior to automatically update the version attribute when a JPQL UPDATE is supplied that omits a version update.  The Jakarta Persistence specification does not require the Persistence provider to add the version update, so tests cannot expect it to happen automatically.  After include the version update, this PR removes the skips for #33277

Also, this PR delays the skips for 33287 until needed.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
