### PR TITLE
Make correction to test and enable for Hibernate

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1629,31 +1629,35 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(3, segments.countByPointAXLessThan(1));
 
-        // TODO enable once #29460 is fixed
-        //assertEquals(List.of(s3.id, s4.id, s2.id, s1.id),
-        //             segments.endingSouthOf(100)
-        //                             .map(s -> s.id)
-        //                             .collect(Collectors.toList()));
+        // TODO enable for EclipseLink once #29460 is fixed
+        if (isHibernate()) {
+            assertEquals(List.of(s5.id, s6.id, s3.id, s4.id, s2.id),
+                         segments.endingSouthOf(175)
+                                         .map(s -> s.id)
+                                         .collect(Collectors.toList()));
 
-        //assertEquals(List.of(-20, 0, 24),
-        //             segments.longerThan(200, Sort.asc("pointA.x"))
-        //                             .stream()
-        //                             .map(s -> s.pointA.x())
-        //                             .collect(Collectors.toList()));
+            assertEquals(List.of(-20, 0, 24),
+                         segments.longerThan(200, Sort.asc("pointA.x"))
+                                         .stream()
+                                         .map(s -> s.pointA.x())
+                                         .collect(Collectors.toList()));
 
-        //s3.pointB = new Point(s3.pointB.x() - s3.pointA.x(), s3.pointB.y() - s3.pointA.y());
-        //s3.pointA = new Point(0, 0);
-        //s3 = segments.addOrModify(s3);
+            s3.pointB = new Point(s3.pointB.x() - s3.pointA.x(), s3.pointB.y() - s3.pointA.y());
+            s3.pointA = new Point(0, 0);
+            s3 = segments.addOrModify(s3);
 
-        // removes s1 and s3
-        //assertEquals(2L, segments.removeStartingAt(0, 0));
+            // removes s1 and s3
+            assertEquals(2L, segments.removeStartingAt(0, 0));
 
-        //Point s2pointB = segments.terminalPoint(s2.id).orElseThrow();
-        //assertEquals(120, s2pointB.x());
-        //assertEquals(171, s2pointB.y());
-
-        assertEquals(6L, // TODO change to 4L, once #29460 is fixed
-                     segments.erase());
+            Point s2pointB = segments.terminalPoint(s2.id).orElseThrow();
+            assertEquals(120, s2pointB.x());
+            assertEquals(171, s2pointB.y());
+            assertEquals(4L,
+                         segments.erase());
+        } else {
+            assertEquals(6L,
+                         segments.erase());
+        }
     }
 
     /**


### PR DESCRIPTION
As pointed out by @pardhiv-krishna , testEmbeddableRecord has an incorrect assertion.  Also, I noticed that although lines of the test are commented out due to failures in EclipseLink, we could fully enable the test when running against Hibernate, so I'll do that as well along with correcting the assertion.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
