### PR TITLE
Test case for server create with space in server name

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
@@ -118,7 +118,10 @@ public class CreateCommandTest {
     public void testServerNameWithSpaceRejected() throws Exception {
         String invalidServerName = "my server";
         
-        ProgramOutput po = LibertyServerUtils.executeLibertyCmd(bootstrap, "server", "create", invalidServerName);
+        // Need to quote the server name to pass it as a single argument with spaces
+        String quotedServerName = "\"" + invalidServerName + "\"";
+        
+        ProgramOutput po = LibertyServerUtils.executeLibertyCmd(bootstrap, "server", "create", quotedServerName);
         
         // Verify that the command failed (non-zero return code)
         assertTrue("Expected non-zero return code when creating server with space in name. STDOUT: " + po.getStdout() + " STDERR: " + po.getStderr(),

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
@@ -108,4 +108,38 @@ public class CreateCommandTest {
         assertTrue("Expected server.env to NOT contain WLP_SKIP_MAXPERMSIZE at: " + serverEnvPath,
                    !serverEnvContents.contains("WLP_SKIP_MAXPERMSIZE"));
     }
+
+    /**
+     * Test that server create command rejects server names containing spaces.
+     * Expected behavior: CWWKE0012E error message should be displayed indicating
+     * that the server name contains an invalid character (space).
+     */
+    @Test
+    public void testServerNameWithSpaceRejected() throws Exception {
+        String invalidServerName = "my server";
+        
+        ProgramOutput po = LibertyServerUtils.executeLibertyCmd(bootstrap, "server", "create", invalidServerName);
+        
+        // Verify that the command failed (non-zero return code)
+        assertTrue("Expected non-zero return code when creating server with space in name. STDOUT: " + po.getStdout() + " STDERR: " + po.getStderr(),
+                   po.getReturnCode() != 0);
+        
+        // Verify that the error output contains the CWWKE0012E error message
+        String stderr = po.getStderr();
+        assertTrue("Expected CWWKE0012E error message in output. STDERR: " + stderr,
+                   stderr.contains("CWWKE0012E"));
+        
+        // Verify that the error message mentions the invalid server name
+        assertTrue("Expected error message to mention the invalid server name '" + invalidServerName + "'. STDERR: " + stderr,
+                   stderr.contains(invalidServerName));
+        
+        // Verify that the error message mentions "character that is not valid" or similar
+        assertTrue("Expected error message to mention invalid character. STDERR: " + stderr,
+                   stderr.contains("character") && (stderr.contains("not valid") || stderr.contains("invalid")));
+        
+        // Verify that the server directory was NOT created
+        String invalidServerPath = installPath + "/usr/servers/" + invalidServerName;
+        assertFalse("Server directory should NOT have been created for invalid server name at " + invalidServerPath,
+                    LibertyFileManager.libertyFileExists(machine, invalidServerPath));
+    }
 }

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
@@ -118,27 +118,27 @@ public class CreateCommandTest {
     public void testServerNameWithSpaceRejected() throws Exception {
         String invalidServerName = "my server";
         
-        // Need to quote the server name to pass it as a single argument with spaces
-        String quotedServerName = "\"" + invalidServerName + "\"";
-        
-        ProgramOutput po = LibertyServerUtils.executeLibertyCmd(bootstrap, "server", "create", quotedServerName);
+        // Use the preserveSpaces flag to ensure the server name with space is passed as a single argument
+        ProgramOutput po = LibertyServerUtils.executeLibertyCmd(bootstrap, "server", true, "create", invalidServerName);
         
         // Verify that the command failed (non-zero return code)
         assertTrue("Expected non-zero return code when creating server with space in name. STDOUT: " + po.getStdout() + " STDERR: " + po.getStderr(),
                    po.getReturnCode() != 0);
         
+        // Error messages may be in stdout or stderr depending on how the command is executed
+        String output = po.getStdout() + " " + po.getStderr();
+        
         // Verify that the error output contains the CWWKE0012E error message
-        String stderr = po.getStderr();
-        assertTrue("Expected CWWKE0012E error message in output. STDERR: " + stderr,
-                   stderr.contains("CWWKE0012E"));
+        assertTrue("Expected CWWKE0012E error message in output. OUTPUT: " + output,
+                   output.contains("CWWKE0012E"));
         
         // Verify that the error message mentions the invalid server name
-        assertTrue("Expected error message to mention the invalid server name '" + invalidServerName + "'. STDERR: " + stderr,
-                   stderr.contains(invalidServerName));
+        assertTrue("Expected error message to mention the invalid server name '" + invalidServerName + "'. OUTPUT: " + output,
+                   output.contains(invalidServerName));
         
         // Verify that the error message mentions "character that is not valid" or similar
-        assertTrue("Expected error message to mention invalid character. STDERR: " + stderr,
-                   stderr.contains("character") && (stderr.contains("not valid") || stderr.contains("invalid")));
+        assertTrue("Expected error message to mention invalid character. OUTPUT: " + output,
+                   output.contains("character") && (output.contains("not valid") || output.contains("invalid")));
         
         // Verify that the server directory was NOT created
         String invalidServerPath = installPath + "/usr/servers/" + invalidServerName;

--- a/dev/fattest.simplicity/src/componenttest/common/apiservices/cmdline/LocalProvider.java
+++ b/dev/fattest.simplicity/src/componenttest/common/apiservices/cmdline/LocalProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/fattest.simplicity/src/componenttest/common/apiservices/cmdline/LocalProvider.java
+++ b/dev/fattest.simplicity/src/componenttest/common/apiservices/cmdline/LocalProvider.java
@@ -133,10 +133,15 @@ public class LocalProvider {
 
     public static ProgramOutput executeCommand(Machine machine, String cmd,
                                                String[] parameters, String workDir, Properties envVars, int timeout) throws Exception {
+        return executeCommand(machine, cmd, parameters, workDir, envVars, timeout, false);
+    }
+
+    public static ProgramOutput executeCommand(Machine machine, String cmd,
+                                               String[] parameters, String workDir, Properties envVars, int timeout, boolean preserveSpaces) throws Exception {
         ByteArrayOutputStream bufferOut = new ByteArrayOutputStream();
         ByteArrayOutputStream bufferErr = new ByteArrayOutputStream();
         int rc = execute(machine, cmd, parameters, envVars, workDir, bufferOut,
-                         bufferErr, false, timeout);
+                         bufferErr, false, timeout, preserveSpaces);
         ProgramOutput ret = new ProgramOutput(cmd, rc, bufferOut.toString(), bufferErr.toString());
         return ret;
     }
@@ -149,6 +154,13 @@ public class LocalProvider {
                                      final String[] parameterArray, Properties envp,
                                      final String workDir, final OutputStream stdOutStream,
                                      final OutputStream stdErrStream, boolean async, int timeout) throws Exception {
+        return execute(machine, command, parameterArray, envp, workDir, stdOutStream, stdErrStream, async, timeout, false);
+    }
+
+    private static final int execute(Machine machine, final String command,
+                                     final String[] parameterArray, Properties envp,
+                                     final String workDir, final OutputStream stdOutStream,
+                                     final OutputStream stdErrStream, boolean async, int timeout, boolean preserveSpaces) throws Exception {
         final String method = "execute";
         Log.entering(CLASS, method, "async is " + async);
 
@@ -195,7 +207,7 @@ public class LocalProvider {
              */
             if (!cmd[0].startsWith(shellCmd) && !cmd[0].endsWith(shellCmd)) {
                 String[] tmp = new String[3];
-                String parsedCommand = shArrayTransform(cmd);
+                String parsedCommand = shArrayTransform(cmd, preserveSpaces);
                 tmp[0] = WLP_CYGWIN_HOME == null ? shellCmd : WLP_CYGWIN_HOME + "/bin/sh";
                 tmp[1] = "-c";
                 tmp[2] = parsedCommand;
@@ -307,12 +319,34 @@ public class LocalProvider {
      * @return
      */
     private static String shArrayTransform(String[] cmd) {
-        String returned = "";
+        return shArrayTransform(cmd, false);
+    }
+
+    /**
+     * This method takes the parameter array and turns it into one long string for
+     * use by the sh -c part of running the command locally on linux
+     *
+     * @param  cmd
+     * @param  preserveSpaces if true, arguments containing spaces will be quoted
+     * @return
+     */
+    private static String shArrayTransform(String[] cmd, boolean preserveSpaces) {
+        StringBuilder returned = new StringBuilder();
         for (int i = 0; i < cmd.length; i++) {
-            returned += cmd[i] + " ";
+            if (i > 0) {
+                returned.append(" ");
+            }
+            String arg = cmd[i];
+            // If preserveSpaces is true and the argument contains spaces, quote it
+            if (preserveSpaces && arg.contains(" ")) {
+                // Use single quotes to preserve the argument literally
+                // Escape any single quotes within the argument
+                returned.append("'").append(arg.replace("'", "'\\''")).append("'");
+            } else {
+                returned.append(arg);
+            }
         }
-        returned = returned.substring(0, (returned.length() - 1)); //should remove the space at the end;
-        return returned;
+        return returned.toString();
     }
 
     public static synchronized AsyncProgramOutput executeCommandAsync(Machine machine,

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/LibertyServerUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/LibertyServerUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:

--- a/dev/fattest.simplicity/src/componenttest/topology/utils/LibertyServerUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/LibertyServerUtils.java
@@ -25,6 +25,7 @@ import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.common.apiservices.Bootstrap;
+import componenttest.common.apiservices.cmdline.LocalProvider;
 
 /**
  *
@@ -212,6 +213,22 @@ public class LibertyServerUtils {
      * @throws Exception
      */
     public static ProgramOutput execute(Machine machine, String javaHome, Properties envVars, String command, String... parms) throws Exception {
+        return execute(machine, javaHome, envVars, command, false, parms);
+    }
+
+    /**
+     * Execute a command on the file system with option to preserve spaces in arguments.
+     *
+     * @param machine
+     * @param javaHome
+     * @param envVars
+     * @param command
+     * @param preserveSpaces if true, arguments containing spaces will be properly quoted
+     * @param parms
+     * @return
+     * @throws Exception
+     */
+    public static ProgramOutput execute(Machine machine, String javaHome, Properties envVars, String command, boolean preserveSpaces, String... parms) throws Exception {
         final String method = "execute";
         Log.finer(c, method, "Executing: " + command, parms);
 
@@ -223,7 +240,12 @@ public class LibertyServerUtils {
         Log.finer(c, method, "Using additional env props: " + _envVars.toString());
 
         parms = parms != null ? parms : new String[] {};
-        ProgramOutput output = machine.execute(command, parms, _envVars);
+        ProgramOutput output;
+        if (preserveSpaces) {
+            output = LocalProvider.executeCommand(machine, command, parms, machine.getWorkDir(), _envVars, 0, preserveSpaces);
+        } else {
+            output = machine.execute(command, parms, _envVars);
+        }
         String stdout = output.getStdout();
         int rc = output.getReturnCode();
         // Skip logging if rc=0 (success) or rc=1 (server not running)
@@ -235,10 +257,14 @@ public class LibertyServerUtils {
     }
 
     public static ProgramOutput executeLibertyCmd(Bootstrap bootstrap, String command, String... parms) throws Exception {
+        return executeLibertyCmd(bootstrap, command, false, parms);
+    }
+
+    public static ProgramOutput executeLibertyCmd(Bootstrap bootstrap, String command, boolean preserveSpaces, String... parms) throws Exception {
         Machine machine = createMachine(bootstrap);
         String hostName = bootstrap.getValue("hostName");
         String javaHome = bootstrap.getValue(hostName + ".JavaHome");
         String cmd = bootstrap.getValue("libertyInstallPath") + "/bin/" + command;
-        return execute(machine, javaHome, null, cmd, parms);
+        return execute(machine, javaHome, null, cmd, preserveSpaces, parms);
     }
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Just adding a test case for the scenario:

`./server create "my server"`

That should produce an error message:

`
CWWKE0012E: The specified server name contains a character that is not valid (name=my server). Valid characters are: Unicode alphanumeric (e.g. 0-9, a-z, A-Z), underscore (_), dash (-), plus (+), and period (.). A server name cannot begin with a dash (-) or period (.).`

This test case depends on pull request [33590](https://github.com/OpenLiberty/open-liberty/pull/33590).  If that happens to get reverted, then this test will need to be modified to use a workaround for the server script's improper handling of spaces in args.   The command would need to use the following weird syntax:

`./server create "my\ server"`