### PR TITLE
refresh of entity can overwrite pending changes

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -124,9 +124,6 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
         if (cursor.isPresent())
             queryInfo.setParametersFromCursor(query, cursor.get());
 
-        if (queryInfo.entityInfo.loadGraph != null)
-            query.setHint(Util.LOADGRAPH, queryInfo.entityInfo.loadGraph);
-
         query.setFirstResult(firstResult);
         query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1)); // extra position is for knowing whether to expect another page
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityInfo.java
@@ -30,7 +30,6 @@ import java.util.concurrent.CompletableFuture;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 import jakarta.data.exceptions.MappingException;
-import jakarta.persistence.EntityGraph;
 import jakarta.persistence.Inheritance;
 
 /**
@@ -85,8 +84,6 @@ public class EntityInfo {
     final SortedMap<String, Member> idClassAttributeAccessors; // null if no IdClass
     final boolean inheritance;
     final boolean isHibernate;
-    final EntityGraph<?> loadGraph; // null if all attributes automatically load eagerly
-    final Map<String, Object> loadGraphMap; // null if all attributes automatically load eagerly
     final String name; // entity name to use in query language. If a record, the name will be [RecordName]Entity.
     final Class<?> recordClass; // null if not a record
     final String versionAttributeName; // null if unversioned
@@ -106,7 +103,6 @@ public class EntityInfo {
                SortedMap<String, Class<?>> attributeTypes,
                Map<String, Class<?>> collectionElementTypes,
                Map<Class<?>, List<String>> relationAttributeNames,
-               EntityGraph<?> loadGraph,
                Class<?> idType,
                SortedMap<String, Member> idClassAttributeAccessors,
                boolean isHibernate,
@@ -122,10 +118,6 @@ public class EntityInfo {
         this.attributeTypes = attributeTypes;
         this.collectionElementTypes = collectionElementTypes;
         this.relationAttributeNames = relationAttributeNames;
-        this.loadGraph = loadGraph;
-        this.loadGraphMap = loadGraph == null //
-                        ? null //
-                        : Map.of(Util.LOADGRAPH, loadGraph);
         this.idType = idType;
         this.idClassAttributeAccessors = idClassAttributeAccessors;
         this.isHibernate = isHibernate;

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/EntityManagerBuilder.java
@@ -51,10 +51,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.MappingException;
-import jakarta.persistence.AttributeNode;
-import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.Subgraph;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.Attribute.PersistentAttributeType;
 import jakarta.persistence.metamodel.EntityType;
@@ -63,7 +60,6 @@ import jakarta.persistence.metamodel.Metamodel;
 import jakarta.persistence.metamodel.PluralAttribute;
 import jakarta.persistence.metamodel.SingularAttribute;
 import jakarta.persistence.metamodel.Type;
-import jakarta.persistence.metamodel.Type.PersistenceType;
 
 /**
  * Creates EntityManager instances from an EntityManagerFactory (from a persistence unit reference)
@@ -144,11 +140,6 @@ public abstract class EntityManagerBuilder {
         this.convertibleTypes = convertibleTypes;
         EntityManager em = createEntityManager();
         try {
-            // TODO remove the following boolean once EclipseLink #33294 is fixed
-            // To temporarily reproduce the issue, set it to true below, then
-            // build this project and run the test bucket:
-            // ./gradlew io.openliberty.data.internal_fat_jpa:buildandrun
-            boolean eagerlyFetchAll = false;
             boolean isHibernate = em.getClass().getName().startsWith("org.hibernate.");
             Set<Class<?>> missingEntityTypes = new HashSet<>(entityTypes);
             Metamodel model = em.getMetamodel();
@@ -178,13 +169,7 @@ public abstract class EntityManagerBuilder {
                     Tr.debug(this, tc, "collecting info for " +
                                        userEntityClass.getName());
 
-                Set<Class<?>> loadGraphPopulated = new HashSet<>();
-                loadGraphPopulated.add(jpaEntityClass);
                 try {
-                    EntityGraph<?> loadGraph = eagerlyFetchAll //
-                                    ? em.createEntityGraph(jpaEntityClass) //
-                                    : null;
-
                     for (Attribute<?, ?> attr : entityType.getAttributes()) {
                         String attributeName = attr.getName();
                         PersistentAttributeType attributeType = attr.getPersistentAttributeType();
@@ -226,21 +211,8 @@ public abstract class EntityManagerBuilder {
                         if (attr.isCollection()) {
                             if (attr instanceof PluralAttribute) {
                                 Type<?> elementType = ((PluralAttribute<?, ?, ?>) attr).getElementType();
-                                Class<?> elementClass = elementType.getJavaType();
                                 collectionElementTypes.put(attributeName,
                                                            elementType.getJavaType());
-                                if (elementType.getPersistenceType() == PersistenceType.ENTITY) {
-                                    if (eagerlyFetchAll &&
-                                        loadGraphPopulated.add(elementClass)) {
-                                        populateSubgraph(loadGraph.addElementSubgraph(attributeName),
-                                                         elementClass,
-                                                         model,
-                                                         loadGraphPopulated);
-                                        loadGraphPopulated.remove(elementClass);
-                                    }
-                                } else if (eagerlyFetchAll) {
-                                    loadGraph.addAttributeNodes(attributeName);
-                                }
                             }
                         } else {
                             SingularAttribute<?, ?> singleAttr = attr instanceof SingularAttribute //
@@ -255,14 +227,6 @@ public abstract class EntityManagerBuilder {
                             } else if (Collection.class.isAssignableFrom(attr.getJavaType())) {
                                 // collection attribute that is not annotated with ElementCollection
                                 collectionElementTypes.put(attributeName, Object.class);
-                            } else if (eagerlyFetchAll &&
-                                       singleAttr.isAssociation() &&
-                                       loadGraphPopulated.add(singleAttr.getJavaType())) {
-                                populateSubgraph(loadGraph.addSubgraph(attributeName),
-                                                 singleAttr.getJavaType(),
-                                                 model,
-                                                 loadGraphPopulated);
-                                loadGraphPopulated.remove(singleAttr.getJavaType());
                             }
                         }
                     }
@@ -356,22 +320,8 @@ public abstract class EntityManagerBuilder {
                             if (relAttr.isCollection()) {
                                 if (relAttr instanceof PluralAttribute) {
                                     Type<?> elementType = ((PluralAttribute<?, ?, ?>) relAttr).getElementType();
-                                    Class<?> elementClass = elementType.getJavaType();
                                     collectionElementTypes.put(fullAttributeName,
                                                                elementType.getJavaType());
-                                    if (isEmbeddablesOnly)
-                                        if (elementType.getPersistenceType() == PersistenceType.ENTITY) {
-                                            if (eagerlyFetchAll &&
-                                                loadGraphPopulated.add(elementClass)) {
-                                                populateSubgraph(loadGraph.addElementSubgraph(relationAttributeName),
-                                                                 elementClass,
-                                                                 model,
-                                                                 loadGraphPopulated);
-                                                loadGraphPopulated.remove(elementClass);
-                                            }
-                                        } else if (eagerlyFetchAll) {
-                                            loadGraph.addAttributeNodes(relationAttributeName);
-                                        }
                                 }
                             } else if (relAttr instanceof SingularAttribute) {
                                 SingularAttribute<?, ?> singleAttr = ((SingularAttribute<?, ?>) relAttr);
@@ -380,15 +330,6 @@ public abstract class EntityManagerBuilder {
                                 } else if (singleAttr.isVersion()) {
                                     versionAttrName = relationAttributeName_; // to be suitable for query-by-method
                                     attributeNamesForUpdate = null;
-                                } else if (eagerlyFetchAll &&
-                                           isEmbeddablesOnly &&
-                                           singleAttr.isAssociation() &&
-                                           loadGraphPopulated.add(singleAttr.getJavaType())) {
-                                    populateSubgraph(loadGraph.addSubgraph(relationAttributeName),
-                                                     singleAttr.getJavaType(),
-                                                     model,
-                                                     loadGraphPopulated);
-                                    loadGraphPopulated.remove(singleAttr.getJavaType());
                                 }
                             }
                         }
@@ -418,14 +359,6 @@ public abstract class EntityManagerBuilder {
                         }
                     }
 
-                    if (eagerlyFetchAll) {
-                        List<AttributeNode<?>> nodes = loadGraph.getAttributeNodes();
-                        if (trace && tc.isDebugEnabled())
-                            Tr.debug(this, tc, "load graph for " + entityType.getName(), nodes);
-                        if (nodes.isEmpty())
-                            loadGraph = null; // avoid using a load graph
-                    }
-
                     EntityInfo entityInfo = new EntityInfo( //
                                     entityType.getName(), //
                                     jpaEntityClass, //
@@ -437,7 +370,6 @@ public abstract class EntityManagerBuilder {
                                     attributeTypes, //
                                     collectionElementTypes, //
                                     relationAttributeNames, //
-                                    loadGraph, //
                                     idType, //
                                     idClassAttributeAccessors, //
                                     isHibernate, //
@@ -664,49 +596,4 @@ public abstract class EntityManagerBuilder {
                cause instanceof SQLTransientConnectionException;
     }
 
-    /**
-     * Populates the subgraph with attributes for which to force eager loading,
-     * which allows entities to be detached.
-     *
-     * @param subgraph           the subgraph.
-     * @param entityClass        the entity class to which the subgraph applies.
-     * @param model              the metamodel.
-     * @param loadGraphPopulated entity classes that have already been covered.
-     *                               This guards against infinite recursion in
-     *                               the case of cycles.
-     */
-    private void populateSubgraph(Subgraph<?> subgraph,
-                                  Class<?> entityClass,
-                                  Metamodel model,
-                                  Set<Class<?>> loadGraphPopulated) {
-        for (Attribute<?, ?> attr : model.entity(entityClass).getAttributes())
-            if (attr.isAssociation() &&
-                attr instanceof SingularAttribute &&
-                loadGraphPopulated.add(attr.getJavaType())) {
-
-                populateSubgraph(subgraph.addSubgraph(attr.getName()),
-                                 attr.getJavaType(),
-                                 model,
-                                 loadGraphPopulated);
-
-                // allow different subgraph to reuse:
-                loadGraphPopulated.remove(attr.getJavaType());
-            } else if (attr instanceof PluralAttribute plural) {
-                Type<?> elementType = plural.getElementType();
-                Class<?> elementClass = elementType.getJavaType();
-                if (elementType.getPersistenceType() == PersistenceType.ENTITY) {
-                    if (loadGraphPopulated.add(elementClass)) {
-                        populateSubgraph(subgraph.addElementSubgraph(attr.getName()),
-                                         elementClass,
-                                         model,
-                                         loadGraphPopulated);
-
-                        // allow different subgraph to reuse:
-                        loadGraphPopulated.remove(elementClass);
-                    }
-                } else {
-                    subgraph.addAttributeNodes(attr.getName());
-                }
-            }
-    }
 }

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -103,9 +103,6 @@ public class PageImpl<T> implements Page<T> {
         jakarta.persistence.Query query = em.createQuery(queryInfo.jpql);
         queryInfo.setParameters(query, args);
 
-        if (queryInfo.entityInfo.loadGraph != null)
-            query.setHint(Util.LOADGRAPH, queryInfo.entityInfo.loadGraph);
-
         int maxPageSize = pageRequest.size();
         query.setFirstResult(queryInfo.computeOffset(pageRequest));
         query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1));

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1906,9 +1906,6 @@ public class QueryInfo {
             jakarta.persistence.Query query = em.createQuery(jpql);
             setParameters(query, args);
 
-            if (entityInfo.loadGraph != null)
-                query.setHint(Util.LOADGRAPH, entityInfo.loadGraph);
-
             if (type == FIND_AND_DELETE)
                 query.setLockMode(LockModeType.PESSIMISTIC_WRITE);
 
@@ -2139,16 +2136,6 @@ public class QueryInfo {
         } else if (void.class.equals(returnType) || Void.class.equals(returnType)) {
             returnValue = null;
         } else {
-            for (Object e : results) {
-                if (entityInfo.loadGraphMap == null)
-                    em.refresh(e);
-                else
-                    em.refresh(e, entityInfo.loadGraphMap);
-
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "refreshed", loggable(e));
-            }
-
             if (entityInfo.recordClass != null)
                 for (int i = 0; i < results.size(); i++)
                     results.set(i, entityInfo.toRecord(results.get(i)));


### PR DESCRIPTION
The Jakarta Data implementation needs to avoid requesting an entity refresh because it can overwrite changes that haven't been flushed to the database yet.

Also, remove disabled code that creates a load graph and conditionally applies it to queries, which was an experimental approach that we decided not to go with because it overrides the entity's requested fetch behavior that was assigned by the user.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
