### PR TITLE
Use buildLabel for version qualifier in all automated builds

### DIFF
--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -95,9 +95,10 @@ def setProperties = { props ->
      */
     String timestamp = new SimpleDateFormat("yyyyMMddHHmm").format(new java.util.Date())
 
-    // For release builds we use the buildLabel as a consistent qualifier.
+    // For automated builds we use the buildLabel as a consistent qualifier.
     // buildLabel is set by the RTC build engines.
-    String qualifier = (isRelease && isAutomatedBuild) ? props.getProperty('buildLabel') : timestamp
+    String buildLabel = props.getProperty('buildLabel')
+    String qualifier = (buildLabel != null && isAutomatedBuild) ? buildLabel : timestamp
 
     props.setProperty('version.qualifier', qualifier)
     props.setProperty('buildLabel', timestamp)


### PR DESCRIPTION
The version qualifier was only set to buildLabel when both `isRelease` and `isAutomatedBuild` were true. This caused `/platforms/` builds to use timestamps instead of the buildLabel, resulting in inconsistent artifact names within the same build. Now, any automated build with a buildLabel property will use it as the version qualifier, ensuring consistent naming across all artifacts in both `/release/` and `/platforms/` builds.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
