### PR TITLE
Fix intermittent test failure in SessionCacheTwoServerTest

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -1,15 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
 package com.ibm.ws.session.cache.fat;
 
 import static org.junit.Assert.assertNotSame;

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -236,8 +236,8 @@ public class SessionCacheTwoServerTest extends FATServletClient {
     public void testModifyWithoutPut() throws Exception {
         List<String> session = new ArrayList<>();
         if (session != null) {
-            appA.sessionPut("testModifyWithoutPut-key", new StringBuffer("MyValue"), session, true);
-        Thread.sleep(500);
+            appA.sessionPut("testModifyWithoutPut-key&sync=true", new StringBuffer("MyValue"), session, true);
+            Thread.sleep(500);
             try {
                 appB.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
                 // appA should not see the update because it does not get written to the persistent store without a putAttribute per writeContents=ONLY_SET_ATTRIBUTES
@@ -331,7 +331,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         List<String> session = new ArrayList<>();
         if (session != null) {
             appA.sessionPut("testMaxInactiveInterval-key", 55901, session, true);
-        Thread.sleep(500);
+            Thread.sleep(500);
             appB.sessionGet("testMaxInactiveInterval-key", 55901, session);
             appA.invokeServlet("setMaxInactiveInterval", session); //set max inactive interval to 1 second
 

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package com.ibm.ws.session.cache.fat;
 
 import static org.junit.Assert.assertNotSame;


### PR DESCRIPTION
Fix intermittent test failure due to race condition. 
Added sync parameter to the sessionPut call to force synchronous write to cache

This change does not affect the functionality of the test as the test is just checking the configuration of [httpSessionCahce-writeContents](https://openliberty.io/docs/latest/reference/config/httpSessionCache.html) 


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

