### PR TITLE
Check secure_file1 has been deleted

### DIFF
--- a/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
+++ b/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
@@ -145,6 +144,15 @@ public class SecurityUtilityCreateLTPAKeysTest {
     @After
     public void tearDown() throws Exception {
         // Delete stray LTPA key files in common locations
+
+        String secureFileName = "Secure_file1.xml";
+        File autoFVTDir = new File(ltpaTestServer.pathToAutoFVTTestFiles);
+        for(File file:autoFVTDir.listFiles()){
+            if(file.getName().contains("Secure_file")){
+                secureFileName = file.getName();
+            }
+        }
+
         String[] filesToCleanup = {
             libertyInstallRoot + "/" + DEFAULT_LTPA_KEY_FILE,
             libertyInstallRoot + "/" + CUSTOM_LTPA_KEY_FILE,
@@ -154,7 +162,7 @@ public class SecurityUtilityCreateLTPAKeysTest {
             ltpaTestServer.pathToAutoFVTTestFiles + "server_ltpa_passwordKey.xml",
             ltpaTestServer.pathToAutoFVTTestFiles + "server_ltpa.xml",
             ltpaTestServer.pathToAutoFVTTestFiles + "overrides.xml",
-            ltpaTestServer.pathToAutoFVTTestFiles + "Secure_file1.xml",
+            ltpaTestServer.pathToAutoFVTTestFiles + secureFileName,
             ltpaTestServer.pathToAutoFVTTestFiles + "temp_aes.xml"
         };
         for (String filePath : filesToCleanup) {
@@ -338,9 +346,9 @@ public class SecurityUtilityCreateLTPAKeysTest {
             ltpaFile.delete();
         }
 
-        // Create a secure key file for testing
-        File outputFile1 = new File(ltpaTestServer.pathToAutoFVTTestFiles, "Secure_file1.xml");
-        
+        // generate file with a random identifier so we are not beholden to windows file locks
+        File outputFile1 = new File(ltpaTestServer.pathToAutoFVTTestFiles, "Secure_file"+ (int)(Math.random() * 101) +".xml");
+
         // Generate secure file
         ProgramOutput firstCommandOutput = testMachine.execute(
             securityUtilityPath,
@@ -613,10 +621,9 @@ public class SecurityUtilityCreateLTPAKeysTest {
         if (ltpaFile.exists()) {
             ltpaFile.delete();
         }
+        // generate file with a random identifier so we are not beholden to windows file locks
+        File outputFile1 = new File(ltpaTestServer.pathToAutoFVTTestFiles, "Secure_file"+ (int)(Math.random() * 101) +".xml");
 
-        // Create a secure key file for testing
-        File outputFile1 = new File(ltpaTestServer.pathToAutoFVTTestFiles, "Secure_file1.xml");
-        
         // Generate secure file
         ProgramOutput firstCommandOutput = testMachine.execute(
             securityUtilityPath,


### PR DESCRIPTION
the Secure_File1.xml occasionally hasn't been deleted by the time the 2nd test that should create it runs. potential issue on windows where it is still potentially considered `in use`. give the files a "random" id such that it should be sufficiently unique given the actual lack of randomness in the number generator.

Update the deletion logic to ensure we don't end up with 100 files on disk if someone keeps rerunning the test

Fixes [307438](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=307438)


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".