### PR TITLE
passwordUtil should not  resolve wlp.aes.encryption.key and wlp.password.encryption.key as normalized paths

### DIFF
--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/VariableResolver.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/VariableResolver.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -32,6 +32,6 @@ public class VariableResolver implements KeyStringResolver {
 
     @Override
     public char[] getKey(String val) {
-        return registry.resolveString(val).toCharArray();
+        return registry.resolveRawString(val).toCharArray();
     }
 }

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/VariableResolver.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/VariableResolver.java
@@ -32,6 +32,7 @@ public class VariableResolver implements KeyStringResolver {
 
     @Override
     public char[] getKey(String val) {
+        // Use resolveRawString instead of resolveString so that VariableRegistry doesn't normalize the value saved in server config.
         return registry.resolveRawString(val).toCharArray();
     }
 }


### PR DESCRIPTION
 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #33609 