### PR TITLE
enable tests after 29460 fixed

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -4442,15 +4442,13 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals("Simon", participants.getFirstName(3).orElseThrow());
 
-        // TODO enable once #29460 is fixed
-        //assertEquals(new Participant.Name("Samantha", "TestRecordAsEmbeddable"),
-        //             participants.findNameById(4).orElseThrow());
+        assertEquals(new Participant.Name("Samantha", "TestRecordAsEmbeddable"),
+                     participants.findNameById(4).orElseThrow());
 
-        // TODO enable once #29460 is fixed
-        //assertEquals(List.of("Samantha", "Sarah", "Simon", "Steve"),
-        //             participants.withSurname("TestRecordAsEmbeddable")
-        //                             .map(p -> p.name.first())
-        //                             .collect(Collectors.toList()));
+        assertEquals(List.of("Samantha", "Sarah", "Simon", "Steve"),
+                     participants.withSurname("TestRecordAsEmbeddable")
+                                     .map(p -> p.name.first())
+                                     .collect(Collectors.toList()));
 
         assertEquals(4L, participants.remove("TestRecordAsEmbeddable"));
     }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/eclipselink/Animals.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/eclipselink/Animals.java
@@ -33,7 +33,7 @@ public interface Animals extends CrudRepository<Animal, ScientificName> {
 
     // Using @Find here would require @Select(ID), which isn't available
     // until Data 1.1
-    @Query("SELECT id WHERE id.genus = ?1")
+    @Query("SELECT o.id FROM Animal o WHERE o.id.genus = ?1")
     @OrderBy("id.species")
     Stream<ScientificName> ofGenus(String id_genus);
 }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/eclipselink/Cylinder.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/eclipselink/Cylinder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,31 +19,15 @@ public record Cylinder(
                 Coordinate center,
                 Side side) {
 
-    public static class Coordinate {
-        public int x, y;
-
-        public Coordinate() {
-        }
-
-        public Coordinate(int x, int y) {
-            this.x = x;
-            this.y = y;
-        }
-
-        public int x() {
-            return x;
-        }
-
-        public int y() {
-            return y;
-        }
-
-        @Override
-        public String toString() {
-            return "Coordinate {x=" + x + ", y=" + y + "}";
-        }
+    public static record Coordinate(
+                    int x,
+                    int y) {
     }
 
+    // TODO switch to record once #33662 is fixed
+    //public static record Side(
+    //                Coordinate a,
+    //                Coordinate b) {
     public static class Side {
         public Coordinate a, b;
 
@@ -67,18 +51,8 @@ public record Cylinder(
         public String toString() {
             return "Side {a=" + a + ", b=" + b + "}";
         }
+
     }
-
-    // TODO switch the above to the following once #29460 is fixed
-    //public static record Coordinate(
-    //                int x,
-    //                int y) {
-    //}
-
-    //public static record Side(
-    //                Coordinate a,
-    //                Coordinate b) {
-    //}
 
     public Cylinder(String cylinderID,
                     int aX, int aY,

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/eclipselink/DataEclipseLinkServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/eclipselink/DataEclipseLinkServlet.java
@@ -212,38 +212,37 @@ public class DataEclipseLinkServlet extends FATServlet {
         assertEquals("niger", foxSquirrel.id().species());
         assertEquals(1, foxSquirrel.version());
 
-        // TODO enable once #29460 is fixed
-        //assertEquals(List.of("Sciurus carolinensis",
-        //                     "Sciurus niger"),
-        //             animals.ofGenus("Sciurus")
-        //                             .map(n -> n.genus() + ' ' + n.species())
-        //                             .collect(Collectors.toList()));
+        assertEquals(List.of("Sciurus carolinensis",
+                             "Sciurus niger"),
+                     animals.ofGenus("Sciurus")
+                                     .map(n -> n.genus() + ' ' + n.species())
+                                     .collect(Collectors.toList()));
 
-        //ScientificName grayFoxId = new ScientificName("Urocyon", "cinereoargenteus");
-        //grayFox = animals.findById(grayFoxId).orElseThrow();
-        //assertEquals("gray fox", grayFox.commonName());
-        //assertEquals("Urocyon", grayFox.id().genus());
-        //assertEquals("cinereoargenteus", grayFox.id().species());
+        ScientificName grayFoxId = new ScientificName("Urocyon", "cinereoargenteus");
+        grayFox = animals.findById(grayFoxId).orElseThrow();
+        assertEquals("gray fox", grayFox.commonName());
+        assertEquals("Urocyon", grayFox.id().genus());
+        assertEquals("cinereoargenteus", grayFox.id().species());
 
-        //ScientificName graySquirrelId = new ScientificName("Sciurus", "carolinensis");
-        //graySquirrel = animals.findById(graySquirrelId).orElseThrow();
-        //assertEquals("gray squirrel", graySquirrel.commonName());
-        //assertEquals("Sciurus", graySquirrel.id().genus());
-        //assertEquals("carolinensis", graySquirrel.id().species());
+        ScientificName graySquirrelId = new ScientificName("Sciurus", "carolinensis");
+        graySquirrel = animals.findById(graySquirrelId).orElseThrow();
+        assertEquals("gray squirrel", graySquirrel.commonName());
+        assertEquals("Sciurus", graySquirrel.id().genus());
+        assertEquals("carolinensis", graySquirrel.id().species());
 
-        //foxSquirrel = foxSquirrel.withCommonName("FOX SQUIRREL");
-        //foxSquirrel = animals.save(foxSquirrel);
-        //assertEquals("FOX SQUIRREL", foxSquirrel.commonName());
-        //assertEquals("Sciurus", foxSquirrel.id().genus());
-        //assertEquals("niger", foxSquirrel.id().species());
-        //assertEquals(2, foxSquirrel.version());
+        foxSquirrel = foxSquirrel.withCommonName("FOX SQUIRREL");
+        foxSquirrel = animals.save(foxSquirrel);
+        assertEquals("FOX SQUIRREL", foxSquirrel.commonName());
+        assertEquals("Sciurus", foxSquirrel.id().genus());
+        assertEquals("niger", foxSquirrel.id().species());
+        assertEquals(2, foxSquirrel.version());
 
-        //foxSquirrel = foxSquirrel.withCommonName("fox squirrel");
-        //foxSquirrel = animals.update(foxSquirrel);
-        //assertEquals("fox squirrel", foxSquirrel.commonName());
-        //assertEquals("Sciurus", foxSquirrel.id().genus());
-        //assertEquals("niger", foxSquirrel.id().species());
-        //assertEquals(3, foxSquirrel.version());
+        foxSquirrel = foxSquirrel.withCommonName("fox squirrel");
+        foxSquirrel = animals.update(foxSquirrel);
+        assertEquals("fox squirrel", foxSquirrel.commonName());
+        assertEquals("Sciurus", foxSquirrel.id().genus());
+        assertEquals("niger", foxSquirrel.id().species());
+        assertEquals(3, foxSquirrel.version());
 
         animals.deleteById(new ScientificName("Sciurus", "niger"));
 

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fraction.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fraction.java
@@ -67,12 +67,10 @@ public class Fraction {
 
     @Embeddable
     public static record Digits(
-                    // TODO switch to false once #29460 is fixed
-                    @Column(nullable = true, table = "Fraction") //
+                    @Column(nullable = false, table = "Fraction") //
                     String nonrepeating,
 
-                    // TODO switch to false once #29460 is fixed
-                    @Column(nullable = true, table = "Fraction") //
+                    @Column(nullable = false, table = "Fraction") //
                     String repeating) {
 
         static Digits of(long[] digitValues, int nonRepeating, int total) {
@@ -202,9 +200,6 @@ public class Fraction {
             throw new IllegalArgumentException(numerator + " / " + denominator +
                                                " has too many fractional digits: " +
                                                Arrays.toString(digits) + "...");
-
-        // TODO remove once #29460 is fixed
-        f.digits = null;
 
         return f;
     }

--- a/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/Part.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/test-applications/DDLGenTestApp/src/test/jakarta/data/ddlgen/web/Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,10 +11,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package test.jakarta.data.ddlgen.web;
-
-import java.util.Objects;
-
-import test.jakarta.data.ddlgen.web.Part.Identifier;
 
 /**
  * A record entity with a composite id.
@@ -30,44 +26,13 @@ public record Part(Identifier id, String name, float price, int version) {
 
     /**
      * Composite id for the Part entity.
-     * TODO switch to a record once issue is resolved: https://github.com/OpenLiberty/open-liberty/issues/29460
      */
-    public static class Identifier {
-        public String partNum;
-        public String vendor;
-
-        public Identifier() {
-        }
-
-        public Identifier(String partNum, String vendor) {
-            this.partNum = partNum;
-            this.vendor = vendor;
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            Identifier o;
-            return other instanceof Identifier &&
-                   Objects.equals((o = (Identifier) other).partNum, partNum) &&
-                   Objects.equals(o.vendor, vendor);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(partNum, vendor);
-        }
-
-        public String partNum() {
-            return partNum;
-        }
+    public static record Identifier(String partNum, String vendor) {
 
         @Override
         public String toString() {
             return vendor + ":" + partNum;
         }
 
-        public String vendor() {
-            return vendor;
-        }
     }
 }

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/DataExperimentalServlet.java
@@ -1617,13 +1617,12 @@ public class DataExperimentalServlet extends FATServlet {
         s2.setStatus("ORDER_RECEIVED");
         shipments.save(s2);
 
-        // TODO enable once #29460 is fixed
-        //Instructions inst1 = shipments.getInstructions(10).orElseThrow();
-        //assertEquals("Handle with care", inst1.handlingRequirements());
-        //assertEquals("Leave at door, send text alert", inst1.deliveryRequirements());
-        //assertEquals(false, inst1.needsSignature());
+        Instructions inst1 = shipments.getInstructions(10).orElseThrow();
+        assertEquals("Handle with care", inst1.handlingRequirements());
+        assertEquals("Leave at door, send text alert", inst1.deliveryRequirements());
+        assertEquals(false, inst1.needsSignature());
 
-        //assertEquals(false, shipments.getInstructions(20).isPresent());
+        assertEquals(false, shipments.getInstructions(20).isPresent());
 
         shipments.removeEverything();
     }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1626,35 +1626,29 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(3, segments.countByPointAXLessThan(1));
 
-        // TODO enable for EclipseLink once #29460 is fixed
-        if (isHibernate()) {
-            assertEquals(List.of(s5.id, s6.id, s3.id, s4.id, s2.id),
-                         segments.endingSouthOf(175)
-                                         .map(s -> s.id)
-                                         .collect(Collectors.toList()));
+        assertEquals(List.of(s5.id, s6.id, s3.id, s4.id, s2.id),
+                     segments.endingSouthOf(175)
+                                     .map(s -> s.id)
+                                     .collect(Collectors.toList()));
 
-            assertEquals(List.of(-20, 0, 24),
-                         segments.longerThan(200, Sort.asc("pointA.x"))
-                                         .stream()
-                                         .map(s -> s.pointA.x())
-                                         .collect(Collectors.toList()));
+        assertEquals(List.of(-20, 0, 24),
+                     segments.longerThan(200, Sort.asc("pointA.x"))
+                                     .stream()
+                                     .map(s -> s.pointA.x())
+                                     .collect(Collectors.toList()));
 
-            s3.pointB = new Point(s3.pointB.x() - s3.pointA.x(), s3.pointB.y() - s3.pointA.y());
-            s3.pointA = new Point(0, 0);
-            s3 = segments.addOrModify(s3);
+        s3.pointB = new Point(s3.pointB.x() - s3.pointA.x(), s3.pointB.y() - s3.pointA.y());
+        s3.pointA = new Point(0, 0);
+        s3 = segments.addOrModify(s3);
 
-            // removes s1 and s3
-            assertEquals(2L, segments.removeStartingAt(0, 0));
+        // removes s1 and s3
+        assertEquals(2L, segments.removeStartingAt(0, 0));
 
-            Point s2pointB = segments.terminalPoint(s2.id).orElseThrow();
-            assertEquals(120, s2pointB.x());
-            assertEquals(171, s2pointB.y());
-            assertEquals(4L,
-                         segments.erase());
-        } else {
-            assertEquals(6L,
-                         segments.erase());
-        }
+        Point s2pointB = segments.terminalPoint(s2.id).orElseThrow();
+        assertEquals(120, s2pointB.x());
+        assertEquals(171, s2pointB.y());
+        assertEquals(4L,
+                     segments.erase());
     }
 
     /**
@@ -2209,7 +2203,6 @@ public class DataJPATestServlet extends FATServlet {
                                          " ORDER BY this.pointB.y ASC, this.id ASC");
             query.setParameter("yExclusiveMax", 200);
 
-            // TODO enable once #29460 is fixed
             @SuppressWarnings("unchecked")
             Stream<Segment> results = query.getResultStream();
 


### PR DESCRIPTION
Enable many tests after #29460 was fixed.
One of the tests is partly enabled and switched to #33662 for tracking a new issue that appeared with hierarchies of record embeddables.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
