### PR TITLE
During authentication, allow HAM processing to be conditionally

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/l10n/metatype.properties
@@ -126,3 +126,7 @@ partitionedCookie.desc=Specifies whether to partition SSO cookies with SameSite 
 partitionedCookieTrue=Always partition SSO cookies that have SameSite set to None.
 partitionedCookieFalse=Do not partition SSO cookies.
 partitionedCookieDefer=Allow the HTTP transport settings to determine whether to partition SSO cookies.
+
+# The word JASPIC should not be translated
+overrideHAMProcessing=Override the use of Http Authentication Mechanisms during JASPIC processing.
+overrideHAMProcessing.desc=When set to true, overrides the use of any defined Http Authentication Mechanisms during JASPIC authentication processing, even if JASPIC is enabled. This applies to all applications. Defaults to false.

--- a/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/metatype/metatype.xml
@@ -160,7 +160,10 @@
         <AD id="loggedOutCookieCacheService.cardinality.minimum" type="String"  default="${count(loggedOutCookieCacheRef)}" 
             ibm:final="true" name="internal" description="internal use only"/>
             
-    </OCD>
+        <AD id="overrideHAMProcessing" name="%overrideHAMProcessing" description="%overrideHAMProcessing.desc" required="false"
+            type="Boolean" default="false"/>
+
+      </OCD>
     <Designate pid="com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl">
         <Object ocdref="com.ibm.ws.webcontainer.security.metatype"/>
     </Designate>

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -17,6 +17,7 @@ import java.security.AccessController;
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -242,10 +243,25 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
         interceptorServiceRef.removeReference(id, ref);
     }
 
+    private void outputStackTraceToDebug() {
+        Tr.debug(tc, "=============== BEGIN STACK TRACE ================");
+        String stackTrace = Arrays.toString(Thread.currentThread().getStackTrace()).replace(',', '\n');
+        Tr.debug(tc, stackTrace);
+        Tr.debug(tc, "================ END STACK TRACE =================");
+
+    }
+
     public void setWebAuthenticator(ServiceReference<WebAuthenticator> ref) {
+        outputStackTraceToDebug();
         String cn = (String) ref.getProperty(KEY_COMPONENT_NAME);
         webAuthenticatorRef.putReference(cn, ref);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "setWebAuthenticator, adding key component name [" + cn + "].");
+        }
         if (cn.equals(JASPI_SERVICE_COMPONENT_NAME)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "setWebAuthenticator, enabling JASPI service for component name [" + JASPI_SERVICE_COMPONENT_NAME + "].");
+            }
             isJaspiEnabled = true;
         }
     }
@@ -253,7 +269,13 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
     public void unsetWebAuthenticator(ServiceReference<WebAuthenticator> ref) {
         String cn = (String) ref.getProperty(KEY_COMPONENT_NAME);
         webAuthenticatorRef.removeReference(cn, ref);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "unsetWebAuthenticator, removing key component name [" + cn + "].");
+        }
         if (cn.equals(JASPI_SERVICE_COMPONENT_NAME)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "setWebAuthenticator, disabling JASPI service for component name [" + JASPI_SERVICE_COMPONENT_NAME + "].");
+            }
             isJaspiEnabled = false;
         }
     }
@@ -667,6 +689,7 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
 
     private void performSecurityChecks(HttpServletRequest req, HttpServletResponse resp, Subject receivedSubject,
                                        WebSecurityContext webSecurityContext, SecurityMetadata securityMetadata) throws SecurityViolationException, IOException {
+        outputStackTraceToDebug();
         String uriName = new URLHandler(webAppSecConfig).getServletURI(req);
 
         savedSubject = receivedSubject;
@@ -736,6 +759,12 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
             }
             boolean isUnprotected = false;
             if (authResult == null || (authResult.getStatus() != AuthResult.SUCCESS && webAppSecConfig.allowFailOver())) {
+                // at this point, if we have specified we want to override HAM processing, then
+                //   return null here so that the parent method can drop down into
+                //   "normal processing" for authentication from server.xml
+                if (webAppSecConfig.isOverrideHAMProcessing() == true) {
+                    return null;
+                }
                 // if client cert is not processed or failed and allowFailOver is configured.
                 // set unprotected flag if the target url is not protected or assigned to everyone role.
                 isUnprotected = (unprotectedResource(webRequest) == PERMIT_REPLY);
@@ -1415,13 +1444,13 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
 
     protected String getApplicationName() {
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-        WebModuleMetaData wmmd = (WebModuleMetaData) ((WebComponentMetaData) cmd).getModuleMetaData();
+        WebModuleMetaData wmmd = ((WebModuleMetaData) cmd.getModuleMetaData());
         return wmmd.getConfiguration().getApplicationName();
     }
 
     protected String getModuleName() {
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-        WebModuleMetaData wmmd = (WebModuleMetaData) ((WebComponentMetaData) cmd).getModuleMetaData();
+        WebModuleMetaData wmmd = ((WebModuleMetaData) cmd.getModuleMetaData());
         return wmmd.getConfiguration().getModuleName();
     }
 
@@ -1431,7 +1460,7 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
 
     protected void setSecurityMetadata(SecurityMetadata secMetadata) {
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-        WebModuleMetaData wmmd = (WebModuleMetaData) ((WebComponentMetaData) cmd).getModuleMetaData();
+        WebModuleMetaData wmmd = ((WebModuleMetaData) cmd.getModuleMetaData());
         wmmd.setSecurityMetaData(secMetadata);
     }
 
@@ -1552,7 +1581,7 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
         WebAppConfig wac = null;
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
         if (cmd instanceof WebComponentMetaData) { // Only get the header for web modules, i.e. not for EJB
-            WebModuleMetaData wmmd = (WebModuleMetaData) ((WebComponentMetaData) cmd).getModuleMetaData();
+            WebModuleMetaData wmmd = ((WebModuleMetaData) cmd.getModuleMetaData());
             wac = wmmd.getConfiguration();
             if (!(wac instanceof com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration)) {
                 wac = null;

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityConfig.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityConfig.java
@@ -67,6 +67,8 @@ public interface WebAppSecurityConfig {
 
     boolean isUseAuthenticationDataForUnprotectedResourceEnabled();
 
+    boolean isOverrideHAMProcessing();
+
     /**
      * Calculates the delta between this WebAppSecurityConfig and the provided
      * WebAppSecurityConfig. The values returned are the values from this Object.

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImpl.java
@@ -73,6 +73,7 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
     public static final String CFG_KEY_PARTITIONED_COOKIE = "partitionedCookie";
     public static final String CFG_KEY_USE_CONTEXT_ROOT_FOR_SSO_COOKIE_PATH = "useContextRootForSSOCookiePath";
     public static final String CFG_KEY_MAX_CONTENT_LENGTH_TO_SAVE_POST_PARAMETERS = "postParamMaxRequestBodySize";
+    public static final String CFG_KEY_OVERRIDE_HAM_PROCESSING = "overrideHAMProcessing";
 
     // New attributes must update getChangedProperties method
     private final Boolean logoutOnHttpSessionExpire;
@@ -107,6 +108,7 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
     private Boolean partitionedCookie = null; // in BETA, mark as final once GA'ed
     private final Boolean useContextRootForSSOCookiePath;
     private final Long postParamMaxRequestBodySize;
+    private final Boolean overrideHAMProcessing;
 
     protected final AtomicServiceReference<WsLocationAdmin> locationAdminRef;
     protected final AtomicServiceReference<SecurityService> securityServiceRef;
@@ -149,6 +151,7 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
             put(CFG_KEY_PARTITIONED_COOKIE, "partitionedCookie");
             put(CFG_KEY_USE_CONTEXT_ROOT_FOR_SSO_COOKIE_PATH, "useContextRootForSSOCookiePath");
             put(CFG_KEY_MAX_CONTENT_LENGTH_TO_SAVE_POST_PARAMETERS, "postParamMaxRequestBodySize");
+            put(CFG_KEY_OVERRIDE_HAM_PROCESSING, "overrideHAMProcessing");
         }
     };
 
@@ -194,9 +197,10 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
         sameSiteCookie = (String) newProperties.get(CFG_KEY_SAME_SITE_COOKIE);
         useContextRootForSSOCookiePath = (Boolean) newProperties.get(CFG_KEY_USE_CONTEXT_ROOT_FOR_SSO_COOKIE_PATH);
         postParamMaxRequestBodySize = (Long) newProperties.get(CFG_KEY_MAX_CONTENT_LENGTH_TO_SAVE_POST_PARAMETERS);
+        overrideHAMProcessing = (Boolean) newProperties.get(CFG_KEY_OVERRIDE_HAM_PROCESSING);
 
         String partValue = (String) newProperties.get(CFG_KEY_PARTITIONED_COOKIE);
-        if ("true".equalsIgnoreCase(partValue)||"false".equalsIgnoreCase(partValue)) {
+        if ("true".equalsIgnoreCase(partValue) || "false".equalsIgnoreCase(partValue)) {
             // we want partitionedCookie to be null unless the value is true or false
             // defer is the default value which mean that the channel config determines the partitioned value
             // if the value is true / false then this config was explicltly set by the user
@@ -615,8 +619,8 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
 
     @Override
     public boolean isPartitionedCookie() {
-        if (partitionedCookie!=null && partitionedCookie==Boolean.TRUE) {
-          return true;
+        if (partitionedCookie != null && partitionedCookie == Boolean.TRUE) {
+            return true;
         }
         return false;
     }
@@ -631,17 +635,21 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
         return postParamMaxRequestBodySize.longValue();
     }
 
+    @Override
+    public boolean isOverrideHAMProcessing() {
+        return overrideHAMProcessing != null ? overrideHAMProcessing.booleanValue() : false;
+    }
+
     // This method is for config users that need to know if an admin has provided a true/false or no value for a
     // boolean config attribute.  The current infrastructure does not properly support this
     public static Boolean getBooleanValue(String attribute, String strValue) {
-      Boolean retVal = null;
-      if (strValue!=null && strValue.length()>0) {
-        //only values that config gives us are true/false/defer
-        if ("true".equalsIgnoreCase(strValue) || "false".equalsIgnoreCase(strValue)) {
-          retVal = Boolean.valueOf(strValue);
-        } 
-      }
-      return(retVal);
+        Boolean retVal = null;
+        if (strValue != null && strValue.length() > 0) {
+            //only values that config gives us are true/false/defer
+            if ("true".equalsIgnoreCase(strValue) || "false".equalsIgnoreCase(strValue)) {
+                retVal = Boolean.valueOf(strValue);
+            }
+        }
+        return (retVal);
     }
-
 }

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImplTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImplTest.java
@@ -805,6 +805,35 @@ public class WebAppSecurityCollaboratorImplTest {
     }
 
     /**
+     * Test method for verifying overrideHAMProcessing configuration is properly loaded
+     * into the collaborator via the configuration flow from the server.xml properties.
+     *
+     * NOTE: Ideally, we would test WebAppSecurityCollaboratorImpl.performSecurityChecks(), but
+     * that would require the method to be made public or protected and registering a real JASPIC
+     * service (which is complex).
+     */
+    @Test
+    public void testOverrideHAMProcessingConfiguration_LoadedCorrectly() {
+        // test with skipJaspi enabled
+        configProps.put(WebAppSecurityConfigImpl.CFG_KEY_OVERRIDE_HAM_PROCESSING, true);
+        setupCollaborator(new WebAppSecurityCollaboratorImplTestDouble(), cc, configProps);
+        assertTrue("When skipJaspi is configured as true, isSkipJaspi() should return true",
+                   secColl.webAppSecConfig.isOverrideHAMProcessing());
+
+        // test with skipJaspi disabled
+        configProps.put(WebAppSecurityConfigImpl.CFG_KEY_OVERRIDE_HAM_PROCESSING, false);
+        setupCollaborator(new WebAppSecurityCollaboratorImplTestDouble(), cc, configProps);
+        assertFalse("When skipJaspi is configured as false, isSkipJaspi() should return false",
+                    secColl.webAppSecConfig.isOverrideHAMProcessing());
+
+        // test default behaviour (not set)
+        configProps.remove(WebAppSecurityConfigImpl.CFG_KEY_OVERRIDE_HAM_PROCESSING);
+        setupCollaborator(new WebAppSecurityCollaboratorImplTestDouble(), cc, configProps);
+        assertFalse("When skipJaspi is not configured, isSkipJaspi() should return false by default",
+                    secColl.webAppSecConfig.isOverrideHAMProcessing());
+    }
+
+    /**
      * Test method for {@link com.ibm.ws.webcontainer.security.internal.WebAppSecurityCollaboratorImpl#authorize(com.ibm.ws.webcontainer.security.internal.AuthenticationResult,
      * java.lang.String, java.lang.String, javax.security.auth.Subject, java.util.List<String>)} .
      */

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImplTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImplTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -403,6 +403,35 @@ public class WebAppSecurityConfigImplTest {
     }
 
     @Test
+    public void getChangedProperties_overrideHAMProcessing() {
+        driveSingleAttributeTest("overrideHAMProcessing",
+                                 Boolean.FALSE, Boolean.TRUE);
+    }
+
+    @Test
+    public void testIsOverrideHAMProcessing_NotSet() {
+        Map<String, Object> cfg = new HashMap<String, Object>();
+        WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
+        assertEquals("False should be returned since the value is not set.", false, webCfg.isOverrideHAMProcessing());
+    }
+
+    @Test
+    public void testIsOverrideHAMProcessing_SetToTrue() {
+        Map<String, Object> cfg = new HashMap<String, Object>();
+        cfg.put("overrideHAMProcessing", Boolean.TRUE);
+        WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
+        assertEquals("Value should be true when overrideHAMProcessing is set to true.", true, webCfg.isOverrideHAMProcessing());
+    }
+
+    @Test
+    public void testIsOverrideHAMProcessing_SetToFalse() {
+        Map<String, Object> cfg = new HashMap<String, Object>();
+        cfg.put("overrideHAMProcessing", Boolean.FALSE);
+        WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
+        assertEquals("Value should be false when overrideHAMProcessing set to false.", false, webCfg.isOverrideHAMProcessing());
+    }
+
+    @Test
     public void testSetSsoCookieName_autoGenSsoCookieName_true_defaultSsoCookieName() {
         Map<String, Object> cfg = new HashMap<String, Object>();
         mockCookie(cfg, true);
@@ -425,7 +454,7 @@ public class WebAppSecurityConfigImplTest {
     public void testGetLoginErrorURL_NotSet() {
         Map<String, Object> cfg = new HashMap<String, Object>();
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertNull("Null should be get since the value is not set.", webCfg.getLoginErrorURL());
+        assertNull("Null should be returned since the value is not set.", webCfg.getLoginErrorURL());
     }
 
     @Test
@@ -434,14 +463,14 @@ public class WebAppSecurityConfigImplTest {
         Map<String, Object> cfg = new HashMap<String, Object>();
         cfg.put("loginErrorURL", ERROR_URL);
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertEquals("Vallid value should be returned.", ERROR_URL, webCfg.getLoginErrorURL());
+        assertEquals("Valid value should be returned.", ERROR_URL, webCfg.getLoginErrorURL());
     }
 
     @Test
     public void testGetLoginFormContextRoot_NotSet() {
         Map<String, Object> cfg = new HashMap<String, Object>();
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertNull("Null should be get since the value is not set.", webCfg.getLoginFormContextRoot());
+        assertNull("Null should be returned since the value is not set.", webCfg.getLoginFormContextRoot());
     }
 
     @Test
@@ -450,14 +479,14 @@ public class WebAppSecurityConfigImplTest {
         Map<String, Object> cfg = new HashMap<String, Object>();
         cfg.put("contextRootForFormAuthenticationMechanism", CONTEXT_ROOT);
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertEquals("Vallid value should be returned.", CONTEXT_ROOT, webCfg.getLoginFormContextRoot());
+        assertEquals("Valid value should be returned.", CONTEXT_ROOT, webCfg.getLoginFormContextRoot());
     }
 
     @Test
     public void testGetBasicAuthRealmName_NotSet() {
         Map<String, Object> cfg = new HashMap<String, Object>();
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertNull("Null should be get since the value is not set.", webCfg.getBasicAuthRealmName());
+        assertNull("Null should be returned since the value is not set.", webCfg.getBasicAuthRealmName());
     }
 
     @Test
@@ -466,15 +495,15 @@ public class WebAppSecurityConfigImplTest {
         Map<String, Object> cfg = new HashMap<String, Object>();
         cfg.put("basicAuthenticationMechanismRealmName", REALM_NAME);
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertEquals("Vallid value should be returned.", REALM_NAME, webCfg.getBasicAuthRealmName());
+        assertEquals("Valid value should be returned.", REALM_NAME, webCfg.getBasicAuthRealmName());
     }
 
     @Test
     public void testPartitioned_notSet() {
         Map<String, Object> cfg = new HashMap<String, Object>();
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertNull("Partitioned value should be null, but is ["+webCfg.getPartitionedCookie()+"]", webCfg.getPartitionedCookie());
-        assertEquals("isPartitioned value should be false, but is ["+webCfg.isPartitionedCookie()+"]", false, webCfg.isPartitionedCookie());
+        assertNull("Partitioned value should be null, but is [" + webCfg.getPartitionedCookie() + "]", webCfg.getPartitionedCookie());
+        assertEquals("isPartitioned value should be false, but is [" + webCfg.isPartitionedCookie() + "]", false, webCfg.isPartitionedCookie());
     }
 
     //defer is same as not set
@@ -483,10 +512,10 @@ public class WebAppSecurityConfigImplTest {
         final String PART_NAME = "partitionedCookie";
         final String PART_VALUE = "Defer";
         Map<String, Object> cfg = new HashMap<String, Object>();
-        cfg.put(PART_NAME,PART_VALUE);
+        cfg.put(PART_NAME, PART_VALUE);
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertNull("Partitioned value should be null, but is ["+webCfg.getPartitionedCookie()+"]", webCfg.getPartitionedCookie());
-        assertEquals("isPartitioned value should be false, but is ["+webCfg.isPartitionedCookie()+"]", false, webCfg.isPartitionedCookie());
+        assertNull("Partitioned value should be null, but is [" + webCfg.getPartitionedCookie() + "]", webCfg.getPartitionedCookie());
+        assertEquals("isPartitioned value should be false, but is [" + webCfg.isPartitionedCookie() + "]", false, webCfg.isPartitionedCookie());
     }
 
     @Test
@@ -494,10 +523,10 @@ public class WebAppSecurityConfigImplTest {
         final String PART_NAME = "partitionedCookie";
         final String PART_VALUE = "true";
         Map<String, Object> cfg = new HashMap<String, Object>();
-        cfg.put(PART_NAME,PART_VALUE);
+        cfg.put(PART_NAME, PART_VALUE);
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertEquals("Partitioned value should be TRUE, but is ["+webCfg.getPartitionedCookie()+"]", Boolean.TRUE, webCfg.getPartitionedCookie());
-        assertTrue("isPartitioned value should be true, but is ["+webCfg.isPartitionedCookie()+"]", webCfg.isPartitionedCookie());
+        assertEquals("Partitioned value should be TRUE, but is [" + webCfg.getPartitionedCookie() + "]", Boolean.TRUE, webCfg.getPartitionedCookie());
+        assertTrue("isPartitioned value should be true, but is [" + webCfg.isPartitionedCookie() + "]", webCfg.isPartitionedCookie());
     }
 
     @Test
@@ -505,10 +534,10 @@ public class WebAppSecurityConfigImplTest {
         final String PART_NAME = "partitionedCookie";
         final String PART_VALUE = "false";
         Map<String, Object> cfg = new HashMap<String, Object>();
-        cfg.put(PART_NAME,PART_VALUE);
+        cfg.put(PART_NAME, PART_VALUE);
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertEquals("Partitioned value should be FALSE, but is ["+webCfg.getPartitionedCookie()+"]", Boolean.FALSE, webCfg.getPartitionedCookie());
-        assertEquals("isPartitioned value should be false, but is ["+webCfg.isPartitionedCookie()+"]", false, webCfg.isPartitionedCookie());
+        assertEquals("Partitioned value should be FALSE, but is [" + webCfg.getPartitionedCookie() + "]", Boolean.FALSE, webCfg.getPartitionedCookie());
+        assertEquals("isPartitioned value should be false, but is [" + webCfg.isPartitionedCookie() + "]", false, webCfg.isPartitionedCookie());
     }
 
     /**


### PR DESCRIPTION
overridden, even if Jaspi configuration is enabled which would normally always use HAMs if they have been configured.
    
The authentication flow remains unaffected if the conditional is not set.

- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).

Fixes #33373 (GitHub issue raised originally).

Links:

[PSIRT issue](https://github.ibm.com/websphere/PSIRT/issues/259)
[Slack Channel Discussion](https://ibm-cloud.slack.com/archives/G01D1UCHA8H/p1762453900316189)
[Another GitHub Issue with acceptance criteria](https://github.com/OpenLiberty/open-liberty/issues/33532) - will merge information from this one into that one (and close this one) if we go ahead with this change.

################################################################################################

