### PR TITLE
Fail startup when onError=FAIL and CWWKG0058E

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigEvaluator.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigEvaluator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2023 IBM Corporation and others.
+ * Copyright (c) 2010, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -226,11 +226,19 @@ class ConfigEvaluator {
         return context.getEvaluationResult();
     }
 
-    void issueError(String label, Object... args) {
-        Tr.error(tc, label, args);
-        // Invalidate the config cache
-        serverXMLConfig.setConfigReadTime(-1);
-
+    void issueError(String label, Object... args) throws ConfigEvaluatorException {
+        switch (ErrorHandler.INSTANCE.getOnError()) {
+            case FAIL:
+                Tr.error(tc, label, args);                
+                serverXMLConfig.setConfigReadTime(-1);  // Invalidate the config cache
+                throw new ConfigEvaluatorException(Tr.formatMessage(tc, label, args));
+            case WARN:
+                Tr.error(tc, label, args);
+                serverXMLConfig.setConfigReadTime(-1);  // Invalidate the config cache
+                break;
+            case IGNORE:
+                break;
+        }
     }
 
     void issueWarning(String label, Object... args) {

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigUpdater.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigUpdater.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -120,7 +120,7 @@ class ConfigUpdater {
                 if (failOnError) {
                     throw e;
                 } else {
-                    configEvaluator.issueError("error.config.update.exception", new Object[] { nodeName, e.getMessage(), info.configElement.getId() });
+                    issueError("error.config.update.exception", new Object[] { nodeName, e.getMessage(), info.configElement.getId() });
                     warnIfOldConfigExists(info, nodeName);
                 }
             } catch (AttributeValidationException e) {
@@ -128,8 +128,8 @@ class ConfigUpdater {
                 if (failOnError) {
                     throw new ConfigUpdateException(e);
                 } else {
-                    configEvaluator.issueError("error.attribute.validation.exception",
-                                               new Object[] { nodeName, e.getAttributeDefintion().getID(), e.getValue(), e.getMessage() });
+                    issueError("error.attribute.validation.exception",
+                               new Object[] { nodeName, e.getAttributeDefintion().getID(), e.getValue(), e.getMessage() });
                     warnIfOldConfigExists(info, nodeName);
                 }
             } catch (ConfigEvaluatorException e) {
@@ -137,7 +137,7 @@ class ConfigUpdater {
                 if (failOnError) {
                     throw new ConfigUpdateException(e);
                 } else {
-                    configEvaluator.issueError("error.config.update.exception", new Object[] { nodeName, e.getMessage(), info.configElement.getId() });
+                    issueError("error.config.update.exception", new Object[] { nodeName, e.getMessage(), info.configElement.getId() });
                     warnIfOldConfigExists(info, nodeName);
                 }
             }
@@ -185,6 +185,23 @@ class ConfigUpdater {
         }
 
         return configElement.getNodeName();
+    }
+
+    /**
+     * Issue an error by delegating to ConfigEvaluator.issueError() and translating
+     * ConfigEvaluatorException to ConfigUpdateException.
+     *
+     * @param label the error message label
+     * @param args the error message arguments
+     * @throws ConfigUpdateException if the error handler is set to FAIL
+     */
+    @FFDCIgnore(ConfigEvaluatorException.class)
+    private void issueError(String label, Object... args) throws ConfigUpdateException {
+        try {
+            configEvaluator.issueError(label, args);
+        } catch (ConfigEvaluatorException e) {
+            throw new ConfigUpdateException(e);
+        }
     }
 
     private void updateConfiguration(ConfigurationInfo info, Collection<ConfigurationInfo> infos, boolean encourageUpdates) throws ConfigEvaluatorException, ConfigUpdateException {
@@ -598,7 +615,7 @@ class ConfigUpdater {
                 // throw an error
                 if (info != null) {
                     String id = failedUpdateAttrDef.get(value).getID();
-                    configEvaluator.issueError("error.unique.value.conflict", id, value);
+                    issueError("error.unique.value.conflict", id, value);
                     String nodeName = getNodeNameForExceptions(info.configElement);
                     String exceptionMessage = "The value " + value + " for attribute " + id + " is not unique";
 
@@ -608,7 +625,7 @@ class ConfigUpdater {
                     if (failOnError) {
                         throw new ConfigUpdateException(exceptionMessage);
                     } else {
-                        configEvaluator.issueError("error.config.update.exception", new Object[] { nodeName, exceptionMessage, info.configElement.getId() });
+                        issueError("error.config.update.exception", new Object[] { nodeName, exceptionMessage, info.configElement.getId() });
                         warnIfOldConfigExists(info, nodeName);
                     }
                 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] Fixes #33452. Verify `release bug` label.
- [x] Resolves an external Known Issue. Fixes #33452. 


1. Added a private issueError(String label, Object... args) method in ConfigUpdater.java that
- Wraps calls to configEvaluator.issueError()
- Translates ConfigEvaluatorException to ConfigUpdateException
- Eliminates code duplication
2. Updated all 5 call sites to use the wrapper method.
3. Added ConfigEvaluatorException to the @FFDCIgnore annotation

