### PR TITLE
Actually Repeat Jakarta 3.0 tests for EE11

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|.*\\/OSGI-INF\\/.*\\.properties$|.+\\.(nlsprops)$|^dev\\/(.*(_test|_fat)).*\\/ltpa.keys$|^dev\\/com.ibm.ws.openapi.ui\\/swagger-ui\\/dist\\/liberty-swagger-ui-bundle-.*\\.js$|^.secrets.baseline.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-07T18:06:44Z",
+  "generated_at": "2026-04-09T10:53:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -31822,7 +31822,7 @@
         "hashed_secret": "bad4bb67da67759f3da19049f4ab6798ba0ca925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 93,
+        "line_number": 94,
         "type": "Box Credentials",
         "verified_result": null
       }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/publish/shared/config/op_features_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/publish/shared/config/op_features_ee11.xml
@@ -1,0 +1,10 @@
+<server>
+
+    <featureManager>
+        <feature>servlet-6.1</feature>
+        <feature>appSecurity-6.0</feature>
+        <feature>openidConnectServer-1.0</feature>
+        <feature>ssl-1.0</feature>
+    </featureManager>
+
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/publish/shared/config/rp_features_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/publish/shared/config/rp_features_ee11.xml
@@ -1,0 +1,10 @@
+<server>
+
+    <featureManager>
+        <feature>servlet-6.1</feature>
+        <feature>appSecurity-6.0</feature>
+        <feature>ssl-1.0</feature>
+        <feature>jsonp-2.1</feature>
+    </featureManager>
+
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonAnnotatedSecurityTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/src/io/openliberty/security/jakartasec/fat/commonTests/CommonAnnotatedSecurityTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -777,6 +777,17 @@ public class CommonAnnotatedSecurityTests extends CommonSecurityFat {
             return true;
         }
 
+    }
+
+    public static String getServerConfigFile(String origConfigFile){
+        String configFile = origConfigFile;
+        String repeatAction = RepeatTestFilter.getRepeatActionsAsString();
+        String[] fileArray = configFile.split("\\.");
+        if (repeatAction.contains("EE11_FEATURES")){
+            configFile = fileArray[0] + "_ee11." + fileArray[1];
+        }
+
+        return configFile;
     }
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/utils/ServletLogger.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/test-applications/BaseServlet.war/src/oidc/client/base/utils/ServletLogger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,19 +18,21 @@ import jakarta.servlet.ServletOutputStream;
 
 public class ServletLogger {
 
+    // only log output stream is null once.
+    private static boolean outputStreamIsNullPrinted = false;
+
     public static void printLine(ServletOutputStream ps, String caller, String msg) throws IOException {
-
         printLine(ps, caller + msg);
-
     }
 
     public static void printLine(ServletOutputStream ps, String msg) throws IOException {
-
         System.out.println(msg);
+
         if (ps != null) {
             ps.println(msg);
-        } else {
+        } else if (!outputStreamIsNullPrinted) {
             System.out.println("output stream is null");
+            outputStreamIsNullPrinted=true;
         }
 
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.1/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2023, 2025 IBM Corporation and others.
+# Copyright (c) 2023, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ src: \
 fat.project: true
 publish.wlp.jar.disabled: true
 
-tested.features: pages-3.1, transportsecurity-1.0, distributedmap-1.0, ssl-1.0, appsecurity-5.0, jndi-1.0, jsonp-2.1, federatedregistry-1.0, oauth-2.0, openidconnectserver-1.0, json-1.0, cdi-4.0, ldapregistry-3.0
+tested.features: pages-3.1, transportsecurity-1.0, distributedmap-1.0, ssl-1.0, appsecurity-5.0, jndi-1.0, jsonp-2.1, federatedregistry-1.0, oauth-2.0, openidconnectserver-1.0, json-1.0, cdi-4.0, ldapregistry-3.0, expressionlanguage-6.0, appsecurity-6.0, cdi-4.1, pages-4.0, servlet-6.1
 
 javac.source: 11
 javac.target: 11

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.2/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2023, 2025 IBM Corporation and others.
+# Copyright (c) 2023, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ src: \
 fat.project: true
 publish.wlp.jar.disabled: true
 
-tested.features: pages-3.1, transportsecurity-1.0, distributedmap-1.0, ssl-1.0, appsecurity-5.0, jndi-1.0, jsonp-2.1, federatedregistry-1.0, oauth-2.0, openidconnectserver-1.0, json-1.0, cdi-4.0, ldapregistry-3.0
+tested.features: pages-3.1, transportsecurity-1.0, distributedmap-1.0, ssl-1.0, appsecurity-5.0, jndi-1.0, jsonp-2.1, federatedregistry-1.0, oauth-2.0, openidconnectserver-1.0, json-1.0, cdi-4.0, ldapregistry-3.0, expressionlanguage-6.0, appsecurity-6.0, cdi-4.1, pages-4.0, servlet-6.1
 
 javac.source: 11
 javac.target: 11

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationClaimsDefinitionTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationClaimsDefinitionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -82,12 +82,12 @@ public class ConfigurationClaimsDefinitionTests extends CommonAnnotatedSecurityT
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationDisplayTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationDisplayTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -80,12 +80,12 @@ public class ConfigurationDisplayTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_display.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_display.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationELValuesOverrideTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationELValuesOverrideTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -73,12 +73,12 @@ public class ConfigurationELValuesOverrideTests extends CommonAnnotatedSecurityT
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationELValuesOverrideWithoutHttpSessionTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationELValuesOverrideWithoutHttpSessionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -71,12 +71,12 @@ public class ConfigurationELValuesOverrideWithoutHttpSessionTests extends Common
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig_withoutHttpSession.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig_withoutHttpSession.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationExtraParametersTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationExtraParametersTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -86,12 +86,12 @@ public class ConfigurationExtraParametersTests extends CommonAnnotatedSecurityTe
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_extraParameters.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_extraParameters.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationPromptTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationPromptTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -91,12 +91,12 @@ public class ConfigurationPromptTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_prompt.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_prompt.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationProviderMetadataTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationProviderMetadataTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,6 +36,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.security.jakartasec.fat.commonTests.CommonAnnotatedSecurityTests;
@@ -107,12 +108,12 @@ public class ConfigurationProviderMetadataTests extends CommonAnnotatedSecurityT
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_providerMetadata.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_providerMetadata.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationResponseModeTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationResponseModeTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,6 +36,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.security.jakartasec.fat.commonTests.CommonAnnotatedSecurityTests;
@@ -93,12 +94,12 @@ public class ConfigurationResponseModeTests extends CommonAnnotatedSecurityTests
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationScopeTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationScopeTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -88,12 +88,12 @@ public class ConfigurationScopeTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_scope.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_scope.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationSigningTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationSigningTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -113,12 +113,12 @@ public class ConfigurationSigningTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_signing.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_signing.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -77,12 +77,12 @@ public class ConfigurationTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -94,12 +94,12 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_tokenMinValidity.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_tokenMinValidity.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUseNonceTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUseNonceTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -92,12 +92,12 @@ public class ConfigurationUseNonceTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_useNonce.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_useNonce.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUserInfoTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUserInfoTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -180,12 +180,12 @@ public class ConfigurationUserInfoTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_display_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_display_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcDisplayProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_extraParameters_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_extraParameters_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcProvider_extraParameters.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_orig_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_orig_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_orig_withoutHttpSession_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_orig_withoutHttpSession_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMiscWithoutHttpSession.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_prompt_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_prompt_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 3.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcPromptProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_providerMetadata_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_providerMetadata_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcProviderMetadataProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_scope_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_scope_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcScopeProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_signing_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_signing_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcSigningProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_tokenMinValidity_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_tokenMinValidity_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcTokenMinValidityProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_useNonce_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.op/configs/server_useNonce_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcUseNonceProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.rp.ELOverrideHttpSession/configs/server_orig_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.rp.ELOverrideHttpSession/configs/server_orig_ee11.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/rp_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/rp_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/RPMiscWithoutHttpSession.xml" />
+ 
+ 	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.rp/configs/server_orig_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.rp/configs/server_orig_ee11.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/rp_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/rp_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/RPMisc.xml" />
+ 
+ 	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.rp/configs/server_orig_withoutHttpSession_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/publish/servers/jakartasec-3.0_fat.config.rp/configs/server_orig_withoutHttpSession_ee11.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/rp_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/rp_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/RPMiscWithoutHttpSession.xml" />
+ 
+ 	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2025 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -26,7 +26,7 @@ src: \
 fat.project: true
 publish.wlp.jar.disabled: true
 
-tested.features: pages-3.1, transportsecurity-1.0, distributedmap-1.0, ssl-1.0, appsecurity-5.0, jndi-1.0, jsonp-2.1, federatedregistry-1.0, oauth-2.0, openidconnectserver-1.0, json-1.0, cdi-4.0, ldapregistry-3.0
+tested.features: pages-3.1, transportsecurity-1.0, distributedmap-1.0, ssl-1.0, appsecurity-5.0, jndi-1.0, jsonp-2.1, federatedregistry-1.0, oauth-2.0, openidconnectserver-1.0, json-1.0, cdi-4.0, ldapregistry-3.0, expressionlanguage-6.0, appsecurity-6.0, cdi-4.1, pages-4.0, servlet-6.1
 
 javac.source: 11
 javac.target: 11

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/fat/src/io/openliberty/security/jakartasec/fat/logout/tests/BasicLogoutTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/fat/src/io/openliberty/security/jakartasec/fat/logout/tests/BasicLogoutTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -98,12 +98,12 @@ public class BasicLogoutTests extends CommonLogoutAndRefreshTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/publish/servers/jakartasec-3.0_fat.logout.op/configs/server_orig_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/publish/servers/jakartasec-3.0_fat.logout.op/configs/server_orig_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/publish/servers/jakartasec-3.0_fat.logout.rp/configs/server_orig_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.logout/publish/servers/jakartasec-3.0_fat.logout.rp/configs/server_orig_ee11.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/rp_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/rp_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/RPMisc.xml" />
+ 
+ 	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2025 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ src: \
 fat.project: true
 publish.wlp.jar.disabled: true
 
-tested.features: pages-3.1, transportsecurity-1.0, distributedmap-1.0, ssl-1.0, appsecurity-5.0, jndi-1.0, jsonp-2.1, federatedregistry-1.0, oauth-2.0, openidconnectserver-1.0, json-1.0, cdi-4.0, ldapregistry-3.0
+tested.features: pages-3.1, transportsecurity-1.0, distributedmap-1.0, ssl-1.0, appsecurity-5.0, jndi-1.0, jsonp-2.1, federatedregistry-1.0, oauth-2.0, openidconnectserver-1.0, json-1.0, cdi-4.0, ldapregistry-3.0, expressionlanguage-6.0, appsecurity-6.0, cdi-4.1, pages-4.0, servlet-6.1
 
 javac.source: 11
 javac.target: 11

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/fat/src/io/openliberty/security/jakartasec/fat/refresh/tests/BasicRefreshTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/fat/src/io/openliberty/security/jakartasec/fat/refresh/tests/BasicRefreshTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -95,12 +95,12 @@ public class BasicRefreshTests extends CommonLogoutAndRefreshTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/publish/servers/jakartasec-3.0_fat.refresh.op/configs/server_orig_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/publish/servers/jakartasec-3.0_fat.refresh.op/configs/server_orig_ee11.xml
@@ -1,0 +1,25 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/op_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+	<include location="${shared.config.dir}/OPMisc.xml" />
+	<include location="${shared.config.dir}/oauthRoles_1.xml" />
+	<include location="${shared.config.dir}/oidcProvider.xml" />
+ 
+	<sslDefault sslRef="ssl_allSigAlg" />
+	
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/publish/servers/jakartasec-3.0_fat.refresh.rp/configs/server_orig_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.refresh/publish/servers/jakartasec-3.0_fat.refresh.rp/configs/server_orig_ee11.xml
@@ -1,0 +1,22 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+ 	<include location="${shared.config.dir}/rp_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/rp_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/RPMisc.xml" />
+ 
+ 	<sslDefault sslRef="ssl_allSigAlg" />
+ 	
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2025 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -42,7 +42,7 @@ src: \
 fat.project: true
 publish.wlp.jar.disabled: true
 
-tested.features: pages-3.1, transportsecurity-1.0, distributedmap-1.0, ssl-1.0, appsecurity-5.0, jndi-1.0, jsonp-2.1, federatedregistry-1.0, oauth-2.0, openidconnectserver-1.0, json-1.0, cdi-4.0, ldapregistry-3.0
+tested.features: pages-3.1, transportsecurity-1.0, distributedmap-1.0, ssl-1.0, appsecurity-5.0, jndi-1.0, jsonp-2.1, federatedregistry-1.0, oauth-2.0, openidconnectserver-1.0, json-1.0, cdi-4.0, ldapregistry-3.0, expressionlanguage-6.0, appsecurity-6.0, cdi-4.1, pages-4.0, servlet-6.1
 
 Import-Package: \
     !*.internal.*, \

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/sharedTests/BasicOIDCAnnotationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/sharedTests/BasicOIDCAnnotationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -74,15 +74,15 @@ public class BasicOIDCAnnotationTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
         if (RepeatTestFilter.getRepeatActionsAsString().contains(withOidcClientConfig)) {
-            rpServer.startServerUsingExpandedConfiguration("server_withOidcClientConfig.xml", waitForMsgs);
+            rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_withOidcClientConfig.xml"), waitForMsgs);
         } else {
-            rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+            rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         }
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationEndpointValidationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationEndpointValidationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -81,12 +81,12 @@ public class AuthenticationEndpointValidationTests extends CommonAnnotatedSecuri
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2065 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -82,7 +82,7 @@ public class AuthenticationTests extends CommonAnnotatedSecurityTests {
 
     // create repeats for opaque and jwt tokens - in lite mode, only run with jwt tokens
     @ClassRule
-    public static RepeatTests repeat = createTokenTypeRepeats(TestMode.LITE, Constants.JWT_TOKEN_FORMAT);
+    public static RepeatTests repeat = createTokenTypeRepeats(TestMode.FULL, Constants.JWT_TOKEN_FORMAT);
 
     private static final String app = "AuthenticationApp";
 
@@ -106,12 +106,12 @@ public class AuthenticationTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/IdentityStoreTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/IdentityStoreTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -71,12 +71,12 @@ public class IdentityStoreTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InjectionScopedTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InjectionScopedTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -69,12 +69,12 @@ public class InjectionScopedTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/TokenValidationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/TokenValidationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -106,12 +106,12 @@ public class TokenValidationTests extends CommonAnnotatedSecurityTests {
         updateTrackers(opServer, rpServer, false);
 
         List<String> waitForMsgs = null;
-        opServer.startServerUsingExpandedConfiguration("server_orig.xml", waitForMsgs);
+        opServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_orig.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(opServer, Constants.BVT_SERVER_1_PORT_NAME_ROOT);
         opHttpBase = "http://localhost:" + opServer.getBvtPort();
         opHttpsBase = "https://localhost:" + opServer.getBvtSecurePort();
 
-        rpServer.startServerUsingExpandedConfiguration("server_tokenValidation.xml", waitForMsgs);
+        rpServer.startServerUsingExpandedConfiguration(getServerConfigFile("server_tokenValidation.xml"), waitForMsgs);
         SecurityFatHttpUtils.saveServerPorts(rpServer, Constants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         rpHttpBase = "http://localhost:" + rpServer.getBvtPort();

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/publish/servers/jakartasec-3.0_fat.op/configs/server_orig_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/publish/servers/jakartasec-3.0_fat.op/configs/server_orig_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+    <include location="${shared.config.dir}/op_features_ee11.xml" />
+    <include location="${shared.config.dir}/op_fatTestPorts.xml" />
+    <include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+    <include location="${shared.config.dir}/goodBasicRegistry.xml" />
+    <include location="${shared.config.dir}/OPMisc.xml" />
+    <include location="${shared.config.dir}/oauthRoles_1.xml" />
+    <include location="${shared.config.dir}/oidcProvider.xml" />
+
+    <sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/publish/servers/jakartasec-3.0_fat.rp/configs/server_orig_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/publish/servers/jakartasec-3.0_fat.rp/configs/server_orig_ee11.xml
@@ -1,0 +1,23 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+<!-- cdi12 enableImplicitBeanArchives="false"/ -->
+
+ 	<include location="${shared.config.dir}/rp_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/rp_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/RPMisc.xml" />
+ 
+ 	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/publish/servers/jakartasec-3.0_fat.rp/configs/server_tokenValidation_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/publish/servers/jakartasec-3.0_fat.rp/configs/server_tokenValidation_ee11.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 3.0 Test Server">
+
+<!-- cdi12 enableImplicitBeanArchives="false"/ -->
+
+ 	<include location="${shared.config.dir}/rp_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/rp_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/RPMisc.xml" />
+ 	<include location="${shared.config.dir}/tokenEndpointApplication.xml" />
+ 
+ 	<sslDefault sslRef="ssl_allSigAlg" />
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/publish/servers/jakartasec-3.0_fat.rp/configs/server_withOidcClientConfig_ee11.xml
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/publish/servers/jakartasec-3.0_fat.rp/configs/server_withOidcClientConfig_ee11.xml
@@ -1,0 +1,64 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Jakarta Security 4.0 Test Server">
+
+<!-- cdi12 enableImplicitBeanArchives="false"/ -->
+
+ 	<include location="${shared.config.dir}/rp_features_ee11.xml" />
+ 	<include location="${shared.config.dir}/rp_fatTestPorts.xml" />
+ 	<include location="${shared.config.dir}/allAlgSSLSettings.xml" />
+ 	<include location="${shared.config.dir}/RPMisc.xml" />
+ 
+ 	<sslDefault sslRef="ssl_allSigAlg" />
+ 	
+<featureManager>
+ 	<feature>openidConnectClient-1.0</feature>
+</featureManager>
+ 	
+ <!-- create an oidc client config that wouldn't work with the OP config that we have -->
+ <!-- with no filter, this client should be used for all apps that are not otherwise protected - this 
+ 		config would show that we didn't use the annotation and tried to use the server specified oidc client config -->
+ 	
+ 	    <openidConnectClient
+                id="rpClientWildcardProtected"
+                clientId="client_98"
+                clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+                discoveryEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OP2/.well-known/openid-configuration"
+                authFilterRef="myAuthFilter01"
+        >
+        </openidConnectClient>
+
+       	<authFilter id="myAuthFilter01">
+                <requestUrl
+                        id="myRequestUrl"
+                        urlPattern="/rpClientProtected"
+                        matchType="notContain" />
+        </authFilter>
+
+ 	    <openidConnectClient
+                id="rpProtectedClient"
+                clientId="client_99"
+                clientSecret="mySharedKeyNowHasToBeLongerStrongerAndMoreSecureAndForHS512EvenLongerToBeStronger"
+                discoveryEndpointUrl="https://localhost:${bvt.prop.security_1_HTTP_default.secure}/oidc/endpoint/OP2/.well-known/openid-configuration"
+                authFilterRef="myAuthFilter02"
+        >
+        </openidConnectClient>
+
+        <authFilter id="myAuthFilter02">
+                <requestUrl
+                        id="myRequestUrl"
+                        urlPattern="/rpClientProtected"
+                        matchType="contains" />
+        </authFilter>
+ 
+</server>

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/AuthAppInjectServlet.war/src/oidc/authAppInjection/servlets/AuthenticationAppServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/AuthAppInjectServlet.war/src/oidc/authAppInjection/servlets/AuthenticationAppServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -72,9 +72,12 @@ public class AuthenticationAppServlet extends BaseServlet {
             System.out.println("Already Authenticated");
         }
 
-        ServletOutputStream outputStream = response.getOutputStream();
+        // Servlet 6.1 onwards has already committed the response, so trying to use its outputstream causes errors in the server logs.
+        ServletOutputStream outputStream = null;
+        if(!response.isCommitted()) {
+            outputStream = response.getOutputStream();
+        }
         recordAppInfo(request, response, outputStream);
-
     }
 
 }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/AuthAppNoInjectServlet.war/src/oidc/authAppNoInjection/servlets/AuthenticationAppServlet.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/test-applications/AuthAppNoInjectServlet.war/src/oidc/authAppNoInjection/servlets/AuthenticationAppServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -71,9 +71,13 @@ public class AuthenticationAppServlet extends SimpleServlet {
             System.out.println("Already Authenticated");
         }
 
-        ServletOutputStream outputStream = response.getOutputStream();
+        ServletOutputStream outputStream = null;
+        // Servlet 6.1 onwards throws an exception that the response has already been committed.
+        // so using the output stream causes exceptions in the log, but the test result is unaffected
+        if(!response.isCommitted()) {
+            outputStream = response.getOutputStream();
+        }
         recordAppInfo(request, outputStream);
-
     }
 
 }


### PR DESCRIPTION
While the repeat logic caused the tests to run twice, due to the nature of how the configuration was managed, all that changed was EE11_FEATURES was added to the test and server names. the server configuration was left as is.

Use the RepeatTestFilter to determine if we are running the EE11 feature set and switch to the ee11 version of the configuration which includes the EE11 compatible feature set.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
