### PR TITLE
Netty: Set defaultStrictLineParsing to false

### DIFF
--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -153,7 +153,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     public static final int DEFAULT_INITIAL_BUFFER_SIZE = 128;
     public static final boolean DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS = false;
     public static final boolean DEFAULT_STRICT_LINE_PARSING =
-            SystemPropertyUtil.getBoolean("io.netty.handler.codec.http.defaultStrictLineParsing", true);
+            SystemPropertyUtil.getBoolean("io.netty.handler.codec.http.defaultStrictLineParsing", false);
 
     private static final Runnable THROW_INVALID_CHUNK_EXTENSION = new Runnable() {
         @Override

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -152,6 +152,19 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     public static final boolean DEFAULT_VALIDATE_HEADERS = true;
     public static final int DEFAULT_INITIAL_BUFFER_SIZE = 128;
     public static final boolean DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS = false;
+
+    /*
+     * Netty uses a default of true, however for Open Liberty we need to set the default to false.
+     *
+     * If this is not set to false by default there are a number of CTS test failures.
+     *
+     * An exception similar to the following will be seen:
+     * io.netty.handler.codec.http.InvalidLineSeparatorException: Line Feed must be preceded by Carriage Return when terminating HTTP start- and header field-lines
+     * at io.netty.handler.codec.http.HttpObjectDecoder$2.run(HttpObjectDecoder.java:168)
+     * at io.netty.handler.codec.http.HttpObjectDecoder$HeaderParser.parse(HttpObjectDecoder.java:1223)
+     * at io.netty.handler.codec.http.HttpObjectDecoder.readHeaders(HttpObjectDecoder.java:754)
+     * at io.netty.handler.codec.http.HttpObjectDecoder.decode(HttpObjectDecoder.java:390)
+     */
     public static final boolean DEFAULT_STRICT_LINE_PARSING =
             SystemPropertyUtil.getBoolean("io.netty.handler.codec.http.defaultStrictLineParsing", false);
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Having this set to `true` causes a number of CTS failures. The update was made as part of the Netty update here: https://github.com/OpenLiberty/open-liberty/pull/32764

Example exception:

> 
> [11/14/25 22:38:34:016 UTC] 00000137 id=f8176e9f m.ws.http.netty.pipeline.inbound.LibertyHttpObjectAggregator > channelRead0 Entry  
>                                                                                                                ChannelHandlerContext(LIBERTY_OBJECT_AGGREGATOR, [id: 0x38161030, L:/127.0.0.1:9080 - R:/127.0.0.1:60211])
>                                                                                                                DefaultHttpRequest(decodeResult: failure(io.netty.handler.codec.http.InvalidLineSeparatorException: Line Feed must be preceded by Carriage Return when terminating HTTP start- and header field-lines), version: HTTP/1.1)
> GET /misc_jndi_earwar_web/TestServlet?testname=appJNDI HTTP/1.1
> [11/14/25 22:38:34:016 UTC] 00000137 id=f8176e9f m.ws.http.netty.pipeline.inbound.LibertyHttpObjectAggregator > exceptionCaught Entry  
>                                                                                                                ChannelHandlerContext(LIBERTY_OBJECT_AGGREGATOR, [id: 0x38161030, L:/127.0.0.1:9080 - R:/127.0.0.1:60211])
>                                                                                                                io.netty.handler.codec.http.InvalidLineSeparatorException: Line Feed must be preceded by Carriage Return when terminating HTTP start- and header field-lines
> 	at io.netty.handler.codec.http.HttpObjectDecoder$2.run(HttpObjectDecoder.java:168)
> 	at io.netty.handler.codec.http.HttpObjectDecoder$HeaderParser.parse(HttpObjectDecoder.java:1223)
> 	at io.netty.handler.codec.http.HttpObjectDecoder.readHeaders(HttpObjectDecoder.java:754)
> 	at io.netty.handler.codec.http.HttpObjectDecoder.decode(HttpObjectDecoder.java:390)
> 	at io.netty.handler.codec.http.HttpServerCodec$HttpServerRequestDecoder.decode(HttpServerCodec.java:178)
> 	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
> 	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
> 	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
> 	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
> 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
> 	at io.netty.handler.codec.ByteToMessageDecoder.handlerRemoved(ByteToMessageDecoder.java:266)
> 	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:537)
> 	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
> 	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
> 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
> 	at io.openliberty.netty.internal.tcp.TCPLoggingHandler.channelRead(TCPLoggingHandler.java:110)
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
> 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
> 	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357)
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
> 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
> 	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868)
> 	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
> 	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:796)
> 	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:732)
> 	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:658)
> 	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
> 	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
> 	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
> 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
> 	at java.lang.Thread.run(Thread.java:826)


for #31008