### PR TITLE
Disable traces in `com.ibm.ws.grpc_fat` 

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.both.metrics.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.both.metrics.server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Client and Server metrics">
     <featureManager>
@@ -19,12 +16,12 @@
 
     <mpMetrics authentication = "false"/>
 
-     <httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
                   
-     <include location="../fatTestCommon.xml" />
+    <include location="../fatTestCommon.xml" />
 
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.disabled.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.disabled.server.xml
@@ -4,23 +4,20 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with no grpcClient-1.0 elements">
     <featureManager>
         <feature>grpc-1.0</feature>
-     </featureManager>
+    </featureManager>
 
-	 <httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
-     <include location="../fatTestCommon.xml" />
-    
+
+    <include location="../fatTestCommon.xml" />
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.htp.match.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.htp.match.server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
     <featureManager>
@@ -17,11 +14,11 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <grpc target="*" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerInterceptor3" />
-    <grpcClient host="*" 
+    <grpcClient host="*"
                 headersToPropagate="testHeader" 
                 clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.htp.multimatch.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.htp.multimatch.server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
     <featureManager>
@@ -17,11 +14,11 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <grpc target="*" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerInterceptor3" />
-    <grpcClient host="*" 
-                headersToPropagate="testHeader1,testHeader2" 
+    <grpcClient host="*"
+                headersToPropagate="testHeader1,testHeader2"
                 clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.htp.nomatch.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.htp.nomatch.server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
     <featureManager>
@@ -17,11 +14,11 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <grpc target="*" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerInterceptor3" />
-    <grpcClient host="*" 
-                headersToPropagate="noMatch" 
+    <grpcClient host="*"
+                headersToPropagate="noMatch"
                 clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.interceptor.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Client with single host and Interceptor">
     <featureManager>
         <feature>grpcClient-1.0</feature>
-     </featureManager>
-     
-     <grpcClient host="*" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor"/>
+    </featureManager>
 
-     <httpEndpoint id="defaultHttpEndpoint"
+    <grpcClient host="*" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor"/>
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
-     <include location="../fatTestCommon.xml" />
-    
+
+    <include location="../fatTestCommon.xml" />
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalid.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalid.interceptor.xml
@@ -4,26 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Client with single host and invalid Interceptor">
     <featureManager>
         <feature>grpcClient-1.0</feature>
-     </featureManager>
-     
-     <grpcClient host="*" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloPlanetServerInterceptor"/>
+    </featureManager>
 
-     <httpEndpoint id="defaultHttpEndpoint"
+    <grpcClient host="*" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloPlanetServerInterceptor"/>
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
-     <include location="../fatTestCommon.xml" />
-    
-    
+
+    <include location="../fatTestCommon.xml" />
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalidkeepalivew.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalidkeepalivew.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with invalid keepAliveWithoutCalls">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
-	 
-	<httpEndpoint id="defaultHttpEndpoint"
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
                   
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="*" keepAliveWithoutCalls="morejunk" keepAliveTime="120" keepAliveTimeout="360" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalidmsgsize.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalidmsgsize.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with no grpc elements">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
-	 
-	<httpEndpoint id="defaultHttpEndpoint"
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
+
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="fakeHost" authntoken="oauth" maxInboundMessageSize="junk" keepAliveTime="120" keepAliveTimeout="360" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invaliduseplaintext.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invaliduseplaintext.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with invalid usePlaintext">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
-	 
-	<httpEndpoint id="defaultHttpEndpoint"
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
+
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="*" usePlaintext="additionaljunk" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.keepalivew.false.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.keepalivew.false.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with keepAliveWithoutCalls false">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
-	 
-	<httpEndpoint id="defaultHttpEndpoint"
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
                   
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="*" keepAliveWithoutCalls="false" keepAliveTime="120" keepAliveTimeout="360" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.keepalivew.true.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.keepalivew.true.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with keepAliveWithoutCalls true">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
-	 
-	<httpEndpoint id="defaultHttpEndpoint"
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
+
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="*" keepAliveWithoutCalls="true" keepAliveTime="120" keepAliveTimeout="360" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.maxmetasize.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.maxmetasize.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with small maxInboundMetadataSize">
     <featureManager>
         <feature>grpcClient-1.0</feature>
-     </featureManager>
+    </featureManager>
 
-	<httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-    
+
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="*" maxInboundMetadataSize="16" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.metrics.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.metrics.server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Client metrics">
     <featureManager>
@@ -18,12 +15,12 @@
 
     <mpMetrics authentication = "false"/>
 
-     <httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
-     <include location="../fatTestCommon.xml" />
+
+    <include location="../fatTestCommon.xml" />
 
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.multiple.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.multiple.interceptor.xml
@@ -4,26 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with single host and multiple Interceptors">
     <featureManager>
         <feature>grpcClient-1.0</feature>
-     </featureManager>
-     
-     <grpcClient host="*" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor,com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor2"/>
+    </featureManager>
 
-     <httpEndpoint id="defaultHttpEndpoint"
+    <grpcClient host="*" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor,com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor2"/>
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
+
      <include location="../fatTestCommon.xml" />            
-    
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.nomatch.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.nomatch.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with no grpc elements">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
-     
-	<httpEndpoint id="defaultHttpEndpoint"
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
+
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="fakeHost" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.notarget.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.notarget.server.xml
@@ -4,22 +4,19 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with no grpc elements">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
 
-	<httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-    
+
     <include location="../fatTestCommon.xml"/>
 
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.param.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.param.server.xml
@@ -4,30 +4,27 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with no grpc elements">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
 
-	<httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-    
+
     <include location="../fatTestCommon.xml"/>
-        
-    <grpcClient host="*" 
-                authntoken="oauth" 
-                maxInboundMessageSize="32000" 
-                keepAliveTime="120" 
-                keepAliveTimeout="360" 
+
+    <grpcClient host="*"
+                authntoken="oauth"
+                maxInboundMessageSize="32000"
+                keepAliveTime="120"
+                keepAliveTimeout="360"
                 clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.secheader.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.secheader.server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
     <featureManager>
@@ -17,12 +14,12 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <grpc target="*" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerInterceptor3" />
     <grpcClient host="*"
                 overrideAuthority="TestDomain123"
-                userAgent="Agent456"                  
+                userAgent="Agent456"
                 clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.security.default.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.security.default.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@
         password="passw0rd"
         type="PKCS12"
         location="${server.config.dir}/trust.p12" />
-    <logging
+    <!--logging
         traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
-        maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
+        maxFileSize="40" maxFiles="1" traceFormat="BASIC" /-->
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.security.default.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.security.default.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="Basic gRPC with security constraints">
     <featureManager>
@@ -16,9 +13,9 @@
         <feature>grpcClient-1.0</feature>
         <feature>appSecurity-2.0</feature>
     </featureManager>
-    
+
     <grpcClient host="*" sslRef="CustomSSLSettings" />
-    
+
     <include location="../fatTestPorts.xml" />
 
     <javaPermission className="java.security.AllPermission"
@@ -43,7 +40,7 @@
         password="passw0rd"
         type="PKCS12"
         location="${server.config.dir}/trust.p12" />
-	<logging
-		traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
-		maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
+    <logging
+        traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
+        maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.security.plaintext.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.security.plaintext.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -41,7 +41,7 @@
         password="passw0rd"
         type="PKCS12"
         location="${server.config.dir}/trust.p12" />
-    <logging
+    <!--logging
         traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
-        maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
+        maxFileSize="40" maxFiles="1" traceFormat="BASIC" /-->
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.security.plaintext.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.security.plaintext.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="Basic gRPC with security constraints">
     <featureManager>
@@ -16,10 +13,10 @@
         <feature>grpcClient-1.0</feature>
         <feature>appSecurity-2.0</feature>
     </featureManager>
-    
+
     <!--  if usePlaintext is set to `true` the sslRef setting won’t be used -->
     <grpcClient host="*" sslRef="CustomSSLSettings" usePlaintext="true" />
-    
+
     <include location="../fatTestPorts.xml" />
 
     <javaPermission className="java.security.AllPermission"
@@ -44,7 +41,7 @@
         password="passw0rd"
         type="PKCS12"
         location="${server.config.dir}/trust.p12" />
-	<logging
-		traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
-		maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
+    <logging
+        traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
+        maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.smallmsgsize.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.smallmsgsize.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with no grpc elements">
     <featureManager>
         <feature>grpcClient-1.0</feature>
-     </featureManager>
+    </featureManager>
 
-	<httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-    
+
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="*" maxInboundMessageSize="12" keepAliveTime="120" keepAliveTimeout="360" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.spec.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.spec.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with grpcClient element">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
 
- 	<httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
     
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="localhost" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.target.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.target.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with no grpc elements">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
 
- 	<httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-    
+
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="*" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.useplaintext.false.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.useplaintext.false.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with usePlaintext false">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
-	 
-	<httpEndpoint id="defaultHttpEndpoint"
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
                   
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="*" usePlaintext="false" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.useplaintext.true.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.useplaintext.true.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with usePlaintext true">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
-	 
-	<httpEndpoint id="defaultHttpEndpoint"
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
+
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="*" usePlaintext="true" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.wildcard.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.wildcard.server.xml
@@ -4,25 +4,22 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with no grpc elements">
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
 
-	<httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-    
+
     <include location="../fatTestCommon.xml"/>
-    
+
     <grpcClient host="*" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor" authntoken="oauth" maxInboundMessageSize="32000" keepAliveTime="120" keepAliveTimeout="360" />
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.xml
@@ -4,23 +4,20 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC client with no grpcClient elements">
     <featureManager>
         <feature>grpcClient-1.0</feature>
-     </featureManager>
+    </featureManager>
 
-	 <httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
-     <include location="../fatTestCommon.xml" />
-    
+
+    <include location="../fatTestCommon.xml" />
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.bad.target.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.bad.target.xml
@@ -4,20 +4,17 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with bad target">
     <featureManager>
         <feature>grpc-1.0</feature>
-     </featureManager>
-     
-     <grpc target="foo.Fighter" maxInboundMessageSize="-1"/>
+    </featureManager>
+
+    <grpc target="foo.Fighter" maxInboundMessageSize="-1"/>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.cdi.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.cdi.interceptor.xml
@@ -4,18 +4,15 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with no grpc elements">
     <featureManager>
         <feature>grpc-1.0</feature>
         <feature>grpcClient-1.0</feature>
         <feature>cdi-2.0</feature>
-     </featureManager>
+    </featureManager>
 
     <include location="../fatTestPorts.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.cdi.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.cdi.xml
@@ -4,21 +4,18 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with no grpc elements">
     <featureManager>
         <feature>grpc-1.0</feature>
         <feature>grpcClient-1.0</feature>
         <feature>cdi-2.0</feature>
-     </featureManager>
+    </featureManager>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.grpc.element.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.grpc.element.xml
@@ -4,20 +4,17 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with single target">
     <featureManager>
         <feature>grpc-1.0</feature>
-     </featureManager>
-     
-     <grpc target="helloworld.Greeter" />
+    </featureManager>
+
+    <grpc target="helloworld.Greeter" />
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.grpc.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.grpc.interceptor.xml
@@ -4,20 +4,17 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with single target and Interceptor">
     <featureManager>
         <feature>grpc-1.0</feature>
-     </featureManager>
-     
-     <grpc target="helloworld.Greeter" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerInterceptor"/>
+    </featureManager>
+
+    <grpc target="helloworld.Greeter" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerInterceptor"/>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.invalid.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.invalid.interceptor.xml
@@ -4,20 +4,17 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with single target and invalid Interceptor">
     <featureManager>
         <feature>grpc-1.0</feature>
-     </featureManager>
-     
-     <grpc target="helloworld.Greeter" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloPlanetServerInterceptor"/>
+    </featureManager>
+
+    <grpc target="helloworld.Greeter" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloPlanetServerInterceptor"/>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.invalid.max.msg.size.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.invalid.max.msg.size.xml
@@ -4,20 +4,17 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with grpc element with invalid max message size">
     <featureManager>
         <feature>grpc-1.0</feature>
-     </featureManager>
-     
-     <grpc target="*" maxInboundMessageSize="-1"/>
+    </featureManager>
 
-     <include location="../fatTestPorts.xml"/>
-    
+    <grpc target="*" maxInboundMessageSize="-1"/>
+
+    <include location="../fatTestPorts.xml"/>
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.metrics.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.metrics.server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server metrics">
     <featureManager>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.multiple.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.multiple.interceptor.xml
@@ -4,20 +4,17 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with single target and multiple Interceptors">
     <featureManager>
         <feature>grpc-1.0</feature>
-     </featureManager>
-     
-     <grpc target="helloworld.Greeter" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerInterceptor,com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerInterceptor2"/>
+    </featureManager>
+
+    <grpc target="helloworld.Greeter" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerInterceptor,com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerInterceptor2"/>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.small.max.msg.size.and.specific.target.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.small.max.msg.size.and.specific.target.xml
@@ -4,20 +4,17 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with grpc element, specific target and small max message size">
     <featureManager>
         <feature>grpc-1.0</feature>
-     </featureManager>
-     
-     <grpc target="helloworld.Greeter" maxInboundMessageSize="1"/>
+    </featureManager>
 
-     <include location="../fatTestPorts.xml"/>
-    
+    <grpc target="helloworld.Greeter" maxInboundMessageSize="1"/>
+
+    <include location="../fatTestPorts.xml"/>
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.small.max.msg.size.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.small.max.msg.size.xml
@@ -4,20 +4,17 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with grpc element, wildcard target and small max message size">
     <featureManager>
         <feature>grpc-1.0</feature>
-     </featureManager>
-     
-     <grpc target="*" maxInboundMessageSize="1"/>
+    </featureManager>
 
-     <include location="../fatTestPorts.xml"/>
-    
+    <grpc target="*" maxInboundMessageSize="1"/>
+
+    <include location="../fatTestPorts.xml"/>
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.tls.default.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.tls.default.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="Basic gRPC TLS server">
     <featureManager>
@@ -16,15 +13,15 @@
         <feature>grpcClient-1.0</feature>
         <feature>transportSecurity-1.0</feature>
     </featureManager>
-    
+
     <grpcClient host="*" sslRef="CustomSSLSettings" />
-    
+
     <include location="../fatTestPorts.xml" />
 
     <javaPermission className="java.security.AllPermission"
         name="*" actions="*" />
 
-    <sslDefault sslRef="CustomSSLSettings" /> 
+    <sslDefault sslRef="CustomSSLSettings" />
     <!--  TLSv1.2 or higher required by Netty client -->
     <ssl
         id="CustomSSLSettings"

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.tls.invalid.trust.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.tls.invalid.trust.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="gRPC TLS server: invalid client trust store">
     <featureManager>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.tls.mutual.auth.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.tls.mutual.auth.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="gRPC TLS server: mutual auth required">
     <featureManager>
@@ -16,9 +13,9 @@
         <feature>grpcClient-1.0</feature>
         <feature>transportSecurity-1.0</feature>
     </featureManager>
-    
+
     <grpcClient host="*" sslRef="CustomSSLSettings" />
-    
+
     <include location="../fatTestPorts.xml" />
 
     <javaPermission className="java.security.AllPermission"

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.tls.outbound.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.tls.outbound.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="Basic gRPC TLS server">
     <featureManager>
@@ -32,7 +29,7 @@
         verifyHostname="false"
         sslProtocol="TLSv1.2">
         <outboundConnection host="*" port="${bvt.prop.HTTP_default.secure}" />
-     </ssl> 
+    </ssl>
     <keyStore
         id="rsa_key"
         password="passw0rd"

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.xml
@@ -4,18 +4,15 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="FAT configuration for gRPC Server with no grpc elements">
     <featureManager>
         <feature>grpc-1.0</feature>
-     </featureManager>
+    </featureManager>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/bootstrap.properties
@@ -4,11 +4,8 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -78,7 +78,7 @@
         </application-bnd>
     </application>
 
-    <logging
+    <!--logging
         traceSpecification="*=info:
             com.ibm.ws.webcontainer*=all:
             com.ibm.wsspi.webcontainer*=all:
@@ -90,7 +90,7 @@
             io.grpc*=all:
             io.netty*=all:
             com.ibm.testapp.g3store*=all"
-        maxFileSize="100" maxFiles="1" traceFormat="BASIC" />
+        maxFileSize="100" maxFiles="1" traceFormat="BASIC" /-->
 
     <jwtBuilder
         id="defaultJWT"

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/server.xml
@@ -1,110 +1,112 @@
-<!-- Copyright (c) 2020 IBM Corporation and others. All rights reserved. 
-	This program and the accompanying materials are made available under the 
-	terms of the Eclipse Public License 2.0 which accompanies this distribution, 
-	and is available at http://www.eclipse.org/legal/epl-2.0/ Contributors: 
-	IBM Corporation - initial API and implementation -->
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
 <server description="Server for ConsumerService REST endpoint and Grpc client">
-	<featureManager>
-		<feature>grpc-1.0</feature>
-		<feature>grpcClient-1.0</feature>
-		<feature>componenttest-1.0</feature>
-		<feature>mpRestClient-1.3</feature>
-		<feature>mpConfig-1.3</feature>
-		<feature>mpOpenAPI-1.1</feature>
-		<feature>jwt-1.0</feature>
-		<feature>ssl-1.0</feature>
-		<feature>appSecurity-2.0</feature>
-	</featureManager>
+    <featureManager>
+        <feature>grpc-1.0</feature>
+        <feature>grpcClient-1.0</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>mpRestClient-1.3</feature>
+        <feature>mpConfig-1.3</feature>
+        <feature>mpOpenAPI-1.1</feature>
+        <feature>jwt-1.0</feature>
+        <feature>ssl-1.0</feature>
+        <feature>appSecurity-2.0</feature>
+    </featureManager>
 
-	<include location="../fatTestCommon.xml"/>
+    <include location="../fatTestCommon.xml"/>
 
-	 <httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.member_1.http}"
-				  httpsPort="${bvt.prop.member_1.https}"/>
-				  
-				  
-<!-- 	 <keyStore id="defaultKeyStore" password="passw0rd" /> -->
+                  httpsPort="${bvt.prop.member_1.https}"/>
 
-	<javaPermission className="java.security.AllPermission"
-		name="*" actions="*" />
+    <!-- <keyStore id="defaultKeyStore" password="passw0rd" /> -->
 
+    <javaPermission className="java.security.AllPermission"
+        name="*" actions="*" />
 
-	<!-- Default SSL configuration enables trust for default certificates from 
-		the Java runtime -->
-	<!-- <ssl id="defaultSSLConfig" trustDefaultCerts="true" /> -->
-	
-	<sslDefault sslRef="DefaultSSLSettings" />
-	<ssl
-		id="DefaultSSLSettings"
-		keyStoreRef="rsa_key"
-		trustStoreRef="rsa_trust"
-		clientAuthenticationSupported="true" />
-	<keyStore
-		id="rsa_key"
-		password="Liberty"
-		type="PKCS12"
-		location="${server.config.dir}/rsa_key.p12" />
-	<keyStore
-		id="rsa_trust"
-		password="LibertyServer"
-		type="PKCS12"
-		location="${server.config.dir}/rsa_trust.p12" />
+    <!-- Default SSL configuration enables trust for default certificates from
+        the Java runtime -->
+    <!-- <ssl id="defaultSSLConfig" trustDefaultCerts="true" /> -->
 
-	<basicRegistry id="basic" realm="consumerRealmBasicReg">
-		<user name="dev" password="hello" /> 
-		<user name="test" password="bug" />
-		<group name="students">
-			<member name="dev" />
-			<member name="test" />
-		</group>
-	</basicRegistry>
+    <sslDefault sslRef="DefaultSSLSettings" />
+    <ssl
+        id="DefaultSSLSettings"
+        keyStoreRef="rsa_key"
+        trustStoreRef="rsa_trust"
+        clientAuthenticationSupported="true" />
+    <keyStore
+        id="rsa_key"
+        password="Liberty"
+        type="PKCS12"
+        location="${server.config.dir}/rsa_key.p12" />
+    <keyStore
+        id="rsa_trust"
+        password="LibertyServer"
+        type="PKCS12"
+        location="${server.config.dir}/rsa_trust.p12" />
 
-	<application id="StoreConsumerApp"
-		location="StoreConsumerApp.war" name="StoreConsumerApp" type="war">
-		<application-bnd>
-			<security-role name="Administrator">
-				<!--group name="${env.ROLE_NAME_ADMINISTRATOR}" access-id="group:${env.OIDC_REALM}/${env.ROLE_NAME_ADMINISTRATOR}"/ -->
-				<group name="Administrator"
-					access-id="group:consumerRealmBasicReg/Administrator" />
-			</security-role>
-			<security-role name="students">
-				<!--group name="${env.ROLE_NAME_EDITOR}" access-id="group:${env.OIDC_REALM}/${env.ROLE_NAME_EDITOR}"/ -->
-				<group name="students"
-					access-id="group:consumerRealmBasicReg/students" />
-			</security-role>
-		</application-bnd>
-	</application>
+    <basicRegistry id="basic" realm="consumerRealmBasicReg">
+        <user name="dev" password="hello" />
+        <user name="test" password="bug" />
+        <group name="students">
+            <member name="dev" />
+            <member name="test" />
+        </group>
+    </basicRegistry>
 
-	<logging
-		traceSpecification="*=info:
-			com.ibm.ws.webcontainer*=all:
-			com.ibm.wsspi.webcontainer*=all:
-			HTTPChannel=all:
-			HTTPTransport=all:
-			TCPChannel=all:
-			GenericBNF=all:
-			GRPC=all:
-			io.grpc*=all:
-			io.netty*=all:
-			com.ibm.testapp.g3store*=all"
-		maxFileSize="100" maxFiles="1" traceFormat="BASIC" />
+    <application id="StoreConsumerApp"
+        location="StoreConsumerApp.war" name="StoreConsumerApp" type="war">
+        <application-bnd>
+            <security-role name="Administrator">
+                <!--group name="${env.ROLE_NAME_ADMINISTRATOR}" access-id="group:${env.OIDC_REALM}/${env.ROLE_NAME_ADMINISTRATOR}"/ -->
+                <group name="Administrator"
+                    access-id="group:consumerRealmBasicReg/Administrator" />
+            </security-role>
+            <security-role name="students">
+                <!--group name="${env.ROLE_NAME_EDITOR}" access-id="group:${env.OIDC_REALM}/${env.ROLE_NAME_EDITOR}"/ -->
+                <group name="students"
+                    access-id="group:consumerRealmBasicReg/students" />
+            </security-role>
+        </application-bnd>
+    </application>
 
-	<jwtBuilder
-		id="defaultJWT" 
-		issuer="testIssuer"
-		 />
-		 
-	<jwtBuilder
-		id="defaultBadJWT" 
-		issuer="testIssuerBad"
-		 />
-		
-	<grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAppInfo" headersToPropagate="authorization"/>
-	<grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAllAppNames" headersToPropagate="authorization"/>
-	<grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAppNameSetBadRoles" headersToPropagate="authorization"/>
-	<grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getNameCookieJWTHeader" headersToPropagate="Cookie"/>
-	<grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAppSetBadRoleCookieJWTHeader" headersToPropagate="Cookie"/>
-	
-	<!-- <grpcClient path="test.g3store.grpc.AppConsumerService/getAllAppNames" authnToken="jwt"/> -->
+    <logging
+        traceSpecification="*=info:
+            com.ibm.ws.webcontainer*=all:
+            com.ibm.wsspi.webcontainer*=all:
+            HTTPChannel=all:
+            HTTPTransport=all:
+            TCPChannel=all:
+            GenericBNF=all:
+            GRPC=all:
+            io.grpc*=all:
+            io.netty*=all:
+            com.ibm.testapp.g3store*=all"
+        maxFileSize="100" maxFiles="1" traceFormat="BASIC" />
+
+    <jwtBuilder
+        id="defaultJWT"
+        issuer="testIssuer"
+    />
+
+    <jwtBuilder
+        id="defaultBadJWT"
+        issuer="testIssuerBad"
+    />
+
+    <grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAppInfo" headersToPropagate="authorization"/>
+    <grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAllAppNames" headersToPropagate="authorization"/>
+    <grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAppNameSetBadRoles" headersToPropagate="authorization"/>
+    <grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getNameCookieJWTHeader" headersToPropagate="Cookie"/>
+    <grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAppSetBadRoleCookieJWTHeader" headersToPropagate="Cookie"/>
+
+    <!-- <grpcClient path="test.g3store.grpc.AppConsumerService/getAllAppNames" authnToken="jwt"/> -->
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcClientOnly/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcClientOnly/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -8,5 +8,5 @@
 # SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
-#com.ibm.ws.logging.trace.specification=*=info
-com.ibm.ws.logging.trace.specification=*=info:io.grpc*=all:GRPC=all:HttpTransport=all:HttpDispatcher=all::GenericBNF=all:HTTPChannel=all:TCPChannel=all:com.ibm.ws.webcontainer*=all:com.ibm.ws.webcontainer31*=all:com.ibm.wsspi.webcontainer*=all
+com.ibm.ws.logging.trace.specification=*=info
+#com.ibm.ws.logging.trace.specification=*=info:io.grpc*=all:GRPC=all:HttpTransport=all:HttpDispatcher=all::GenericBNF=all:HTTPChannel=all:TCPChannel=all:com.ibm.ws.webcontainer*=all:com.ibm.ws.webcontainer31*=all:com.ibm.wsspi.webcontainer*=all

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcClientOnly/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcClientOnly/bootstrap.properties
@@ -4,11 +4,8 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
 #com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcClientOnly/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcClientOnly/server.xml
@@ -4,23 +4,20 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
     <featureManager>
         <feature>grpcClient-1.0</feature>
     </featureManager>
 
-	 <httpEndpoint id="defaultHttpEndpoint"
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
-      <include location="../fatTestCommon.xml" />
-    
+
+    <include location="../fatTestCommon.xml" />
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServer/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServer/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -8,5 +8,5 @@
 # SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
-#com.ibm.ws.logging.trace.specification=*=info
-com.ibm.ws.logging.trace.specification=io.grpc*=all:com.ibm.ws.grpc*=all:io.grpc.servlet*=all:com.ibm.ws.grpc.*=all
+com.ibm.ws.logging.trace.specification=*=info
+#com.ibm.ws.logging.trace.specification=io.grpc*=all:com.ibm.ws.grpc*=all:io.grpc.servlet*=all:com.ibm.ws.grpc.*=all

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServer/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServer/bootstrap.properties
@@ -4,11 +4,8 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
 #com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServer/server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
     <featureManager>
@@ -17,6 +14,6 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServerOnly/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServerOnly/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020, 2021 IBM Corporation and others.
+# Copyright (c) 2020, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -8,4 +8,5 @@
 # SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:io.grpc*=all:GRPC=all:HttpTransport=all:HttpDispatcher=all::GenericBNF=all:HTTPChannel=all:TCPChannel=all:com.ibm.ws.webcontainer*=all:com.ibm.ws.webcontainer31*=all:com.ibm.wsspi.webcontainer*=all:ChannelFramework=all
+#com.ibm.ws.logging.trace.specification=*=info:io.grpc*=all:GRPC=all:HttpTransport=all:HttpDispatcher=all::GenericBNF=all:HTTPChannel=all:TCPChannel=all:com.ibm.ws.webcontainer*=all:com.ibm.ws.webcontainer31*=all:com.ibm.wsspi.webcontainer*=all:ChannelFramework=all
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServerOnly/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServerOnly/bootstrap.properties
@@ -4,11 +4,8 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:io.grpc*=all:GRPC=all:HttpTransport=all:HttpDispatcher=all::GenericBNF=all:HTTPChannel=all:TCPChannel=all:com.ibm.ws.webcontainer*=all:com.ibm.ws.webcontainer31*=all:com.ibm.wsspi.webcontainer*=all:ChannelFramework=all

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServerOnly/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcServerOnly/server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
     <featureManager>
@@ -16,6 +13,6 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServer/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServer/bootstrap.properties
@@ -4,11 +4,8 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServer/server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
 -->
 <server>
     <featureManager>
@@ -22,6 +19,6 @@
     <keyStore id="defaultKeyStore" password="passw0rd" />
 
     <include location="../fatTestPorts.xml"/>
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServerEar/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServerEar/bootstrap.properties
@@ -4,11 +4,8 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServerEar/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServerEar/server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
 -->
 <server>
     <featureManager>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServerTls/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServerTls/bootstrap.properties
@@ -4,11 +4,8 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServerTls/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldServerTls/server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="Basic gRPC TLS server">
     <featureManager>
@@ -16,9 +13,9 @@
         <feature>grpcClient-1.0</feature>
         <feature>transportSecurity-1.0</feature>
     </featureManager>
-    
+
     <grpcClient host="*" sslRef="CustomSSLSettings" />
-    
+
     <include location="../fatTestPorts.xml" />
 
     <javaPermission className="java.security.AllPermission"

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldThirdPartyAPIServer/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldThirdPartyAPIServer/bootstrap.properties
@@ -4,11 +4,8 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldThirdPartyAPIServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldThirdPartyAPIServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -28,8 +28,8 @@
             apiTypeVisibility="spec, ibm-api, stable, third-party" />
     </application>
 
-    <logging
+    <!--logging
         traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
-        maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
+        maxFileSize="40" maxFiles="1" traceFormat="BASIC" /-->
 
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldThirdPartyAPIServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/HelloWorldThirdPartyAPIServer/server.xml
@@ -4,35 +4,32 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
-	<featureManager>
-		<feature>grpc-1.0</feature>
-		<feature>grpcClient-1.0</feature>
-	</featureManager>
+    <featureManager>
+        <feature>grpc-1.0</feature>
+        <feature>grpcClient-1.0</feature>
+    </featureManager>
 
-	<mpMetrics authentication="false" />
-	<keyStore id="defaultKeyStore" password="passw0rd" />
+    <mpMetrics authentication="false" />
+    <keyStore id="defaultKeyStore" password="passw0rd" />
 
-	<include location="../fatTestPorts.xml" />
+    <include location="../fatTestPorts.xml" />
 
-	<javaPermission className="java.security.AllPermission"
-		name="*" actions="*" />
+    <javaPermission className="java.security.AllPermission"
+        name="*" actions="*" />
 
-	<application id="HelloWorldClient"
-		name="HelloWorldClient" type="war"
-		location="HelloWorldClient.war">
-		<classloader
-			apiTypeVisibility="spec, ibm-api, stable, third-party" />
-	</application>
+    <application id="HelloWorldClient"
+        name="HelloWorldClient" type="war"
+        location="HelloWorldClient.war">
+        <classloader
+            apiTypeVisibility="spec, ibm-api, stable, third-party" />
+    </application>
 
-	<logging
-		traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
-		maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
+    <logging
+        traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
+        maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
 
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ProducerServer/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ProducerServer/bootstrap.properties
@@ -4,11 +4,8 @@
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ProducerServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ProducerServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@
         the Java runtime -->
     <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
 
-    <logging
+    <!--logging
         traceSpecification="*=info:
             com.ibm.ws.webcontainer*=all:
             com.ibm.wsspi.webcontainer*=all:
@@ -48,6 +48,6 @@
             io.grpc*=all:
             io.netty*=all:
             com.ibm.testapp.g3store*=all"
-        maxFileSize="200" maxFiles="1" traceFormat="BASIC" />
+        maxFileSize="200" maxFiles="1" traceFormat="BASIC" /-->
 
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ProducerServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ProducerServer/server.xml
@@ -1,49 +1,53 @@
-<!-- Copyright (c) 2020 IBM Corporation and others. All rights reserved. 
-	This program and the accompanying materials are made available under the 
-	terms of the Eclipse Public License 2.0 which accompanies this distribution, 
-	and is available at http://www.eclipse.org/legal/epl-2.0/ Contributors: 
-	IBM Corporation - initial API and implementation -->
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
 
 <server description="Server for ProducerService REST endpoint and Grpc client">
 
-	<featureManager>
-		<feature>grpc-1.0</feature>
-		<feature>grpcClient-1.0</feature>
-		<feature>mpRestClient-1.3</feature>
-		<feature>mpOpenAPI-1.1</feature>
-		<feature>componenttest-1.0</feature>
+    <featureManager>
+        <feature>grpc-1.0</feature>
+        <feature>grpcClient-1.0</feature>
+        <feature>mpRestClient-1.3</feature>
+        <feature>mpOpenAPI-1.1</feature>
+        <feature>componenttest-1.0</feature>
         <feature>mpMetrics-2.3</feature>
     </featureManager>
 
     <mpMetrics authentication = "false"/>
-	
-	<include location="../fatTestCommon.xml"/>
-	
-	 <httpEndpoint id="defaultHttpEndpoint"
+
+    <include location="../fatTestCommon.xml"/>
+
+    <httpEndpoint id="defaultHttpEndpoint"
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-      <keyStore id="defaultKeyStore" password="passw0rd" />
-            
-	<javaPermission className="java.security.AllPermission"
-		name="*" actions="*" />
+    <keyStore id="defaultKeyStore" password="passw0rd" />
 
-	<!-- Default SSL configuration enables trust for default certificates from 
-		the Java runtime -->
-	<ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+    <javaPermission className="java.security.AllPermission"
+        name="*" actions="*" />
 
-	<logging
-		traceSpecification="*=info:
-			com.ibm.ws.webcontainer*=all:
-			com.ibm.wsspi.webcontainer*=all:
-			HTTPChannel=all:
-			HTTPTransport=all:
-			TCPChannel=all:
-			GenericBNF=all:
-			GRPC=all:
-			io.grpc*=all:
-			io.netty*=all:
-			com.ibm.testapp.g3store*=all"
-		maxFileSize="200" maxFiles="1" traceFormat="BASIC" />
+    <!-- Default SSL configuration enables trust for default certificates from
+        the Java runtime -->
+    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+
+    <logging
+        traceSpecification="*=info:
+            com.ibm.ws.webcontainer*=all:
+            com.ibm.wsspi.webcontainer*=all:
+            HTTPChannel=all:
+            HTTPTransport=all:
+            TCPChannel=all:
+            GenericBNF=all:
+            GRPC=all:
+            io.grpc*=all:
+            io.netty*=all:
+            com.ibm.testapp.g3store*=all"
+        maxFileSize="200" maxFiles="1" traceFormat="BASIC" />
 
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/SecureHelloWorldServer/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/SecureHelloWorldServer/bootstrap.properties
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/SecureHelloWorldServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/SecureHelloWorldServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@
         password="passw0rd"
         type="PKCS12"
         location="${server.config.dir}/trust.p12" />
-    <logging
+    <!--logging
         traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
-        maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
+        maxFileSize="40" maxFiles="1" traceFormat="BASIC" /-->
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/SecureHelloWorldServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/SecureHelloWorldServer/server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="Basic gRPC with security constraints">
     <featureManager>
@@ -16,9 +13,9 @@
         <feature>grpcClient-1.0</feature>
         <feature>appSecurity-2.0</feature>
     </featureManager>
-    
+
     <grpcClient host="*" sslRef="CustomSSLSettings" />
-    
+
     <include location="../fatTestPorts.xml" />
 
     <javaPermission className="java.security.AllPermission"
@@ -43,7 +40,7 @@
         password="passw0rd"
         type="PKCS12"
         location="${server.config.dir}/trust.p12" />
-	<logging
-		traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
-		maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
+    <logging
+        traceSpecification="*=info=enabled:io.openliberty.grpc*=all"
+        maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/StoreJWTSSoServer/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/StoreJWTSSoServer/bootstrap.properties
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/StoreJWTSSoServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/StoreJWTSSoServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -97,11 +97,11 @@
         </application-bnd>
     </application>
 
-    <logging
+    <!--logging
         traceSpecification="*=info=enabled
         :io.openliberty.grpc*=all
         :com.ibm.testapp.g3store*=all:io.grpc*=all:com.ibm.ws.security*=all"
-        maxFileSize="200" maxFiles="4" traceFormat="BASIC" />
+        maxFileSize="200" maxFiles="4" traceFormat="BASIC" /-->
 
         <!-- :com.ibm.ws.webcontainer*=all
         :com.ibm.wsspi.webcontainer*=all

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/StoreJWTSSoServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/StoreJWTSSoServer/server.xml
@@ -4,113 +4,107 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="Server for Store Grpc service">
-	<featureManager>
-		<feature>grpc-1.0</feature>
-		<feature>grpcClient-1.0</feature>
-		<feature>mpOpenAPI-1.1</feature>
-		<feature>mpRestClient-1.3</feature>
-		<feature>mpConfig-1.3</feature>
-		<feature>distributedMap-1.0</feature>
-		<feature>appSecurity-2.0</feature>
-		<feature>ssl-1.0</feature>
-		<feature>jsp-2.3</feature>
+    <featureManager>
+        <feature>grpc-1.0</feature>
+        <feature>grpcClient-1.0</feature>
+        <feature>mpOpenAPI-1.1</feature>
+        <feature>mpRestClient-1.3</feature>
+        <feature>mpConfig-1.3</feature>
+        <feature>distributedMap-1.0</feature>
+        <feature>appSecurity-2.0</feature>
+        <feature>ssl-1.0</feature>
+        <feature>jsp-2.3</feature>
         <feature>monitor-1.0</feature>
         <feature>mpMetrics-2.3</feature>
         <feature>jwtSso-1.0</feature>
         <feature>mpJwt-1.1</feature>
     </featureManager>
-    
+
     <mpMetrics authentication = "false"/>
-	
-	<include location="../fatTestPorts.xml" />
 
-	<distributedMap id="gRPCDistMap" />
-	
-<!-- 	<keyStore id="defaultKeyStore" password="passw0rd" /> -->
+    <include location="../fatTestPorts.xml" />
 
-	<javaPermission className="java.security.AllPermission"
-		name="*" actions="*" />
+    <distributedMap id="gRPCDistMap" />
 
-	<!-- Default SSL configuration enables trust for default certificates from 
-		the Java runtime -->
-	<!-- <ssl id="defaultSSLConfig" trustDefaultCerts="true" /> -->
-	
-	<sslDefault sslRef="DefaultSSLSettings" />
-	
-	<ssl
-		id="DefaultSSLSettings"
-		keyStoreRef="rsa_key"
-		trustStoreRef="rsa_trust"
-		clientAuthenticationSupported="true" />
-	<keyStore
-		id="rsa_key"
-		password="Liberty"
-		type="PKCS12"
-		location="${server.config.dir}/rsa_key.p12" />
-	<keyStore
-		id="rsa_trust"
-		password="LibertyServer"
-		type="PKCS12"
-		location="${server.config.dir}/rsa_trust.p12" />
-	
-	
-	<!-- The security setup in this server will apply on grpc services -->
-	
-	<!--  This is for Cookie header with JWT -->	
-	<mpJwt id="myMpJWT" issuer="testIssuer" groupNameAttribute="groups"/>
-	<jwtSso cookieName="myjwtCookie"/>
-	
-	
-	<!-- the openidConnectClient does not use the registry by default, 
-so the group information is what is in the token, 
-and that access id must then exist in the role map -->
+    <!-- <keyStore id="defaultKeyStore" password="passw0rd" /> -->
 
-	<basicRegistry id="basic" realm="storeRealmBasicReg">
-		<user name="dev" password="hello" /> <!--user name="${env.BASIC_REGISTRY_USERNAME}" -->
-		<user name="test" password="bug" />
-		<group name="students"> <!-- group name="${env.ROLE_NAME_ADMINISTRATOR}" -->
-			<member name="dev" />
-			<member name="test" />
-		</group>
-	</basicRegistry>
+    <javaPermission className="java.security.AllPermission"
+        name="*" actions="*" />
 
-	<application id="StoreApp"
-		location="StoreApp.war" name="StoreApp" type="war">
-		<application-bnd>
-			<security-role name="Administrator">				
-				<group name="Administrator"
-					access-id="group:testIssuer/Administrator" />
-			</security-role>
-			<security-role name="students">
-				<!-- For Token auth case -->
-				<group name="students-jwt"
-					access-id="group:testIssuer/students" />
-				<!-- For basic auth case -->
-				<group name="students"
-					access-id="group:storeRealmBasicReg/students" />
-				<!-- For Token auth sso case -->
-				<group name="students-jwtsso"
-					access-id="group:consumerRealmBasicReg/students" />
-			</security-role>
-		</application-bnd>
-	</application>
-		
-	<logging
-		traceSpecification="*=info=enabled
-		:io.openliberty.grpc*=all
-		:com.ibm.testapp.g3store*=all:io.grpc*=all:com.ibm.ws.security*=all"
-		maxFileSize="200" maxFiles="4" traceFormat="BASIC" />
-		
-		
-		<!-- :com.ibm.ws.webcontainer*=all
-		:com.ibm.wsspi.webcontainer*=all
-		:com.ibm.ws.security*=all" -->
+    <!-- Default SSL configuration enables trust for default certificates from
+        the Java runtime -->
+    <!-- <ssl id="defaultSSLConfig" trustDefaultCerts="true" /> -->
+
+    <sslDefault sslRef="DefaultSSLSettings" />
+
+    <ssl
+        id="DefaultSSLSettings"
+        keyStoreRef="rsa_key"
+        trustStoreRef="rsa_trust"
+        clientAuthenticationSupported="true" />
+    <keyStore
+        id="rsa_key"
+        password="Liberty"
+        type="PKCS12"
+        location="${server.config.dir}/rsa_key.p12" />
+    <keyStore
+        id="rsa_trust"
+        password="LibertyServer"
+        type="PKCS12"
+        location="${server.config.dir}/rsa_trust.p12" />
+
+    <!-- The security setup in this server will apply on grpc services -->
+
+    <!--  This is for Cookie header with JWT -->
+    <mpJwt id="myMpJWT" issuer="testIssuer" groupNameAttribute="groups"/>
+    <jwtSso cookieName="myjwtCookie"/>
+
+    <!-- the openidConnectClient does not use the registry by default,
+        so the group information is what is in the token,
+        and that access id must then exist in the role map -->
+
+    <basicRegistry id="basic" realm="storeRealmBasicReg">
+        <user name="dev" password="hello" /> <!--user name="${env.BASIC_REGISTRY_USERNAME}" -->
+        <user name="test" password="bug" />
+        <group name="students"> <!-- group name="${env.ROLE_NAME_ADMINISTRATOR}" -->
+            <member name="dev" />
+            <member name="test" />
+        </group>
+    </basicRegistry>
+
+    <application id="StoreApp"
+        location="StoreApp.war" name="StoreApp" type="war">
+        <application-bnd>
+            <security-role name="Administrator">
+                <group name="Administrator"
+                    access-id="group:testIssuer/Administrator" />
+            </security-role>
+            <security-role name="students">
+                <!-- For Token auth case -->
+                <group name="students-jwt"
+                    access-id="group:testIssuer/students" />
+                <!-- For basic auth case -->
+                <group name="students"
+                    access-id="group:storeRealmBasicReg/students" />
+                <!-- For Token auth sso case -->
+                <group name="students-jwtsso"
+                    access-id="group:consumerRealmBasicReg/students" />
+            </security-role>
+        </application-bnd>
+    </application>
+
+    <logging
+        traceSpecification="*=info=enabled
+        :io.openliberty.grpc*=all
+        :com.ibm.testapp.g3store*=all:io.grpc*=all:com.ibm.ws.security*=all"
+        maxFileSize="200" maxFiles="4" traceFormat="BASIC" />
+
+        <!-- :com.ibm.ws.webcontainer*=all
+        :com.ibm.wsspi.webcontainer*=all
+        :com.ibm.ws.security*=all" -->
 
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/StoreServer/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/StoreServer/bootstrap.properties
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/StoreServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/StoreServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -129,7 +129,7 @@
         </application-bnd>
     </application>
 
-    <logging
+    <!--logging
         traceSpecification="*=info:
             com.ibm.ws.webcontainer*=all:
             com.ibm.wsspi.webcontainer*=all:
@@ -141,6 +141,6 @@
             io.grpc*=all:
             io.netty*=all:
             com.ibm.testapp.g3store*=all"
-        maxFileSize="200" maxFiles="1" traceFormat="BASIC" />
+        maxFileSize="200" maxFiles="1" traceFormat="BASIC" /-->
 
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/StoreServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/StoreServer/server.xml
@@ -4,148 +4,143 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server description="Server for Store Grpc service">
-	<featureManager>
-		<feature>grpc-1.0</feature>
-		<feature>grpcClient-1.0</feature>
-		<feature>mpOpenAPI-1.1</feature>
-		<feature>mpRestClient-1.3</feature>
-		<feature>distributedMap-1.0</feature>
-		<feature>appSecurity-2.0</feature>
-		<feature>jwt-1.0</feature>
-		<feature>openidConnectClient-1.0</feature>
-		<feature>jsp-2.3</feature>
+    <featureManager>
+        <feature>grpc-1.0</feature>
+        <feature>grpcClient-1.0</feature>
+        <feature>mpOpenAPI-1.1</feature>
+        <feature>mpRestClient-1.3</feature>
+        <feature>distributedMap-1.0</feature>
+        <feature>appSecurity-2.0</feature>
+        <feature>jwt-1.0</feature>
+        <feature>openidConnectClient-1.0</feature>
+        <feature>jsp-2.3</feature>
         <feature>mpMetrics-2.3</feature>
     </featureManager>
-    
+
     <mpMetrics authentication = "false"/>
-	
-	<include location="../fatTestPorts.xml" />
 
-	<distributedMap id="gRPCDistMap" />
-	
-<!-- 	<keyStore id="defaultKeyStore" password="passw0rd" /> -->
+    <include location="../fatTestPorts.xml" />
 
-	<javaPermission className="java.security.AllPermission"
-		name="*" actions="*" />
+    <distributedMap id="gRPCDistMap" />
 
-	<!-- Default SSL configuration enables trust for default certificates from 
-		the Java runtime -->
-	<!-- <ssl id="defaultSSLConfig" trustDefaultCerts="true" /> -->
-	
-	<sslDefault sslRef="DefaultSSLSettings" />
-	
-	<ssl
-		id="DefaultSSLSettings"
-		keyStoreRef="rsa_key"
-		trustStoreRef="rsa_trust"
-		clientAuthenticationSupported="true" />
-	<keyStore
-		id="rsa_key"
-		password="Liberty"
-		type="PKCS12"
-		location="${server.config.dir}/rsa_key.p12" />
-	<keyStore
-		id="rsa_trust"
-		password="LibertyServer"
-		type="PKCS12"
-		location="${server.config.dir}/rsa_trust.p12" />
-	
-	
-	<!-- The security setup in this server will apply on grpc services -->
-	
-	<openidConnectClient
-		id="defaultJWT"
-		scope="openid profile"
-		httpsRequired="false"
-		inboundPropagation="required"
-		issuerIdentifier="testIssuer"
-		signatureAlgorithm="RS256"
-		trustStoreRef="rsa_trust"
-		trustAliasName="rsacert"
-		clockSkew="2s"
-		groupIdentifier="groups"
-		authFilterRef="myAuthFilter">
-	</openidConnectClient>
-	
-	<authFilter id="myAuthFilter">
-		<requestUrl
-			id="myRequestUrla"
-			urlPattern="getAllAppNames"
-			matchType="contains" />
-	</authFilter>
-	
-	
-	<openidConnectClient
-		id="defaultBadJWT"
-		scope="openid profile"
-		httpsRequired="false"
-		inboundPropagation="required"
-		issuerIdentifier="testIssuerBad"
-		signatureAlgorithm="RS256"
-		trustStoreRef="rsa_trust"
-		trustAliasName="rsacert"
-		clockSkew="2s"
-		groupIdentifier="groups"
-		authFilterRef="myBadAuthFilter">
-	</openidConnectClient>
-	
-	<authFilter id="myBadAuthFilter">
-		<requestUrl
-			id="myRequestUrlb"
-			urlPattern="getAppNameSetBadRoles"
-			matchType="contains" />
-	</authFilter>
-	
-	<!-- the openidConnectClient does not use the registry by default, 
-so the group information is what is in the token, 
-and that access id must then exist in the role map -->
+    <!-- <keyStore id="defaultKeyStore" password="passw0rd" /> -->
 
-	<basicRegistry id="basic" realm="storeRealmBasicReg">
-		<user name="dev" password="hello" /> <!--user name="${env.BASIC_REGISTRY_USERNAME}" -->
-		<user name="test" password="bug" />
-		<group name="students"> <!-- group name="${env.ROLE_NAME_ADMINISTRATOR}" -->
-			<member name="dev" />
-			<member name="test" />
-		</group>
-	</basicRegistry>
+    <javaPermission className="java.security.AllPermission"
+        name="*" actions="*" />
 
-	<application id="StoreApp"
-		location="StoreApp.war" name="StoreApp" type="war">
-		<application-bnd>
-			<security-role name="Administrator">				
-				<group name="Administrator"
-					access-id="group:testIssuer/Administrator" />
-			</security-role>
-			<security-role name="students">
-			<!-- For Token auth case -->
-				<group name="students-jwt"
-					access-id="group:testIssuer/students" />
-				<!-- For basic auth case -->
-				<group name="students"
-					access-id="group:storeRealmBasicReg/students" />
-			</security-role>
-		</application-bnd>
-	</application>
+    <!-- Default SSL configuration enables trust for default certificates from
+        the Java runtime -->
+    <!-- <ssl id="defaultSSLConfig" trustDefaultCerts="true" /> -->
 
-	<logging
-		traceSpecification="*=info:
-			com.ibm.ws.webcontainer*=all:
-			com.ibm.wsspi.webcontainer*=all:
-			HTTPChannel=all:
-			HTTPTransport=all:
-			TCPChannel=all:
-			GenericBNF=all:
-			GRPC=all:
-			io.grpc*=all:
-			io.netty*=all:
-			com.ibm.testapp.g3store*=all"
-		maxFileSize="200" maxFiles="1" traceFormat="BASIC" />
+    <sslDefault sslRef="DefaultSSLSettings" />
+
+    <ssl
+        id="DefaultSSLSettings"
+        keyStoreRef="rsa_key"
+        trustStoreRef="rsa_trust"
+        clientAuthenticationSupported="true" />
+    <keyStore
+        id="rsa_key"
+        password="Liberty"
+        type="PKCS12"
+        location="${server.config.dir}/rsa_key.p12" />
+    <keyStore
+        id="rsa_trust"
+        password="LibertyServer"
+        type="PKCS12"
+        location="${server.config.dir}/rsa_trust.p12" />
+
+    <!-- The security setup in this server will apply on grpc services -->
+
+    <openidConnectClient
+        id="defaultJWT"
+        scope="openid profile"
+        httpsRequired="false"
+        inboundPropagation="required"
+        issuerIdentifier="testIssuer"
+        signatureAlgorithm="RS256"
+        trustStoreRef="rsa_trust"
+        trustAliasName="rsacert"
+        clockSkew="2s"
+        groupIdentifier="groups"
+        authFilterRef="myAuthFilter">
+    </openidConnectClient>
+
+    <authFilter id="myAuthFilter">
+        <requestUrl
+            id="myRequestUrla"
+            urlPattern="getAllAppNames"
+            matchType="contains" />
+    </authFilter>
+
+    <openidConnectClient
+        id="defaultBadJWT"
+        scope="openid profile"
+        httpsRequired="false"
+        inboundPropagation="required"
+        issuerIdentifier="testIssuerBad"
+        signatureAlgorithm="RS256"
+        trustStoreRef="rsa_trust"
+        trustAliasName="rsacert"
+        clockSkew="2s"
+        groupIdentifier="groups"
+        authFilterRef="myBadAuthFilter">
+    </openidConnectClient>
+
+    <authFilter id="myBadAuthFilter">
+        <requestUrl
+            id="myRequestUrlb"
+            urlPattern="getAppNameSetBadRoles"
+            matchType="contains" />
+    </authFilter>
+
+    <!-- the openidConnectClient does not use the registry by default,
+        so the group information is what is in the token,
+        and that access id must then exist in the role map -->
+
+    <basicRegistry id="basic" realm="storeRealmBasicReg">
+        <user name="dev" password="hello" /> <!--user name="${env.BASIC_REGISTRY_USERNAME}" -->
+        <user name="test" password="bug" />
+        <group name="students"> <!-- group name="${env.ROLE_NAME_ADMINISTRATOR}" -->
+            <member name="dev" />
+            <member name="test" />
+        </group>
+    </basicRegistry>
+
+    <application id="StoreApp"
+        location="StoreApp.war" name="StoreApp" type="war">
+        <application-bnd>
+            <security-role name="Administrator">
+                <group name="Administrator"
+                    access-id="group:testIssuer/Administrator" />
+            </security-role>
+            <security-role name="students">
+            <!-- For Token auth case -->
+                <group name="students-jwt"
+                    access-id="group:testIssuer/students" />
+                <!-- For basic auth case -->
+                <group name="students"
+                    access-id="group:storeRealmBasicReg/students" />
+            </security-role>
+        </application-bnd>
+    </application>
+
+    <logging
+        traceSpecification="*=info:
+            com.ibm.ws.webcontainer*=all:
+            com.ibm.wsspi.webcontainer*=all:
+            HTTPChannel=all:
+            HTTPTransport=all:
+            TCPChannel=all:
+            GenericBNF=all:
+            GRPC=all:
+            io.grpc*=all:
+            io.netty*=all:
+            com.ibm.testapp.g3store*=all"
+        maxFileSize="200" maxFiles="1" traceFormat="BASIC" />
 
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/StreamingServer/bootstrap.properties
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/StreamingServer/bootstrap.properties
@@ -6,9 +6,6 @@
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/StreamingServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/StreamingServer/server.xml
@@ -4,11 +4,8 @@
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
-    
+
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
     <featureManager>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #33636

1) Clean up formatting in server.xml and bootstrap.properties files.
2) Disable traces to increase FAT execution time.
