### PR TITLE
Update H2 Secure tests

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/com/ibm/ws/http2/client/SecureHttp2Client.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/com/ibm/ws/http2/client/SecureHttp2Client.java
@@ -18,8 +18,8 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -91,7 +91,7 @@ public class SecureHttp2Client {
         LOGGER.logp(Level.INFO, CLASS_NAME, "drivePushRequests", "testing requests to:" + sb.toString());
 
         // keep track of the text of every response received
-        final List<String> responseMessages = new ArrayList<String>();
+        final List<String> responseMessages = new CopyOnWriteArrayList<String>();
         // latch to consider expected number of streams
         final CountDownLatch latch = new CountDownLatch(requestUris.length + expectedPushStreams);
 
@@ -226,7 +226,9 @@ public class SecureHttp2Client {
                             }
                         }
                         if (sb.length() > 0) {
-                            responseMessages.add(sb.toString());
+                            String response = sb.toString();
+                            LOGGER.logp(Level.INFO, CLASS_NAME, "drivePushRequests", "Adding response: " + response);
+                            responseMessages.add(response);
                         }
                         data.clear();
                     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Made push accumulation of H2 testing for secure test be sync due to intermittent race conditions. This is for Defect 307440