### PR TITLE
Openapiui testbreak

### DIFF
--- a/dev/com.ibm.ws.openapi.ui_fat/publish/servers/openapi-ui-test/bootstrap.properties
+++ b/dev/com.ibm.ws.openapi.ui_fat/publish/servers/openapi-ui-test/bootstrap.properties
@@ -1,21 +1,21 @@
 ###############################################################################
-# Copyright (c) 2023 IBM Corporation and others.
+# Copyright (c) 2023, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 mp.openapi.extensions.liberty.enable.private.url=true
 #com.ibm.ws.logging.trace.specification=*=info:MPOPENAPI=debug:io.smallrye.openapi.*=all
-com.ibm.ws.logging.trace.specification=*=info=enabled:\
+com.ibm.ws.logging.trace.specification=\
+*=info=enabled:\
 com.ibm.ws.runtime.update.*=all:\
 channelframework=all:\
 HTTPChannel=all:\
-com.ibm.ws.http.internal*=all
+com.ibm.ws.http.internal*=all:\
+com.ibm.ws.webcontainer.*=fine
 com.ibm.ws.logging.max.file.size=300
+


### PR DESCRIPTION
For the build break Defect 305572, we also need to enable the webcontainer traces