### PR TITLE
33571 support merging zos connect's OpenAPI extension between multiple docs

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
@@ -680,7 +680,7 @@ public class MergeProcessorImpl implements MergeProcessor {
     private static boolean isZConRolesAllowedIdentical(List<InProgressModel> models) {
         List<Object> zconExtensions = models.stream().map(d -> d.model.getExtensions())
                                             .filter(Objects::nonNull).map(e -> e.get("x-ibm-zcon-roles-allowed")).collect(toList());
-        return allEqual(zconExtensions, ModelEquality::equals);
+        return models.size() == zconExtensions.size() && allEqual(zconExtensions, ModelEquality::equals);
     }
 
     private static boolean isSecurityIdentical(List<InProgressModel> models) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,10 +75,16 @@ public class MergeProcessorImpl implements MergeProcessor {
 
     private static final Info MERGED_INFO;
 
+    private static final Set<String> EXTENSIONS_NOT_CHEKCED_FOR_DUPLICATES = new HashSet<>();
+
     static {
         MERGED_INFO = OASFactory.createInfo();
         MERGED_INFO.setTitle(Constants.MERGED_OPENAPI_DOC_TITLE);
         MERGED_INFO.setVersion(Constants.DEFAULT_OPENAPI_DOC_VERSION);
+
+        //if there are merge conflicts in x-ibm-zcon-roles-allowed they will be handled in the second pass
+        // Documentation for x-ibm-zcon-roles-allowed is at https://www.ibm.com/docs/en/zos-connect/3.0.0?topic=authorization-how-define-roles
+        EXTENSIONS_NOT_CHEKCED_FOR_DUPLICATES.add("x-ibm-zcon-roles-allowed");
     }
 
     @Reference
@@ -336,6 +343,8 @@ public class MergeProcessorImpl implements MergeProcessor {
                 return false;
             }
 
+            EXTENSIONS_NOT_CHEKCED_FOR_DUPLICATES.stream().forEach(extensions::remove);
+
             boolean clashesFound = false;
             for (Entry<OpenAPIProvider, Map<String, Object>> entry : this.topLevelExtensions.entrySet()) {
                 OpenAPIProvider otherProvider = entry.getKey();
@@ -437,6 +446,7 @@ public class MergeProcessorImpl implements MergeProcessor {
 
             document.setSecurity(null);
         }
+
     }
 
     /**

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
@@ -679,8 +679,8 @@ public class MergeProcessorImpl implements MergeProcessor {
 
     private static boolean isZConRolesAllowedIdentical(List<InProgressModel> models) {
         List<Object> zconExtensions = models.stream().map(d -> d.model.getExtensions())
-                                            .filter(Objects::nonNull).map(e -> e.get("x-ibm-zcon-roles-allowed")).collect(toList());
-        return models.size() == zconExtensions.size() && allEqual(zconExtensions, ModelEquality::equals);
+                                            .filter(Objects::nonNull).map(e -> e.get("x-ibm-zcon-roles-allowed")).filter(Objects::nonNull).collect(toList());
+        return zconExtensions.size() >= 1 && models.size() == zconExtensions.size() && allEqual(zconExtensions, ModelEquality::equals);
     }
 
     private static boolean isSecurityIdentical(List<InProgressModel> models) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
@@ -680,7 +680,7 @@ public class MergeProcessorImpl implements MergeProcessor {
     private static boolean isZConRolesAllowedIdentical(List<InProgressModel> models) {
         List<Object> zconExtensions = models.stream().map(d -> d.model.getExtensions())
                                             .filter(Objects::nonNull).map(e -> e.get("x-ibm-zcon-roles-allowed")).filter(Objects::nonNull).collect(toList());
-        return zconExtensions.size() >= 1 && models.size() == zconExtensions.size() && allEqual(zconExtensions, ModelEquality::equals);
+        return zconExtensions.isEmpty() || (models.size() == zconExtensions.size() && allEqual(zconExtensions, ModelEquality::equals));
     }
 
     private static boolean isSecurityIdentical(List<InProgressModel> models) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
@@ -462,7 +462,7 @@ public class MergeProcessorImpl implements MergeProcessor {
             final String MAP_KEY = "x-ibm-zcon-roles-allowed";
 
             Map<String, Object> extensions = new HashMap<>(document.getExtensions());
-            if (extensions == null) {
+            if (extensions.isEmpty() || !extensions.containsKey(MAP_KEY)) {
                 return;
             }
 
@@ -676,7 +676,8 @@ public class MergeProcessorImpl implements MergeProcessor {
     }
 
     private static boolean isZConRolesAllowedIdentical(List<InProgressModel> models) {
-        List<Object> zconExtensions = models.stream().map(d -> d.model.getExtensions().get("x-ibm-zcon-roles-allowed")).collect(toList());
+        List<Object> zconExtensions = models.stream().map(d -> d.model.getExtensions())
+                                            .filter(Objects::nonNull).map(e -> e.get("x-ibm-zcon-roles-allowed")).collect(toList());
         return allEqual(zconExtensions, ModelEquality::equals);
     }
 

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
@@ -461,10 +461,12 @@ public class MergeProcessorImpl implements MergeProcessor {
 
             final String MAP_KEY = "x-ibm-zcon-roles-allowed";
 
-            Map<String, Object> extensions = new HashMap<>(document.getExtensions());
-            if (extensions.isEmpty() || !extensions.containsKey(MAP_KEY)) {
+            Map<String, Object> oldExtensions = document.getExtensions();
+            if (oldExtensions == null || oldExtensions.isEmpty() || !oldExtensions.containsKey(MAP_KEY)) {
                 return;
             }
+
+            Map<String, Object> extensions = new HashMap<>(document.getExtensions());
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
                 Tr.event(this, tc, "Moving ibm-zcon-roles-allowed from the top level to under paths");

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/merge/MergeProcessorImpl.java
@@ -204,6 +204,7 @@ public class MergeProcessorImpl implements MergeProcessor {
                 }
             }
 
+            boolean zConRolesIdentical = isZConRolesAllowedIdentical(inProgressModels);
             boolean securityIdentical = isSecurityIdentical(inProgressModels);
             boolean infoIdentical = isInfoIdentical(inProgressModels);
             boolean externalDocsIdentical = isExternalDocsIdentical(inProgressModels);
@@ -244,6 +245,10 @@ public class MergeProcessorImpl implements MergeProcessor {
 
                 if (!serversIdentical) {
                     moveServersUnderPaths(inProgress.model);
+                }
+
+                if (!zConRolesIdentical) {
+                    moveZConRolesAllow(inProgress.model);
                 }
 
                 if (inProgress.documentNameProcessor.hasRenames()) {
@@ -343,13 +348,16 @@ public class MergeProcessorImpl implements MergeProcessor {
                 return false;
             }
 
-            EXTENSIONS_NOT_CHEKCED_FOR_DUPLICATES.stream().forEach(extensions::remove);
-
             boolean clashesFound = false;
             for (Entry<OpenAPIProvider, Map<String, Object>> entry : this.topLevelExtensions.entrySet()) {
                 OpenAPIProvider otherProvider = entry.getKey();
                 Map<String, Object> otherExtensions = entry.getValue();
                 for (Entry<String, Object> extensionEntry : extensions.entrySet()) {
+
+                    if (EXTENSIONS_NOT_CHEKCED_FOR_DUPLICATES.contains(extensionEntry.getKey())) {
+                        continue;
+                    }
+
                     String key = extensionEntry.getKey();
                     Object value = extensionEntry.getValue();
                     Object otherValue = otherExtensions.get(key);
@@ -447,6 +455,45 @@ public class MergeProcessorImpl implements MergeProcessor {
             document.setSecurity(null);
         }
 
+        //See https://www.ibm.com/docs/en/zos-connect/3.0.0?topic=authorization-how-define-roles for details on x-ibm-zcon-roles-allowed
+        //Like security, it can be defined on the top level or on specific operations
+        private void moveZConRolesAllow(OpenAPI document) {
+
+            final String MAP_KEY = "x-ibm-zcon-roles-allowed";
+
+            Map<String, Object> extensions = new HashMap<>(document.getExtensions());
+            if (extensions == null) {
+                return;
+            }
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                Tr.event(this, tc, "Moving ibm-zcon-roles-allowed from the top level to under paths");
+            }
+
+            Paths paths = document.getPaths();
+            if (paths == null) {
+                return;
+            }
+
+            for (PathItem item : notNull(paths.getPathItems()).values()) {
+                for (Operation op : notNull(item.getOperations()).values()) {
+                    if (op.getExtensions() == null) {
+                        //Hopefully OpenAPI can handle the same map being passed in
+                        //to multiple operations, but why risk it?
+                        Map<String, Object> zConMap = new HashMap<>();
+                        zConMap.put(MAP_KEY, extensions.get(MAP_KEY));
+                        op.setExtensions(zConMap);
+                    } else {
+                        Map<String, Object> localExtenionsMap = new HashMap<>(op.getExtensions());
+                        localExtenionsMap.putIfAbsent(MAP_KEY, extensions.get(MAP_KEY)); //A more specific setting will override the default
+                        op.setExtensions(localExtenionsMap);
+                    }
+                }
+            }
+
+            extensions.remove(MAP_KEY);
+            document.setExtensions(extensions);
+        }
     }
 
     /**
@@ -626,6 +673,11 @@ public class MergeProcessorImpl implements MergeProcessor {
 
     private static boolean serverEndsWithContextRoot(Server server, String contextRoot) {
         return server.getUrl().endsWith(contextRoot) || server.getUrl().endsWith(contextRoot + "/");
+    }
+
+    private static boolean isZConRolesAllowedIdentical(List<InProgressModel> models) {
+        List<Object> zconExtensions = models.stream().map(d -> d.model.getExtensions().get("x-ibm-zcon-roles-allowed")).collect(toList());
+        return allEqual(zconExtensions, ModelEquality::equals);
     }
 
     private static boolean isSecurityIdentical(List<InProgressModel> models) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/bnd.bnd
@@ -49,4 +49,5 @@ tested.features=\
     io.openliberty.org.eclipse.microprofile.openapi.2.0;version=latest,\
     io.openliberty.org.eclipse.microprofile.config.2.0;version=latest,\
     com.ibm.ws.kernel.service;version=latest, \
-    io.openliberty.com.fasterxml.jackson;version=latest
+    io.openliberty.com.fasterxml.jackson;version=latest, \
+    com.ibm.ws.org.apache.commons.lang3;version=latest

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/build.gradle
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/build.gradle
@@ -13,5 +13,5 @@
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 dependencies {
-  requiredLibs project(path: ':io.openliberty.org.eclipse.microprofile', configuration: 'openapi20')
+  requiredLibs project(path: ':io.openliberty.org.eclipse.microprofile', configuration: 'openapi20'), project(':com.ibm.ws.org.apache.commons.lang3')
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/ApplicationProcessorTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/ApplicationProcessorTest.java
@@ -55,6 +55,8 @@ import io.openliberty.microprofile.openapi20.fat.utils.OpenAPITestUtil;
  * - Scenarios involving context root, host/port, servers
  * - Make a pure JAX-RS app with the ApplicationPath annotation and ensure that the annotations are scanned and a document is generated
  * - Complete flow: model, static, annotation, filter in order
+ * 
+ * Most of these are tested in com.ibm.ws.microprofile.openapi_fat
  */
 @RunWith(FATRunner.class)
 public class ApplicationProcessorTest extends FATServletClient {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
@@ -26,6 +26,7 @@ import io.openliberty.microprofile.openapi20.fat.deployments.MergeConfigTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.MergeTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.MergeWithServletTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.StartupWarningMessagesTest;
+import io.openliberty.microprofile.openapi20.fat.deployments.ZOSConnectExtensionTest;
 import io.openliberty.microprofile.openapi20.fat.shutdown.ShutdownTest;
 import io.openliberty.microprofile.openapi20.fat.version.OpenAPIVersionTest;
 
@@ -41,7 +42,8 @@ import io.openliberty.microprofile.openapi20.fat.version.OpenAPIVersionTest;
     MergeWithServletTest.class,
     OpenAPIVersionTest.class,
     ShutdownTest.class,
-    StartupWarningMessagesTest.class
+    StartupWarningMessagesTest.class,
+    ZOSConnectExtensionTest.class
 })
 public class FATSuite {
     public static RepeatTests repeatDefault(String serverName) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/ZOSConnectExtensionTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/ZOSConnectExtensionTest.java
@@ -38,6 +38,8 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
@@ -48,6 +50,7 @@ import io.openliberty.microprofile.openapi20.fat.utils.OpenAPIConnection;
 import io.openliberty.microprofile.openapi20.fat.utils.OpenAPITestUtil;
 
 @RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
 public class ZOSConnectExtensionTest {
 
     private static final String SERVER_NAME = "OpenAPIMergeWithServerXMLTestServer";

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/ZOSConnectExtensionTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/ZOSConnectExtensionTest.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.fat.deployments;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.MpOpenAPIElement;
+import com.ibm.websphere.simplicity.config.MpOpenAPIInfoElement;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyFileManager;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.microprofile.openapi20.fat.FATSuite;
+import io.openliberty.microprofile.openapi20.fat.deployments.zosconnect.app.ZOSConnectTestApp;
+import io.openliberty.microprofile.openapi20.fat.deployments.zosconnect.app.ZOSConnectTestResource;
+import io.openliberty.microprofile.openapi20.fat.utils.OpenAPIConnection;
+import io.openliberty.microprofile.openapi20.fat.utils.OpenAPITestUtil;
+
+@RunWith(FATRunner.class)
+public class ZOSConnectExtensionTest {
+
+    private static final String SERVER_NAME = "OpenAPIMergeWithServerXMLTestServer";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
+
+    @BeforeClass
+    public static void startup() throws Exception {
+        server.saveServerConfiguration();
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void shutdown() throws Exception {
+        server.stopServer("CWWKO1683W", // Invalid info element
+                          "CWWKO1678W", // Invalid application name
+                          "CWWKO1679W" // Invalid module name
+        );
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        server.setMarkToEndOfLog();
+        server.restoreServerConfiguration(); // Will stop all apps deployed via server.xml and clear openapi config
+        server.waitForConfigUpdateInLogUsingMark(null);
+
+        server.deleteAllDropinApplications(); // Will stop all dropin apps
+        server.removeAllInstalledAppsForValidation(); // Validates that all apps stop
+
+        // Delete everything from the apps directory
+        server.deleteDirectoryFromLibertyServerRoot("apps");
+        LibertyFileManager.createRemoteFile(server.getMachine(), server.getServerRoot() + "/apps").mkdir();
+    }
+
+    //This test creates an openAPI doc with a map containing values from two apps, and checks they preserve their ordering
+    @Test
+    public void testMergePreservesMapOrdering() throws Exception {
+        setMergeConfig(list("test1", "test2"), null, null);
+
+        PropertiesAsset scanConfig = new PropertiesAsset().addProperty("mp.openapi.scan.disable",
+                                                                       "true");
+
+        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "test1.war")
+                                    .addClasses(ZOSConnectTestApp.class, ZOSConnectTestResource.class)
+                                    .addAsResource(scanConfig, "META-INF/microprofile-config.properties")
+                                    .addAsManifestResource(ZOSConnectTestApp.class.getPackage(), "static-file-foo.json", "openapi.json");
+        deployApp(war1);
+
+        WebArchive war2 = ShrinkWrap.create(WebArchive.class, "test2.war")
+                                    .addClasses(ZOSConnectTestApp.class, ZOSConnectTestResource.class)
+                                    .addAsResource(scanConfig, "META-INF/microprofile-config.properties")
+                                    .addAsManifestResource(ZOSConnectTestApp.class.getPackage(), "static-file-bar.json", "openapi.json");
+        deployApp(war2);
+
+        // check that documentation includes all paths in the right order
+        String doc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
+        JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc).get("paths");
+
+        List<String> pathNames = new ArrayList<>();
+        openapiNode.fieldNames().forEachRemaining(pathNames::add);
+
+        assertThat("Path names not found in expected order in " + doc,
+                   pathNames, contains("/test2/foo1", "/test2/foo2", "/test2/foo3", "/test3/bar1", "/test3/bar2", "/test3/bar3"));
+    }
+
+    private void setMergeConfig(List<String> included, List<String> excluded, MpOpenAPIInfoElement info) throws Exception {
+        ServerConfiguration config = server.getServerConfiguration();
+        MpOpenAPIElement mpOpenAPI = config.getMpOpenAPIElement();
+
+        clearMergeConfig(mpOpenAPI);
+
+        mpOpenAPI.getIncludedApplications().addAll(applications(included));
+        mpOpenAPI.getIncludedModules().addAll(modules(included));
+        mpOpenAPI.getExcludedApplications().addAll(applications(excluded));
+        mpOpenAPI.getExcludedModules().addAll(modules(excluded));
+
+        mpOpenAPI.setInfo(info);
+
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(null);
+    }
+
+    private static void clearMergeConfig(MpOpenAPIElement mpOpenAPI) {
+        List<String> includedApplications = mpOpenAPI.getIncludedApplications();
+        includedApplications.clear();
+
+        List<String> includedModules = mpOpenAPI.getIncludedModules();
+        includedModules.clear();
+
+        List<String> excludedApplications = mpOpenAPI.getExcludedApplications();
+        excludedApplications.clear();
+
+        List<String> excludedModules = mpOpenAPI.getExcludedModules();
+        excludedModules.clear();
+
+        mpOpenAPI.setInfo(null);
+    }
+
+    private static List<String> list(String... values) {
+        return new ArrayList<>(Arrays.asList(values));
+    }
+
+    private static List<String> applications(List<String> values) {
+        if (values == null) {
+            return Collections.emptyList();
+        }
+        return values.stream()
+                     .filter(v -> !v.contains("/"))
+                     .collect(Collectors.toList());
+    }
+
+    private static List<String> modules(List<String> values) {
+        if (values == null) {
+            return Collections.emptyList();
+        }
+        return values.stream()
+                     .filter(v -> v.contains("/"))
+                     .collect(Collectors.toList());
+    }
+
+    private void deployApp(Archive<?> app) throws Exception {
+        ShrinkHelper.exportDropinAppToServer(server, app, SERVER_ONLY);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/ZOSConnectExtensionTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/ZOSConnectExtensionTest.java
@@ -10,8 +10,7 @@
 package io.openliberty.microprofile.openapi20.fat.deployments;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -113,8 +113,16 @@ public class ZOSConnectExtensionTest {
         List<String> pathNames = new ArrayList<>();
         openapiNode.fieldNames().forEachRemaining(pathNames::add);
 
-        assertThat("Path names not found in expected order in " + doc,
-                   pathNames, contains("/test2/foo1", "/test2/foo2", "/test2/foo3", "/test3/bar1", "/test3/bar2", "/test3/bar3"));
+        assertEquals("There should be exactly six instances of [x-ibm-zcon-roles-allowed] (one per operation) in " + doc,
+                     6, StringUtils.countMatches(openapiNode.toPrettyString(), "x-ibm-zcon-roles-allowed"));
+
+        assertEquals("Bobs", openapiNode.path("/test1/foo1").path("get").path("x-ibm-zcon-roles-allowed").get(0).asText());
+        assertEquals("Bobs", openapiNode.path("/test1/foo2").path("get").path("x-ibm-zcon-roles-allowed").get(0).asText());
+        assertEquals("Robs", openapiNode.path("/test1/foo3").path("get").path("x-ibm-zcon-roles-allowed").get(0).asText());
+        assertEquals("Staff", openapiNode.path("/test2/bar1").path("get").path("x-ibm-zcon-roles-allowed").get(0).asText());
+        assertEquals("Staff", openapiNode.path("/test2/bar2").path("get").path("x-ibm-zcon-roles-allowed").get(0).asText());
+        assertEquals("Guests", openapiNode.path("/test2/bar3").path("get").path("x-ibm-zcon-roles-allowed").get(0).asText());
+
     }
 
     private void setMergeConfig(List<String> included, List<String> excluded, MpOpenAPIInfoElement info) throws Exception {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/ZOSConnectTestApp.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/ZOSConnectTestApp.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.fat.deployments.zosconnect.app;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class ZOSConnectTestApp extends Application {}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/ZOSConnectTestResource.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/ZOSConnectTestResource.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.fat.deployments.zosconnect.app;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+@Path("/")
+public class ZOSConnectTestResource {
+
+    @GET
+    @Path("/test")
+    @Operation(summary = "test method")
+    @APIResponse(responseCode = "200", description = "constant \"OK\" response")
+    @Produces(value = MediaType.TEXT_PLAIN)
+    public String test() {
+        return "OK";
+    }
+
+    @GET
+    @Path("/log")
+    @Operation(summary = "log method", hidden = true)
+    @APIResponse(responseCode = "200", description = "logs the queryparam message")
+    @Produces(value = MediaType.TEXT_PLAIN)
+    public String log(@QueryParam("message") String message) {
+        System.out.println(message);
+        return "OK";
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/static-file-bar.json
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/static-file-bar.json
@@ -47,6 +47,7 @@
 		},
 		"/bar3": {
 			"get": {
+     		    "x-ibm-zcon-roles-allowed": [ "Guests" ],
 				"summary": "openapi.json - Get test data",
 				"responses": {
 					"200": {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/static-file-bar.json
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/static-file-bar.json
@@ -1,0 +1,65 @@
+{
+	"openapi": "3.0.0",
+	"x-ibm-zcon-roles-allowed": [ "Staff" ],
+	"info": {
+		"title": "Test REST API",
+		"version": "1.0.0",
+		"description": "Test REST API in Liberty with tabs in json",
+		"termsOfService": "http://example.com/terms/",
+		"contact": {
+			"name": "Open API support team",
+			"email": "oapisupport@example.com",
+			"url": "http://www.example.com/support"
+		}
+	},
+	"paths": {
+		"/bar1": {
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
+		},
+		"/bar2": {
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
+		},
+		"/bar3": {
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
+		}
+	}
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/static-file-foo.json
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/static-file-foo.json
@@ -1,0 +1,65 @@
+{
+	"openapi": "3.0.0",
+	"x-ibm-zcon-roles-allowed": [ "Bobs" ],
+	"info": {
+		"title": "Test REST API",
+		"version": "1.0.0",
+		"description": "Test REST API in Liberty with tabs in json",
+		"termsOfService": "http://example.com/terms/",
+		"contact": {
+			"name": "Open API support team",
+			"email": "oapisupport@example.com",
+			"url": "http://www.example.com/support"
+		}
+	},
+	"paths": {
+		"/foo1": {
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
+		},
+		"/foo2": {
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
+		},
+		"/foo3": {
+			"get": {
+				"summary": "openapi.json - Get test data",
+				"responses": {
+					"200": {
+						"description": "Test data retrieved",
+						"schema": {
+							"$ref": "#/components/schemas/TestData"
+						}
+					},
+					"404": {
+						"description": "Test data not found"
+					}
+				}
+			}
+		}
+	}
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/static-file-foo.json
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/zosconnect/app/static-file-foo.json
@@ -47,6 +47,7 @@
 		},
 		"/foo3": {
 			"get": {
+		        "x-ibm-zcon-roles-allowed": [ "Robs" ],
 				"summary": "openapi.json - Get test data",
 				"responses": {
 					"200": {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPIMergeWithServerXMLTestServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPIMergeWithServerXMLTestServer/bootstrap.properties
@@ -11,4 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-
+com.ibm.ws.logging.trace.specification=*=info=enabled:mpOpenAPI=all=enabled

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPIMergeWithServerXMLTestServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPIMergeWithServerXMLTestServer/bootstrap.properties
@@ -11,4 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info=enabled:mpOpenAPI=all=enabled
+

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_test/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_test/bnd.bnd
@@ -37,7 +37,8 @@ test.project: true
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	org.hamcrest:hamcrest-all;version='1.3',\
-	com.ibm.ws.componenttest.2.0
+	com.ibm.ws.componenttest.2.0,\
+	com.ibm.ws.org.apache.commons.lang3;version=latest
 	
 -testpath: \
     io.openliberty.com.fasterxml.jackson;version=latest,\

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/MergeProcessorTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/MergeProcessorTest.java
@@ -336,6 +336,9 @@ public class MergeProcessorTest {
 
         assertEquals("Alices", result.getPaths().getPathItem("/test2/testA").getGET().getExtensions().get(TESTED_EXTENSION).toString());
         assertEquals("Eves", result.getPaths().getPathItem("/test2/testB").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+
+        //Finally assert that there is no mention of the zcon extension on the top level
+        assertFalse(result.getExtensions().containsKey(TESTED_EXTENSION));
     }
 
     /**
@@ -363,6 +366,9 @@ public class MergeProcessorTest {
         assertFalse(result.getPaths().getPathItem("/test3/testB") == null); //and we are explicitly testing if it merged in.
         assertTrue(result.getPaths().getPathItem("/test3/testA").getGET().getExtensions() == null);
         assertFalse(result.getPaths().getPathItem("/test3/testB").getGET().getExtensions().containsKey(TESTED_EXTENSION));
+
+        //Finally assert that there is no mention of the zcon extension on the top level
+        assertFalse(result.getExtensions().containsKey(TESTED_EXTENSION));
     }
 
     /**
@@ -386,6 +392,9 @@ public class MergeProcessorTest {
         assertFalse(result.getPaths().getPathItem("/test3/testB") == null); //and we are explicitly testing if it merged in.
         assertTrue(result.getPaths().getPathItem("/test3/testA").getGET().getExtensions() == null);
         assertFalse(result.getPaths().getPathItem("/test3/testB").getGET().getExtensions().containsKey(TESTED_EXTENSION));
+
+        //Finally assert that there is no mention of the zcon extension on the top level
+        assertFalse(result.getExtensions().containsKey(TESTED_EXTENSION));
     }
 
     private OpenAPI loadModel(String modelResource) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/MergeProcessorTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/MergeProcessorTest.java
@@ -18,7 +18,10 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -312,6 +315,77 @@ public class MergeProcessorTest {
         assertThat(resultProvider.getApplicationPath(), is("/test1"));
 
         assertModelsEqual(model1.getModel(), result);
+    }
+
+    /**
+     * Test the special case extension x-ibm-zcon-roles-allowed merges correctly.
+     */
+    @Test
+    public void testClashingZConRolesAllowdExtension() {
+
+        final String TESTED_EXTENSION = "x-ibm-zcon-roles-allowed";
+
+        OpenAPIProvider model1 = loadModel("zos-clashing-extension-1.yaml", "/test1");
+        OpenAPIProvider model2 = loadModel("zos-clashing-extension-2.yaml", "/test2");
+
+        OpenAPIProvider resultProvider = mergeProcessor.mergeDocuments(Arrays.asList(model1, model2));
+        OpenAPI result = resultProvider.getModel();
+
+        assertEquals("Bobs", result.getPaths().getPathItem("/test1/testA").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+        assertEquals("Robs", result.getPaths().getPathItem("/test1/testB").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+
+        assertEquals("Alices", result.getPaths().getPathItem("/test2/testA").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+        assertEquals("Eves", result.getPaths().getPathItem("/test2/testB").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+    }
+
+    /**
+     * Test the special case extension x-ibm-zcon-roles-allowed merges correctly, including a third app that does not use the extension.
+     */
+    @Test
+    public void testClashingZConRolesAllowdExtensionThreeApps() {
+
+        final String TESTED_EXTENSION = "x-ibm-zcon-roles-allowed";
+
+        OpenAPIProvider model1 = loadModel("zos-clashing-extension-1.yaml", "/test1");
+        OpenAPIProvider model2 = loadModel("zos-clashing-extension-2.yaml", "/test2");
+        OpenAPIProvider model3 = loadModel("zos-clashing-extension-3.yaml", "/test3");
+
+        OpenAPIProvider resultProvider = mergeProcessor.mergeDocuments(Arrays.asList(model1, model2, model3));
+        OpenAPI result = resultProvider.getModel();
+
+        assertEquals("Bobs", result.getPaths().getPathItem("/test1/testA").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+        assertEquals("Robs", result.getPaths().getPathItem("/test1/testB").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+
+        assertEquals("Alices", result.getPaths().getPathItem("/test2/testA").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+        assertEquals("Eves", result.getPaths().getPathItem("/test2/testB").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+
+        assertFalse(result.getPaths().getPathItem("/test3/testA") == null); //A bit neater than seeing if the next part NPEs.
+        assertFalse(result.getPaths().getPathItem("/test3/testB") == null); //and we are explicitly testing if it merged in.
+        assertTrue(result.getPaths().getPathItem("/test3/testA").getGET().getExtensions() == null);
+        assertFalse(result.getPaths().getPathItem("/test3/testB").getGET().getExtensions().containsKey(TESTED_EXTENSION));
+    }
+
+    /**
+     * Test the special case extension x-ibm-zcon-roles-allowed merges correctly, when only one app uses the extension.
+     */
+    @Test
+    public void testClashingZConRolesAllowdOneAppPlusOne() {
+
+        final String TESTED_EXTENSION = "x-ibm-zcon-roles-allowed";
+
+        OpenAPIProvider model1 = loadModel("zos-clashing-extension-1.yaml", "/test1");
+        OpenAPIProvider model3 = loadModel("zos-clashing-extension-3.yaml", "/test3");
+
+        OpenAPIProvider resultProvider = mergeProcessor.mergeDocuments(Arrays.asList(model1, model3));
+        OpenAPI result = resultProvider.getModel();
+
+        assertEquals("Bobs", result.getPaths().getPathItem("/test1/testA").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+        assertEquals("Robs", result.getPaths().getPathItem("/test1/testB").getGET().getExtensions().get(TESTED_EXTENSION).toString());
+
+        assertFalse(result.getPaths().getPathItem("/test3/testA") == null); //A bit neater than seeing if the next part NPEs.
+        assertFalse(result.getPaths().getPathItem("/test3/testB") == null); //and we are explicitly testing if it merged in.
+        assertTrue(result.getPaths().getPathItem("/test3/testA").getGET().getExtensions() == null);
+        assertFalse(result.getPaths().getPathItem("/test3/testB").getGET().getExtensions().containsKey(TESTED_EXTENSION));
     }
 
     private OpenAPI loadModel(String modelResource) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/MergeProcessorTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/MergeProcessorTest.java
@@ -338,7 +338,9 @@ public class MergeProcessorTest {
         assertEquals("Eves", result.getPaths().getPathItem("/test2/testB").getGET().getExtensions().get(TESTED_EXTENSION).toString());
 
         //Finally assert that there is no mention of the zcon extension on the top level
-        assertFalse(result.getExtensions().containsKey(TESTED_EXTENSION));
+        //On Smallrye OpenAPI 4.0.9 getExtensions will return null if there are no extensions
+        //(BaseExtensibleModel will return null if stream.allMatch(<predicate>) is true, which is always is for an empty stream
+        assertFalse(result.getExtensions() != null && result.getExtensions().containsKey(TESTED_EXTENSION));
     }
 
     /**
@@ -368,7 +370,9 @@ public class MergeProcessorTest {
         assertFalse(result.getPaths().getPathItem("/test3/testB").getGET().getExtensions().containsKey(TESTED_EXTENSION));
 
         //Finally assert that there is no mention of the zcon extension on the top level
-        assertFalse(result.getExtensions().containsKey(TESTED_EXTENSION));
+        //On Smallrye OpenAPI 4.0.9 getExtensions will return null if there are no extensions
+        //(BaseExtensibleModel will return null if stream.allMatch(<predicate>) is true, which is always is for an empty stream
+        assertFalse(result.getExtensions() != null && result.getExtensions().containsKey(TESTED_EXTENSION));
     }
 
     /**
@@ -394,7 +398,9 @@ public class MergeProcessorTest {
         assertFalse(result.getPaths().getPathItem("/test3/testB").getGET().getExtensions().containsKey(TESTED_EXTENSION));
 
         //Finally assert that there is no mention of the zcon extension on the top level
-        assertFalse(result.getExtensions().containsKey(TESTED_EXTENSION));
+        //On Smallrye OpenAPI 4.0.9 getExtensions will return null if there are no extensions
+        //(BaseExtensibleModel will return null if stream.allMatch(<predicate>) is true, which is always is for an empty stream
+        assertFalse(result.getExtensions() != null && result.getExtensions().containsKey(TESTED_EXTENSION));
     }
 
     private OpenAPI loadModel(String modelResource) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/zos-clashing-extension-1.yaml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/zos-clashing-extension-1.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+x-ibm-zcon-roles-allowed: "Bobs"
+info:
+  title: "test1"
+  version: "1.0"
+paths:
+  /testA:
+    get:
+      responses:
+        202:
+          description: "success"
+  /testB:
+    get:
+      x-ibm-zcon-roles-allowed: "Robs"
+      responses:
+        202:
+          description: "success"

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/zos-clashing-extension-2.yaml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/zos-clashing-extension-2.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+x-ibm-zcon-roles-allowed: "Alices"
+info:
+  title: "test1"
+  version: "1.0"
+paths:
+  /testA:
+    get:
+      responses:
+        202:
+          description: "success"
+  /testB:
+    get:
+      x-ibm-zcon-roles-allowed: "Eves"
+      responses:
+        202:
+          description: "success"

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/zos-clashing-extension-3.yaml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_test/src/io/openliberty/microprofile/openapi20/test/merge/zos-clashing-extension-3.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: "test1"
+  version: "1.0"
+paths:
+  /testA:
+    get:
+      responses:
+        202:
+          description: "success"
+  /testB:
+    get:
+      x-foo: "bar"
+      responses:
+        202:
+          description: "success"


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

ZOS has their own non-standard roles attribute, this adds support for merging it between multiple OpenAPI docs. 

fixes #33571