### PR TITLE
Fix JDBC fat missing attribute

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMap/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMap/server.xml
@@ -63,7 +63,7 @@
     <dataSource jndiName="jdbc/invalid/noTarget" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">
         <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
         <!-- invalid configuration: the 'as' attribute is not defined-->
-        <identifyException errorCode="1234"/>
+        <identifyException errorCode="1234" as="BOGUS"/>
     </dataSource>
     
     <dataSource jndiName="jdbc/invalid/bogusTarget" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This just fixes the server.xml of a JDBC fat.   The "as" attribute was missing from a datasource element.
