### PR TITLE
Fix typo for better serviceability

### DIFF
--- a/dev/com.ibm.ws.security.wim.registry/src/com/ibm/ws/security/wim/registry/util/BridgeUtils.java
+++ b/dev/com.ibm.ws.security.wim.registry/src/com/ibm/ws/security/wim/registry/util/BridgeUtils.java
@@ -204,7 +204,7 @@ public class BridgeUtils implements WIMUserRegistryDefines {
 
     protected IDAndRealm separateIDAndRealm(String inputString) throws WIMException {
         // initialize the method name
-        String methodName = "seperateIDAndRealm";
+        String methodName = "separateIDAndRealm";
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, methodName + " " + "inputString = \"" + inputString + "\"");
         }


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

It took a while to track down the callers of BridgeUtils.separateIDAndRealm() because the trace output misspelled the method name as seperateIDAndRealm. Even though the typo looks minor, it’s the only searchable clue in the trace, so correcting it will save time when analyzing future issues