### PR TITLE
update to a recent byte-buddy that should hopefully support JDK 25

### DIFF
--- a/dev/com.ibm.ws.cdi.third.party_fat/build.gradle
+++ b/dev/com.ibm.ws.cdi.third.party_fat/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     'org.jboss.logging:jboss-logging:3.6.0.Final',
     'org.hibernate.orm:hibernate-community-dialects:7.0.9.Final',
     'org.hibernate.models:hibernate-models:1.0.1',
-    'net.bytebuddy:byte-buddy:1.16.1',
+    'net.bytebuddy:byte-buddy:1.18.2',
     'com.fasterxml:classmate:1.5.0',
     'javassist:javassist:3.12.1.GA',
     'org.antlr:antlr4-runtime:4.13.2'


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This should hopefully fix https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=307351 by updating to a version of byte-buddy compatible with JDK-25