### PR TITLE
Reset SyncToOSThread in EJB After Each Invocation

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImpl.java
@@ -226,9 +226,12 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
 
         performDelegation(methodMetaData, subjectToAuthorize);
         subjectManager.setCallerSubject(subjectToAuthorize);
-        EJBSecurityContext ejbSecurityContext = new EJBSecurityContext(subjectManager.getInvocationSubject(), subjectManager.getCallerSubject());
-        syncToOSThread(ejbSecurityContext);
         SecurityCookieImpl securityCookie = new SecurityCookieImpl(originalInvokedSubject, originalCallerSubject, subjectManager.getInvocationSubject(), subjectToAuthorize);
+        if (ThreadIdentityManager.isAppThreadIdentityEnabled()) {
+            EJBSecurityContext ejbSecurityContext = new EJBSecurityContext(subjectManager.getInvocationSubject(), subjectManager.getCallerSubject());
+            syncToOSThread(ejbSecurityContext);
+            securityCookie.setSyncToOSThreadToken(ejbSecurityContext.getSyncToOSThreadToken());
+        }
         return securityCookie;
     }
 
@@ -262,8 +265,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
                 }
             }
             try {
-                 EJBSecurityContext ejbSecurityContext = new EJBSecurityContext(subjectManager.getInvocationSubject(), subjectManager.getCallerSubject());
-                resetSyncToOSThread(ejbSecurityContext);
+                resetSyncToOSThread(securityCookie);
 
             } catch (ThreadIdentityException e) {
                 throw new EJBAccessDeniedException(TraceNLS.getFormattedMessage(this.getClass(),
@@ -816,10 +818,6 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "Thread identity set successfully");
                 }
-            } else {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Application thread identity is not enabled");
-                }
             }
         } catch (ThreadIdentityException tie) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -840,8 +838,8 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
      *            MUST NOT BE NULL.
      * @throws ThreadIdentityException
      */
-    private void resetSyncToOSThread(EJBSecurityContext ejbSecurityContext) throws ThreadIdentityException {
-        Object token = ejbSecurityContext.getSyncToOSThreadToken();
+    private void resetSyncToOSThread(SecurityCookieImpl securityCookie) throws ThreadIdentityException {
+        Object token = securityCookie.getSyncToOSThreadToken();
         if (token != null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "Resetting thread identity for EJB application");

--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/SecurityCookieImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/SecurityCookieImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ public class SecurityCookieImpl {
     private final Subject receivedSubject;
     private final Subject adjustedInvokedSubject;
     private final Subject adjustedReceivedSubject;
+    private Object syncToOSThreadToken;
 
     SecurityCookieImpl(Subject invokedSubject, Subject receivedSubject) {
         this.invokedSubject = this.adjustedInvokedSubject =invokedSubject;
@@ -49,5 +50,13 @@ public class SecurityCookieImpl {
 
     public Subject getAdjustedReceivedSubject() {
         return adjustedReceivedSubject;
+    }
+    
+    public Object getSyncToOSThreadToken() {
+        return syncToOSThreadToken;
+    }
+    
+    public void setSyncToOSThreadToken(Object token) {
+        this.syncToOSThreadToken = token;
     }
 }


### PR DESCRIPTION
Description:

We need to update the code to reset the thread identity back to the server identity when EJBSecurityCollaboratorImpl.postInvoke() is called.

Currently, although we are correctly setting the syncToOSThreadToken in the EJBSecurityContext during preInvoke, this token is not being propagated to postInvoke because we are returning a SecurityCookieImpl object that does not contain the token field.

This fix adds the syncToOSThreadToken field to SecurityCookieImpl and ensures the token is properly transferred from the EJBSecurityContext to the cookie during preInvoke, allowing postInvoke to retrieve and use it to reset the thread identity.


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

