### PR TITLE
Address NettyFrameworkImpl TODOs (GlobalEventExecutor removal)

### DIFF
--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/tcp/TCPUtils.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/tcp/TCPUtils.java
@@ -28,7 +28,6 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.util.concurrent.GlobalEventExecutor;
 import io.openliberty.netty.internal.BootstrapConfiguration;
 import io.openliberty.netty.internal.BootstrapExtended;
 import io.openliberty.netty.internal.ChannelInitializerWrapper;
@@ -130,7 +129,7 @@ public class TCPUtils {
                         Tr.debug(tc, "Adding new channel group for " + channel);
                     }
                     synchronized (framework.getActiveChannelsMap()) {
-                        framework.getActiveChannelsMap().put(channel, new DefaultChannelGroup(GlobalEventExecutor.INSTANCE));
+                        framework.getActiveChannelsMap().put(channel, new DefaultChannelGroup(framework.getChildGroup().next()));
                     }
                 } else {
                     synchronized (framework.getOutboundConnections()) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

for #31361 

GlobalEventExecutor [JavaDoc] - Single-thread singleton [EventExecutor](https://netty.io/4.0/api/io/netty/util/concurrent/EventExecutor.html). It starts the thread automatically and stops it when there is no task pending in the task queue for 1 second. *Please note it is not scalable to schedule large number of tasks to this executor; use a dedicated executor. *


By using the EventExecutorGroup instead, we'll get a thread from the pool instead, which is preferred I believe?  Per the note in the description, it recommends a dedicated executor for performance under load.  
