### PR TITLE
work around Hibernate considering rolled back entity detached by creating a new instance

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1996,7 +1996,7 @@ public class DataJPATestServlet extends FATServlet {
         PurchaseOrder o7 = new PurchaseOrder();
         o7.purchasedBy = "testEntitiesAsParameters-Customer7";
         o7.purchasedOn = OffsetDateTime.now();
-        o7.total = 70.99f;
+        o7.total = 70.19f;
 
         // TODO SQLServer throws com.microsoft.sqlserver.jdbc.SQLServerException: Violation of PRIMARY KEY constraint ...
         // which is not a subset of SQLIntegrityConstraintViolationException
@@ -2010,21 +2010,22 @@ public class DataJPATestServlet extends FATServlet {
         if (!jdbcJarName.startsWith("mssql-jdbc") &&
             !jdbcJarName.startsWith("postgresql")) {
             try {
-                // TODO When using Hibernate, o7 insert succeeds,
-                // causing subsequent failure on:
-                // orders.insertAll(List.of(o7, o8))
-                if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33200")) {
-                    ; //TODO remove skip when fixed in Hibernate or Liberty
-                } else {
-                    orders.insertAll(List.of(o7, o5));
-                    fail("Should not be able insert an entity with an Id that is already present.");
-                }
+                orders.insertAll(List.of(o7, o5));
+                fail("Should not be able insert an entity with an Id that is already present.");
             } catch (EntityExistsException x) {
                 // expected
             }
         }
 
         assertEquals(false, orders.findFirstByPurchasedBy("testEntitiesAsParameters-Customer7").isPresent());
+
+        // Hibernate considers the previous instance of o7 that was rolled back
+        // to be a detached entity that it will not persist. So we need a new
+        // instance:
+        o7 = new PurchaseOrder();
+        o7.purchasedBy = "testEntitiesAsParameters-Customer7";
+        o7.purchasedOn = OffsetDateTime.now();
+        o7.total = 70.99f;
 
         PurchaseOrder o8 = new PurchaseOrder();
         o8.purchasedBy = "testEntitiesAsParameters-Customer8";


### PR DESCRIPTION
After an attempt to insert a new entity rolls back, Hibernate considers the entity to be detached rather than new and prevents a subsequent valid attempt to insert the entity (Issue #33200).  The test case can work around this be creating a new instance for the second insert attempt.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
