### PR TITLE
jvm.options no longer needed, no beta function in servlet60_partitioned server

### DIFF
--- a/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/publish/servers/servlet60_partitioned/jvm.options
+++ b/dev/io.openliberty.webcontainer.servlet.6.0.internal_fat/publish/servers/servlet60_partitioned/jvm.options
@@ -1,1 +1,0 @@
--Dcom.ibm.ws.beta.edition=true


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #33657