### PR TITLE
Temporary workaround for 33232

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -65,6 +65,13 @@ public class EntityInfo {
      */
     final SortedSet<String> attributeNamesForEntityUpdate;
 
+    /**
+     * Setter methods for entity attributes that have getter methods.
+     * Null if the workaround to create copies of detached entities
+     * is not needed.
+     */
+    final Map<String, Method> attributeSetters;
+
     // properly cased/qualified JPQL attribute name --> type
     final SortedMap<String, Class<?>> attributeTypes;
 
@@ -77,6 +84,7 @@ public class EntityInfo {
     final Class<?> idType; // type of the id, which could be a JPA IdClass for composite ids
     final SortedMap<String, Member> idClassAttributeAccessors; // null if no IdClass
     final boolean inheritance;
+    final boolean isHibernate;
     final EntityGraph<?> loadGraph; // null if all attributes automatically load eagerly
     final Map<String, Object> loadGraphMap; // null if all attributes automatically load eagerly
     final String name; // entity name to use in query language. If a record, the name will be [RecordName]Entity.
@@ -94,12 +102,14 @@ public class EntityInfo {
                Map<String, List<Member>> attributeAccessors,
                Map<String, String> attributeNames,
                SortedSet<String> attributeNamesForUpdate,
+               Map<String, Method> attributeSetters,
                SortedMap<String, Class<?>> attributeTypes,
                Map<String, Class<?>> collectionElementTypes,
                Map<Class<?>, List<String>> relationAttributeNames,
                EntityGraph<?> loadGraph,
                Class<?> idType,
                SortedMap<String, Member> idClassAttributeAccessors,
+               boolean isHibernate,
                String versionAttributeName,
                EntityManagerBuilder entityManagerBuilder) {
         this.name = entityName;
@@ -108,6 +118,7 @@ public class EntityInfo {
         this.attributeAccessors = attributeAccessors;
         this.attributeNames = attributeNames;
         this.attributeNamesForEntityUpdate = attributeNamesForUpdate;
+        this.attributeSetters = attributeSetters;
         this.attributeTypes = attributeTypes;
         this.collectionElementTypes = collectionElementTypes;
         this.relationAttributeNames = relationAttributeNames;
@@ -117,6 +128,7 @@ public class EntityInfo {
                         : Map.of(Util.LOADGRAPH, loadGraph);
         this.idType = idType;
         this.idClassAttributeAccessors = idClassAttributeAccessors;
+        this.isHibernate = isHibernate;
         this.recordClass = recordClass;
         this.versionAttributeName = versionAttributeName;
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -587,6 +587,8 @@ public class RepositoryImpl<R> implements InvocationHandler {
                         // TODO Is this necessary after a transaction?
                         if (em != null && queryType.detachEntities) {
                             // TODO 1.1 only detach if a stateless repository
+                            if (trace && tc.isDebugEnabled())
+                                Tr.debug(this, tc, "clear");
                             em.clear();
                         }
                     } else {
@@ -597,12 +599,22 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 provider.tranMgr.setRollbackOnly();
                             } else if (em != null && queryType.detachEntities) {
                                 // flush changes first because detach interferes with updates
+                                if (trace && tc.isDebugEnabled())
+                                    Tr.debug(this, tc, "flush");
                                 em.flush();
                                 // TODO 1.1 only detach if a stateless repository
-                                em.clear();
+                                if (entityInfo != null && !entityInfo.isHibernate) {
+                                    // Only valid if flush writes to the database,
+                                    // and Hibernate does not seem to honor flush.
+                                    if (trace && tc.isDebugEnabled())
+                                        Tr.debug(this, tc, "clear");
+                                    em.clear();
+                                }
                             }
                         } else if (em != null && queryType.detachEntities) {
                             // TODO 1.1 only detach if a stateless repository
+                            if (trace && tc.isDebugEnabled())
+                                Tr.debug(this, tc, "clear");
                             em.clear();
                         }
                     }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
@@ -82,11 +82,11 @@ public interface Orders extends CrudRepository<PurchaseOrder, UUID> {
     @OrderBy("total")
     List<Float> purchaseTotalsFor(String purchaser);
 
-    @Query("SELECT VERSION(THIS)")
+    @Query("SELECT VERSION(this)")
     @OrderBy("version(this)")
     List<Integer> versionsAsc();
 
-    @Query("SELECT VERSION(THIS)")
+    @Query("SELECT VERSION(this)")
     @OrderBy(value = "versionNum", descending = true)
     List<Integer> versionsDesc();
 }


### PR DESCRIPTION
Temporary workaround for Hibernate not merging detached entities.
The workaround replaces the detached entity instance with a new instance.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
