### PR TITLE
Increase ds.lock.timeout.milliseconds to 30000 for wcServer in Servlet 4.0 FAT

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_wcServer/bootstrap.properties
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_wcServer/bootstrap.properties
@@ -1,14 +1,11 @@
 ###############################################################################
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 osgi.console=7777
@@ -16,3 +13,4 @@ com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.webcontainer*=all:com.i
 com.ibm.ws.logging.max.file.size=20
 com.ibm.ws.logging.max.files=10
 com.ibm.ws.logging.trace.format=BASIC
+ds.lock.timeout.milliseconds=30000


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #33510
