### PR TITLE
adding 2 new fat tests to ensure the change in 33609 does not regress

### DIFF
--- a/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
+++ b/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
@@ -449,6 +449,8 @@ public class SecurityUtilityCreateLTPAKeysTest {
                 "--passwordBase64Key=" + aesEncryptionKey,
                 "--passwordEncoding=aes"},
             libertyInstallRoot, testEnvironment);
+        Log.info(thisClass, testName.getMethodName(), "stdout:\n" + output.getStdout());
+        Log.info(thisClass, testName.getMethodName(), "Return code: " + output.getReturnCode());
         assertEquals("createLTPAKeys should succeed", SUCCESS_RC, output.getReturnCode());
 
         // Extract LTPA configuration and apply to server
@@ -514,6 +516,8 @@ public class SecurityUtilityCreateLTPAKeysTest {
             },
             libertyInstallRoot,
             testEnvironment);
+        Log.info(thisClass, testName.getMethodName(), "stdout:\n" + commandOutput.getStdout());
+        Log.info(thisClass, testName.getMethodName(), "Return code: " + commandOutput.getReturnCode());
         assertEquals("createLTPAKeys should succeed", SUCCESS_RC, commandOutput.getReturnCode());
 
         // Build ltpa.keys path for the server
@@ -577,6 +581,8 @@ public class SecurityUtilityCreateLTPAKeysTest {
             },
             libertyInstallRoot,
             testEnvironment);
+        Log.info(thisClass, testName.getMethodName(), "stdout:\n" + commandOutput.getStdout());
+        Log.info(thisClass, testName.getMethodName(), "Return code: " + commandOutput.getReturnCode());
         assertEquals("createLTPAKeys should succeed", SUCCESS_RC, commandOutput.getReturnCode());
 
         // Build server.xml using the snippet
@@ -779,6 +785,8 @@ public class SecurityUtilityCreateLTPAKeysTest {
             },
             libertyInstallRoot,
             testEnvironment);
+        Log.info(thisClass, testName.getMethodName(), "stdout:\n" + commandOutput.getStdout());
+        Log.info(thisClass, testName.getMethodName(), "Return code: " + commandOutput.getReturnCode());
         assertEquals("createLTPAKeys should succeed", SUCCESS_RC, commandOutput.getReturnCode());
 
         // Build server.xml using the snippet
@@ -814,6 +822,8 @@ public class SecurityUtilityCreateLTPAKeysTest {
             },
             libertyInstallRoot,
             testEnvironment);
+        Log.info(thisClass, testName.getMethodName(), "stdout:\n" + commandOutput.getStdout());
+        Log.info(thisClass, testName.getMethodName(), "Return code: " + commandOutput.getReturnCode());
         assertEquals("createLTPAKeys should succeed", SUCCESS_RC, commandOutput.getReturnCode());
 
         // Build server.xml using the snippet

--- a/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
+++ b/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
@@ -758,4 +758,61 @@ public class SecurityUtilityCreateLTPAKeysTest {
         assertEquals("createLTPAKeys command should fail with exclusive arguments", 
                     FAILURE_RC, commandOutput.getReturnCode());
     }
+    @Test
+    public void testCreateLTPAKeysWithPasswordEncodingAndNotNormalizedKey() throws Exception {
+    	String key = "not//normalized//key";
+        // Run createLTPAKeys with passwordEncoding=aes for the test server
+        ProgramOutput commandOutput = testMachine.execute(
+            securityUtilityPath,
+            new String[] {
+                "createLTPAKeys",
+                "--password=" + ltpaPassword,
+                "--passwordEncoding=aes",
+                "--server=" + LTPA_TEST_SERVER_NAME,
+                "--passwordKey=" + key
+            },
+            libertyInstallRoot,
+            testEnvironment);
+        assertEquals("createLTPAKeys should succeed", SUCCESS_RC, commandOutput.getReturnCode());
+
+        // Build server.xml using the snippet
+		String ltpaSnippet = getLtpaOverride(commandOutput,
+				"<variable name=\"wlp.password.encryption.key\" value=\"" + key + "\" />");
+		writeStringToServerOverride(ltpaSnippet, ltpaTestServer);
+        // Start the server
+        ltpaTestServer.startServer();
+
+        // Verify startup log contains LTPA initialization
+        assertNotNull("Expected LTPA configuration ready message not found in the log.",
+                      ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
+        ltpaTestServer.stopServer();
+    }
+    @Test
+    public void testCreateLTPAKeysWithPasswordEncodingAndNotNormalizedBase64Key() throws Exception {
+    	String key = "3ORhx1L0ME//P2JDl1elDjOqhhagCoMAZ4XFbhQxJoM=";
+        // Run createLTPAKeys with passwordEncoding=aes for the test server
+        ProgramOutput commandOutput = testMachine.execute(
+            securityUtilityPath,
+            new String[] {
+                "createLTPAKeys",
+                "--password=" + ltpaPassword,
+                "--passwordEncoding=aes",
+                "--server=" + LTPA_TEST_SERVER_NAME,
+                "--passwordBase64Key=" + key
+            },
+            libertyInstallRoot,
+            testEnvironment);
+        assertEquals("createLTPAKeys should succeed", SUCCESS_RC, commandOutput.getReturnCode());
+
+        // Build server.xml using the snippet
+		String ltpaSnippet = getLtpaOverride(commandOutput, key);
+		writeStringToServerOverride(ltpaSnippet, ltpaTestServer);
+        // Start the server
+        ltpaTestServer.startServer();
+
+        // Verify startup log contains LTPA initialization
+        assertNotNull("Expected LTPA configuration ready message not found in the log.",
+                      ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
+        ltpaTestServer.stopServer();
+    }
 }

--- a/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
+++ b/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
@@ -758,6 +758,12 @@ public class SecurityUtilityCreateLTPAKeysTest {
         assertEquals("createLTPAKeys command should fail with exclusive arguments", 
                     FAILURE_RC, commandOutput.getReturnCode());
     }
+    
+    /**
+     * Test LTPA key creation with a passphrase which has two `//` characters in it. This 
+     * ensures the key is not Path normalized when the server starts. 
+     * @throws Exception
+     */
     @Test
     public void testCreateLTPAKeysWithPasswordEncodingAndNotNormalizedKey() throws Exception {
     	String key = "not//normalized//key";
@@ -787,6 +793,12 @@ public class SecurityUtilityCreateLTPAKeysTest {
                       ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
         ltpaTestServer.stopServer();
     }
+    
+    /**
+     * Test LTPA key creation with a base64Key which has two `//` characters in it. This 
+     * ensures the key is not Path normalized when the server starts. 
+     * @throws Exception
+     */
     @Test
     public void testCreateLTPAKeysWithPasswordEncodingAndNotNormalizedBase64Key() throws Exception {
     	String key = "3ORhx1L0ME//P2JDl1elDjOqhhagCoMAZ4XFbhQxJoM=";


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Follow up PR with FAT tests for https://github.com/OpenLiberty/open-liberty/issues/33609

