### PR TITLE
Increase DS lock timeout for JCA FAT

### DIFF
--- a/dev/com.ibm.ws.jca.1.7_fat/publish/servers/com.ibm.ws.jca.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jca.1.7_fat/publish/servers/com.ibm.ws.jca.fat/bootstrap.properties
@@ -1,5 +1,6 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:logservice=all:rarInstall=all:WAS.j2c=all:test=all:web.*=all:container.service=all:app.manager=all:com.ibm.ws.injectionengine.*=all:com.ibm.ws.threadContext.*=all
 
 osgi.console=5678
+ds.lock.timeout.milliseconds=30000
 
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jca.1.7_jakarta_fat/publish/servers/com.ibm.ws.jca.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jca.1.7_jakarta_fat/publish/servers/com.ibm.ws.jca.fat/bootstrap.properties
@@ -1,5 +1,6 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:logservice=all:rarInstall=all:WAS.j2c=all:test=all:web.*=all:container.service=all:app.manager=all:com.ibm.ws.injectionengine.*=all:com.ibm.ws.threadContext.*=all
 
 osgi.console=5678
+ds.lock.timeout.milliseconds=30000
 
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jca_fat_bvt.jms/publish/servers/com.ibm.ws.jca.bvt.jms/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_bvt.jms/publish/servers/com.ibm.ws.jca.bvt.jms/bootstrap.properties
@@ -2,4 +2,5 @@ bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info=enabled:WAS.j2c=all:concurrent=all:context=all:jeeMetadataContext=all:ClassloaderContext=all:TransactionContext=all:LogService=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
+ds.lock.timeout.milliseconds=30000
 osgi.console=5678

--- a/dev/com.ibm.ws.jca_fat_bvt/publish/servers/com.ibm.ws.jca.fat.bvt/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_bvt/publish/servers/com.ibm.ws.jca.fat.bvt/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011,2022 IBM Corporation and others.
+# Copyright (c) 2011,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,4 +14,5 @@ com.ibm.ws.logging.trace.specification=*=info=enabled:rarInstall=all:WAS.j2c=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 ds.loglevel=debug
+ds.lock.timeout.milliseconds=30000
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jca_fat_dynamicConfig/publish/servers/com.ibm.ws.jca.fat.dynamicConfig/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_dynamicConfig/publish/servers/com.ibm.ws.jca.fat.dynamicConfig/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013, 2020 IBM Corporation and others.
+# Copyright (c) 2013, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ com.ibm.ws.container.service.app.recycle=all:\
 app.manager=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
+ds.lock.timeout.milliseconds=30000
 osgi.console=5678
 
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/publish/servers/com.ibm.ws.jca.fat.enterpriseApp/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/publish/servers/com.ibm.ws.jca.fat.enterpriseApp/bootstrap.properties
@@ -2,4 +2,5 @@ com.ibm.ws.logging.trace.specification=*=info=enabled:RARInstall=all:com.ibm.ejs
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 ds.loglevel=debug
+ds.lock.timeout.milliseconds=30000
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jca_fat_errorpaths/publish/servers/com.ibm.ws.jca.fat.errorpaths/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_errorpaths/publish/servers/com.ibm.ws.jca.fat.errorpaths/bootstrap.properties
@@ -1,5 +1,6 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:logservice=all:WAS.j2c=all:test=all:web.*=all:app.manager=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
+ds.lock.timeout.milliseconds=30000
 
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jca_fat_example/publish/servers/com.ibm.ws.jca.fat.example/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_example/publish/servers/com.ibm.ws.jca.fat.example/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2012,2022 IBM Corporation and others.
+# Copyright (c) 2012,2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,4 +14,5 @@ com.ibm.ws.logging.trace.specification=*=info=enabled:rarInstall=all:WAS.j2c=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 ds.loglevel=debug
+ds.lock.timeout.milliseconds=30000
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jca_fat_example_anno/publish/servers/jca.fat.example.anno/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_example_anno/publish/servers/jca.fat.example.anno/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,4 +14,5 @@ com.ibm.ws.logging.trace.specification=*=info=enabled:rarInstall=all:WAS.j2c=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 ds.loglevel=debug
+ds.lock.timeout.milliseconds=30000
 bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jca_fat_regr/publish/servers/com.ibm.ws.jca.fat.regr/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_regr/publish/servers/com.ibm.ws.jca.fat.regr/bootstrap.properties
@@ -1,5 +1,6 @@
 com.ibm.ws.logging.trace.specification=*=event=enabled:logservice=all:rarInstall=all:WAS.j2c=all:test=all:web.*=all:app.manager=all:com.ibm.adapter.*=all:com.ibm.ws.security.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
+ds.lock.timeout.milliseconds=30000
 
 bootstrap.include=../testports.properties


### PR DESCRIPTION
These FAT tests either have DS logging enabled, which seems to result in an error in server logs when run on slower systems, or have encountered a similar error when run on slower systems. Although test methods pass, the error fails the fat.

Increase the lock timeout to avoid the error:

CWWKE0701E: bundle com.ibm.ws.transport.http:1.0.108.cl251220251026-1102 (115)[com.ibm.ws.http.internal.HttpEndpointImpl(251)] : Timeout waiting for reg change to complete registered


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

