### PR TITLE
reproduce ClassCastException for ArrayList ElementCollection

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Prime.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Prime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@ public class Prime {
 
     public String romanNumeral;
 
-    public List<String> romanNumeralSymbols; //TODO revert to ArrayList once https://github.com/OpenLiberty/open-liberty/issues/33205 is closed
+    public List<String> romanNumeralSymbols;
 
     public int sumOfBits;
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -868,9 +868,6 @@ public class DataJPATestServlet extends FATServlet {
      */
     @Test
     public void testElementCollection() throws Exception {
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33205")) {
-            return; //TODO remove skip when fixed in Hibernate or Liberty
-        }
 
         ECEntity e1 = new ECEntity();
         e1.setId("EC1");

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ECEntity.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ECEntity.java
@@ -12,6 +12,7 @@ package test.jakarta.data.jpa.web;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import jakarta.persistence.ElementCollection;
@@ -33,7 +34,7 @@ public class ECEntity {
     ArrayList<Long> longList = new ArrayList<>();
 
     @ElementCollection(fetch = FetchType.EAGER)
-    ArrayList<Long> longListEC = new ArrayList<>();
+    List<Long> longListEC = new ArrayList<>();
 
     Set<String> stringSet = new HashSet<>();
 
@@ -52,7 +53,7 @@ public class ECEntity {
         return longList;
     }
 
-    public ArrayList<Long> getLongListEC() {
+    public List<Long> getLongListEC() {
         return longListEC;
     }
 
@@ -76,7 +77,7 @@ public class ECEntity {
         this.longList = longList;
     }
 
-    public void setLongListEC(ArrayList<Long> longListEC) {
+    public void setLongListEC(List<Long> longListEC) {
         this.longListEC = longListEC;
     }
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/hibernate/DataJPAHibernateServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/hibernate/DataJPAHibernateServlet.java
@@ -14,6 +14,9 @@ package test.jakarta.data.jpa.web.hibernate;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.page.CursoredPage;
@@ -144,6 +147,52 @@ public class DataJPAHibernateServlet extends FATServlet {
                                                         pageReq);
 
         assertEquals(10, page1.totalElements());
+    }
+
+    /**
+     * Reproduces a migration issue (33205) from EclipseLink to Hibernate
+     * where Hibernate does not tolerate an ElementCollection of type
+     * java.util.ArrayList, which EclipseLink does tolerate.
+     */
+    @Test
+    public void testEntityWithArrayListAttribute() throws Exception {
+        EntityManagerFactory emf = InitialContext
+                        .doLookup("java:comp/env/persistence/HibernatePersistenceUnitRef");
+        UserTransaction tx = InitialContext
+                        .doLookup("java:comp/UserTransaction");
+
+        EntityWithArrayList entity = new EntityWithArrayList();
+        entity.setId("TestEntityWithArrayListAttribute");
+        entity.setLongList(new ArrayList<>(List.of(1L, 2L, 3L)));
+
+        EntityManager em = null;
+
+        tx.begin();
+        try {
+            em = emf.createEntityManager();
+            em.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
+            assertEquals(true, em.isJoinedToTransaction());
+
+            em.persist(entity);
+        } finally {
+            if (tx.getStatus() == Status.STATUS_ACTIVE)
+                tx.commit();
+            else
+                tx.rollback();
+            em.clear();
+            em.close();
+        }
+
+        em = emf.createEntityManager();
+        try {
+            entity = em.find(EntityWithArrayList.class,
+                             "TestEntityWithArrayListAttribute");
+        } finally {
+            em.close();
+        }
+
+        assertEquals(List.of(1L, 2L, 3L),
+                     entity.getLongList());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/hibernate/EntityWithArrayList.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/hibernate/EntityWithArrayList.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.jpa.web.hibernate;
+
+import java.util.ArrayList;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+
+/**
+ * Entity with an attribute that is an ArrayList.
+ */
+@Entity
+public class EntityWithArrayList {
+
+    @Id
+    String id;
+
+    // TODO enable if #33205 is addressed
+    //@ElementCollection(fetch = FetchType.EAGER)
+    ArrayList<Long> longList = new ArrayList<>();
+
+    public String getId() {
+        return id;
+    }
+
+    public ArrayList<Long> getLongList() {
+        return longList;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setLongList(ArrayList<Long> longList) {
+        this.longList = longList;
+    }
+
+}


### PR DESCRIPTION
Reproduces a difference between EclipseLink and Hibernate where Hibernate does not tolerate the ArrayList type for ElementCollection entity attributes (it is not required to) and raises ClassCastException #33205.  After reproducing using an EntityManager directly, I am updating other tests to switch from `ArrayList` to `List` so that they can run cleanly and cover other assertions that are further along in those tests.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
