### PR TITLE
Record entity that lacks an id

### DIFF
--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -210,6 +210,12 @@ public class Data_1_0 implements DataVersionCompatibility {
 
     @Override
     @Trivial
+    public String persistenceFeatureName() {
+        return "persistence-3.2";
+    }
+
+    @Override
+    @Trivial
     public Set<Class<?>> resourceAccessorTypes(boolean stateful) {
         return stateful ? RESOURCE_ACCESSOR_CLASSES_STATEFUL //
                         : RESOURCE_ACCESSOR_CLASSES_STATELESS;

--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -486,6 +486,12 @@ public class Data_1_1 implements DataVersionCompatibility {
 
     @Override
     @Trivial
+    public String persistenceFeatureName() {
+        return "persistence-4.0";
+    }
+
+    @Override
+    @Trivial
     public Set<Class<?>> resourceAccessorTypes(boolean stateful) {
         return stateful ? RESOURCE_ACCESSOR_CLASSES_STATEFUL //
                         : RESOURCE_ACCESSOR_CLASSES_STATELESS;

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1220,3 +1220,23 @@ CWWKD1120.cursor.keyword.mismatch.explanation=Keywords such as GROUP BY, HAVING,
  pagination.
 CWWKD1120.cursor.keyword.mismatch.useraction=Rewrite the query to include only \
  the clauses: SELECT, FROM, and WHERE.
+
+CWWKD1121.record.lacks.id=CWWKD1121E: The {0} record cannot be used as an entity \
+ because it lacks a unqiue identifier. One of the record components ({1}) must \
+ be named id, have a name that ends with _id, Id or ID, or be of the type \
+ java.util.UUID.
+CWWKD1121.record.lacks.id.explanation=Entities are required to have a unique \
+ identifier attribute.
+CWWKD1121.record.lacks.id.useraction=Add or rename a record component to \
+ follow one of the stated conventions for assigning a unique identifier.
+
+CWWKD1122.entity.lacks.id=CWWKD1122E: The {0} class cannot be used as an \
+ entity because it lacks a unique identifier. To assign a unique identifier, \
+ ensure the {1} feature is enabled and the entity class is annotated \
+ @jakarta.persistence.Entity and has a field or getter method annoated \
+ @jakarta.persistence.Id. Alternatively, use a META-INF/orm.xml file to \
+ define the entity and its unique identifier.
+CWWKD1122.entity.lacks.id.explanation=Entities are required to have a unique \
+ identifier attribute.
+CWWKD1122.entity.lacks.id.useraction=Enable the Jakarta Persistence feature \
+ and follow the Jakarta Persistence entity model to assign a unique identifier.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1232,9 +1232,10 @@ CWWKD1121.record.lacks.id.useraction=Add or rename a record component to \
 
 CWWKD1122.entity.lacks.id=CWWKD1122E: The {0} class cannot be used as an \
  entity because it lacks a unique identifier. To assign a unique identifier, \
- ensure the {1} feature is enabled and the entity class is annotated \
- @jakarta.persistence.Entity and has a field or getter method annoated \
- @jakarta.persistence.Id. Alternatively, use a META-INF/orm.xml file to \
+ ensure the {1} feature is enabled and add the @jakarta.persistence.Entity annotation \
+ to the entity class and add the @jakarta.persistence.Id annotation to at most one \
+ field or getter method of the entity class. \
+ Alternatively, use a META-INF/orm.xml file to \
  define the entity and its unique identifier.
 CWWKD1122.entity.lacks.id.explanation=Entities are required to have a unique \
  identifier attribute.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/orm/EntityParser.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/orm/EntityParser.java
@@ -34,11 +34,13 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 
+import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.Util;
 import io.openliberty.data.internal.persistence.orm.Models.AccessType;
 import io.openliberty.data.internal.persistence.orm.Models.Attribute;
@@ -90,6 +92,7 @@ public class EntityParser {
     private final LinkedHashSet<String> classNames;
 
     // Global configurations
+    private final DataProvider provider;
     private final String tablePrefix;
 
     // State controls flow from initialization to generation
@@ -99,8 +102,14 @@ public class EntityParser {
     private Class<?> currentEntity;
     private Set<Attribute> idAttributes;
 
+    /**
+     * Construct a new entity parser.
+     *
+     * @param tablePrefix the table prefix or empty string if none.
+     * @param provider    OSGi service representing this Data provider.
+     */
     @Trivial
-    public EntityParser(String tablePrefix) {
+    public EntityParser(String tablePrefix, DataProvider provider) {
         this.mappedSuperclasses = new HashMap<>();
         this.entities = new HashMap<>();
         this.embeddables = new HashMap<>();
@@ -113,6 +122,7 @@ public class EntityParser {
         this.tableNames = new LinkedHashSet<>();
         this.classNames = new LinkedHashSet<>();
 
+        this.provider = provider;
         this.tablePrefix = tablePrefix;
 
         this.doneParsing = false;
@@ -543,17 +553,24 @@ public class EntityParser {
     @Trivial
     private void verify() {
         if (idAttributes.isEmpty()) {
-            EntityRecord invalid = entities.get(currentEntity);
-            Set<Class<?>> supers = entitiesSuperclasses.get(currentEntity);
-            Set<MappedSuperclass> invalidSupers = supers == null || supers.isEmpty() ? //
-                            Set.of() : //
-                            supers.stream() //
-                                            .map(c -> mappedSuperclasses.get(c))//
-                                            .collect(Collectors.toSet());
-
-            //TODO NLS
-            throw new MappingException("The entity " + invalid + " had no id attribute"
-                                       + (invalidSupers.isEmpty() ? " " : " nor was any id attribute found on any mapped superclass " + invalidSupers));
+            Class<?> recordEntityClass = entityToRecord.get(currentEntity);
+            if (recordEntityClass == null) {
+                throw exc(MappingException.class,
+                          "CWWKD1122.entity.lacks.id",
+                          currentEntity.getName(),
+                          provider.compat.persistenceFeatureName());
+            } else { // a Java record entity
+                String recordComponentNames = Stream //
+                                .of(recordEntityClass.getRecordComponents()) //
+                                .map(RecordComponent::getName) //
+                                .reduce("", (s, n) -> s.length() == 0 //
+                                                ? n //
+                                                : (s + ", " + n));
+                throw exc(MappingException.class,
+                          "CWWKD1121.record.lacks.id",
+                          recordEntityClass.getName(),
+                          recordComponentNames);
+            }
         }
 
         if (idAttributes.size() > 1) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/service/DBStoreEMBuilder.java
@@ -349,7 +349,7 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
 
         ArrayList<InMemoryMappingFile> generatedEntities = new ArrayList<InMemoryMappingFile>();
 
-        EntityParser parser = new EntityParser(tablePrefix);
+        EntityParser parser = new EntityParser(tablePrefix, provider);
 
         for (Class<?> c : entityTypes) {
             if (c.isAnnotationPresent(Entity.class)) {

--- a/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/EntityParserErrorTests.java
+++ b/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/EntityParserErrorTests.java
@@ -12,19 +12,38 @@ package io.openliberty.data.internal.persistence.orm;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Map;
+
 import org.junit.Test;
 
+import io.openliberty.data.internal.persistence.DataProvider;
 import io.openliberty.data.internal.persistence.orm.TestConverters.InvalidConverter;
 import jakarta.data.exceptions.MappingException;
 
 /**
- *
+ * Unit testing of error paths in EntityParser.
  */
 public class EntityParserErrorTests {
+    private final DataProvider provider;
+
+    public EntityParserErrorTests() {
+        provider = new DataProvider(//
+                        Map.of(), // properties
+                        null, // CDIService
+                        null, // ClassLoaderIdentifierService
+                        new MockVersionCompatibility(), //
+                        null, // ConfigurationAdmin
+                        null, // ExecutorService
+                        null, // LocalTransactionCurrent
+                        null, // MetaDataIdentifierService
+                        null, // ResourceConfigFactory
+                        null // EmbeddableWebSphereTransactionManager
+        );
+    }
 
     @Test
     public void noIdEntityTest() {
-        EntityParser p = new EntityParser("", null);
+        EntityParser p = new EntityParser("", provider);
 
         try {
             p.parseUnannotatedEntity(WithoutId.class);
@@ -37,23 +56,25 @@ public class EntityParserErrorTests {
 
     @Test
     public void noIdInMappedSuperclassEntityTest() {
-        EntityParser p = new EntityParser("", null);
+        EntityParser p = new EntityParser("", provider);
 
         try {
             p.parseUnannotatedEntity(WithoutIdMappedSuperclass.class);
             fail("Should not have been able to parse an entity without an id atribute");
         } catch (MappingException e) {
-            assertTrue("Error message should have contained entity class name " + WithoutIdMappedSuperclass.class.getName() + " but was " + e.getMessage(),
-                       e.getMessage().contains("WithoutIdMappedSuperclass"));
+            assertTrue("The CWWKD1122E error message should be used,",
+                       e.getMessage().startsWith("CWWKD1122E:"));
 
-            assertTrue("Error message should have contained mappedsuperclass name " + SuperAlpha.class.getName() + " but was " + e.getMessage(),
-                       e.getMessage().contains("SuperAlpha"));
+            assertTrue("Error message should have contained entity class name " +
+                       WithoutIdMappedSuperclass.class.getName() +
+                       " but was " + e.getMessage(),
+                       e.getMessage().contains("WithoutIdMappedSuperclass"));
         }
     }
 
     @Test
     public void multipleIdInMappedSuperclassEntityTest() {
-        EntityParser p = new EntityParser("", null);
+        EntityParser p = new EntityParser("", provider);
 
         try {
             p.parseUnannotatedEntity(WithMultipleIds.class);
@@ -69,7 +90,7 @@ public class EntityParserErrorTests {
 
     @Test
     public void invalidConverterEntityTest() {
-        EntityParser p = new EntityParser("", null);
+        EntityParser p = new EntityParser("", provider);
 
         try {
             p.parseUnannotatedEntity(WithConverterInvalid.class);

--- a/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/EntityParserErrorTests.java
+++ b/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/EntityParserErrorTests.java
@@ -24,7 +24,7 @@ public class EntityParserErrorTests {
 
     @Test
     public void noIdEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
 
         try {
             p.parseUnannotatedEntity(WithoutId.class);
@@ -37,7 +37,7 @@ public class EntityParserErrorTests {
 
     @Test
     public void noIdInMappedSuperclassEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
 
         try {
             p.parseUnannotatedEntity(WithoutIdMappedSuperclass.class);
@@ -53,7 +53,7 @@ public class EntityParserErrorTests {
 
     @Test
     public void multipleIdInMappedSuperclassEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
 
         try {
             p.parseUnannotatedEntity(WithMultipleIds.class);
@@ -69,7 +69,7 @@ public class EntityParserErrorTests {
 
     @Test
     public void invalidConverterEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
 
         try {
             p.parseUnannotatedEntity(WithConverterInvalid.class);

--- a/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/EntityParserTests.java
+++ b/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/EntityParserTests.java
@@ -22,7 +22,7 @@ public class EntityParserTests {
 
     @Test
     public void simpleEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(Simple.class);
         List<String> xmls = p.generateView();
 
@@ -48,7 +48,7 @@ public class EntityParserTests {
 
     @Test
     public void simpleEntityWithPrefixTest() {
-        EntityParser p = new EntityParser("prefix");
+        EntityParser p = new EntityParser("prefix", null);
         p.parseUnannotatedEntity(Simple.class);
         List<String> xmls = p.generateView();
 
@@ -74,7 +74,7 @@ public class EntityParserTests {
 
     @Test
     public void versionedEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(Versioned.class);
         List<String> xmls = p.generateView();
 
@@ -101,7 +101,7 @@ public class EntityParserTests {
 
     @Test
     public void recordEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseRecord(RecordEntity.class, RecordEntityEntity.class);
         List<String> xmls = p.generateView();
 
@@ -129,7 +129,7 @@ public class EntityParserTests {
 
     @Test
     public void recordComplexEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseRecord(RecordComplex.class, RecordComplexEntity.class);
         List<String> xmls = p.generateView();
 
@@ -174,7 +174,7 @@ public class EntityParserTests {
 
     @Test
     public void collectionEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(Collection.class);
         List<String> xmls = p.generateView();
 
@@ -202,7 +202,7 @@ public class EntityParserTests {
 
     @Test
     public void collectionEmbeddedEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(CollectionEmbedded.class);
         List<String> xmls = p.generateView();
 
@@ -248,7 +248,7 @@ public class EntityParserTests {
 
     @Test
     public void propertyEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(Property.class);
         List<String> xmls = p.generateView();
 
@@ -278,7 +278,7 @@ public class EntityParserTests {
 
     @Test
     public void embeddedEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(WithEmbedded.class);
         List<String> xmls = p.generateView();
 
@@ -319,7 +319,7 @@ public class EntityParserTests {
 
     @Test
     public void embeddedIdEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(WithEmbeddedId.class);
         List<String> xmls = p.generateView();
 
@@ -359,7 +359,7 @@ public class EntityParserTests {
 
     @Test
     public void embeddedRecordEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(WithEmbeddedRecord.class);
         List<String> xmls = p.generateView();
 
@@ -402,7 +402,7 @@ public class EntityParserTests {
 
     @Test
     public void mappedSuperClassEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(WithMappedSuperclass.class);
         List<String> xmls = p.generateView();
 
@@ -478,7 +478,7 @@ public class EntityParserTests {
 
     @Test
     public void mappedSuperClassEmbeddedIdEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(WithMappedSuperclassPrime.class);
         List<String> xmls = p.generateView();
 
@@ -572,7 +572,7 @@ public class EntityParserTests {
 
     @Test
     public void converterEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(WithConverter.class);
         List<String> xmls = p.generateView();
 
@@ -619,7 +619,7 @@ public class EntityParserTests {
 
     @Test
     public void converterComplexEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(WithConverterComplex.class);
         List<String> xmls = p.generateView();
 
@@ -685,7 +685,7 @@ public class EntityParserTests {
 
     @Test
     public void annotatedWithConverterEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseAnnotatedEntity(WithEntityAnnotation.class);
         List<String> xmls = p.generateView();
 
@@ -712,7 +712,7 @@ public class EntityParserTests {
 
     @Test
     public void multilayerEmbeddedEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(WithMultilayerEmbedded.class);
         List<String> xmls = p.generateView();
 
@@ -782,7 +782,7 @@ public class EntityParserTests {
 
     @Test
     public void multilayerEmbeddedCollectionEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(WithMultilayerEmbeddedCollection.class);
         List<String> xmls = p.generateView();
 
@@ -854,7 +854,7 @@ public class EntityParserTests {
 
     @Test
     public void embeddedMulilayerCollectionEntityTest() {
-        EntityParser p = new EntityParser("");
+        EntityParser p = new EntityParser("", null);
         p.parseUnannotatedEntity(WithEmbeddedMultilayerCollection.class);
         List<String> xmls = p.generateView();
 

--- a/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/EntityParserTests.java
+++ b/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/EntityParserTests.java
@@ -12,13 +12,32 @@ package io.openliberty.data.internal.persistence.orm;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
+
+import io.openliberty.data.internal.persistence.DataProvider;
 
 /**
  * TODO test an annotated entity
  */
 public class EntityParserTests {
+    private final DataProvider provider;
+
+    public EntityParserTests() {
+        provider = new DataProvider(//
+                        Map.of(), // properties
+                        null, // CDIService
+                        null, // ClassLoaderIdentifierService
+                        new MockVersionCompatibility(), //
+                        null, // ConfigurationAdmin
+                        null, // ExecutorService
+                        null, // LocalTransactionCurrent
+                        null, // MetaDataIdentifierService
+                        null, // ResourceConfigFactory
+                        null // EmbeddableWebSphereTransactionManager
+        );
+    }
 
     @Test
     public void simpleEntityTest() {

--- a/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/MockVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/MockVersionCompatibility.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.data.internal.persistence.orm;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+import io.openliberty.data.internal.AttributeConstraint;
+import io.openliberty.data.internal.QueryType;
+import io.openliberty.data.internal.version.DataVersionCompatibility;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Find;
+
+/**
+ * A mock DataVersionCompatibility implementation.
+ */
+public class MockVersionCompatibility implements DataVersionCompatibility {
+
+    @Override
+    @Trivial
+    public StringBuilder appendConstraint(StringBuilder q,
+                                          String o_,
+                                          String attrName,
+                                          AttributeConstraint constraint,
+                                          int qp,
+                                          boolean isCollection,
+                                          Annotation[] annos) {
+        return q;
+    }
+
+    @Override
+    @Trivial
+    public boolean atLeast(int major, int minor) {
+        return false;
+    }
+
+    @Override
+    @Trivial
+    public Annotation getCountAnnotation(Method method) {
+        return null;
+    }
+
+    @Override
+    @Trivial
+    public Class<?> getEntityClass(Find find) {
+        return void.class;
+    }
+
+    @Override
+    @Trivial
+    public Annotation getExistsAnnotation(Method method) {
+        return null;
+    }
+
+    @Override
+    @Trivial
+    public String[] getSelections(AnnotatedElement element) {
+        return NO_SELECTIONS;
+    }
+
+    @Override
+    @Trivial
+    public String[] getUpdateAttributeAndOperation(Annotation[] annos) {
+        return null;
+    }
+
+    @Override
+    @Trivial
+    public int inspectMethodParam(int p,
+                                  Class<?> paramType,
+                                  Annotation[] paramAnnos,
+                                  String[] attrNames,
+                                  AttributeConstraint[] constraints,
+                                  char[] updateOps,
+                                  int qpNext) {
+        return qpNext;
+    }
+
+    @Override
+    @Trivial
+    public boolean isSpecialParamValid(Class<?> paramType,
+                                       QueryType queryType) {
+        return true;
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<? extends Annotation>> lifeCycleAnnoTypes(boolean stateful) {
+        return Set.of();
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<? extends Annotation>> operationAnnoTypes(boolean stateful) {
+        return Set.of();
+    }
+
+    @Override
+    @Trivial
+    public String paramAnnosForUpdate() {
+        return By.class.getName();
+    }
+
+    @Override
+    @Trivial
+    public String persistenceFeatureName() {
+        return "";
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<?>> resourceAccessorTypes(boolean stateful) {
+        return Set.of();
+    }
+
+    @Override
+    @Trivial
+    public String specialParamsForFind() {
+        return "";
+    }
+
+    @Override
+    @Trivial
+    public String specialParamsForFindAndDelete() {
+        return "";
+    }
+
+    @Override
+    @Trivial
+    public Set<Class<?>> specialParamTypes() {
+        return Set.of();
+    }
+
+    @Override
+    @Trivial
+    public Object[] toConstraintValues(Object value) {
+        return null;
+    }
+
+}

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -206,6 +206,14 @@ public interface DataVersionCompatibility {
     String paramAnnosForUpdate();
 
     /**
+     * Returns the name of the Liberty feature that provides Jakarta Persistence.
+     * For example, persistence-3.2.
+     *
+     * @return the name of the Liberty feature that provides Jakarta Persistence.
+     */
+    String persistenceFeatureName();
+
+    /**
      * List of valid return types for resource accessor methods.
      *
      * @param stateful true for a stateful repository; false for stateless.

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -127,7 +127,8 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1120E.*groupedByAddress", // cursor pagination with GROUP BY
                                    "CWWKD1120E.*unionOfAddresses", // cursor pagination with UNION
                                    "CWWKD1120E.*withNameAndAddress", // cursor pagination with INTERSECT
-                                   "CWWKD1120E.*withNameNotAddress" // cursor pagination with EXCEPT
+                                   "CWWKD1120E.*withNameNotAddress", // cursor pagination with EXCEPT
+                                   "CWWKD1121E.*VoterRegistration" // record entity without id
                     };
 
     @Server("io.openliberty.data.internal.fat.errpaths")

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -110,6 +110,9 @@ public class DataErrPathsTestServlet extends FATServlet {
     Investments errRecordEnityWithJPAAnnoRepo;
 
     @Inject
+    InvalidRegistrations errRecordEntityWithoutId;
+
+    @Inject
     WrongPersistenceUnitRefRepo errWrongPersistenceUnitRef;
 
     @Resource
@@ -2107,6 +2110,32 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1109E:") ||
                 !x.getMessage().contains("jakarta.persistence.Column"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify that an appropriate and informative error is raised when a
+     * record entity lacks an identifier attribute.
+     */
+    @Test
+    public void testRecordEntityWithoutId() {
+        VoterRegistration reg = new VoterRegistration( //
+                        989898989, //
+                        "Victoria", //
+                        "7 1st Ave SW, Rochester, MN 55902", //
+                        LocalDate.of(1997, 10, 28));
+
+        try {
+            reg = errRecordEntityWithoutId.save(reg);
+
+            fail("Used a record entity that has no identifier attribute: " +
+                 reg);
+        } catch (MappingException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1121E:") ||
+                !x.getMessage().contains(VoterRegistration.class.getName()) ||
+                !x.getMessage().contains("ssn"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/InvalidRegistrations.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/InvalidRegistrations.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.web;
+
+import jakarta.annotation.Resource;
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository for an invalid record entity that lacks an identifier attribute.
+ */
+@Repository(dataStore = "java:comp/jdbc/DataSourceForInvalidRecordEntityRef")
+@Resource(name = "java:comp/jdbc/DataSourceForInvalidRecordEntityRef",
+          lookup = "java:module/jdbc/DataSourceForInvalidEntity")
+public interface InvalidRegistrations extends BasicRepository<VoterRegistration, String> {
+
+}


### PR DESCRIPTION
I noticed a user attempting to use an entity that was missing a unique identifier and also not annotated `@Entity`.  If the latter were present, Jakarta Persistence would raise an error and we even have an error path test for that already.  However, in this case, there was no `@Entity` annotation, and we missed detecting any problem until ending up with a NullPointerException and raised a misleading error message.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
