### PR TITLE
Stop building classes with Java 7 byte code

### DIFF
--- a/dev/com.ibm.ws.appclient.boot.cmdline/bnd.bnd
+++ b/dev/com.ibm.ws.appclient.boot.cmdline/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -12,11 +12,6 @@
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
-
-javac.source: 1.7
-javac.target: 1.7
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 
 Bundle-SymbolicName: com.ibm.ws.appclient.boot.cmdline
 

--- a/dev/com.ibm.ws.ejbcontainer.remote.portable.core/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.remote.portable.core/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -12,11 +12,6 @@
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
-
-javac.source: 1.7
-javac.target: 1.7
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 
 Export-Package: \
 	com.ibm.ejs.container,\

--- a/dev/com.ibm.ws.ejbcontainer.remote.portable/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.remote.portable/bnd.bnd
@@ -4,7 +4,7 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -15,11 +15,6 @@
 -sub: *.bnd
 
 bVersion=1.0
-
-javac.source: 1.7
-javac.target: 1.7
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 
 Import-Package: \
     !com.ibm.ws.logging, \

--- a/dev/com.ibm.ws.kernel.boot.cmdline/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.boot.cmdline/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -12,11 +12,6 @@
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
-
-javac.source: 1.7
-javac.target: 1.7
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 
 Export-Package: com.ibm.ws.kernel.boot.cmdline;-split-package:=merge-last
 

--- a/dev/com.ibm.ws.kernel.boot.nested/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.boot.nested/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -12,11 +12,6 @@
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
-
-javac.source: 1.7
-javac.target: 1.7
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 
 Export-Package: \
 	com.ibm.ws.kernel.launch.service,\

--- a/dev/com.ibm.ws.kernel.boot/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.boot/bnd.bnd
@@ -18,11 +18,6 @@
 -nouses=true
 bVersion=1.0
 
-javac.source: 1.7
-javac.target: 1.7
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.7))"
-
 # We're going to create a bad bundle here: don't want imports
 # or anything else for the launcher. So just swallow the errors.
 -failok=true

--- a/dev/com.ibm.ws.kernel.feature.resolver/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.feature.resolver/bnd.bnd
@@ -13,12 +13,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-# Compile at Java 7 in order for this to run in WebSphere Migration Tools and Transformation Advisor.
-javac.source: 1.7
-javac.target: 1.7
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.7))"
-
 Bundle-Name: Liberty Feature Resolver
 Bundle-SymbolicName: com.ibm.ws.kernel.feature.resolver
 Bundle-Description: Liberty Feature Resolver implementation; version=${bVersion}

--- a/dev/com.ibm.ws.kernel.instrument.check/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.instrument.check/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -12,11 +12,6 @@
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
-
-javac.source: 1.7
-javac.target: 1.7
-
-Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 
 Private-Package: com.ibm.ws.kernel.instrument;-split-package:=merge-last
 Can-Redefine-Classes: false

--- a/dev/wlp-gradle/java.gradle
+++ b/dev/wlp-gradle/java.gradle
@@ -96,13 +96,6 @@ subprojects {
   
   tasks.withType(JavaCompile).configureEach({
       int javaVersionNumVal = Integer.parseInt(JavaVersion.current().getMajorVersion())
-      // javac 20 has a min target of 1.8, so upgrade any 1.7 projects to 1.8 if running on Java 20
-      
-      if ('1.7'.equals(sourceCompatibility) && javaVersionNumVal >= 20) {
-          sourceCompatibility = "1.8"
-          targetCompatibility = "1.8"
-      }
-
       if (javaVersionNumVal < 21 && '21'.equals(sourceCompatibility)) {
           javaCompiler = javaToolchains.compilerFor {
               languageVersion = JavaLanguageVersion.of(21)

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -260,9 +260,6 @@ if (bnd.get('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd.get('pub
 
     int javaVersionNumVal = Integer.parseInt(JavaVersion.current().getMajorVersion())
     def release = bnd.get('javac.source')
-    if ('1.7'.equals(release) && javaVersionNumVal >= 20) {
-      release = "8"
-    }
 
     if(release.startsWith('1.')) {
       release = release.substring(2);


### PR DESCRIPTION
- Liberty has not supported Java 7 for 6 years.  Update to no longer create Java 7 byte code for classes used for interop with other frameworks like the ejbportable classes, or to give out a nice message if someone uses Java 7 byte code.
- This changes allows us to build with Java 21 or higher with all projects instead of having to use Java 17 for most projects and only Java 21 for the Java 21 specific projects.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
