### PR TITLE
Fix test bug in WebContainer Servlet 31 FAT CDIUpgradeHandlerTest

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestHttpUpgradeHandler.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestHttpUpgradeHandler.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -263,6 +263,10 @@ public class CDITestHttpUpgradeHandler implements HttpUpgradeHandler {
         logState(methodName);
 
         logBeanActivity(methodName, "Exit");
+
+        logInfo(methodName, "null out readListener [" + readListener + "] , writeListener [" + writeListener + "]");
+        readListener = null;
+        writeListener = null;
 
         logExit(methodName);
     }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestHttpUpgradeHandler.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestHttpUpgradeHandler.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet_31_fat.cdi12testv2upgrade.war.cdi.upgrade.handlers;
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestReadListener.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestReadListener.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet_31_fat.cdi12testv2upgrade.war.cdi.upgrade.handlers;
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestReadListener.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestReadListener.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -93,6 +93,7 @@ public class CDITestReadListener implements ReadListener {
     public void onDataAvailable() throws IOException {
         String methodName = "onDataAvailable";
         logEntry(methodName);
+        logInfo(methodName, "this [" + this + "]");
 
         logBeanActivity(methodName, "Entry");
         appendBeanData("RV"); // 'R' for "ReadListener"; 'V' for "Available"

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestWriteListener.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestWriteListener.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 IBM Corporation and others.
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet_31_fat.cdi12testv2upgrade.war.cdi.upgrade.handlers;
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestWriteListener.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestWriteListener.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -96,6 +96,7 @@ public class CDITestWriteListener implements WriteListener {
     public void onWritePossible() throws IOException {
         String methodName = "onWritePossible";
         logEntry(methodName);
+        logInfo(methodName, "this [" + this + "]");
 
         logBeanActivity(methodName, "Entry");
         appendBeanData("WP"); // 'W' for "WriteListener"; 'P' for "Possible"


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

fix build break 304040 
Test Failure: com.ibm.ws.webcontainer.servlet31.fat.tests.CDIUpgradeHandlerTest.testCDIUpgradeHandlerUpgrade