### PR TITLE
Remove onError=FAIL setting from JDBC FAT test

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMap/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMap/server.xml
@@ -94,6 +94,4 @@
     <!--  Permissions for application to access mbeans -->
     <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="javax.management.MBeanPermission" actions="queryNames"/>
     <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
-    
-    <variable name="onError" value="FAIL"/>
 </server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

A test in com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/ErrorMappingTest.java tests an invalid configuration, a missing "as" property on a datasource element.   It verifies that an error message is produced, but also expects the server to start.  However, the server.xml also had a setting of onError=fail.   All tests are expecting the server to start.  Fixing by removing the setting.  The server.xml is only used by ErrorMappingTest.java.
