### PR TITLE
Implment retry behavior within WebPage#get call

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2_fat.2/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat.2/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
@@ -44,6 +44,7 @@ import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
 import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
+import io.openliberty.faces.fat.selenium.util.internal.WebPage;
 
 /**
  * JSF 2.2 Tests
@@ -122,6 +123,22 @@ public class FATSuite extends TestContainerSuite {
         if(DRIVER == null) {
             throw new Exception("Failed to initialize WebDriver after multiple attempts! See log for details.");
         }
+
+        // Register the driver reset callback statically for the WebPage to use if exceptions occur.
+        WebPage.setDriverResetCallback(() -> {
+            Log.info(c, "DriverResetCallback", "Resetting WebDriver due to some error. See log for details");
+            if (DRIVER != null) {
+                try {
+                    DRIVER.quit();
+                } catch (Exception e) {
+                    // no-op
+                }
+                DRIVER = null;
+            }
+            DRIVER = getWebDriver();
+            return DRIVER;
+        });
+
         return DRIVER;
     }
 

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
@@ -47,6 +47,8 @@ import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
 import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
+import io.openliberty.faces.fat.selenium.util.internal.WebPage;
+
 /**
  * JSF 2.2 Tests
  *
@@ -133,6 +135,22 @@ public class FATSuite extends TestContainerSuite {
         if(DRIVER == null) {
             throw new Exception("Failed to initialize WebDriver after multiple attempts! See log for details.");
         }
+
+        // Register the driver reset callback statically for the WebPage to use if exceptions occur.
+        WebPage.setDriverResetCallback(() -> {
+            Log.info(c, "DriverResetCallback", "Resetting WebDriver due to some error. See log for details");
+            if (DRIVER != null) {
+                try {
+                    DRIVER.quit();
+                } catch (Exception e) {
+                    // no-op
+                }
+                DRIVER = null;
+            }
+            DRIVER = getWebDriver();
+            return DRIVER;
+        });
+
         return DRIVER;
     }
 

--- a/dev/com.ibm.ws.jsf.2.3_fat.2/fat/src/com/ibm/ws/jsf23/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat.2/fat/src/com/ibm/ws/jsf23/fat/FATSuite.java
@@ -37,6 +37,7 @@ import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
 import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
+import io.openliberty.faces.fat.selenium.util.internal.WebPage;
 
 /**
  * JSF 2.3 Tests
@@ -107,6 +108,22 @@ public class FATSuite extends TestContainerSuite {
         if(DRIVER == null) {
             throw new Exception("Failed to initialize WebDriver after multiple attempts! See log for details.");
         }
+
+        // Register the driver reset callback statically for the WebPage to use if exceptions occur.
+        WebPage.setDriverResetCallback(() -> {
+            Log.info(c, "DriverResetCallback", "Resetting WebDriver due to some error. See log for details");
+            if (DRIVER != null) {
+                try {
+                    DRIVER.quit();
+                } catch (Exception e) {
+                    // no-op
+                }
+                DRIVER = null;
+            }
+            DRIVER = getWebDriver();
+            return DRIVER;
+        });
+
         return DRIVER;
     }
 

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/FATSuite.java
@@ -49,6 +49,7 @@ import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
 import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
+import io.openliberty.faces.fat.selenium.util.internal.WebPage;
 
 /**
  * JSF 2.3 Tests
@@ -139,6 +140,22 @@ public class FATSuite extends TestContainerSuite {
         if(DRIVER == null) {
             throw new Exception("Failed to initialize WebDriver after multiple attempts! See log for details.");
         }
+
+        // Register the driver reset callback statically for the WebPage to use if exceptions occur.
+        WebPage.setDriverResetCallback(() -> {
+            Log.info(c, "DriverResetCallback", "Resetting WebDriver due to some error. See log for details");
+            if (DRIVER != null) {
+                try {
+                    DRIVER.quit();
+                } catch (Exception e) {
+                    // no-op
+                }
+                DRIVER = null;
+            }
+            DRIVER = getWebDriver();
+            return DRIVER;
+        });
+
         return DRIVER;
     }
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
@@ -45,6 +45,7 @@ import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.JavaInfo;
 import io.openliberty.faces.fat.selenium.util.internal.CustomDriver;
 import io.openliberty.faces.fat.selenium.util.internal.ExtendedWebDriver;
+import io.openliberty.faces.fat.selenium.util.internal.WebPage;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -160,6 +161,22 @@ public class FATSuite extends TestContainerSuite {
         if(DRIVER == null) {
             throw new Exception("Failed to initialize WebDriver after multiple attempts! See log for details.");
         }
+
+        // Register the driver reset callback statically for the WebPage to use if exceptions occur.
+        WebPage.setDriverResetCallback(() -> {
+            Log.info(c, "DriverResetCallback", "Resetting WebDriver due to some error. See log for details");
+            if (DRIVER != null) {
+                try {
+                    DRIVER.quit();
+                } catch (Exception e) {
+                    // no-op
+                }
+                DRIVER = null;
+            }
+            DRIVER = getWebDriver();
+            return DRIVER;
+        });
+
         return DRIVER;
     }
 

--- a/dev/io.openliberty.faces.fat.selenium.util.internal/src/io/openliberty/faces/fat/selenium/util/internal/WebPage.java
+++ b/dev/io.openliberty.faces.fat.selenium.util.internal/src/io/openliberty/faces/fat/selenium/util/internal/WebPage.java
@@ -38,6 +38,23 @@ public class WebPage {
     public static final Duration LONG_TIMEOUT = Duration.ofMillis(16000);
 
     protected ExtendedWebDriver webDriver;
+    private static DriverResetCallback driverResetCallback = null;
+
+    /*
+     * Interface to reset the driver, see setDriverResetCallback
+     */
+    @FunctionalInterface
+    public interface DriverResetCallback {
+        ExtendedWebDriver resetDriver() throws Exception;
+    }
+
+    /*
+     * Set a callback to reset the driver 
+     * Must be called once within the FATSuite during driver initialization
+     */
+    public static void setDriverResetCallback(DriverResetCallback callback) {
+        driverResetCallback = callback;
+    }
 
     public WebPage(ExtendedWebDriver webDriver) {
         this.webDriver = webDriver;
@@ -52,7 +69,30 @@ public class WebPage {
     }
 
     public void get(String url) {
-        webDriver.get(url);
+        int maxAttempts = 2;
+        Exception lastException = null;
+        
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                webDriver.get(url);
+                return; 
+            } catch (Exception e) {
+                lastException = e;
+                
+                // callback exists and we have attempts left
+                if (driverResetCallback != null && attempt < maxAttempts) {
+                    try {
+                        Thread.sleep(10000); // Wait 10 seconds before retrying if it's some network issue. 
+                        webDriver = driverResetCallback.resetDriver();
+                    } catch (Exception resetEx) {
+                        // no-op, as we may have attempts left
+                    }
+                } else if (attempt == maxAttempts) {
+                    // Last attempt failed, throw exception
+                    throw new RuntimeException("Failed to navigate to URL after " + maxAttempts + " attempts: " + url, lastException);
+                }
+            }
+        }
     }
 
     public String getTitle() {

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/FATSuite.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/FATSuite.java
@@ -56,6 +56,8 @@ import io.openliberty.org.apache.myfaces40.fat.tests.WebSocketTests;
 import io.openliberty.org.apache.myfaces40.fat.tests.bugfixes.MyFaces4628Test;
 import io.openliberty.org.apache.myfaces40.fat.tests.bugfixes.MyFaces4658Test;
 
+import io.openliberty.faces.fat.selenium.util.internal.WebPage;
+
 @RunWith(Suite.class)
 @SuiteClasses({
                 AcceptInputFileTest.class,
@@ -152,6 +154,22 @@ public class FATSuite extends TestContainerSuite {
         if(DRIVER == null) {
             throw new Exception("Failed to initialize WebDriver after multiple attempts! See log for details.");
         }
+        
+        // Register the driver reset callback statically for the WebPage to use if exceptions occur.
+        WebPage.setDriverResetCallback(() -> {
+            Log.info(c, "DriverResetCallback", "Resetting WebDriver due to some error. See log for details");
+            if (DRIVER != null) {
+                try {
+                    DRIVER.quit();
+                } catch (Exception e) {
+                    // no-op
+                }
+                DRIVER = null;
+            }
+            DRIVER = getWebDriver();
+            return DRIVER;
+        });
+        
         return DRIVER;
     }
 

--- a/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/tests/WebSocketTests.java
+++ b/dev/io.openliberty.org.apache.myfaces.4.0_fat/fat/src/io/openliberty/org/apache/myfaces40/fat/tests/WebSocketTests.java
@@ -87,7 +87,7 @@ public class WebSocketTests {
 
         String contextRoot = "WebSocket";
 
-        String url = JSFUtils.createSeleniumURLString(server, contextRoot, "OnErrorWebSocketTest.jsf");;
+        String url = JSFUtils.createSeleniumURLString(server, contextRoot, "OnErrorWebSocketTest.jsf");
         WebPage page = new WebPage(driver);
         page.get(url);
         page.waitForPageToLoad();


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

for #33382

Originally wanted to implement retry behavior within each test, but that's too much refactoring. Instead, I created a callback within the Webpage to retry if an exception occurs.  

Once this is merged and in release, the JSF 2.0 FAT in Closed Liberty can also be updated. 