### PR TITLE
Cleanup Netty Request/Response/Base classes

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
@@ -857,11 +857,11 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
     @Override
     public void setCharset(Charset set) {
         String contentType = getHeader(HttpHeaderKeys.HDR_CONTENT_TYPE).asString();
-        if (null == contentType) {
+        if (null == contentType || contentType.isEmpty()) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "setCharset: no Content-Type header present");
             }
-            contentType = "test/html";
+            contentType = "text/html";
         } else {
             // Get everything prior to the first semicolon (if any).
             int length = contentType.length();
@@ -924,7 +924,11 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public HttpTrailersImpl createTrailers() {
-        throw new UnsupportedOperationException("createTrailers() not supported in Netty context");
+        // In the case of Netty, this operation is a NOOP because there is no
+        // implementation of HttpTrailersImpl on a Netty context so this API
+        // will always return null.
+        // @see com.ibm.wsspi.http.channel.HttpBaseMessage
+        return null;
     }
 
     public void processCookies() {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
@@ -249,7 +249,6 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
         for (String value : values) {
             result.add(new NettyHeader(name, value));
         }
-
         return result;
     }
 
@@ -365,7 +364,7 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public void removeHeader(byte[] header, int instance) {
-
+        throw new UnsupportedOperationException("removeHeader(byte[] header, int instance) not supported in Netty context");
     }
 
     @Override
@@ -375,7 +374,7 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public void removeHeader(HeaderKeys header, int instance) {
-
+        throw new UnsupportedOperationException("removeHeader(HeaderKeys header, int instance) not supported in Netty context");
     }
 
     @Override
@@ -385,7 +384,7 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public void removeHeader(String header, int instance) {
-
+        throw new UnsupportedOperationException("removeHeader(HeaderKeys header, int instance) not supported in Netty context");
     }
 
     @Override
@@ -395,27 +394,27 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public void setHeader(byte[] header, byte[] value) {
-
+        throw new UnsupportedOperationException("setHeader(byte[] header, byte[] value) not supported in Netty context");
     }
 
     @Override
     public void setHeader(byte[] header, byte[] value, int offset, int length) {
-
+        throw new UnsupportedOperationException("setHeader(byte[] header, byte[] value, int offset, int length) not supported in Netty context");
     }
 
     @Override
     public void setHeader(byte[] header, String value) {
-
+        throw new UnsupportedOperationException("setHeader(byte[] header, String value) not supported in Netty context");
     }
 
     @Override
     public void setHeader(HeaderKeys header, byte[] value) {
-
+        throw new UnsupportedOperationException("setHeader(HeaderKeys header, byte[] value) not supported in Netty context");
     }
 
     @Override
     public void setHeader(HeaderKeys header, byte[] value, int offset, int length) {
-
+        throw new UnsupportedOperationException("setHeader(HeaderKeys header, byte[] value, int offset, int length) not supported in Netty context");
     }
 
     @Override
@@ -427,22 +426,20 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
     public HeaderField setHeaderIfAbsent(HeaderKeys header, String value) {
         Objects.requireNonNull(header);
         Objects.requireNonNull(value);
-
         if (!headers.contains(header.getName())) {
             headers.set(header.getName(), value);
         }
-
         return null;
     }
 
     @Override
     public void setHeader(String header, byte[] value) {
-
+        throw new UnsupportedOperationException("setHeader(String header, byte[] value) not supported in Netty context");
     }
 
     @Override
     public void setHeader(String header, byte[] value, int offset, int length) {
-
+        throw new UnsupportedOperationException("setHeader(String header, byte[] value, int offset, int length) not supported in Netty context");
     }
 
     @Override
@@ -505,7 +502,6 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
         if(cache.isDirty()){
             parseAllCookies(cache, header);
         }
-        
         cache.getAllCookieValues(name, list);
     }
 
@@ -534,7 +530,6 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
 
     protected HttpCookie getCookie(String name, HttpHeaderKeys header) {
-        
         if(name == null) { return null;}
 
         if(!isValidCookieHeader(header) && !containsHeader(header)){
@@ -682,7 +677,7 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public List<String> getAllCookieValues(String name) {
-        return null;
+        throw new UnsupportedOperationException("getAllCookieValues(String name) not supported in Netty context");
     }
 
     @Override
@@ -762,17 +757,17 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public void setConnection(ConnectionValues value) {
-
+        throw new UnsupportedOperationException("setConnection(ConnectionValues value) not supported in Netty context");
     }
 
     @Override
     public void setConnection(ConnectionValues[] values) {
-
+        throw new UnsupportedOperationException("setConnection(ConnectionValues[] values) not supported in Netty context");
     }
 
     @Override
     public ConnectionValues[] getConnection() {
-        return null;
+        throw new UnsupportedOperationException("getConnection() not supported in Netty context");
     }
 
     @Override
@@ -787,32 +782,32 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public void setContentEncoding(ContentEncodingValues value) {
-
+        throw new UnsupportedOperationException("setContentEncoding(ContentEncodingValues value) not supported in Netty context");
     }
 
     @Override
     public void setContentEncoding(ContentEncodingValues[] values) {
-
+        throw new UnsupportedOperationException("setContentEncoding(ContentEncodingValues[] values) not supported in Netty context");
     }
 
     @Override
     public ContentEncodingValues[] getContentEncoding() {
-        return null;
+        throw new UnsupportedOperationException("getContentEncoding() not supported in Netty context");
     }
 
     @Override
     public void setTransferEncoding(TransferEncodingValues value) {
-        throw new UnsupportedOperationException("Tried setting transfer encoding in Netty!");
+        throw new UnsupportedOperationException("setTransferEncoding(TransferEncodingValues value) not supported in Netty context");
     }
 
     @Override
     public void setTransferEncoding(TransferEncodingValues[] values) {
-        throw new UnsupportedOperationException("Tried setting transfer encoding in Netty!");
+        throw new UnsupportedOperationException("setTransferEncoding(TransferEncodingValues[] values) not supported in Netty context");
     }
 
     @Override
     public TransferEncodingValues[] getTransferEncoding() {
-        return null;
+        throw new UnsupportedOperationException("getTransferEncoding() not supported in Netty context");
     }
 
     @Override
@@ -822,17 +817,17 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public void setCurrentDate() {
-
+        throw new UnsupportedOperationException("setCurrentDate() not supported in Netty context");
     }
 
     @Override
     public void setExpect(ExpectValues value) {
-
+        throw new UnsupportedOperationException("setExpect(ExpectValues value) not supported in Netty context");
     }
 
     @Override
     public byte[] getExpect() {
-        return null;
+        throw new UnsupportedOperationException("getExpect() not supported in Netty context");
     }
 
     @Override
@@ -847,22 +842,22 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public void setMIMEType(String type) {
-
+        throw new UnsupportedOperationException("setMIMEType(String type) not supported in Netty context");
     }
 
     @Override
     public Charset getCharset() {
-        return null;
+        throw new UnsupportedOperationException("getCharset() not supported in Netty context");
     }
 
     @Override
     public void setCharset(Charset set) {
-
+        throw new UnsupportedOperationException("setCharset(Charset set) not supported in Netty context");
     }
 
     @Override
     public HttpTrailers getTrailers() {
-        return null;
+        throw new UnsupportedOperationException("getTrailers() not supported in Netty context");
     }
 
     @Override
@@ -883,22 +878,22 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public void setVersion(VersionValues version) {
-
+        throw new UnsupportedOperationException("setVersion(VersionValues version) not supported in Netty context");
     }
 
     @Override
     public void setVersion(String version) throws UnsupportedProtocolVersionException {
-
+        throw new UnsupportedOperationException("setVersion(String version) not supported in Netty context");
     }
 
     @Override
     public void setVersion(byte[] version) throws UnsupportedProtocolVersionException {
-
+        throw new UnsupportedOperationException("setVersion(byte[] version) not supported in Netty context");
     }
 
     @Override
     public HttpTrailersImpl createTrailers() {
-        return null;
+        throw new UnsupportedOperationException("createTrailers() not supported in Netty context");
     }
 
     public void processCookies() {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ import com.ibm.ws.http.channel.internal.cookies.CookieCacheData;
 import com.ibm.ws.http.channel.internal.cookies.CookieHeaderByteParser;
 import com.ibm.ws.http.channel.internal.cookies.CookieUtils;
 import com.ibm.ws.http.channel.internal.cookies.SameSiteCookieUtils;
+import com.ibm.wsspi.genericbnf.BNFHeaders;
 import com.ibm.wsspi.genericbnf.HeaderField;
 import com.ibm.wsspi.genericbnf.HeaderKeys;
 import com.ibm.wsspi.genericbnf.exception.UnsupportedProtocolVersionException;
@@ -837,7 +838,10 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public String getMIMEType() {
-        return HttpUtil.getMimeType(message).toString();
+        CharSequence type = HttpUtil.getMimeType(message);
+        if (null == type)
+            return null;
+        return type.toString();
     }
 
     @Override
@@ -847,12 +851,39 @@ public class NettyBaseMessage implements HttpBaseMessage, Externalizable {
 
     @Override
     public Charset getCharset() {
-        throw new UnsupportedOperationException("getCharset() not supported in Netty context");
+        return HttpUtil.getCharset(message);
     }
 
     @Override
     public void setCharset(Charset set) {
-        throw new UnsupportedOperationException("setCharset(Charset set) not supported in Netty context");
+        String contentType = getHeader(HttpHeaderKeys.HDR_CONTENT_TYPE).asString();
+        if (null == contentType) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "setCharset: no Content-Type header present");
+            }
+            contentType = "test/html";
+        } else {
+            // Get everything prior to the first semicolon (if any).
+            int length = contentType.length();
+            int end = -1;
+            for (int i = 0; i < length; i++) {
+                // Semi-colon exists, <type>;<charset>
+                if (BNFHeaders.SEMICOLON == contentType.charAt(i)) {
+                    end = i;
+                    break;
+                }
+            }
+            // check to see if the semi-colon was not found (just <type>)
+            if (-1 == end) {
+                end = length;
+            }
+            contentType = contentType.substring(0, end);
+        }
+        StringBuilder buff = new StringBuilder();
+        buff.append(contentType);
+        buff.append(";charset=");
+        buff.append(set.toString());
+        setHeader(HttpHeaderKeys.HDR_CONTENT_TYPE, buff.toString());
     }
 
     @Override

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
@@ -359,18 +359,15 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
     public String getMethod() {
         if (Objects.isNull(method)) {
             method = MethodValues.find(request.method().name());
-
         }
         return method.getName();
     }
 
     @Override
     public MethodValues getMethodValue() {
-
         if (Objects.isNull(method)) {
             method = MethodValues.find(request.method().name());
         }
-
         return method;
     }
 
@@ -440,9 +437,7 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
 
     @Override
     public String getQueryString() {
-
         return Objects.isNull(parameters) || parameters.isEmpty() ? null : query.rawQuery();
-
     }
 
     @Override
@@ -452,9 +447,7 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
 
     @Override
     public String getParameter(String name) {
-
         return parameters.containsKey(name) ? parameters.get(name)[0] : null;
-
     }
 
     @Override
@@ -626,7 +619,6 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
                 Tr.debug(tc, "getVirtualHost: No host header: [" + host + "]");
             }
             return null;
-//            host = host.substring(0, host.indexOf(":"));
         }
         int index = -1;
         if (LEFT_BRACKET == host.charAt(0)) {
@@ -750,7 +742,6 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
 
     @Override
     public String getScheme() {
-
         return Objects.isNull(scheme) ? null : scheme.getName();
     }
 
@@ -770,7 +761,6 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
             throw new UnsupportedSchemeException("Illegal scheme " + scheme);
         }
         setScheme(value);
-
     }
 
     @Override
@@ -781,13 +771,10 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
             throw new UnsupportedSchemeException("Illegal scheme " + GenericUtils.getEnglishString(scheme));
         }
         setScheme(value);
-
     }
 
     @Override
     public HttpTrailers getTrailers() {
-//        if (request.trailingHeaders().isEmpty())
-//            return null;
         return new NettyTrailers(this.request.trailingHeaders());
     }
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -471,7 +471,7 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
 
     @Override
     public void setReasonPhrase(byte[] reason) {
-        setReasonPhrase(new String(reason));
+        // See {@link #seeReasonPhrase(String)}
     }
 
     @Override

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -205,36 +205,14 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
-    public void setTransferEncoding(TransferEncodingValues value) {
-    }
-
-    @Override
-    public void setTransferEncoding(TransferEncodingValues[] values) {
-    }
-
-    @Override
-    public TransferEncodingValues[] getTransferEncoding() {
-        return null;
-    }
-
-    @Override
     public boolean isChunkedEncodingSet() {
         return HttpUtil.isTransferEncodingChunked(nettyResponse);
     }
 
     @Override
     public void setCurrentDate() {
-        setHeader(HttpHeaderKeys.HDR_DATE, HttpDispatcher.getDateFormatter().getRFC1123TimeAsBytes(this.config.getDateHeaderRange()));
-    }
-
-    @Override
-    public void setExpect(ExpectValues value) {
-
-    }
-
-    @Override
-    public byte[] getExpect() {
-        return null;
+        String date = new String(HttpDispatcher.getDateFormatter().getRFC1123TimeAsBytes(this.config.getDateHeaderRange()), StandardCharsets.UTF_8)
+        setHeader(HttpHeaderKeys.HDR_DATE, date);
     }
 
     @Override
@@ -248,52 +226,12 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
-    public void setMIMEType(String type) {
-
-    }
-
-    @Override
-    public Charset getCharset() {
-        return null;
-    }
-
-    @Override
-    public void setCharset(Charset set) {
-
-    }
-
-    @Override
     public HttpTrailers getTrailers() {
         return nettyTrailerWrapper;
     }
 
     public HttpHeaders getNettyTrailers() {
         return trailers;
-    }
-
-    @Override
-    public void setVersion(VersionValues version) {
-
-    }
-
-    @Override
-    public void setVersion(String version) throws UnsupportedProtocolVersionException {
-
-    }
-
-    @Override
-    public void setVersion(byte[] version) throws UnsupportedProtocolVersionException {
-
-    }
-
-    @Override
-    public HttpTrailersImpl createTrailers() {
-        return null;
-    }
-
-    @Override
-    public void setDebugContext(Object o) {
-
     }
 
     @Override
@@ -318,7 +256,6 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
         for (String value : values) {
             result.add(new NettyHeader(name, value));
         }
-
         return result;
     }
 
@@ -359,14 +296,8 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
-    public void appendHeader(byte[] header, byte[] value, int offset, int length) {
-
-    }
-
-    @Override
     public void appendHeader(byte[] header, String value) {
         appendHeader(new String(header, StandardCharsets.UTF_8), value);
-
     }
 
     @Override
@@ -376,14 +307,8 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
-    public void appendHeader(HeaderKeys header, byte[] value, int offset, int length) {
-
-    }
-
-    @Override
     public void appendHeader(HeaderKeys header, String value) {
         appendHeader(header.getName(), value);
-
     }
 
     @Override
@@ -393,15 +318,9 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
-    public void appendHeader(String header, byte[] value, int offset, int length) {
-
-    }
-
-    @Override
     public void appendHeader(String header, String value) {
         String normalizedName = HeaderValidator.process(header, FieldType.NAME, config);
         String normalizedValue = HeaderValidator.process(value, FieldType.VALUE, config);
-
         headers.add(normalizedName, normalizedValue);
     }
 
@@ -441,18 +360,8 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
-    public void removeHeader(byte[] header, int instance) {
-
-    }
-
-    @Override
     public void removeHeader(HeaderKeys header) {
         removeHeader(header.getName());
-    }
-
-    @Override
-    public void removeHeader(HeaderKeys header, int instance) {
-
     }
 
     @Override
@@ -461,38 +370,8 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
-    public void removeHeader(String header, int instance) {
-
-    }
-
-    @Override
     public void removeAllHeaders() {
         headers.clear();
-    }
-
-    @Override
-    public void setHeader(byte[] header, byte[] value) {
-
-    }
-
-    @Override
-    public void setHeader(byte[] header, byte[] value, int offset, int length) {
-
-    }
-
-    @Override
-    public void setHeader(byte[] header, String value) {
-
-    }
-
-    @Override
-    public void setHeader(HeaderKeys header, byte[] value) {
-
-    }
-
-    @Override
-    public void setHeader(HeaderKeys header, byte[] value, int offset, int length) {
-
     }
 
     @Override
@@ -513,38 +392,8 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
-    public void setHeader(String header, byte[] value) {
-
-    }
-
-    @Override
-    public void setHeader(String header, byte[] value, int offset, int length) {
-
-    }
-
-    @Override
     public void setHeader(String header, String value) {
         headers.set(header.trim(), value.trim());
-    }
-
-    @Override
-    public void setLimitOnNumberOfHeaders(int number) {
-
-    }
-
-    @Override
-    public int getLimitOnNumberOfHeaders() {
-        return 0;
-    }
-
-    @Override
-    public void setLimitOfTokenSize(int size) {
-
-    }
-
-    @Override
-    public int getLimitOfTokenSize() {
-        return 0;
     }
 
     @Override
@@ -568,28 +417,8 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
-    public String getReasonPhrase() {
-        return null;
-    }
-
-    @Override
     public byte[] getReasonPhraseBytes() {
         return this.nettyResponse.status().reasonPhrase().getBytes();
-    }
-
-    @Override
-    public void setReasonPhrase(String reason) {
-
-    }
-
-    @Override
-    public void setReasonPhrase(byte[] reason) {
-
-    }
-
-    @Override
-    public HttpResponseMessage duplicate() {
-        return null;
     }
 
     /**

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -418,7 +418,7 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
 
     @Override
     public String getReasonPhrase() {
-        throw new UnsupportedOperationException("getReasonPhrase() not supported in Netty context");
+        return this.nettyResponse.status().reasonPhrase();
     }
 
     @Override
@@ -468,12 +468,15 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
 
     @Override
     public void setReasonPhrase(String reason) {
-        throw new UnsupportedOperationException("setReasonPhrase(String reason) not supported in Netty context");
+        // The reason phrase historically is not actually used when writing the http response.
+        // For this reason, this method is intentionally left blank and unimplemented. The
+        // returned reason phrase will match the code the response is assigned to.
+        // @see com.ibm.ws.http.channel.internal.HttpResponseMessageImpl
     }
 
     @Override
     public void setReasonPhrase(byte[] reason) {
-        throw new UnsupportedOperationException("setReasonPhrase(byte[] reason) not supported in Netty context");
+        setReasonPhrase(new String(reason));
     }
 
     @Override

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -211,7 +211,7 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
 
     @Override
     public void setCurrentDate() {
-        String date = new String(HttpDispatcher.getDateFormatter().getRFC1123TimeAsBytes(this.config.getDateHeaderRange()), StandardCharsets.UTF_8)
+        String date = new String(HttpDispatcher.getDateFormatter().getRFC1123TimeAsBytes(this.config.getDateHeaderRange()), StandardCharsets.UTF_8);
         setHeader(HttpHeaderKeys.HDR_DATE, date);
     }
 
@@ -417,6 +417,11 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
+    public String getReasonPhrase() {
+        throw new UnsupportedOperationException("getReasonPhrase() not supported in Netty context");
+    }
+
+    @Override
     public byte[] getReasonPhraseBytes() {
         return this.nettyResponse.status().reasonPhrase().getBytes();
     }
@@ -459,6 +464,21 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
             return false;
         }
         return true;
+    }
+
+    @Override
+    public void setReasonPhrase(String reason) {
+        throw new UnsupportedOperationException("setReasonPhrase(String reason) not supported in Netty context");
+    }
+
+    @Override
+    public void setReasonPhrase(byte[] reason) {
+        throw new UnsupportedOperationException("setReasonPhrase(byte[] reason) not supported in Netty context");
+    }
+
+    @Override
+    public HttpResponseMessage duplicate() {
+        throw new UnsupportedOperationException("duplicate() not supported in Netty context");
     }
 
     /**

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -221,11 +221,6 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     }
 
     @Override
-    public String getMIMEType() {
-        return HttpUtil.getMimeType(nettyResponse).toString();
-    }
-
-    @Override
     public HttpTrailers getTrailers() {
         return nettyTrailerWrapper;
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Removed unimplemented method from Netty message subclasses and added unsupported exceptions to unimplemented methods in base message to stop usage of said methods and eventually mark as deprecated to remove them if possible.

