### PR TITLE
Disable auto release of messages in LibertyHttpObjectAggregator / Return 413

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
@@ -33,6 +33,7 @@ public class LibertyHttpObjectAggregator extends SimpleChannelInboundHandler<Htt
     private static final AttributeKey<CompositeByteBuf> COMPOSITE_CONTENT = AttributeKey.valueOf("compositeContent");
 
     public LibertyHttpObjectAggregator(long maxContentLength) {
+        super(false); //  messages should NOT be released automatically, we will handle reference counting manually instead (i.e ReferenceCountUtil.release )
         if (maxContentLength <= 0) {
             throw new IllegalArgumentException("maxContentLength must be a positive integer.");
         }

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/HttpOptions.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/HttpOptions.java
@@ -17,6 +17,16 @@ import javax.xml.bind.annotation.XmlAttribute;
 public class HttpOptions extends ConfigElement {
 
     private Boolean ignoreWriteAfterCommit;
+    private Integer messageSizeLimit;
+
+    public Integer getMessageSizeLimit() {
+        return this.messageSizeLimit;
+    }
+    
+    @XmlAttribute
+    public void setMessageSizeLimit(Integer messageSizeLimit) {
+        this.messageSizeLimit = messageSizeLimit;
+    }
 
     public Boolean isIgnoreWriteAfterCommit() {
         return this.ignoreWriteAfterCommit;
@@ -34,6 +44,8 @@ public class HttpOptions extends ConfigElement {
             buf.append("id=\"" + this.getId() + "\" ");
         if (ignoreWriteAfterCommit != null)
             buf.append("ignoreWriteAfterCommit=\"" + ignoreWriteAfterCommit + "\" ");
+        if (messageSizeLimit != null)
+            buf.append("messageSizeLimit=\"" + messageSizeLimit + "\" ");
         buf.append("}");
         return buf.toString();
     }

--- a/dev/io.openliberty.transport.http_fat/bnd.bnd
+++ b/dev/io.openliberty.transport.http_fat/bnd.bnd
@@ -14,7 +14,8 @@ src: \
     fat/src,\
     test-applications/app1/src,\
     test-applications/contentTypeApp/src,\
-    test-applications/InactivityTimeout.war/src
+    test-applications/InactivityTimeout.war/src,\
+    test-applications/FileUpload.war
 
 fat.project: true
 

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/FATSuite.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/FATSuite.java
@@ -30,7 +30,8 @@ import io.openliberty.transport.http_fat.accesslists.AccessListsTests;
                 SoReuseAddrTest.class,
                 TcpOptionsDefaultTests.class,
                 ContentTypeResponseHeaderTests.class,
-                AccessLogRolloverTest.class
+                AccessLogRolloverTest.class,
+                MaxMessageSizeLimitTests.class
 })
 
 public class FATSuite {

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxMessageSizeLimitTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxMessageSizeLimitTests.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.transport.http_fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.HttpEndpoint;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.rules.repeater.EE6FeatureReplacementAction;
+
+/**
+ * Test to ensure that the tcpOptions inactivityTimeout works.
+ */
+@SkipForRepeat(EE6FeatureReplacementAction.ID) // Part.getSubmittedFileName requires Servlet 3.1+
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class MaxMessageSizeLimitTests {
+
+    private static final Logger LOG = Logger.getLogger(MaxMessageSizeLimitTests.class.getName());
+    private static final String APP_NAME = "FileUpload";
+    private static final String NETTY_TCP_CLASS_NAME = "io.openliberty.netty.internal.tcp.TCPUtils";
+    private static boolean runningNetty = false;
+
+    @Server("MaxMessageSize")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, APP_NAME + ".war", "io.openliberty.transport.http.fileupload.servlet");
+
+        // Start the server and use the class name so we can find logs easily.
+        server.startServer(MaxMessageSizeLimitTests.class.getSimpleName() + ".log");
+
+        // Go through logs and check if Netty is being used.
+        // Wait for the TCP Channel to finish loading and get the TCP Channel started message.
+        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv6) port 8010.
+        String tcpChannelMessage = server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint");
+        LOG.info("Endpoint: " + tcpChannelMessage);
+
+        runningNetty = tcpChannelMessage.contains(NETTY_TCP_CLASS_NAME);
+        LOG.info("Running Netty? " + runningNetty);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * Save the server configuration before each test, this should be the default server
+     * configuration.
+     *
+     * @throws Exception
+     */
+    @Before
+    public void beforeTest() throws Exception {
+        server.saveServerConfiguration();
+    }
+
+    /**
+     * Restore the server configuration to the default state after each test.
+     *
+     * @throws Exception
+     */
+    @After
+    public void afterTest() throws Exception {
+        // Restore the server to the default state.
+        server.setMarkToEndOfLog();
+        server.setTraceMarkToEndOfDefaultTrace();
+        server.restoreServerConfiguration();
+        server.waitForConfigUpdateInLogUsingMark(null);
+    }
+
+    @Test
+    public void testFileThatIsWithinLimit() throws Exception {
+        ServerConfiguration configuration = server.getServerConfiguration();
+        LOG.info("Server configuration that the test started with: " + configuration);
+
+        HttpEndpoint httpEndpoint = configuration.getHttpEndpoints().getById("defaultHttpEndpoint");
+        httpEndpoint.getHttpOptions().setMessageSizeLimit(3000); // Larger than our file content size
+
+        server.setMarkToEndOfLog();
+        server.setTraceMarkToEndOfDefaultTrace();
+        server.updateServerConfiguration(configuration);
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton(APP_NAME), false, "CWWKT0016I:.*FileUpload.*");
+
+        String boundary = "-----------------" + System.currentTimeMillis();
+        
+        URL url = new URL("http://" + server.getHostname() + ":" + 
+                         server.getHttpDefaultPort() + "/" + APP_NAME + "/FileUploadServlet");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+        conn.setDoOutput(true); // Sending Data 
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+
+        String fileName = "test.txt";
+        String fileContent = "Hello, world! This is some test file content!";
+        
+        StringBuilder body = new StringBuilder();
+        body.append("--").append(boundary).append("\r\n");
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"");
+        body.append(fileName).append("\"\r\n");
+        body.append("Content-Type: text/plain\r\n\r\n");
+        body.append(fileContent).append("\r\n");
+        body.append("--").append(boundary).append("--\r\n");
+
+        // Send the request with file content
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(body.toString().getBytes(StandardCharsets.UTF_8));
+            os.flush();
+        }
+
+        try {
+            assertEquals("Expected HTTP 200", 200, conn.getResponseCode());
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    @Test
+    public void testFileThatExceedsLimit() throws Exception {
+        ServerConfiguration configuration = server.getServerConfiguration();
+        LOG.info("Server configuration that the test started with: " + configuration);
+
+        HttpEndpoint httpEndpoint = configuration.getHttpEndpoints().getById("defaultHttpEndpoint");
+        httpEndpoint.getHttpOptions().setMessageSizeLimit(2); // Smaller than our file content size, should cause an error
+
+        server.setMarkToEndOfLog();
+        server.setTraceMarkToEndOfDefaultTrace();
+        server.updateServerConfiguration(configuration);
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton(APP_NAME), false, "CWWKT0016I:.*FileUpload.*");
+
+        String boundary = "-----------------" + System.currentTimeMillis();
+        
+        URL url = new URL("http://" + server.getHostname() + ":" + 
+                         server.getHttpDefaultPort() + "/" + APP_NAME + "/FileUploadServlet");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+        conn.setDoOutput(true); // Sending Data 
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+
+        String fileName = "test.txt";
+        String fileContent = "This is test file content!";
+        
+        StringBuilder body = new StringBuilder();
+        body.append("--").append(boundary).append("\r\n");
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"");
+        body.append(fileName).append("\"\r\n");
+        body.append("Content-Type: text/plain\r\n\r\n");
+        body.append(fileContent).append("\r\n");
+        body.append("--").append(boundary).append("--\r\n");
+
+        // Send the request with file content
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(body.toString().getBytes(StandardCharsets.UTF_8));
+            os.flush();
+        }
+
+        try {
+            assertEquals("Expected HTTP 413", 413, conn.getResponseCode());
+        } finally {
+            conn.disconnect();
+        }
+
+    }
+}

--- a/dev/io.openliberty.transport.http_fat/publish/servers/MaxMessageSize/bootstrap.properties
+++ b/dev/io.openliberty.transport.http_fat/publish/servers/MaxMessageSize/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:TCPChannel=all:HTTPTransport=all:io.netty*=all:io.openliberty.netty*=all:
+com.ibm.ws.logging.max.file.size=100
+com.ibm.ws.logging.max.files=10
+com.ibm.ws.logging.trace.format=BASIC

--- a/dev/io.openliberty.transport.http_fat/publish/servers/MaxMessageSize/server.xml
+++ b/dev/io.openliberty.transport.http_fat/publish/servers/MaxMessageSize/server.xml
@@ -1,0 +1,27 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server description="Test httpOptions MessageSizeLimit configuration.">
+
+    <include location="../fatTestCommon.xml"/>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="${bvt.prop.HTTP_default}"
+                  httpsPort="${bvt.prop.HTTP_default.secure}">
+        <tcpOptions portOpenRetries="60"/>
+        <!-- dummy value initially. actual values will be set via test  -->
+        <httpOptions messageSizeLimit="10000"/>
+    </httpEndpoint>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+    </featureManager>
+
+</server>

--- a/dev/io.openliberty.transport.http_fat/test-applications/FileUpload.war/src/io/openliberty/transport/http/fileupload/servlet/FileUploadServlet.java
+++ b/dev/io.openliberty.transport.http_fat/test-applications/FileUpload.war/src/io/openliberty/transport/http/fileupload/servlet/FileUploadServlet.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.transport.http.fileupload.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.annotation.MultipartConfig;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+
+/**
+ * Simple Servlet for testing the httpOptions maxMessageSize.
+ */
+@MultipartConfig
+@WebServlet("/FileUploadServlet")
+public class FileUploadServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        System.out.println("Entered FileUploadServlet#doPost");
+        PrintWriter writer = response.getWriter();
+        writer.println("Response from FileUploadServlet!");
+
+        Part filePart = request.getPart("file");
+        String fileName = filePart.getSubmittedFileName();
+        long fileSize = filePart.getSize();
+                
+        response.setContentType("text/plain");
+        writer.println("File uploaded: " + fileName);
+        writer.println("Size: " + fileSize);
+
+        writer.flush();
+        writer.close();
+        System.out.println("Exited FileUploadServlet#doPost");
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes [#33106](https://github.com/OpenLiberty/open-liberty/issues/33106)

Now when we upload a large file (which exceeds the max size limit), the correct exception is logged: 
```
[11/19/25, 15:01:48:649 EST] 00000082 HttpDispatche >  exceptionCaught Entry  
                                 ChannelHandlerContext(HTTP_DISPATCHER, [id: 0x6beca064, L:/127.0.0.1:9080 - R:/127.0.0.1:58506])
                                 io.netty.handler.codec.TooLongFrameException: Content length exceeded max of 2000 bytes.
    at com.ibm.ws.http.netty.pipeline.inbound.LibertyHttpObjectAggregator.channelRead0(LibertyHttpObjectAggregator.java:83)
    at com.ibm.ws.http.netty.pipeline.inbound.LibertyHttpObjectAggregator.channelRead0(LibertyHttpObjectAggregator.java:25)
    at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
    at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
    at io.netty.handler.codec.http.HttpServerKeepAliveHandler.channelRead(HttpServerKeepAliveHandler.java:64)

```