### PR TITLE
Fix NPE when handling empty CLOB values on Oracle 21c/23c

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -1881,7 +1881,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    //@SkipIfSysProp(DB_Oracle)  // Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33573
+    // Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33573
     public void testLobInsertAndRetrieve() throws Exception {
 
         try {

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -1903,7 +1903,7 @@ public class JakartaPersistenceServlet extends FATServlet {
             DocumentEntity r1 = em.find(DocumentEntity.class, 1L);
             tx.commit();
             
-            assertNull(r1.getContent());
+            assertEquals("", r1.getContent());
         } catch (Exception e) {
             if (tx.getStatus() == jakarta.transaction.Status.STATUS_ACTIVE) {
                 tx.rollback();

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -1881,7 +1881,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    @SkipIfSysProp(DB_Oracle)  // Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33573
+    //@SkipIfSysProp(DB_Oracle)  // Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33573
     public void testLobInsertAndRetrieve() throws Exception {
 
         try {
@@ -1900,11 +1900,10 @@ public class JakartaPersistenceServlet extends FATServlet {
 
         try {
             tx.begin();
-
             DocumentEntity r1 = em.find(DocumentEntity.class, 1L);
-   
-            assertEquals("", r1.getContent());
             tx.commit();
+            
+            assertNull(r1.getContent());
         } catch (Exception e) {
             if (tx.getStatus() == jakarta.transaction.Status.STATUS_ACTIVE) {
                 tx.rollback();

--- a/dev/io.openliberty.persistence.3.1.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/bnd.bnd
@@ -131,7 +131,8 @@ Include-Resource: \
   @\${repo;org.eclipse.persistence:org.eclipse.persistence.jpa;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
   @\${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.jpql;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
   @\${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
-  @\${repo;org.eclipse.persistence:org.eclipse.persistence.json;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class)
+  @\${repo;org.eclipse.persistence:org.eclipse.persistence.json;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
+  org/eclipse/persistence/platform/database=${bin}/org/eclipse/persistence/platform/database
 
 publish.wlp.jar.suffix: dev/api/third-party
 

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/platform/database/Oracle21Platform.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/platform/database/Oracle21Platform.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     13/01/2022-4.0.0 Tomas Kraus - 1391: JSON support in JPA
+package org.eclipse.persistence.platform.database;
+
+import org.eclipse.persistence.core.sessions.CoreSession;
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.internal.databaseaccess.FieldTypeDefinition;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Hashtable;
+
+public class Oracle21Platform extends Oracle19Platform {
+    public Oracle21Platform() {
+        super();
+    }
+
+    @Override
+    protected Hashtable<Class<?>, FieldTypeDefinition> buildFieldTypes() {
+        Hashtable<Class<?>, FieldTypeDefinition> fieldTypes = super.buildFieldTypes();
+        fieldTypes.put(java.time.LocalDateTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+        fieldTypes.put(java.time.LocalTime.class, new FieldTypeDefinition("TIMESTAMP", 9));
+        return fieldTypes;
+    }
+
+    /**
+    * INTERNAL:
+    * Allow for conversion from the Oracle type to the Java type. Used in cases when DB connection is needed like BLOB, CLOB.
+    */
+    public <T> T convertObject(Object sourceObject, Class<T> javaClass, CoreSession<?, ?, ? ,?, ?> session) throws ConversionException, DatabaseException {
+        //Handle special case when empty String ("") is passed from the entity into CLOB type column
+        if (ClassConstants.CLOB.equals(javaClass) && sourceObject instanceof String && "".equals(sourceObject)) {
+        	Connection connection = ((AbstractSession) session).getAccessor().getConnection();
+            Clob clob = null;
+            try {
+                clob = connection.createClob();
+                clob.setString(1, (String)sourceObject);
+            } catch (SQLException e) {
+                throw ConversionException.couldNotBeConvertedToClass(sourceObject, ClassConstants.CLOB, e);
+            }
+            return (T) clob;
+        }
+        return super.convertObject(sourceObject, javaClass);
+    }
+
+    /**
+     * INTERNAL:
+     * Check whether current platform is Oracle 21c or later.
+     * @return Always returns {@code true} for instances of Oracle 21c platform.
+     * @since 4.0.8
+     */
+    @Override
+    public boolean isOracle21() {
+        return true;
+    }
+}

--- a/dev/io.openliberty.persistence.3.2.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/bnd.bnd
@@ -133,7 +133,8 @@ Include-Resource: \
   @\${repo;org.eclipse.persistence:org.eclipse.persistence.json;${eclFullVersion};EXACT}!/!(META-INF/maven/*|module-info.class),\
   org/eclipse/persistence/internal/jpa=${bin}/org/eclipse/persistence/internal/jpa,\
   org/eclipse/persistence/queries=${bin}/org/eclipse/persistence/queries,\
-  org/eclipse/persistence/internal/expressions=${bin}/org/eclipse/persistence/internal/expressions
+  org/eclipse/persistence/internal/expressions=${bin}/org/eclipse/persistence/internal/expressions,\
+  org/eclipse/persistence/platform/database=${bin}/org/eclipse/persistence/platform/database
 
 
 publish.wlp.jar.suffix: dev/api/third-party

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/platform/database/Oracle23Platform.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/platform/database/Oracle23Platform.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.platform.database;
+
+import org.eclipse.persistence.core.sessions.CoreSession;
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class Oracle23Platform extends Oracle21Platform {
+
+    public Oracle23Platform() {
+        super();
+    }
+
+    /**
+     * INTERNAL:
+     * Check whether current platform is Oracle 23c or later.
+     * @return Always returns {@code true} for instances of Oracle 23c platform.
+     * @since 4.0.2
+     */
+    @Override
+    public boolean isOracle23() {
+        return true;
+    }
+
+    /**
+     * INTERNAL:
+     * Allow for conversion from the Oracle type to the Java type. Used in cases when DB connection is needed like BLOB, CLOB.
+     */
+    public <T> T convertObject(Object sourceObject, Class<T> javaClass, CoreSession<?, ?, ? ,?, ?> session) throws ConversionException, DatabaseException {
+        //Handle special case when empty String ("") is passed from the entity into CLOB type column
+        if (ClassConstants.CLOB.equals(javaClass) && sourceObject instanceof String && "".equals(sourceObject)) {
+            Connection connection = ((AbstractSession) session).getAccessor().getConnection();
+            Clob clob = null;
+            try {
+                clob = connection.createClob();
+                clob.setString(1, (String)sourceObject);
+            } catch (SQLException e) {
+                throw ConversionException.couldNotBeConvertedToClass(sourceObject, ClassConstants.CLOB, e);
+            }
+            return (T) clob;
+        }
+        return super.convertObject(sourceObject, javaClass);
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Edits Oracle 21 and 23 platform files to fix NPE issue when inserting empty string value to a `@Lob` field of an entity.
Fixes #33573 