### PR TITLE
FIPS Test Updates

### DIFF
--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FIPSTestUtils.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FIPSTestUtils.java
@@ -30,6 +30,7 @@ public class FIPSTestUtils {
     public static final String ENABLE_FIPS140_3_ENV_VAR = "ENABLE_FIPS140_3";
     public static final String SEMERU_FIPS_PROVIDER = "OpenJCEPlusFIPS";
     public static final String IBM_FIPS_PROVIDER = "IBMJCEPlusFIPS";
+    public static final String LIBERTY_BASE_FIPS_PROFILE_FILENAME = "FIPS140-3-Liberty.properties";
     public static final String LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME = "FIPS140-3-Liberty-Application.properties";
     public static final String STANDALONE_FIPS_PROFILE_FILENAME = "semeruFips140_3CustomProfile.properties";
 

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/client/FIPS1403ClientTest.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/client/FIPS1403ClientTest.java
@@ -66,8 +66,6 @@ public class FIPS1403ClientTest {
         }
         if (ji.majorVersion() > 8) {
             expectedProvider = "OpenJCEPlusFIPS";
-            // temporarily enable Beta for Semeru
-            // client.addEnvVar("JVM_ARGS","-Dcom.ibm.ws.beta.edition=true");
         } else {
             expectedProvider = "IBMJCEPlusFIPS";
         }

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/security/utility/FIPS1403SecurityUtilityTests.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/security/utility/FIPS1403SecurityUtilityTests.java
@@ -50,13 +50,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assume.assumeThat;
 
 
-/**
- * Due to nature of these tests, If you are having to provide a default.env file ahead of these tests being run
- * e.g. supply JAVA_HOME, include the beta_flag for the server
- * You must include `# enable_variable_expansion' for the tests to work correctly
- *
- * The commands have the beta flag currently added for them. but for other scenarios the beta flag might be required
- */
 @RunWith(FATRunner.class)
 @Mode(Mode.TestMode.LITE)
 @SkipIfSysProp({SkipIfSysProp.OS_ZOS, SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
@@ -104,15 +97,12 @@ public class FIPS1403SecurityUtilityTests {
         }
         if (ji.majorVersion() > 8) {
             expectedProvider = SEMERU_FIPS_PROVIDER;
-            // temporarily enable Beta for Semeru
-            server.addEnvVar("JVM_ARGS","-Dcom.ibm.ws.beta.edition=true");
         } else {
             expectedProvider = IBM_FIPS_PROVIDER;
         }
 
         installRoot = server.getInstallRoot();
         env = new Properties();
-        env.put("JVM_ARGS","-Dcom.ibm.ws.beta.edition=true");
         machine = server.getMachine();
         // Save configuration at this point, so each test can restore to this point so that we don't pollute each test
         server.saveServerConfiguration();

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/security/utility/FIPS1403SecurityUtilityTests.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/security/utility/FIPS1403SecurityUtilityTests.java
@@ -14,6 +14,7 @@ import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
@@ -288,8 +289,8 @@ public class FIPS1403SecurityUtilityTests {
 
     @Test
     @AllowedFFDC({ "java.lang.RuntimeException" })
+    @MinimumJavaLevel(javaLevel = 11)
     public void fips140_3NoSuchAlgorithmExceptionTest() throws Exception {
-
         // Enable FIPS at server level without referencing the custom profile
         ProgramOutput po = runSecurityUtilityCommand(new String[] {SEC_CONF_FIPS_COMMAND, OPT_SERVER + "=" + SERVER_NAME});
         assertEquals("securityUtility configureFIPS did not result in expected return code.",0, po.getReturnCode());

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/server/FIPS1403ServerTest.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/server/FIPS1403ServerTest.java
@@ -198,6 +198,7 @@ public class FIPS1403ServerTest {
 
     @Test
     public void fips140_3MinifiedPackageTest() throws Exception{
+        assumeThat(Files.exists(Paths.get(server.getInstallRoot() + "/lib/extract")), is(true));
         Machine machine = server.getMachine();
         String[] parameters = new String[]{"package", server.getServerName(), "--include=minify"};
         ProgramOutput po = machine.execute(server.getInstallRoot()+"/bin/server", parameters);

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/server/FIPS1403ServerTest.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/server/FIPS1403ServerTest.java
@@ -10,7 +10,9 @@
 
 package io.openliberty.security.fips.fat.tests.fips1403.server;
 
+import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.OperatingSystem;
+import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfSysProp;
@@ -29,11 +31,16 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import static io.openliberty.security.fips.fat.FIPSTestUtils.*;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
 @RunWith(FATRunner.class)
@@ -60,8 +67,6 @@ public class FIPS1403ServerTest {
         }
         if (ji.majorVersion() > 8) {
             expectedProvider = "OpenJCEPlusFIPS";
-            // temporarily enable Beta for Semeru
-            server.addEnvVar("JVM_ARGS","-Dcom.ibm.ws.beta.edition=true");
         } else {
             expectedProvider = "IBMJCEPlusFIPS";
         }
@@ -164,6 +169,56 @@ public class FIPS1403ServerTest {
         Files.write(path, serverEnv.getBytes(StandardCharsets.UTF_8));
         server.startServer();
         checkServerLogForFipsEnablementMessage(server, expectedProvider);
+    }
+
+    @Test
+    public void fips140_3PacakageTest() throws Exception {
+        Machine machine = server.getMachine();
+        String[] parameters = new String[]{"package", server.getServerName()};
+        ProgramOutput po = machine.execute(server.getInstallRoot()+"/bin/server", parameters);
+        Log.info(FIPS1403ServerTest.class, "fips140_3PacakageTest", "Executed securityUtility configureFIPS command: "+ po.getCommand());
+        Log.info(FIPS1403ServerTest.class, "fips140_3PacakageTest", "Result: "+ po.getStdout());
+        Log.info(FIPS1403ServerTest.class, "fips140_3PacakageTest", "Error: "+ po.getStderr());
+        assertEquals("Package command failed with a non-zero return code", 0, po.getReturnCode());
+        String zipName = server.getServerName()+".zip";
+        Path zipPath = Paths.get(server.getServerRoot()+"/"+zipName);
+        boolean foundFipsSecurityFile = false;
+        try (ZipFile zipFile = new ZipFile(zipPath.toFile())) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements() && !foundFipsSecurityFile) {
+                ZipEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if(name.endsWith(LIBERTY_BASE_FIPS_PROFILE_FILENAME)){
+                    foundFipsSecurityFile = true;
+                }
+            }
+        }
+        assertTrue("Did not locate the base Liberty Profile in the zip file", foundFipsSecurityFile);
+    }
+
+    @Test
+    public void fips140_3MinifiedPackageTest() throws Exception{
+        Machine machine = server.getMachine();
+        String[] parameters = new String[]{"package", server.getServerName(), "--include=minify"};
+        ProgramOutput po = machine.execute(server.getInstallRoot()+"/bin/server", parameters);
+        Log.info(FIPS1403ServerTest.class, "serverEnvFipsTest", "Executed securityUtility configureFIPS command: "+ po.getCommand());
+        Log.info(FIPS1403ServerTest.class, "serverEnvFipsTest", "Result: "+ po.getStdout());
+        Log.info(FIPS1403ServerTest.class, "serverEnvFipsTest", "Error: "+ po.getStderr());
+        assertEquals("Package command failed with a non-zero return code", 0, po.getReturnCode());
+        String zipName = server.getServerName()+".zip";
+        Path zipPath = Paths.get(server.getServerRoot()+"/"+zipName);
+        boolean foundFipsSecurityFile = false;
+        try (ZipFile zipFile = new ZipFile(zipPath.toFile())) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements() && !foundFipsSecurityFile) {
+                ZipEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if(name.endsWith(LIBERTY_BASE_FIPS_PROFILE_FILENAME)){
+                    foundFipsSecurityFile = true;
+                }
+            }
+        }
+        assertTrue("Did not locate the base Liberty Profile in the zip file", foundFipsSecurityFile);
     }
 
 

--- a/dev/io.openliberty.security.fips.internal_fat/publish/clients/FIPSClient/client.xml
+++ b/dev/io.openliberty.security.fips.internal_fat/publish/clients/FIPSClient/client.xml
@@ -14,7 +14,6 @@
 <client>
     <featureManager>
         <feature>javaeeClient-8.0</feature>
-        <feature>appSecurityClient-1.0</feature>
     </featureManager>
 
     <application location="HelloAppClient.ear"/>


### PR DESCRIPTION
Update the FIPS FAT bucket
- remove the beta flags
- add tests for minification - skip if `wlp/lib/extract` is not present
- Fix NoSuchAlgorithmException test so that it does not run on Java's earlier then 11. Fixes [307654](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=307654)
- Fix Client defautSSLConfig start failure for clients. Fixes [307652](https://wasrtc.hursley.ibm.com:9443/jazz/resource/itemName/com.ibm.team.workitem.WorkItem/307652)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

