### PR TITLE
Explicitly enable in-memory identity store usage.

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/Utils.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/beans/Utils.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -100,6 +100,7 @@ public class Utils {
     }
 
     public AuthenticationStatus validateWithIdentityStore(String realmName, Subject clientSubject, @Sensitive Credential credential, IdentityStoreHandler identityStoreHandler) {
+
         AuthenticationStatus status = AuthenticationStatus.SEND_FAILURE;
         CredentialValidationResult result = identityStoreHandler.validate(credential);
         if (result.getStatus() == CredentialValidationResult.Status.VALID) {
@@ -109,6 +110,25 @@ public class Utils {
             status = AuthenticationStatus.NOT_DONE;
         }
         return status;
+    }
+
+    /**
+     * Check if identity stores are skipped via webAppSecurity configuration.
+     *
+     * @return true if skipped
+     */
+    private boolean isIdentityStoresSkipped() {
+        try {
+            com.ibm.ws.webcontainer.security.WebAppSecurityConfig config = com.ibm.ws.webcontainer.security.util.WebConfigUtils.getWebAppSecurityConfig();
+            if (config != null) {
+                return config.getSkipIdentityStores();
+            }
+        } catch (Exception e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Error checking skipIdentityStores config", e);
+            }
+        }
+        return false;
     }
 
     private AuthenticationStatus validateWithUserRegistry(Subject clientSubject, @Sensitive Credential credential,
@@ -249,6 +269,14 @@ public class Utils {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public boolean isIdentityStoreAvailable(CDI cdi) {
+        // check if identity stores are skipped via webAppSecurity config
+        if (isIdentityStoresSkipped()) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Identity stores skipped via webAppSecurity configuration");
+            }
+            return false;
+        }
+
         Instance<IdentityStore> identityStoreInstances = cdi.select(IdentityStore.class);
         if (identityStoreInstances != null && !identityStoreInstances.isUnsatisfied() && !identityStoreInstances.isAmbiguous()) {
             return true;

--- a/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/beans/UtilsSkipIdentityStoresTest.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/test/com/ibm/ws/security/javaeesec/cdi/beans/UtilsSkipIdentityStoresTest.java
@@ -1,0 +1,188 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.javaeesec.cdi.beans;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.security.auth.Subject;
+import javax.security.enterprise.AuthenticationStatus;
+import javax.security.enterprise.credential.UsernamePasswordCredential;
+import javax.security.enterprise.identitystore.CredentialValidationResult;
+import javax.security.enterprise.identitystore.IdentityStoreHandler;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for Utils.validateWithIdentityStore with skipIdentityStores functionality.
+ */
+public class UtilsSkipIdentityStoresTest {
+
+    private final Mockery mockery = new JUnit4Mockery();
+    private Utils utils;
+    private IdentityStoreHandler identityStoreHandler;
+    private Subject clientSubject;
+    private UsernamePasswordCredential credential;
+    private static final String REALM_NAME = "testRealm";
+
+    @Before
+    public void setUp() {
+        utils = new Utils();
+        identityStoreHandler = mockery.mock(IdentityStoreHandler.class);
+        clientSubject = new Subject();
+        credential = new UsernamePasswordCredential("testUser", "testPassword");
+    }
+
+    @After
+    public void tearDown() {
+        mockery.assertIsSatisfied();
+    }
+
+    /**
+     * Normal operation: skipIdentityStores is false and valid credentials,
+     * so return SUCCESS.
+     */
+    @Test
+    public void testValidateWithIdentityStore_SkipIdentityStoresFalse_ValidCredentials() {
+        final CredentialValidationResult validResult = new CredentialValidationResult("testUser");
+
+        mockery.checking(new Expectations() {
+            {
+                oneOf(identityStoreHandler).validate(credential);
+                will(returnValue(validResult));
+            }
+        });
+
+        AuthenticationStatus status = utils.validateWithIdentityStore(REALM_NAME, clientSubject,
+                                                                      credential, identityStoreHandler);
+
+        assertEquals("Should return SUCCESS for valid credentials",
+                     AuthenticationStatus.SUCCESS, status);
+        assertNotNull("Client subject should be populated", clientSubject.getPrincipals());
+    }
+
+    /**
+     * Normal operation: skipIdentityStores is false and invalid credentials,
+     * so return NOT_DONE.
+     */
+    @Test
+    public void testValidateWithIdentityStore_SkipIdentityStoresFalse_InvalidCredentials() {
+        final CredentialValidationResult invalidResult = CredentialValidationResult.INVALID_RESULT;
+
+        mockery.checking(new Expectations() {
+            {
+                oneOf(identityStoreHandler).validate(credential);
+                will(returnValue(invalidResult));
+            }
+        });
+
+        AuthenticationStatus status = utils.validateWithIdentityStore(REALM_NAME, clientSubject,
+                                                                      credential, identityStoreHandler);
+
+        assertEquals("Should return SEND_FAILURE for invalid credentials",
+                     AuthenticationStatus.SEND_FAILURE, status);
+    }
+
+    /**
+     * Normal operation: skipIdentityStores is false, so return NOT_DONE.
+     */
+    @Test
+    public void testValidateWithIdentityStore_SkipIdentityStoresFalse_NotValidated() {
+        final CredentialValidationResult notValidatedResult = CredentialValidationResult.NOT_VALIDATED_RESULT;
+
+        mockery.checking(new Expectations() {
+            {
+                oneOf(identityStoreHandler).validate(credential);
+                will(returnValue(notValidatedResult));
+            }
+        });
+
+        AuthenticationStatus status = utils.validateWithIdentityStore(REALM_NAME, clientSubject,
+                                                                      credential, identityStoreHandler);
+
+        assertEquals("Should return NOT_DONE when not validated",
+                     AuthenticationStatus.NOT_DONE, status);
+    }
+
+    /**
+     * Test validateWithIdentityStore handles null identity store.
+     */
+    @Test(expected = NullPointerException.class)
+    public void testValidateWithIdentityStore_NullHandler() {
+        // will throw NullPointerException - look at the code!
+        utils.validateWithIdentityStore(REALM_NAME, clientSubject, credential, null);
+    }
+
+    /**
+     * Test null credential for validateWithIdentityStore.
+     */
+    @Test
+    public void testValidateWithIdentityStore_NullCredential() {
+        mockery.checking(new Expectations() {
+            {
+                oneOf(identityStoreHandler).validate(null);
+                will(returnValue(CredentialValidationResult.INVALID_RESULT));
+            }
+        });
+
+        AuthenticationStatus status = utils.validateWithIdentityStore(REALM_NAME, clientSubject,
+                                                                      null, identityStoreHandler);
+
+        assertEquals("Should return SEND_FAILURE for null credential",
+                     AuthenticationStatus.SEND_FAILURE, status);
+    }
+
+    /**
+     * Test empty "" realm name for validateWithIdentityStore.
+     */
+    @Test
+    public void testValidateWithIdentityStore_EmptyRealmName() {
+        final CredentialValidationResult validResult = new CredentialValidationResult("testUser");
+
+        mockery.checking(new Expectations() {
+            {
+                oneOf(identityStoreHandler).validate(credential);
+                will(returnValue(validResult));
+            }
+        });
+
+        AuthenticationStatus status = utils.validateWithIdentityStore("", clientSubject,
+                                                                      credential, identityStoreHandler);
+
+        assertEquals("Should return SUCCESS even with empty realm name",
+                     AuthenticationStatus.SUCCESS, status);
+    }
+
+    /**
+     * Test null realm name for validateWithIdentityStore.
+     */
+    @Test
+    public void testValidateWithIdentityStore_NullRealmName() {
+        final CredentialValidationResult validResult = new CredentialValidationResult("testUser");
+
+        mockery.checking(new Expectations() {
+            {
+                oneOf(identityStoreHandler).validate(credential);
+                will(returnValue(validResult));
+            }
+        });
+
+        AuthenticationStatus status = utils.validateWithIdentityStore(null, clientSubject,
+                                                                      credential, identityStoreHandler);
+
+        assertEquals("Should return SUCCESS even with null realm name",
+                     AuthenticationStatus.SUCCESS, status);
+    }
+}

--- a/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/l10n/metatype.properties
@@ -126,3 +126,6 @@ partitionedCookie.desc=Specifies whether to partition SSO cookies with SameSite 
 partitionedCookieTrue=Always partition SSO cookies that have SameSite set to None.
 partitionedCookieFalse=Do not partition SSO cookies.
 partitionedCookieDefer=Allow the HTTP transport settings to determine whether to partition SSO cookies.
+
+skipIdentityStores=Skip identity stores during authentication
+skipIdentityStores.desc=When set to true, all identity stores (both internal and custom) are skipped and will not be used during the authentication process. Authentication will fall back to external configuration (i.e. a registry in server.xml).

--- a/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/metatype/metatype.xml
@@ -159,6 +159,9 @@
             ibm:final="true" name="internal" description="internal use only" />
         <AD id="loggedOutCookieCacheService.cardinality.minimum" type="String"  default="${count(loggedOutCookieCacheRef)}" 
             ibm:final="true" name="internal" description="internal use only"/>
+
+        <AD id="skipIdentityStores" name="%skipIdentityStores" description="%skipIdentityStores.desc"
+            required="false" type="Boolean" default="false"/>
             
     </OCD>
     <Designate pid="com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl">

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -1415,13 +1415,13 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
 
     protected String getApplicationName() {
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-        WebModuleMetaData wmmd = (WebModuleMetaData) ((WebComponentMetaData) cmd).getModuleMetaData();
+        WebModuleMetaData wmmd = (WebModuleMetaData) cmd.getModuleMetaData();
         return wmmd.getConfiguration().getApplicationName();
     }
 
     protected String getModuleName() {
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-        WebModuleMetaData wmmd = (WebModuleMetaData) ((WebComponentMetaData) cmd).getModuleMetaData();
+        WebModuleMetaData wmmd = (WebModuleMetaData) cmd.getModuleMetaData();
         return wmmd.getConfiguration().getModuleName();
     }
 
@@ -1431,7 +1431,7 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
 
     protected void setSecurityMetadata(SecurityMetadata secMetadata) {
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-        WebModuleMetaData wmmd = (WebModuleMetaData) ((WebComponentMetaData) cmd).getModuleMetaData();
+        WebModuleMetaData wmmd = (WebModuleMetaData) cmd.getModuleMetaData();
         wmmd.setSecurityMetaData(secMetadata);
     }
 
@@ -1552,7 +1552,7 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
         WebAppConfig wac = null;
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
         if (cmd instanceof WebComponentMetaData) { // Only get the header for web modules, i.e. not for EJB
-            WebModuleMetaData wmmd = (WebModuleMetaData) ((WebComponentMetaData) cmd).getModuleMetaData();
+            WebModuleMetaData wmmd = (WebModuleMetaData) cmd.getModuleMetaData();
             wac = wmmd.getConfiguration();
             if (!(wac instanceof com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration)) {
                 wac = null;

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityConfig.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityConfig.java
@@ -162,4 +162,11 @@ public interface WebAppSecurityConfig {
     boolean isUseContextRootForSSOCookiePath();
 
     long postParamMaxRequestBodySize();
+
+    /**
+     * Check if identity stores should be skipped.
+     *
+     * @return true if identity stores are skipped
+     */
+    boolean getSkipIdentityStores();
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImpl.java
@@ -73,6 +73,7 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
     public static final String CFG_KEY_PARTITIONED_COOKIE = "partitionedCookie";
     public static final String CFG_KEY_USE_CONTEXT_ROOT_FOR_SSO_COOKIE_PATH = "useContextRootForSSOCookiePath";
     public static final String CFG_KEY_MAX_CONTENT_LENGTH_TO_SAVE_POST_PARAMETERS = "postParamMaxRequestBodySize";
+    public static final String CFG_KEY_SKIP_IDENTITY_STORES = "skipIdentityStores";
 
     // New attributes must update getChangedProperties method
     private final Boolean logoutOnHttpSessionExpire;
@@ -107,6 +108,7 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
     private Boolean partitionedCookie = null; // in BETA, mark as final once GA'ed
     private final Boolean useContextRootForSSOCookiePath;
     private final Long postParamMaxRequestBodySize;
+    private final Boolean skipIdentityStores;
 
     protected final AtomicServiceReference<WsLocationAdmin> locationAdminRef;
     protected final AtomicServiceReference<SecurityService> securityServiceRef;
@@ -149,6 +151,7 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
             put(CFG_KEY_PARTITIONED_COOKIE, "partitionedCookie");
             put(CFG_KEY_USE_CONTEXT_ROOT_FOR_SSO_COOKIE_PATH, "useContextRootForSSOCookiePath");
             put(CFG_KEY_MAX_CONTENT_LENGTH_TO_SAVE_POST_PARAMETERS, "postParamMaxRequestBodySize");
+            put(CFG_KEY_SKIP_IDENTITY_STORES, "skipIdentityStores");
         }
     };
 
@@ -194,9 +197,10 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
         sameSiteCookie = (String) newProperties.get(CFG_KEY_SAME_SITE_COOKIE);
         useContextRootForSSOCookiePath = (Boolean) newProperties.get(CFG_KEY_USE_CONTEXT_ROOT_FOR_SSO_COOKIE_PATH);
         postParamMaxRequestBodySize = (Long) newProperties.get(CFG_KEY_MAX_CONTENT_LENGTH_TO_SAVE_POST_PARAMETERS);
+        skipIdentityStores = (Boolean) newProperties.get(CFG_KEY_SKIP_IDENTITY_STORES);
 
         String partValue = (String) newProperties.get(CFG_KEY_PARTITIONED_COOKIE);
-        if ("true".equalsIgnoreCase(partValue)||"false".equalsIgnoreCase(partValue)) {
+        if ("true".equalsIgnoreCase(partValue) || "false".equalsIgnoreCase(partValue)) {
             // we want partitionedCookie to be null unless the value is true or false
             // defer is the default value which mean that the channel config determines the partitioned value
             // if the value is true / false then this config was explicltly set by the user
@@ -615,8 +619,8 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
 
     @Override
     public boolean isPartitionedCookie() {
-        if (partitionedCookie!=null && partitionedCookie==Boolean.TRUE) {
-          return true;
+        if (partitionedCookie != null && partitionedCookie == Boolean.TRUE) {
+            return true;
         }
         return false;
     }
@@ -631,17 +635,22 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
         return postParamMaxRequestBodySize.longValue();
     }
 
+    @Override
+    public boolean getSkipIdentityStores() {
+        return skipIdentityStores != null ? skipIdentityStores.booleanValue() : false;
+    }
+
     // This method is for config users that need to know if an admin has provided a true/false or no value for a
     // boolean config attribute.  The current infrastructure does not properly support this
     public static Boolean getBooleanValue(String attribute, String strValue) {
-      Boolean retVal = null;
-      if (strValue!=null && strValue.length()>0) {
-        //only values that config gives us are true/false/defer
-        if ("true".equalsIgnoreCase(strValue) || "false".equalsIgnoreCase(strValue)) {
-          retVal = Boolean.valueOf(strValue);
-        } 
-      }
-      return(retVal);
+        Boolean retVal = null;
+        if (strValue != null && strValue.length() > 0) {
+            //only values that config gives us are true/false/defer
+            if ("true".equalsIgnoreCase(strValue) || "false".equalsIgnoreCase(strValue)) {
+                retVal = Boolean.valueOf(strValue);
+            }
+        }
+        return (retVal);
     }
 
 }

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImplSkipIdentityStoresTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImplSkipIdentityStoresTest.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.security.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.ws.security.SecurityService;
+import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
+import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
+
+/**
+ * Unit tests for skipIdentityStores configuration in WebAppSecurityConfigImpl.
+ */
+public class WebAppSecurityConfigImplSkipIdentityStoresTest {
+
+    private final Mockery mockery = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+    private AtomicServiceReference<WsLocationAdmin> locationAdminRef;
+    private AtomicServiceReference<SecurityService> securityServiceRef;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() {
+        locationAdminRef = mockery.mock(AtomicServiceReference.class, "locationAdminRef");
+        securityServiceRef = mockery.mock(AtomicServiceReference.class, "securityServiceRef");
+    }
+
+    @After
+    public void tearDown() {
+        mockery.assertIsSatisfied();
+    }
+
+    /**
+     * Test returning false when not set.
+     */
+    @Test
+    public void testSkipIdentityStores_NotConfigured_ReturnsFalse() {
+        Map<String, Object> props = new HashMap<>();
+        mockCookie(props, false);
+        // skipIdentityStores not set in properties
+
+        WebAppSecurityConfigImpl config = new WebAppSecurityConfigImpl(props, locationAdminRef, securityServiceRef, null, null);
+
+        assertFalse("skipIdentityStores should default to false when not configured",
+                    config.getSkipIdentityStores());
+    }
+
+    /**
+     * Test returning false when explicitly set.
+     */
+    @Test
+    public void testSkipIdentityStores_SetToFalse_ReturnsFalse() {
+        Map<String, Object> props = new HashMap<>();
+        mockCookie(props, false);
+        props.put(WebAppSecurityConfigImpl.CFG_KEY_SKIP_IDENTITY_STORES, Boolean.FALSE);
+
+        WebAppSecurityConfigImpl config = new WebAppSecurityConfigImpl(props, locationAdminRef, securityServiceRef, null, null);
+
+        assertFalse("skipIdentityStores should return false when set to false",
+                    config.getSkipIdentityStores());
+    }
+
+    /**
+     * Test returning true when explicitly set.
+     */
+    @Test
+    public void testSkipIdentityStores_SetToTrue_ReturnsTrue() {
+        Map<String, Object> props = new HashMap<>();
+        mockCookie(props, false);
+        props.put(WebAppSecurityConfigImpl.CFG_KEY_SKIP_IDENTITY_STORES, Boolean.TRUE);
+
+        WebAppSecurityConfigImpl config = new WebAppSecurityConfigImpl(props, locationAdminRef, securityServiceRef, null, null);
+
+        assertTrue("skipIdentityStores should return true when set to true",
+                   config.getSkipIdentityStores());
+    }
+
+    /**
+     * Test correct default value for skipIdentityStores.
+     */
+    @Test
+    public void testSkipIdentityStores_SetToNull_ReturnsFalse() {
+        Map<String, Object> props = new HashMap<>();
+        mockCookie(props, false);
+        props.put(WebAppSecurityConfigImpl.CFG_KEY_SKIP_IDENTITY_STORES, null);
+
+        WebAppSecurityConfigImpl config = new WebAppSecurityConfigImpl(props, locationAdminRef, securityServiceRef, null, null);
+
+        assertFalse("skipIdentityStores should return false when set to null",
+                    config.getSkipIdentityStores());
+    }
+
+    /**
+     * Test configAttributes update.
+     */
+    @Test
+    public void testSkipIdentityStores_IncludedInConfigAttributes() {
+        assertTrue("CFG_KEY_SKIP_IDENTITY_STORES should be in configAttributes map",
+                   WebAppSecurityConfigImpl.configAttributes.containsKey(WebAppSecurityConfigImpl.CFG_KEY_SKIP_IDENTITY_STORES));
+    }
+
+    /**
+     * Test correct mapping.
+     */
+    @Test
+    public void testSkipIdentityStores_ConfigAttributesMapping() {
+        String mappedValue = WebAppSecurityConfigImpl.configAttributes.get(WebAppSecurityConfigImpl.CFG_KEY_SKIP_IDENTITY_STORES);
+
+        assertTrue("skipIdentityStores should map to 'skipIdentityStores' in configAttributes",
+                   "skipIdentityStores".equals(mappedValue));
+    }
+
+    /**
+     * set up SSO cookie configuration to avoid IllegalArgumentException in constructor.
+     */
+    private void mockCookie(Map<String, Object> cfg, Boolean autoGenCookieName) {
+        if (!autoGenCookieName) {
+            cfg.put("ssoCookieName", "webSSOCookie");
+        }
+        cfg.put("autoGenSsoCookieName", autoGenCookieName);
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).

Fixes #33536 (GitHub Issue with acceptance criteria)

Explicitly enable the usage of in-memory identity stores via server.xml configuration, server wide.  By default, the usage of an in-memory identity store defined within an application is disabled, therefore there is zero-migration concerns.  This cannot be overridden with a custom identity store handler.

If explicitly enabled, the in-memory identity store will be created and involved within the authentication work flow. 